### PR TITLE
fix(mcp): fail closed on invalid change.detect source fields

### DIFF
--- a/internal/mcp/facade_change_detect_source_test.go
+++ b/internal/mcp/facade_change_detect_source_test.go
@@ -1,0 +1,80 @@
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestChangeDetectSourceFailClosedBeforeActiveRepoFallback(t *testing.T) {
+	spec := facadeOperationSpec{Facade: "change", Operation: "detect", Legacy: "detect_changes"}
+	result := validateFacadeInput(spec, map[string]any{
+		"source": map[string]any{
+			"scope":     "unstaged",
+			"repo_path": `C:\work\repo-b`,
+		},
+	})
+	if result == nil || !result.IsError {
+		t.Fatalf("validateFacadeInput() = %#v, want structured tool error", result)
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	for _, want := range []string{
+		`\"error_code\":\"invalid_argument\"`,
+		`source.repo_path`,
+		`unsupported_field`,
+		`options.repo`,
+	} {
+		if !strings.Contains(string(payload), want) {
+			t.Errorf("error payload %s does not contain %q", payload, want)
+		}
+	}
+}
+
+func TestChangeDetectSourceFailClosedForUnknownField(t *testing.T) {
+	spec := facadeOperationSpec{Facade: "change", Operation: "detect", Legacy: "detect_changes"}
+	result := validateFacadeInput(spec, map[string]any{
+		"source": map[string]any{"paths": []string{"README.md"}},
+	})
+	if result == nil || !result.IsError {
+		t.Fatalf("validateFacadeInput() = %#v, want structured tool error", result)
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	for _, want := range []string{`source.paths`, `\"allowed_fields\":[\"scope\"]`} {
+		if !strings.Contains(string(payload), want) {
+			t.Errorf("error payload %s does not contain %q", payload, want)
+		}
+	}
+	if strings.Contains(string(payload), `options.repo`) {
+		t.Errorf("generic unknown field should not receive repo-specific guidance: %s", payload)
+	}
+}
+
+func TestChangeDetectSourceAllowsOptionsRepo(t *testing.T) {
+	spec := facadeOperationSpec{Facade: "change", Operation: "detect", Legacy: "detect_changes"}
+	input := map[string]any{
+		"source":  map[string]any{"scope": "compare"},
+		"options": map[string]any{"repo": `C:\work\repo-b`, "base_ref": "upstream/main"},
+	}
+	if result := validateFacadeInput(spec, input); result != nil {
+		t.Fatalf("validateFacadeInput() rejected supported selector: %#v", result)
+	}
+	normalized := normalizeFacadeArguments(spec, input)
+	if got := normalized["repo"]; got != `C:\work\repo-b` {
+		t.Fatalf("normalized repo = %#v, want explicit repo B path", got)
+	}
+	if got := normalized["scope"]; got != "compare" {
+		t.Fatalf("normalized scope = %#v, want compare", got)
+	}
+	if got := normalized["base_ref"]; got != "upstream/main" {
+		t.Fatalf("normalized base_ref = %#v, want upstream/main", got)
+	}
+	if _, leaked := normalized["repo_path"]; leaked {
+		t.Fatalf("normalized arguments unexpectedly contain repo_path: %#v", normalized)
+	}
+}

--- a/internal/mcp/facade_tools.go
+++ b/internal/mcp/facade_tools.go
@@ -1399,6 +1399,32 @@ func validateFacadeInput(spec facadeOperationSpec, input map[string]any) *mcpgo.
 			})
 		}
 	}
+	if spec.Facade == "change" && spec.Operation == "detect" {
+		if source, ok := input["source"].(map[string]any); ok {
+			for _, field := range sortedSelectorKeys(source) {
+				if field == "scope" {
+					continue
+				}
+				data := map[string]any{
+					"field":          "source." + field,
+					"reason":         "unsupported_field",
+					"domain":         spec.Facade,
+					"operation":      spec.Operation,
+					"allowed_fields": []string{"scope"},
+				}
+				message := fmt.Sprintf("change.detect does not accept source.%s", field)
+				if field == "repo_path" {
+					data["supported_field"] = "options.repo"
+					message += "; use options.repo to select a repository"
+				}
+				return NewStructuredErrorResult(StructuredError{
+					ErrorCode: ErrCodeInvalidArgument,
+					Message:   message,
+					Data:      data,
+				})
+			}
+		}
+	}
 	for _, field := range []string{"target", "to"} {
 		if raw, present := input[field]; present && raw != nil {
 			if invalid := validateFacadeSelector(field, raw); invalid != nil {


### PR DESCRIPTION
## Summary

- fail closed when `change.detect` receives unknown fields in its `source` container instead of silently forwarding and dropping them
- return a structured `invalid_argument` for `source.repo_path` with an explicit `options.repo` migration hint
- preserve the supported `source.scope` plus `options.repo` / `options.base_ref` lowering to the legacy change detector
- add focused regression coverage for the wrong-active-repository fallback and generic unknown source fields

## Scope

This is intentionally limited to `change.detect`, where an ignored repository selector can produce a successful analysis of the wrong working tree. It does not introduce a facade-wide nested-schema validator or change other operations' compatibility aliases.

## Verification

- `go test ./internal/mcp -run '^TestChangeDetectSource(FailClosed|Allows)' -count=1`
- `go test -race ./internal/mcp -run '^TestChangeDetectSource(FailClosed|Allows)' -count=1`
- `go vet ./internal/mcp`
- `go build ./cmd/gortex`
- `gofmt -d internal/mcp/facade_change_detect_source_test.go`
- `git show --check HEAD`

Fixes #549