### PR TITLE
Stop resolver helpers resurrecting router-reaped LSP providers as orphan processes

### DIFF
--- a/cmd/gortex/daemon.go
+++ b/cmd/gortex/daemon.go
@@ -1317,6 +1317,18 @@ func renderDaemonHeader(w io.Writer, st daemon.StatusResponse) {
 			t.AppendRow(table.Row{"trigram", row})
 		}
 	}
+	// Alive language servers are subprocesses the daemon is holding
+	// open — the one class of daemon-owned resource that survives
+	// outside the Go heap, and the one whose leak is invisible in every
+	// other row here. The section is omitted entirely when no router is
+	// wired or nothing is alive, so the common case stays as terse as
+	// it was.
+	if summary, providers := formatLSPRouterRows(st.LSPRouter, time.Now()); summary != "" {
+		t.AppendRow(table.Row{"lsp", summary})
+		for _, line := range providers {
+			t.AppendRow(table.Row{"", line})
+		}
+	}
 	rt := st.Runtime
 	if rt.Sys > 0 {
 		t.AppendRow(table.Row{"runtime", fmt.Sprintf(
@@ -1337,6 +1349,58 @@ func renderDaemonHeader(w io.Writer, st daemon.StatusResponse) {
 			st.PProfAddr, st.PProfAddr)})
 	}
 	t.Render()
+}
+
+// formatLSPRouterRows renders the daemon's LSP-router state into the
+// `lsp` summary cell plus one indented line per alive language-server
+// subprocess. Returns an empty summary when there is nothing to show
+// — no router wired (nil status) or no provider alive — so the header
+// table keeps its previous shape on daemons that never spawn one.
+//
+// The per-provider line reports last_used as an age rather than a
+// timestamp because the question it answers is "is the 10-minute idle
+// reaper about to take this one?", and in_use because a pin count
+// that never falls back to zero is precisely what keeps a provider
+// out of the reaper's and the LRU evictor's reach.
+//
+// now is passed in rather than read here so the rendering is
+// deterministic under test.
+func formatLSPRouterRows(r *daemon.LSPRouterStatus, now time.Time) (string, []string) {
+	if r == nil || len(r.ActiveProviders) == 0 {
+		return "", nil
+	}
+	summary := fmt.Sprintf("alive=%d", len(r.ActiveProviders))
+	if r.MaxAlive > 0 {
+		summary = fmt.Sprintf("alive=%d/%d", len(r.ActiveProviders), r.MaxAlive)
+	}
+	if r.Evictions > 0 {
+		summary += fmt.Sprintf("  evictions=%d", r.Evictions)
+	}
+
+	lines := make([]string, 0, len(r.ActiveProviders))
+	for _, p := range r.ActiveProviders {
+		lines = append(lines, fmt.Sprintf("  %s@%s  last_used=%s  in_use=%d",
+			p.Spec, p.Workspace, formatLSPLastUsed(p.LastUsed, now), p.InUse))
+	}
+	return summary, lines
+}
+
+// formatLSPLastUsed turns the RFC3339 timestamp the daemon sends into
+// a "3m12s ago" age. An unparseable value is passed through verbatim
+// rather than dropped — a malformed timestamp from an older daemon
+// build should still be visible, not silently rendered as "now".
+func formatLSPLastUsed(raw string, now time.Time) string {
+	ts, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return raw
+	}
+	age := now.Sub(ts)
+	if age < 0 {
+		// Clock skew between the status read and the daemon's own
+		// clock; "0s ago" beats a negative duration.
+		age = 0
+	}
+	return formatDuration(age.Truncate(time.Second)) + " ago"
 }
 
 // formatEnrichmentProgress renders the semantic-enrichment progress

--- a/cmd/gortex/daemon_controller.go
+++ b/cmd/gortex/daemon_controller.go
@@ -1238,6 +1238,8 @@ func (c *realController) collectLSPRouterStatus() *daemon.LSPRouterStatus {
 	}
 	out := &daemon.LSPRouterStatus{
 		DefaultWorkspace: router.DefaultWorkspace(),
+		MaxAlive:         router.MaxAlive(),
+		Evictions:        router.EvictionCount(),
 	}
 	for _, name := range router.EnabledSpecNames() {
 		out.EnabledSpecs = append(out.EnabledSpecs, daemon.LSPSpecStatus{
@@ -1251,6 +1253,7 @@ func (c *realController) collectLSPRouterStatus() *daemon.LSPRouterStatus {
 			Spec:      s.Spec,
 			Workspace: s.Workspace,
 			LastUsed:  s.LastUsed.Format(time.RFC3339),
+			InUse:     s.InUse,
 		})
 	}
 	return out

--- a/cmd/gortex/daemon_status_render_test.go
+++ b/cmd/gortex/daemon_status_render_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -171,6 +172,74 @@ func TestRenderDaemonHeader_EnrichmentProgress_NoCurrentPass(t *testing.T) {
 	var buf bytes.Buffer
 	renderDaemonHeader(&buf, st)
 	assert.Contains(t, buf.String(), "enriching 5/5 repos")
+}
+
+// TestRenderDaemonHeader_LSPRouterSection — alive language servers are
+// subprocesses the daemon holds open, and until they were rendered
+// here the only way to see one leak was `ps`. The row reports the cap
+// it is running against, the eviction count, and per provider the idle
+// age plus the pin count that keeps a provider out of the reaper's
+// reach.
+func TestRenderDaemonHeader_LSPRouterSection(t *testing.T) {
+	st := sampleStatus()
+	st.LSPRouter = &daemon.LSPRouterStatus{
+		MaxAlive:  6,
+		Evictions: 3,
+		ActiveProviders: []daemon.LSPActiveProvider{
+			{
+				Spec:      "gopls",
+				Workspace: "/tmp/code/project1",
+				LastUsed:  time.Now().Add(-3*time.Minute - 12*time.Second).Format(time.RFC3339),
+			},
+			{
+				Spec:      "typescript-language-server",
+				Workspace: "/tmp/code/project2",
+				LastUsed:  time.Now().Add(-30 * time.Second).Format(time.RFC3339),
+				InUse:     1,
+			},
+		},
+	}
+	var buf bytes.Buffer
+	renderDaemonHeader(&buf, st)
+	out := buf.String()
+	assert.Contains(t, out, "lsp")
+	assert.Contains(t, out, "alive=2/6")
+	assert.Contains(t, out, "evictions=3")
+	assert.Contains(t, out, "gopls@/tmp/code/project1")
+	assert.Contains(t, out, "3m12s ago")
+	assert.Contains(t, out, "in_use=1")
+}
+
+// TestRenderDaemonHeader_LSPRouterOmittedWhenIdle — the section must
+// vanish when no router is wired or nothing is alive, so daemons that
+// never spawn a language server keep the terser header they had.
+func TestRenderDaemonHeader_LSPRouterOmittedWhenIdle(t *testing.T) {
+	for name, router := range map[string]*daemon.LSPRouterStatus{
+		"no router wired": nil,
+		"router with no alive provider": {
+			MaxAlive:     6,
+			EnabledSpecs: []daemon.LSPSpecStatus{{Name: "gopls", Available: true}},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			st := sampleStatus()
+			st.LSPRouter = router
+			var buf bytes.Buffer
+			renderDaemonHeader(&buf, st)
+			assert.NotContains(t, buf.String(), "alive=")
+		})
+	}
+}
+
+// TestFormatLSPLastUsed_UnparseablePassesThrough — a timestamp an
+// older daemon build renders differently must stay visible rather than
+// silently reading as "now".
+func TestFormatLSPLastUsed_UnparseablePassesThrough(t *testing.T) {
+	now := time.Now()
+	assert.Equal(t, "not-a-timestamp", formatLSPLastUsed("not-a-timestamp", now))
+	// Clock skew must not print a negative age.
+	future := now.Add(5 * time.Second).Format(time.RFC3339)
+	assert.Equal(t, "0s ago", formatLSPLastUsed(future, now))
 }
 
 func TestRenderDaemonHeader_ReadyAndEnriched_NoWarmupLabelChange(t *testing.T) {

--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -150,10 +150,11 @@ opam install ocaml-lsp-server
 brew install zls
 ```
 
-Verify with `gortex daemon status` — the LSP-router section lists
-`alive`, `last_used`, and the resolved command for each running
-server. Newly enabled specs show up only after the first request that
-needs them.
+Verify with `gortex daemon status` — the `lsp` row reports `alive`
+against the live-provider cap plus the eviction count, followed by one
+line per running server carrying its workspace, `last_used` age, and
+`in_use` pin count. Newly enabled specs show up only after the first
+request that needs them.
 
 ## Lifecycle
 

--- a/internal/daemon/proto.go
+++ b/internal/daemon/proto.go
@@ -377,6 +377,15 @@ type LSPRouterStatus struct {
 	// owning an alive LSP subprocess. May be empty even when several
 	// specs are enabled — the router lazy-spawns on first request.
 	ActiveProviders []LSPActiveProvider `json:"active_providers,omitempty"`
+	// MaxAlive is the router's concurrent-provider cap; zero means
+	// unbounded. Read alongside len(ActiveProviders) it says how close
+	// the daemon is to LRU-evicting warm language servers.
+	MaxAlive int `json:"max_alive,omitempty"`
+	// Evictions counts LRU evictions since daemon start. A number that
+	// climbs while the workspace set is stable means the cap is too
+	// low for the repos actually being touched — every eviction is a
+	// language server that will be re-spawned cold on next demand.
+	Evictions uint64 `json:"evictions,omitempty"`
 }
 
 // LSPSpecStatus is one row in LSPRouterStatus.EnabledSpecs.
@@ -391,6 +400,11 @@ type LSPActiveProvider struct {
 	Spec      string `json:"spec"`
 	Workspace string `json:"workspace"`
 	LastUsed  string `json:"last_used"` // RFC3339
+	// InUse is the router's pin count for this provider — callers
+	// currently holding it for a long operation. Nonzero means neither
+	// the reaper nor the LRU evictor can reclaim it; a count stuck
+	// above zero on an otherwise-idle daemon is a leaked pin.
+	InUse int `json:"in_use,omitempty"`
 }
 
 // EnrichmentProgress summarizes the semantic-enrichment manager's

--- a/internal/semantic/lsp/resolver_helper.go
+++ b/internal/semantic/lsp/resolver_helper.go
@@ -22,17 +22,44 @@ import (
 // across the whole resolve pass and applies a per-call timeout so a
 // stalled server never gates the resolve.
 //
-// Concurrency model: the helper owns a pool of N independent
-// providers (= N tsserver processes for the TS spec). Each Definition
-// call borrows one provider from the pool, runs FindDefinition, and
-// returns it. Within a single provider tsserver is single-threaded,
-// but across providers calls are parallel. Pool size 1 collapses to
-// the original "one provider, fully serialised" model.
+// Two ownership contracts live behind this one type, and they differ
+// in exactly one respect — who owns the *Provider:
+//
+//   - Router-backed (NewLazyResolverHelper). The helper owns NO
+//     provider. Every Definition call re-runs the lookup closure
+//     (Router.ForSpecWorkspace) to acquire the provider for that one
+//     call. On a router cache hit that lookup is a map read which also
+//     refreshes the router's lastUsed, so a provider under active
+//     resolve traffic is never reaped mid-pass; when the router has
+//     already reaped or LRU-evicted it, the lookup spawns a fresh,
+//     router-TRACKED replacement. Caching the pointer across calls
+//     (what this helper used to do) let the router drop the provider
+//     from its map while the helper kept the only reference: the next
+//     EnsureClient saw a dead client and re-spawned the LSP subprocess
+//     behind the router's back, leaking a process tree that nothing
+//     could ever reap for the life of the daemon.
+//   - Helper-owned (NewPooledResolverHelper with poolSize > 1, and
+//     NewResolverHelper with a concrete provider). The helper spawns
+//     and owns its providers and borrows one per call from a pool
+//     channel. These providers sit outside the router's bookkeeping by
+//     construction, so an in-place respawn inside EnsureClient is the
+//     helper's own business; Close shuts them down.
+//
+// Concurrency model: one Definition call uses exactly one provider at
+// a time. Router-backed mode holds h.mu across the whole call — the
+// router hands every caller the same *Provider and a provider's stdio
+// is single-threaded, and pool size is 1 in that mode anyway, so this
+// matches the throughput of the borrow channel it replaced.
+// Owned-pool mode borrows from a channel of N independent providers
+// (= N tsserver processes for the TS spec), giving mutual exclusion
+// per provider and parallelism across them.
 //
 // Lifecycle:
 //   - Constructed once per (workspace, language family) at index time.
-//   - Lazy-spawns N underlying LSP subprocesses on the first Definition
-//     call.
+//   - Owned-pool mode lazy-spawns N underlying LSP subprocesses on the
+//     first Definition call. Router-backed mode spawns nothing of its
+//     own — the router does, on demand, inside its own reap/evict
+//     accounting.
 //   - Caches no answers across passes — the resolver owns dedup via
 //     its lspIndex.
 //
@@ -41,9 +68,22 @@ import (
 // the per-provider state can add up; the pool size knob trades
 // throughput for tsserver memory.
 type ResolverHelper struct {
+	// routerBacked marks the NewLazyResolverHelper flavour, whose
+	// provider belongs to the LSP router rather than to this helper.
+	// It selects the per-call lookup path in acquire and makes Close a
+	// no-op. See the type comment for why the two modes must differ.
+	routerBacked bool
+
+	// mu serialises Definition in router-backed mode, where every call
+	// runs against the single router-cached provider for this (spec,
+	// workspace) pair. Unused in owned-pool mode — the pool channel
+	// already provides the same per-provider exclusion there.
+	mu sync.Mutex
+
 	// spawnOnce gates the lazy creation of the provider pool so the
 	// underlying LSP processes aren't started until the first
-	// Definition call lands.
+	// Definition call lands. Owned-pool mode only; router-backed mode
+	// never touches the pool.
 	spawnOnce sync.Once
 	spawnErr  error
 
@@ -62,9 +102,12 @@ type ResolverHelper struct {
 	// (which may have providers in flight).
 	providers []*Provider
 
-	// spawnFn produces a fresh, initialised *Provider each call. Pool
-	// mode calls it poolSize times; legacy single-provider mode uses
-	// it as a lookup that returns a cached singleton (called once).
+	// spawnFn produces the *Provider a call runs against. Owned-pool
+	// mode requires a FRESH, fully-initialised provider per call and
+	// invokes it poolSize times at pool construction. Router-backed
+	// mode invokes it once per Definition call — a router cache hit is
+	// a cheap map read, and going through it every time is precisely
+	// what keeps the router's idle/LRU accounting honest.
 	// At most one of spawnFn and provider is set at construction.
 	spawnFn func() (*Provider, error)
 
@@ -150,18 +193,34 @@ func NewResolverHelper(provider *Provider, workspaceRoot string, timeout time.Du
 	return h
 }
 
-// NewLazyResolverHelper builds a helper whose underlying *Provider
-// is resolved on first use via lookup(). This is the router-backed
-// flavour — pass a closure that calls Router.ForSpecWorkspace or
-// equivalent. lookup() runs at most once across the helper's
-// lifetime (subsequent failures sticky); concurrent first-use calls
-// see the same result.
+// NewLazyResolverHelper builds the router-backed helper: pass a
+// closure that calls Router.ForSpecWorkspace (or equivalent) and the
+// helper will run it on EVERY Definition call rather than caching the
+// resulting *Provider.
+//
+// Per-call lookup is the contract, not an inefficiency. The router
+// owns provider lifetime — idle reaping and LRU eviction both Close
+// providers and delete them from its map — so a helper holding a
+// cached pointer would keep driving a provider the router no longer
+// tracks, and Provider.EnsureClient would silently re-spawn the
+// language server as an untracked orphan. Re-asking the router is a
+// map read on the hot path (it also refreshes lastUsed, which is what
+// stops the reaper from taking a provider mid-pass), and returns a
+// fresh router-tracked provider when the previous one is gone.
+//
+// Lookup errors are NOT sticky: the router's own markSpawnFailed
+// already fails a genuinely broken server fast for every subsequent
+// call, so per-call lookup cannot turn into a respawn storm, and a
+// helper poisoned by one transient failure would stay blind for the
+// life of the daemon.
 //
 // extensions narrows the set of file extensions the helper claims
-// before lookup() fires. Pass nil to use the default TS-family set
-// (matching N5 scope).
+// without consulting the router at all. Pass nil to use the default
+// TS-family set.
 func NewLazyResolverHelper(lookup func() (*Provider, error), workspaceRoot string, extensions []string, timeout time.Duration, logger *zap.Logger) *ResolverHelper {
-	return NewPooledResolverHelper(lookup, workspaceRoot, extensions, timeout, 1, logger)
+	h := NewPooledResolverHelper(lookup, workspaceRoot, extensions, timeout, 1, logger)
+	h.routerBacked = true
+	return h
 }
 
 // NewPooledResolverHelper builds a helper backed by `poolSize`
@@ -171,8 +230,14 @@ func NewLazyResolverHelper(lookup func() (*Provider, error), workspaceRoot strin
 // ceiling that dominated multi-repo resolve-time profiles (29 min
 // `deferred_passes_all` on a 488-repo TS-heavy workspace).
 //
+// The providers are owned by the helper — they are NOT registered
+// with the LSP router, so nothing idle-reaps them and Close is the
+// only thing that shuts them down. NewLazyResolverHelper wraps this
+// constructor with poolSize 1 and flips the helper to the
+// router-backed contract instead (per-call lookup, no ownership).
+//
 // spawn must produce a fresh, fully-initialised provider each call.
-// For the typical router-backed wiring the closure is something like:
+// For the typical owned-pool wiring the closure is something like:
 //
 //	func() (*Provider, error) {
 //	    p := lsp.NewProviderFromSpec(spec, logger)
@@ -228,6 +293,10 @@ func NewPooledResolverHelper(
 // ensurePool spawns the pool's providers on first call, populating
 // the borrow channel. Subsequent calls are a no-op. Returns the
 // cached error when spawn failed — Definition then short-circuits.
+//
+// Owned-pool / eager mode only. Router-backed helpers never call it:
+// they own no providers, so there is no pool to fill and no spawn
+// error worth remembering (see NewLazyResolverHelper).
 func (h *ResolverHelper) ensurePool() error {
 	h.spawnOnce.Do(func() {
 		// Eager-construction path (NewResolverHelper): the pool was
@@ -280,6 +349,54 @@ func (h *ResolverHelper) borrow() (*Provider, func()) {
 	return p, func() { h.pool <- p }
 }
 
+// acquire returns the provider one Definition call should run
+// against, plus the release closure the caller must defer. ok is
+// false when no provider could be obtained — the caller then falls
+// through to the resolver's heuristics, and release must not be
+// called.
+//
+// This is the single point where the two ownership contracts diverge:
+//
+//   - Router-backed: take h.mu, then ask the router again. The lookup
+//     is what keeps the router's lastUsed fresh (so an in-flight
+//     resolve pass is never reaped) and what guarantees a provider the
+//     router already reaped is replaced by a new router-tracked one
+//     instead of being resurrected in place behind the router's back.
+//     The lock is held until release so a provider shared with every
+//     other caller of ForSpecWorkspace still sees serialised stdio.
+//   - Owned pool: spawn the pool once, then borrow a provider from the
+//     channel for the duration of the call.
+//
+// relPath is carried purely for the failure log — a lookup that fails
+// is worth one Debug line naming the file that wanted it, never an
+// error that poisons the helper.
+func (h *ResolverHelper) acquire(relPath string) (*Provider, func(), bool) {
+	if h.routerBacked {
+		h.mu.Lock()
+		p, err := h.spawnFn()
+		if err != nil || p == nil {
+			h.mu.Unlock()
+			h.logger.Debug("resolve-time LSP: provider lookup failed",
+				zap.String("path", relPath), zap.Error(err))
+			return nil, nil, false
+		}
+		return p, func() { h.mu.Unlock() }, true
+	}
+
+	if err := h.ensurePool(); err != nil {
+		h.logger.Debug("resolve-time LSP: pool spawn failed",
+			zap.String("path", relPath), zap.Error(err))
+		return nil, nil, false
+	}
+	if h.pool == nil {
+		// Eager-construction path was given a nil provider — short-
+		// circuit instead of deadlocking on a never-fed channel.
+		return nil, nil, false
+	}
+	p, release := h.borrow()
+	return p, release, true
+}
+
 // SupportsPath implements resolver.LSPHelper.
 //
 // SupportsPath does NOT trigger the lazy provider lookup — it's
@@ -304,7 +421,8 @@ func (h *ResolverHelper) SupportsPath(relPath string) bool {
 // (definitionRelPath, 1-based line, ok).
 //
 // Implementation notes:
-//   - The provider is spawned lazily on first call (EnsureClient).
+//   - The provider for the call comes from acquire: a per-call router
+//     lookup in router-backed mode, a pool borrow in owned-pool mode.
 //   - The file is opened with didOpen on first call (EnsureFileOpen)
 //     so tsserver has the buffer in its workspace state.
 //   - The identifier column on `oneBasedLine` is resolved from the
@@ -322,18 +440,10 @@ func (h *ResolverHelper) Definition(relPath string, oneBasedLine int, name strin
 		return "", 0, false
 	}
 
-	if err := h.ensurePool(); err != nil {
-		h.logger.Debug("resolve-time LSP: pool spawn failed",
-			zap.String("path", relPath), zap.Error(err))
+	provider, release, ok := h.acquire(relPath)
+	if !ok {
 		return "", 0, false
 	}
-	if h.pool == nil {
-		// Eager-construction path was given a nil provider — short-
-		// circuit instead of deadlocking on a never-fed channel.
-		return "", 0, false
-	}
-
-	provider, release := h.borrow()
 	defer release()
 
 	if err := provider.EnsureClient(h.workspaceRoot); err != nil {
@@ -455,17 +565,24 @@ func ResolverPoolSizeFromEnv(defaultSize int) int {
 	return n
 }
 
-// Close shuts down every provider in the pool. Called by the indexer
-// at shutdown when the helper owns its providers; helpers built
-// around router-managed providers (NewLazyResolverHelper /
-// NewPooledResolverHelper that close over Router.ForSpecWorkspace)
-// can still call Close — the underlying Provider.Close is idempotent
-// and routers re-spawn on next demand.
+// Close shuts down every provider the helper owns. Called by the
+// indexer at shutdown.
+//
+// Router-backed helpers (NewLazyResolverHelper) own nothing, so Close
+// is deliberately a no-op for them: their provider is the router's,
+// shared with enrichment and with every other helper for the same
+// (spec, workspace), and closing it here would kill a subprocess the
+// router still lists as alive — the mirror image of the orphan bug
+// per-call lookup exists to prevent. Router.Close is what shuts those
+// down.
 //
 // Safe to call when the lazy spawn has not yet fired — Close is a
-// no-op in that case.
+// no-op in that case too.
 func (h *ResolverHelper) Close() error {
 	if h == nil {
+		return nil
+	}
+	if h.routerBacked {
 		return nil
 	}
 	var firstErr error

--- a/internal/semantic/lsp/resolver_helper_test.go
+++ b/internal/semantic/lsp/resolver_helper_test.go
@@ -1,0 +1,272 @@
+package lsp
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// newTestProvider builds a Provider that has never dialled anything —
+// enough to be handed around as a pool/router entry without spawning a
+// language server. Close on such a provider is a no-op (nil client), so
+// tests can "reap" one the way the router would.
+func newTestProvider() *Provider {
+	return NewProvider("noop-cmd", nil, []string{"typescript"}, false, 1, zap.NewNop())
+}
+
+// TestResolverHelper_RouterBacked_LooksUpEveryAcquire is the core
+// regression for the orphaned-LSP-process bug: the router-backed
+// helper must consult its lookup closure on EVERY call instead of
+// caching the provider it got the first time.
+//
+// The cached-pointer version let Router.Reap / maybeEvictLRULocked
+// close a provider and delete it from the router map while the helper
+// kept using it — Provider.EnsureClient then re-spawned the subprocess
+// on an object the router no longer tracked, and nothing could ever
+// reap the result. Re-asking the router per call also refreshes its
+// lastUsed, which is what stops the reaper from taking a provider out
+// from under an in-flight resolve pass in the first place.
+func TestResolverHelper_RouterBacked_LooksUpEveryAcquire(t *testing.T) {
+	var calls int
+	provider := newTestProvider()
+	h := NewLazyResolverHelper(
+		func() (*Provider, error) {
+			calls++
+			return provider, nil
+		},
+		t.TempDir(),
+		[]string{".ts"},
+		time.Second,
+		zap.NewNop(),
+	)
+
+	const acquisitions = 5
+	for i := 0; i < acquisitions; i++ {
+		got, release, ok := h.acquire("src/foo.ts")
+		require.True(t, ok, "acquire %d must succeed", i)
+		assert.Same(t, provider, got)
+		release()
+	}
+	assert.Equal(t, acquisitions, calls,
+		"router-backed helper must run the router lookup once per acquisition")
+}
+
+// TestResolverHelper_RouterBacked_ReplacesReapedProvider — once the
+// router has reaped provider A (closed it and dropped it from its
+// map), the next acquisition must return the router's NEW provider B.
+// A resurrected A is exactly the orphan: a live subprocess the router
+// does not know about.
+func TestResolverHelper_RouterBacked_ReplacesReapedProvider(t *testing.T) {
+	providerA := newTestProvider()
+	providerB := newTestProvider()
+
+	var reaped bool
+	h := NewLazyResolverHelper(
+		func() (*Provider, error) {
+			if reaped {
+				return providerB, nil
+			}
+			return providerA, nil
+		},
+		t.TempDir(),
+		[]string{".ts"},
+		time.Second,
+		zap.NewNop(),
+	)
+
+	got, release, ok := h.acquire("src/foo.ts")
+	require.True(t, ok)
+	assert.Same(t, providerA, got, "first acquisition uses the router's current provider")
+	release()
+
+	// Simulate the router's idle reaper: close the provider and swap
+	// in a fresh, router-tracked replacement for the next lookup.
+	require.NoError(t, providerA.Close())
+	reaped = true
+
+	got, release, ok = h.acquire("src/foo.ts")
+	require.True(t, ok)
+	assert.Same(t, providerB, got, "a reaped provider must be replaced, never reused")
+	assert.NotSame(t, providerA, got)
+	release()
+}
+
+// TestResolverHelper_RouterBacked_LookupFailureIsNotSticky — a lookup
+// that fails must not poison the helper. The router's markSpawnFailed
+// already short-circuits a broken server, so a helper that latched the
+// first error would simply stay blind for the daemon's lifetime.
+func TestResolverHelper_RouterBacked_LookupFailureIsNotSticky(t *testing.T) {
+	provider := newTestProvider()
+	fail := true
+	h := NewLazyResolverHelper(
+		func() (*Provider, error) {
+			if fail {
+				return nil, errors.New("router evicted mid-spawn")
+			}
+			return provider, nil
+		},
+		t.TempDir(),
+		[]string{".ts"},
+		time.Second,
+		zap.NewNop(),
+	)
+
+	if _, _, ok := h.acquire("src/foo.ts"); ok {
+		t.Fatal("acquire must fail while the lookup errors")
+	}
+
+	fail = false
+	got, release, ok := h.acquire("src/foo.ts")
+	require.True(t, ok, "a later acquisition must retry the lookup")
+	assert.Same(t, provider, got)
+	release()
+}
+
+// TestResolverHelper_RouterBacked_AcquireSerialises — the router hands
+// every caller the same *Provider and a provider's stdio is
+// single-threaded, so acquire must serialise router-backed calls the
+// way the old borrow channel did. Run under -race this also proves the
+// per-call lookup itself is not a data race.
+func TestResolverHelper_RouterBacked_AcquireSerialises(t *testing.T) {
+	provider := newTestProvider()
+	var (
+		mu       sync.Mutex
+		inFlight int
+		maxSeen  int
+		lookups  int
+	)
+	h := NewLazyResolverHelper(
+		func() (*Provider, error) {
+			mu.Lock()
+			lookups++
+			mu.Unlock()
+			return provider, nil
+		},
+		t.TempDir(),
+		[]string{".ts"},
+		time.Second,
+		zap.NewNop(),
+	)
+
+	const goroutines = 8
+	const perGoroutine = 25
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perGoroutine; j++ {
+				_, release, ok := h.acquire("src/foo.ts")
+				if !ok {
+					t.Error("acquire failed unexpectedly")
+					return
+				}
+				mu.Lock()
+				inFlight++
+				if inFlight > maxSeen {
+					maxSeen = inFlight
+				}
+				mu.Unlock()
+
+				mu.Lock()
+				inFlight--
+				mu.Unlock()
+				release()
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, 1, maxSeen, "router-backed acquisitions must not overlap")
+	assert.Equal(t, goroutines*perGoroutine, lookups,
+		"every acquisition must reach the router")
+}
+
+// TestResolverHelper_RouterBacked_CloseIsNoOp — the router owns the
+// provider, sharing it with enrichment and with every other helper for
+// the same (spec, workspace). A helper that closed it on shutdown
+// would kill a subprocess the router still lists as alive.
+func TestResolverHelper_RouterBacked_CloseIsNoOp(t *testing.T) {
+	provider := newTestProvider()
+	h := NewLazyResolverHelper(
+		func() (*Provider, error) { return provider, nil },
+		t.TempDir(),
+		[]string{".ts"},
+		time.Second,
+		zap.NewNop(),
+	)
+
+	_, release, ok := h.acquire("src/foo.ts")
+	require.True(t, ok)
+	release()
+
+	require.NoError(t, h.Close())
+	assert.Empty(t, h.providers, "a router-backed helper must never adopt providers")
+
+	// Still usable after Close — nothing was torn down.
+	got, release, ok := h.acquire("src/foo.ts")
+	require.True(t, ok)
+	assert.Same(t, provider, got)
+	release()
+}
+
+// TestResolverHelper_OwnedPool_SpawnsOnceAndBorrows — the opt-in
+// pooled flavour (GORTEX_LSP_POOL_SIZE > 1) keeps its original
+// contract: it owns its providers, so it spawns poolSize of them once
+// and then borrows from the channel without re-invoking spawn.
+func TestResolverHelper_OwnedPool_SpawnsOnceAndBorrows(t *testing.T) {
+	const poolSize = 3
+	var spawns int
+	h := NewPooledResolverHelper(
+		func() (*Provider, error) {
+			spawns++
+			return newTestProvider(), nil
+		},
+		t.TempDir(),
+		[]string{".ts"},
+		time.Second,
+		poolSize,
+		zap.NewNop(),
+	)
+
+	for i := 0; i < 10; i++ {
+		_, release, ok := h.acquire("src/foo.ts")
+		require.True(t, ok)
+		release()
+	}
+	assert.Equal(t, poolSize, spawns, "owned pool spawns exactly poolSize providers")
+	assert.Len(t, h.providers, poolSize, "owned pool must retain its providers for Close")
+	require.NoError(t, h.Close())
+}
+
+// TestResolverHelper_OwnedPool_SpawnFailureIsSticky — an owned pool
+// that cannot spawn stays poisoned, because retrying would spawn a
+// fresh unreaped subprocess on every resolve-time call. Only the
+// router-backed flavour retries, and only because the router itself
+// bounds the retry.
+func TestResolverHelper_OwnedPool_SpawnFailureIsSticky(t *testing.T) {
+	var spawns int
+	h := NewPooledResolverHelper(
+		func() (*Provider, error) {
+			spawns++
+			return nil, errors.New("tsserver missing")
+		},
+		t.TempDir(),
+		[]string{".ts"},
+		time.Second,
+		2,
+		zap.NewNop(),
+	)
+
+	for i := 0; i < 3; i++ {
+		if _, _, ok := h.acquire("src/foo.ts"); ok {
+			t.Fatal("acquire must fail when the pool cannot spawn")
+		}
+	}
+	assert.Equal(t, 1, spawns, "a poisoned owned pool must not retry the spawn")
+}

--- a/internal/semantic/lsp/resolver_registry_test.go
+++ b/internal/semantic/lsp/resolver_registry_test.go
@@ -132,10 +132,13 @@ func TestResolverHelperMux_RoutesByExtension(t *testing.T) {
 	assert.Equal(t, 9, defLine)
 }
 
-// TestNewLazyResolverHelper_LookupFiresOnce verifies that the lazy
-// provider lookup runs exactly once and the result (or error) is
-// cached for subsequent calls.
-func TestNewLazyResolverHelper_LookupFiresOnce(t *testing.T) {
+// TestNewLazyResolverHelper_LookupRunsPerCall verifies the
+// router-backed contract through the public Definition entry point: a
+// failing lookup is re-run on the next call rather than poisoning the
+// helper. Sticky failures were how a helper went permanently blind
+// after one transient router hiccup; the router's own markSpawnFailed
+// is what fails a genuinely-broken server fast.
+func TestNewLazyResolverHelper_LookupRunsPerCall(t *testing.T) {
 	var calls int
 	h := NewLazyResolverHelper(
 		func() (*Provider, error) {
@@ -152,7 +155,7 @@ func TestNewLazyResolverHelper_LookupFiresOnce(t *testing.T) {
 	assert.False(t, ok)
 	_, _, ok = h.Definition("foo.ts", 2, "y")
 	assert.False(t, ok)
-	assert.Equal(t, 1, calls, "lookup must run exactly once")
+	assert.Equal(t, 2, calls, "router-backed lookup must run once per Definition call")
 }
 
 func TestResolverHelper_NilSafe(t *testing.T) {

--- a/internal/semantic/lsp/router.go
+++ b/internal/semantic/lsp/router.go
@@ -885,6 +885,14 @@ type RouterStat struct {
 	Spec      string    `json:"spec"`
 	Workspace string    `json:"workspace"`
 	LastUsed  time.Time `json:"last_used"`
+	// InUse is the provider's pin count — how many callers currently
+	// hold it for a long operation via ProviderForSpecWorkspace. A
+	// pinned provider is skipped by both the reaper and the LRU
+	// evictor, so a count that never returns to zero is the signature
+	// of a pass that ended without its ReleaseSpecWorkspace, and it
+	// pins a subprocess alive for the life of the daemon. Surfacing it
+	// is what makes that leak observable from `gortex daemon status`.
+	InUse int `json:"in_use"`
 }
 
 // Stats returns one entry per live (spec, workspace) provider.
@@ -897,6 +905,7 @@ func (r *Router) Stats() []RouterStat {
 			Spec:      key.specName,
 			Workspace: key.workspace,
 			LastUsed:  rp.lastUsed,
+			InUse:     rp.inUse,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool {

--- a/internal/semantic/lsp/router_test.go
+++ b/internal/semantic/lsp/router_test.go
@@ -566,3 +566,46 @@ func TestRouter_SetMaxAlive_NeverEvictsPinned(t *testing.T) {
 		t.Fatalf("want 2 unpinned evictions, got %d", got)
 	}
 }
+
+// TestRouter_Stats_ReportsInUsePin — Stats must carry the pin count,
+// not just the last-used time. A pinned provider is skipped by both
+// the reaper and the LRU evictor, so a count that never returns to
+// zero holds a language-server subprocess alive for the life of the
+// daemon; without InUse in Stats that leak is invisible to
+// `gortex daemon status`.
+func TestRouter_Stats_ReportsInUsePin(t *testing.T) {
+	workspace := t.TempDir()
+	r := NewRouter(workspace, zap.NewNop())
+	defer r.Close()
+
+	const specName = "fake-spec"
+	injectProvider(r, specName, workspace, time.Now(), 0)
+	// Register the spec and force-mark it available so the pinning
+	// fetch takes the cache-hit path without a real binary on PATH.
+	r.RegisterSpec(&ServerSpec{Name: specName, Languages: []string{"go"}})
+	r.availMu.Lock()
+	r.avail[specName] = true
+	r.availMu.Unlock()
+
+	stats := r.Stats()
+	if len(stats) != 1 {
+		t.Fatalf("want 1 stats row, got %d", len(stats))
+	}
+	if stats[0].InUse != 0 {
+		t.Fatalf("want InUse=0 before pinning, got %d", stats[0].InUse)
+	}
+
+	if _, err := r.ProviderForSpecWorkspace(specName, workspace); err != nil {
+		t.Fatalf("ProviderForSpecWorkspace: %v", err)
+	}
+	stats = r.Stats()
+	if len(stats) != 1 || stats[0].InUse != 1 {
+		t.Fatalf("want InUse=1 while pinned, got %+v", stats)
+	}
+
+	r.ReleaseSpecWorkspace(specName, workspace)
+	stats = r.Stats()
+	if len(stats) != 1 || stats[0].InUse != 0 {
+		t.Fatalf("want InUse=0 after release, got %+v", stats)
+	}
+}


### PR DESCRIPTION
## Bug

The router-backed `ResolverHelper` (resolve-time TS/Python hot-path helper) resolved its `*Provider` through `Router.ForSpecWorkspace` exactly once (`spawnOnce`) and cached the pointer for its lifetime. The router could not see the helper's usage, so its idle reaper (10 min) or LRU evictor would close the provider and delete it from the router map. On the next resolve pass the helper called `EnsureClient` on the stale pointer; the liveness probe saw the dead client and `dialOrSpawn` re-spawned the language server on a Provider object the router no longer tracked — an unreapable subprocess (a 4-process node tree per typescript-language-server) that lived until the daemon exited.

Observed in production: 18 orphaned node processes under one daemon after an overnight run, and pyright orphans several days old under long-lived `gortex mcp` processes. Daemon logs show the exact sequence: the router reaped/evicted `pyright` and five `typescript-language-server` providers, and the orphan processes' spawn times all post-date those reaps.

## Fix

**`fix(lsp)`** — router-backed helpers now re-run the router lookup on every `Definition` call instead of caching the provider:
- a router cache hit is a map read that also refreshes `lastUsed`, so providers under active resolve traffic are no longer reaped mid-pass;
- a reaped/evicted provider is replaced by a fresh **router-tracked** one instead of being resurrected behind the router's back;
- lookup errors are no longer sticky (`markSpawnFailed` in the router already fails broken servers fast);
- `Close()` becomes a no-op for this mode — it previously killed a subprocess the router still listed as alive (the same bug mirrored). Owned-pool (`GORTEX_LSP_POOL_SIZE > 1`) and eager modes keep their existing spawn-once/borrow contract.

**`feat(daemon)`** — `gortex daemon status` now renders the LSP router section the docs already promised (the payload existed; the CLI never rendered it): alive count vs `MaxAlive`, lifetime LRU evictions, and per-provider `spec@workspace`, `last_used` age, and pin count. `RouterStat`/daemon proto gain `InUse`/`MaxAlive`/`Evictions`, making a leaked `ReleaseSpecWorkspace` pin directly observable.

## Tests

- `TestResolverHelper_RouterBacked_LooksUpEveryAcquire`, `_ReplacesReapedProvider` (closed provider never reused), `_LookupFailureIsNotSticky`, `_AcquireSerialises` (race-clean), `_CloseIsNoOp`
- `TestResolverHelper_OwnedPool_SpawnsOnceAndBorrows`, `_SpawnFailureIsSticky` (pins the unchanged contract)
- `TestRouter_Stats_ReportsInUsePin`; status render tests for the new lsp section and its omission when idle

Gates: `go build ./...`, `go test -race ./internal/semantic/lsp/... ./internal/serverstack/...`, `go test ./cmd/gortex/ ./internal/daemon/...`, `golangci-lint run` on changed packages — all clean.