### PR TITLE
fix(mcp): publish directly callable request shapes

### DIFF
--- a/docs/mcp-facade-v1.md
+++ b/docs/mcp-facade-v1.md
@@ -207,7 +207,7 @@ Each facade advertises only its high-frequency stable fields. A read request ill
 
 The dispatcher flattens the advertised `arguments`, `options`, `source`, `context`, `guard`, and `output` objects into the selected legacy handler's arguments. Common top-level fields win where the adapter defines a friendly alias. Operation-specific fields that are not worth mounting in every model turn remain discoverable through `capabilities`.
 
-`operation` is a normalized string rather than an ever-growing schema enum. It MAY be omitted when a selector uniquely determines the common read/edit default. The public description lists common operations, while `capabilities(domain=<tool>, operation=<operation>, detail="schema")` returns both the exact operation-specific public input schema and a `request_shape`. The dispatcher MUST reject unknown values and return the valid operation names. Capability lists use the public keys `domains` and `domain`; compatibility terminology is not exposed to callers.
+`operation` is a normalized string rather than an ever-growing schema enum. It MAY be omitted when a selector uniquely determines the common read/edit default. The public description lists common operations, while `capabilities(domain=<tool>, operation=<operation>, detail="schema")` returns both the exact operation-specific public input schema and a `request_shape`. The `request_shape` object is the caller-level argument object: pass its fields directly to the named facade tool, without nesting it under an `arguments` or `params` key. The dispatcher MUST reject unknown values and return the valid operation names. Capability lists use the public keys `domains` and `domain`; compatibility terminology is not exposed to callers.
 
 ### 8.2 Target references
 

--- a/internal/mcp/facade_change_targets_test.go
+++ b/internal/mcp/facade_change_targets_test.go
@@ -141,9 +141,8 @@ func TestFacadeChangeTargetShapesAreAdvertisedOnce(t *testing.T) {
 				require.NotContains(t, optionProperties, "ids", "compatibility aliases must not duplicate the canonical target schema")
 			}
 
-			shape := payload["request_shape"].(map[string]any)
-			arguments := shape["arguments"].(map[string]any)
-			require.Contains(t, arguments, "target")
+			requestShape := payload["request_shape"].(map[string]any)
+			require.Contains(t, requestShape, "target")
 		})
 	}
 }

--- a/internal/mcp/facade_legacy_target_test.go
+++ b/internal/mcp/facade_legacy_target_test.go
@@ -203,9 +203,8 @@ func TestAnalyzeAdvertisedTargetMatchesAcceptedTarget(t *testing.T) {
 			aliased++
 		}
 		capability := srv.facadeCapability(spec, true)
-		shape, _ := capability["request_shape"].(map[string]any)
-		arguments, _ := shape["arguments"].(map[string]any)
-		_, publishesTarget := arguments["target"]
+		requestShape, _ := capability["request_shape"].(map[string]any)
+		_, publishesTarget := requestShape["target"]
 
 		id++
 		result := call(id, "analyze", map[string]any{

--- a/internal/mcp/facade_schema.go
+++ b/internal/mcp/facade_schema.go
@@ -28,7 +28,7 @@ func facadePublicCapabilitySchema(
 ) map[string]any {
 	definition := facadeToolDefinition(spec.Facade)
 	staticProperties := definition.InputSchema.Properties
-	requestArguments, _ := requestShape["arguments"].(map[string]any)
+	requestArguments := requestShape
 
 	properties := make(map[string]any)
 	requiredTop := make(map[string]struct{})

--- a/internal/mcp/facade_schema_test.go
+++ b/internal/mcp/facade_schema_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -36,19 +37,35 @@ func TestFacadeCapabilityRequestShapeIsDirectCallerInput(t *testing.T) {
 
 func TestFacadeInvalidArgumentsEnvelopeErrorIsSelfCorrecting(t *testing.T) {
 	srv, _ := setupTestServer(t)
-	spec, ok := srv.facades.operation("search", "symbols")
-	require.True(t, ok)
+	for _, test := range []struct {
+		facade       string
+		operation    string
+		arguments    any
+		receivedType string
+	}{
+		{facade: "search", operation: "symbols", arguments: `{"query":"MyType"}`, receivedType: "string"},
+		{facade: "read", operation: "file", arguments: []any{"main.go"}, receivedType: "array"},
+		{facade: "change", operation: "impact", arguments: float64(1), receivedType: "number"},
+	} {
+		t.Run(test.facade+"."+test.operation, func(t *testing.T) {
+			spec, ok := srv.facades.operation(test.facade, test.operation)
+			require.True(t, ok)
+			acceptedFields := srv.facadeAcceptedTopLevelFields(spec)
 
-	result := validateFacadeInput(spec, map[string]any{
-		"operation": "symbols",
-		"query":     "MyType",
-		"arguments": `{"query":"MyType"}`,
-	})
-	require.NotNil(t, result)
-	message := toolResultText(result)
-	require.Contains(t, message, `unexpected top-level key`)
-	require.Contains(t, message, `received string`)
-	require.Contains(t, message, `Pass operation/query/options at the top level`)
+			result := srv.validateFacadeInput(spec, map[string]any{
+				"operation": test.operation,
+				"query":     "MyType",
+				"arguments": test.arguments,
+			})
+			require.NotNil(t, result)
+			message := toolResultText(result)
+			require.Contains(t, message, `unexpected top-level key`)
+			require.Contains(t, message, `received `+test.receivedType)
+			require.Contains(t, message, `pass `+strings.Join(acceptedFields, "/")+` at the top level`)
+			require.NotContains(t, message, "interface {}")
+			require.NotContains(t, message, "float64")
+		})
+	}
 }
 
 func TestFacadeCapabilitiesPublicSchemasMatchEveryAvailableOperation(t *testing.T) {

--- a/internal/mcp/facade_schema_test.go
+++ b/internal/mcp/facade_schema_test.go
@@ -9,6 +9,48 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestFacadeCapabilityRequestShapeIsDirectCallerInput(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	for _, test := range []struct {
+		domain    string
+		operation string
+	}{
+		{domain: "search", operation: "symbols"},
+		{domain: "read", operation: "file"},
+	} {
+		t.Run(test.domain+"."+test.operation, func(t *testing.T) {
+			spec, ok := srv.facades.operation(test.domain, test.operation)
+			require.True(t, ok)
+			capability := srv.facadeCapability(spec, true)
+			requestShape := capability["request_shape"].(map[string]any)
+			publicSchema := facadeSchemaMapForTest(t, capability["input_schema"])
+
+			require.Equal(t, test.operation, requestShape["operation"])
+			require.NotContains(t, requestShape, "tool")
+			require.NotContains(t, requestShape, "arguments")
+			require.NoError(t, validateFacadeSchema(publicSchema, requestShape, "$"))
+			require.Contains(t, capability["request_shape_note"], "directly")
+		})
+	}
+}
+
+func TestFacadeInvalidArgumentsEnvelopeErrorIsSelfCorrecting(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	spec, ok := srv.facades.operation("search", "symbols")
+	require.True(t, ok)
+
+	result := validateFacadeInput(spec, map[string]any{
+		"operation": "symbols",
+		"query":     "MyType",
+		"arguments": `{"query":"MyType"}`,
+	})
+	require.NotNil(t, result)
+	message := toolResultText(result)
+	require.Contains(t, message, `unexpected top-level key`)
+	require.Contains(t, message, `received string`)
+	require.Contains(t, message, `Pass operation/query/options at the top level`)
+}
+
 func TestFacadeCapabilitiesPublicSchemasMatchEveryAvailableOperation(t *testing.T) {
 	srv, _ := setupTestServer(t)
 	checked := 0
@@ -30,8 +72,7 @@ func TestFacadeCapabilitiesPublicSchemasMatchEveryAvailableOperation(t *testing.
 			t.Run(name, func(t *testing.T) {
 				capability := srv.facadeCapability(spec, true)
 				publicSchema := facadeSchemaMapForTest(t, capability["input_schema"])
-				requestShape := capability["request_shape"].(map[string]any)
-				arguments := requestShape["arguments"].(map[string]any)
+				arguments := capability["request_shape"].(map[string]any)
 
 				require.NoError(t, validateFacadeSchema(publicSchema, arguments, "$"), "public schema must accept its own request_shape")
 				require.NoError(t, validateFacadeSchema(staticSchema, arguments, "$"), "request_shape must remain valid against the static tools/list schema")

--- a/internal/mcp/facade_tools.go
+++ b/internal/mcp/facade_tools.go
@@ -538,7 +538,7 @@ func (s *Server) handleFacade(ctx context.Context, facade string, req mcpgo.Call
 		s.recordFacadeTelemetry(facade, "unknown", facadeOutcomeInvalidOperation, time.Since(started))
 		return result, nil
 	}
-	if invalid := validateFacadeInput(spec, input); invalid != nil {
+	if invalid := s.validateFacadeInput(spec, input); invalid != nil {
 		if completion, consumed := terminal.consumeInvalidRecovery(facade, operation, recoveryGeneration); consumed {
 			invalid, _ = decorateExhaustedLocalizationReadFailure(invalid, nil, completion, spec)
 		}
@@ -956,7 +956,7 @@ func (s *Server) invokeFacadeSpec(ctx context.Context, req mcpgo.CallToolRequest
 			Data:      map[string]any{"facade": spec.Facade, "operation": spec.Operation, "legacy_tool": spec.Legacy},
 		}), nil
 	}
-	if invalid := validateFacadeInput(spec, req.GetArguments()); invalid != nil {
+	if invalid := s.validateFacadeInput(spec, req.GetArguments()); invalid != nil {
 		outcome = facadeOutcomeInvalidArgument
 		return invalid, nil
 	}
@@ -1385,7 +1385,52 @@ func facadeLegacyManagesOwnOverlay(name string) bool {
 	}
 }
 
-func validateFacadeInput(spec facadeOperationSpec, input map[string]any) *mcpgo.CallToolResult {
+func facadeJSONType(value any) string {
+	switch value.(type) {
+	case nil:
+		return "null"
+	case bool:
+		return "boolean"
+	case string:
+		return "string"
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+		return "number"
+	case []any, []string, []map[string]any:
+		return "array"
+	case map[string]any:
+		return "object"
+	default:
+		return "unsupported value"
+	}
+}
+
+func (s *Server) facadeAcceptedTopLevelFields(spec facadeOperationSpec) []string {
+	capability := s.facadeCapability(spec, true)
+	schema, _ := capability["input_schema"].(map[string]any)
+	properties, _ := schema["properties"].(map[string]any)
+	fields := sortedFacadeMapKeys(properties)
+	fieldRank := func(field string) int {
+		switch field {
+		case "operation":
+			return 0
+		case "options":
+			return 2
+		default:
+			return 1
+		}
+	}
+	sort.SliceStable(fields, func(i, j int) bool {
+		leftRank := fieldRank(fields[i])
+		rightRank := fieldRank(fields[j])
+		if leftRank != rightRank {
+			return leftRank < rightRank
+		}
+		return fields[i] < fields[j]
+	})
+	return fields
+}
+
+func (s *Server) validateFacadeInput(spec facadeOperationSpec, input map[string]any) *mcpgo.CallToolResult {
 	for _, field := range []string{"arguments", "options", "source", "context", "guard", "output"} {
 		value, present := input[field]
 		if !present || value == nil {
@@ -1395,16 +1440,18 @@ func validateFacadeInput(spec facadeOperationSpec, input map[string]any) *mcpgo.
 			if field == "arguments" {
 				_, declared := facadeToolDefinition(spec.Facade).InputSchema.Properties[field]
 				if !declared {
-					receivedType := fmt.Sprintf("%T", value)
+					receivedType := facadeJSONType(value)
+					acceptedFields := s.facadeAcceptedTopLevelFields(spec)
 					return NewStructuredErrorResult(StructuredError{
 						ErrorCode: ErrCodeInvalidArgument,
 						Message: fmt.Sprintf(
-							"arguments is an unexpected top-level key for %s.%s (received %s); Pass operation/query/options at the top level; arguments is the JSON-RPC envelope, not a parameter",
-							spec.Facade, spec.Operation, receivedType,
+							"arguments is an unexpected top-level key for %s.%s (received %s); pass %s at the top level; arguments is the JSON-RPC envelope, not a parameter",
+							spec.Facade, spec.Operation, receivedType, strings.Join(acceptedFields, "/"),
 						),
 						Data: map[string]any{
 							"field": "arguments", "received_type": receivedType,
-							"accepted_shape": "pass request_shape fields directly as tool arguments",
+							"accepted_fields": acceptedFields,
+							"accepted_shape":  "pass request_shape fields directly as tool arguments",
 						},
 					})
 				}
@@ -2568,8 +2615,8 @@ func analyzeFieldApplies(kind, field string, raw any) bool {
 
 // facadeRequestShape makes capabilities actionable without teaching callers
 // canonical handler names. input_schema describes the operation-specific
-// fields; request_shape shows where those fields belong in the stable public
-// envelope and which target selector to use.
+// fields; request_shape shows the directly callable top-level fields and the
+// target selector to use.
 func facadeRequestShape(spec facadeOperationSpec, properties map[string]any, required []string) map[string]any {
 	args := map[string]any{"operation": spec.Operation}
 	placeholder := func(key string) map[string]any { return map[string]any{key: "<" + key + ">"} }

--- a/internal/mcp/facade_tools.go
+++ b/internal/mcp/facade_tools.go
@@ -1392,6 +1392,23 @@ func validateFacadeInput(spec facadeOperationSpec, input map[string]any) *mcpgo.
 			continue
 		}
 		if _, ok := value.(map[string]any); !ok {
+			if field == "arguments" {
+				_, declared := facadeToolDefinition(spec.Facade).InputSchema.Properties[field]
+				if !declared {
+					receivedType := fmt.Sprintf("%T", value)
+					return NewStructuredErrorResult(StructuredError{
+						ErrorCode: ErrCodeInvalidArgument,
+						Message: fmt.Sprintf(
+							"arguments is an unexpected top-level key for %s.%s (received %s); Pass operation/query/options at the top level; arguments is the JSON-RPC envelope, not a parameter",
+							spec.Facade, spec.Operation, receivedType,
+						),
+						Data: map[string]any{
+							"field": "arguments", "received_type": receivedType,
+							"accepted_shape": "pass request_shape fields directly as tool arguments",
+						},
+					})
+				}
+			}
 			return NewStructuredErrorResult(StructuredError{
 				ErrorCode: ErrCodeInvalidArgument,
 				Message:   fmt.Sprintf("%s must be an object", field),
@@ -2372,6 +2389,7 @@ func (s *Server) facadeCapability(spec facadeOperationSpec, includeSchema bool) 
 			}
 			out["input_schema"] = inputSchema
 			out["request_shape"] = requestShape
+			out["request_shape_note"] = fmt.Sprintf("Pass each request_shape field directly in the %s tool call; do not nest the object under arguments or params.", spec.Facade)
 			if raw, err := json.Marshal(inputSchema); err == nil {
 				sum := sha256.Sum256(raw)
 				out["schema_hash"] = hex.EncodeToString(sum[:])
@@ -2746,7 +2764,7 @@ func facadeRequestShape(spec facadeOperationSpec, properties map[string]any, req
 		}
 		extras[field] = facadeSchemaPlaceholder(field, properties[field])
 	}
-	return map[string]any{"tool": spec.Facade, "arguments": args}
+	return args
 }
 
 // applyFacadeSurface provides session-level surface negotiation. Legacy

--- a/internal/mcp/facade_tools_test.go
+++ b/internal/mcp/facade_tools_test.go
@@ -1048,13 +1048,10 @@ func TestFacadeCapabilitiesReturnsOperationSchema(t *testing.T) {
 	require.Equal(t, true, out["available"])
 	require.NotEmpty(t, out["schema_hash"])
 	require.NotNil(t, out["input_schema"])
-	shape, ok := out["request_shape"].(map[string]any)
+	requestShape, ok := out["request_shape"].(map[string]any)
 	require.True(t, ok)
-	require.Equal(t, "read", shape["tool"])
-	arguments, ok := shape["arguments"].(map[string]any)
-	require.True(t, ok)
-	require.Equal(t, "file", arguments["operation"])
-	require.Equal(t, map[string]any{"file": "<file>"}, arguments["target"])
+	require.Equal(t, "file", requestShape["operation"])
+	require.Equal(t, map[string]any{"file": "<file>"}, requestShape["target"])
 }
 
 func TestFacadeCapabilitiesChangeImpactUsesPublicTargetSchema(t *testing.T) {
@@ -1094,8 +1091,8 @@ func TestFacadeCapabilitiesChangeImpactUsesPublicTargetSchema(t *testing.T) {
 	for _, field := range []string{"summary_only", "offset", "limit", "format", "max_bytes"} {
 		require.Contains(t, outputProperties, field)
 	}
-	shape := out["request_shape"].(map[string]any)["arguments"].(map[string]any)
-	require.Equal(t, map[string]any{"symbol": "<symbol>"}, shape["target"])
+	requestShape := out["request_shape"].(map[string]any)
+	require.Equal(t, map[string]any{"symbol": "<symbol>"}, requestShape["target"])
 }
 
 func TestFacadeCapabilitiesRequestShapesUsePublicMutationFields(t *testing.T) {
@@ -1135,11 +1132,9 @@ func TestFacadeCapabilitiesRequestShapesUsePublicMutationFields(t *testing.T) {
 		result, err := srv.handleCapabilities(context.Background(), req)
 		require.NoError(t, err)
 		out := unmarshalResult(t, result)
-		shape, ok := out["request_shape"].(map[string]any)
+		requestShape, ok := out["request_shape"].(map[string]any)
 		require.True(t, ok)
-		arguments, ok := shape["arguments"].(map[string]any)
-		require.True(t, ok)
-		return arguments
+		return requestShape
 	}
 
 	edit := requestShape("edit", "file")
@@ -1202,8 +1197,8 @@ func TestFacadeCapabilitiesDiscoversNativeAnalyzeKinds(t *testing.T) {
 	out := unmarshalResult(t, result)
 	require.Equal(t, true, out["available"])
 	require.Equal(t, AnalyzeKindDescription("todos"), out["summary"])
-	shape := out["request_shape"].(map[string]any)["arguments"].(map[string]any)
-	require.Equal(t, "todos", shape["kind"])
+	requestShape := out["request_shape"].(map[string]any)
+	require.Equal(t, "todos", requestShape["kind"])
 	schema := out["input_schema"].(map[string]any)
 	schemaProperties := schema["properties"].(map[string]any)
 	optionsProperties := schemaProperties["options"].(map[string]any)["properties"].(map[string]any)
@@ -1299,15 +1294,15 @@ func TestFacadeCapabilitiesCollapseSessionSubscriptionChannels(t *testing.T) {
 	schemaReq.Params.Arguments = map[string]any{"domain": "session", "operation": "subscribe", "detail": "schema"}
 	schemaResult, err := srv.handleCapabilities(context.Background(), schemaReq)
 	require.NoError(t, err)
-	shape := unmarshalResult(t, schemaResult)["request_shape"].(map[string]any)["arguments"].(map[string]any)
-	require.Equal(t, "subscribe", shape["operation"])
-	require.Equal(t, "<channel>", shape["channel"])
+	requestShape := unmarshalResult(t, schemaResult)["request_shape"].(map[string]any)
+	require.Equal(t, "subscribe", requestShape["operation"])
+	require.Equal(t, "<channel>", requestShape["channel"])
 
 	cursorReq := mcpgo.CallToolRequest{}
 	cursorReq.Params.Arguments = map[string]any{"domain": "session", "operation": "cursor", "detail": "schema"}
 	cursorResult, err := srv.handleCapabilities(context.Background(), cursorReq)
 	require.NoError(t, err)
-	cursorShape := unmarshalResult(t, cursorResult)["request_shape"].(map[string]any)["arguments"].(map[string]any)
+	cursorShape := unmarshalResult(t, cursorResult)["request_shape"].(map[string]any)
 	require.Equal(t, "cursor", cursorShape["operation"])
 	require.Equal(t, "<action>", cursorShape["arguments"].(map[string]any)["action"])
 


### PR DESCRIPTION
## Summary

- return `request_shape` as the direct caller-level facade input instead of wrapping it in `tool` and `arguments`
- keep legitimate operation-level `arguments` containers, such as `session.cursor`, intact
- return self-correcting diagnostics when an undeclared top-level `arguments` value is sent
- align public capability-schema validation, documentation, and existing request-shape consumers with the direct shape

## Verification

- `go test ./internal/mcp -run 'Facade|Capability' -count=1`
- `go test -race ./internal/mcp -run '^(TestFacadeCapabilityRequestShapeIsDirectCallerInput|TestFacadeInvalidArgumentsEnvelopeErrorIsSelfCorrecting|TestFacadeCapabilitiesPublicSchemasMatchEveryAvailableOperation)$' -count=1`
- `go vet ./internal/mcp`
- `go build ./cmd/gortex`
- `git diff --check`

A full `go test ./internal/mcp -count=1` was also run on Windows. The capability-related failure it exposed was fixed; the remaining failures are unrelated platform/index-fixture failures already outside this diff (Windows file URI/path normalization, symlink privilege, file-mode preservation, and several index fixtures).

Fixes #542