### PR TITLE
fix: stop two call shapes binding to the wrong target

### DIFF
--- a/internal/graph/edge.go
+++ b/internal/graph/edge.go
@@ -1166,3 +1166,13 @@ func ConfidenceLabelFor(kind EdgeKind, confidence float64) string {
 		return "INFERRED"
 	}
 }
+
+// MetaGenericInstantiation is the edge Meta key marking a call whose
+// callee spelled explicit type arguments. Some grammars cannot separate
+// that from unrelated constructs — Go writes `Zero[int]()` exactly like
+// indexing a func-valued map and `One[int](1)` exactly like converting
+// to a generic type — so the extractor emits all of them and records
+// which ones claimed to be instantiations. A resolver may then bind such
+// an edge only to a declaration that really is generic, which is the one
+// property a true instantiation guarantees and the impostors never have.
+const MetaGenericInstantiation = "generic_instantiation"

--- a/internal/indexer/extractor_version.go
+++ b/internal/indexer/extractor_version.go
@@ -32,9 +32,9 @@ var extractorVersions = map[string]int{
 	//   "go": 2,
 	"c":      generatedParserProjectionPolicyVersion, // generated parser projection covers all strictly detected table sizes
 	"php":    2,                                      // class/interface inheritance now emits typed structural edges
-	"csharp": 9,                                      // generic invocations emit call edges (was: interface base lists emit extends edges)
+	"csharp": 10,                                     // qualified static-form extension calls pick the right overload (was: generic invocations emit call edges)
 	"scala":  2,                                      // explicitly instantiated generic calls emit call edges
-	"go":     2,                                      // explicitly instantiated generic calls emit call edges
+	"go":     3,                                      // generic instantiations are marked so indexing a func value cannot bind (was: generic calls emit call edges)
 	"cpp":    2,                                      // templated and namespace-qualified calls emit call edges
 	"swift":  2,                                      // generic calls and ordinary member calls emit call edges
 }

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -670,6 +670,15 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 				}
 			} else if strings.Contains(c.receiver, ".") || strings.Contains(c.receiver, "(") {
 				stampFactoryChainReceiver(edge, c.receiver, resolveChainType(c.receiver, tenvByOwner[callerID], result))
+				if edge.Meta == nil && !strings.Contains(c.receiver, "(") {
+					// A namespace-qualified receiver the chain walker could
+					// not type (`Lib.BagExt.Add(bag)`). That is the same
+					// static-form evidence as the bare spelling below —
+					// without it the binder reads the call as extension
+					// form, discounts a `this` slot the argument list never
+					// filled, and lands on the wrong overload.
+					edge.Meta = map[string]any{"receiver_name": c.receiver}
+				}
 			} else if c.receiver != "" {
 				// A bare receiver nothing above could type. Its spelling
 				// is still evidence: reaching here means no local, param

--- a/internal/parser/languages/golang.go
+++ b/internal/parser/languages/golang.go
@@ -65,13 +65,13 @@ const qGoAll = `
   ; and were never affected.
   (call_expression
     function: (index_expression
-      operand: (identifier) @call.name)) @call.expr
+      operand: (identifier) @callg.name)) @callg.expr
 
   (call_expression
     function: (index_expression
       operand: (selector_expression
-        operand: (_) @callm.receiver
-        field: (field_identifier) @callm.method))) @callm.expr
+        operand: (_) @callmg.receiver
+        field: (field_identifier) @callmg.method))) @callmg.expr
 
   ; ...and with exactly one VALUE argument the same call is not even a
   ; call_expression: One[int](1) is indistinguishable from a conversion
@@ -80,13 +80,13 @@ const qGoAll = `
   ; cannot share a package-scope name with a function.
   (type_conversion_expression
     type: (generic_type
-      type: (type_identifier) @call.name)) @call.expr
+      type: (type_identifier) @callg.name)) @callg.expr
 
   (type_conversion_expression
     type: (generic_type
       type: (qualified_type
-        package: (_) @callm.receiver
-        name: (type_identifier) @callm.method))) @callm.expr
+        package: (_) @callmg.receiver
+        name: (type_identifier) @callmg.method))) @callmg.expr
 
   (var_declaration
     (var_spec
@@ -243,7 +243,13 @@ type goDeferredCall struct {
 	receiver   string // selector call receiver text
 	line       int    // 1-based line of call_expression
 	isSelector bool
-	spawn      bool // call is launched via `go` — emit EdgeSpawns alongside EdgeCalls
+	// genericInst marks a call whose callee spelled explicit type
+	// arguments. Go writes those exactly like indexing a func-valued
+	// map or field, and like converting to a generic type, so the
+	// marker rides onto the edge and the resolver binds it only to a
+	// declaration that is actually generic.
+	genericInst bool
+	spawn       bool // call is launched via `go` — emit EdgeSpawns alongside EdgeCalls
 	// returnUsage is how the call site consumes the return value
 	// (graph.ReturnUsage* label), classified from the call node's
 	// parent chain at capture time and stamped as edge Meta on every
@@ -479,6 +485,35 @@ func (e *GoExtractor) Extract(filePath string, src []byte) (*parser.ExtractionRe
 				dc.grpcRegService, dc.grpcRegArgNode = svc, argNode
 			}
 			calls = append(calls, dc)
+
+		// An explicitly instantiated generic call. The grammar spells
+		// these exactly like indexing a func-valued map/field and like
+		// converting to a generic type, so the marker rides along and
+		// the resolver refuses to bind unless the target really is
+		// generic — see goGenericInstantiationOnly.
+		case m.Captures["callg.expr"] != nil:
+			expr := m.Captures["callg.expr"]
+			calls = append(calls, goDeferredCall{
+				callName:    m.Captures["callg.name"].Text,
+				line:        expr.StartLine + 1,
+				spawn:       isGoroutineSpawn(expr.Node),
+				returnUsage: classifyReturnUsage(expr.Node, src, goReturnUsageSpec),
+				callNode:    expr.Node,
+				genericInst: true,
+			})
+
+		case m.Captures["callmg.expr"] != nil:
+			expr := m.Captures["callmg.expr"]
+			calls = append(calls, goDeferredCall{
+				method:      m.Captures["callmg.method"].Text,
+				receiver:    m.Captures["callmg.receiver"].Text,
+				line:        expr.StartLine + 1,
+				isSelector:  true,
+				spawn:       isGoroutineSpawn(expr.Node),
+				returnUsage: classifyReturnUsage(expr.Node, src, goReturnUsageSpec),
+				callNode:    expr.Node,
+				genericInst: true,
+			})
 
 		case m.Captures["callm.expr"] != nil:
 			expr := m.Captures["callm.expr"]
@@ -999,6 +1034,7 @@ func (e *GoExtractor) Extract(filePath string, src []byte) (*parser.ExtractionRe
 				From: callerID, To: target,
 				Kind: graph.EdgeCalls, FilePath: filePath, Line: c.line,
 			}
+			stampGoGenericInstantiation(edge, c)
 			applyGoGRPCRegisterMeta(edge, c, src, tenv)
 			applyGoTemporalRegisterMeta(edge, c)
 			applyGoTemporalHandlerMeta(edge, c)
@@ -1016,6 +1052,7 @@ func (e *GoExtractor) Extract(filePath string, src []byte) (*parser.ExtractionRe
 				From: callerID, To: target,
 				Kind: graph.EdgeCalls, FilePath: filePath, Line: c.line,
 			}
+			stampGoGenericInstantiation(edge, c)
 			applyGoGRPCRegisterMeta(edge, c, src, tenv)
 			applyGoTemporalRegisterMeta(edge, c)
 			applyGoTemporalHandlerMeta(edge, c)
@@ -1065,6 +1102,7 @@ func (e *GoExtractor) Extract(filePath string, src []byte) (*parser.ExtractionRe
 			}
 			stampFactoryChainReceiver(edge, c.receiver, resolveChainType(c.receiver, composed, result))
 		}
+		stampGoGenericInstantiation(edge, c)
 		applyGoGRPCRegisterMeta(edge, c, src, tenv)
 		applyGoTemporalRegisterMeta(edge, c)
 		applyGoTemporalSignalQueryMeta(edge, c)
@@ -2993,4 +3031,22 @@ func isGoBuiltinOrKeyword(name string) bool {
 		return true
 	}
 	return false
+}
+
+// stampGoGenericInstantiation marks a call edge whose callee spelled
+// explicit type arguments. Go's grammar cannot separate that from
+// indexing a func-valued map or field, nor from a conversion to a
+// generic type, so the extractor emits all three and records which ones
+// claimed to be instantiations. The resolver then binds such an edge
+// only to a declaration that actually declares type parameters, which
+// is the one thing a real instantiation guarantees and the impostors
+// never do.
+func stampGoGenericInstantiation(edge *graph.Edge, c goDeferredCall) {
+	if edge == nil || !c.genericInst {
+		return
+	}
+	if edge.Meta == nil {
+		edge.Meta = map[string]any{}
+	}
+	edge.Meta[graph.MetaGenericInstantiation] = true
 }

--- a/internal/resolver/csharp_applicability.go
+++ b/internal/resolver/csharp_applicability.go
@@ -1,6 +1,8 @@
 package resolver
 
 import (
+	"strings"
+
 	"github.com/zzet/gortex/internal/graph"
 )
 
@@ -142,15 +144,22 @@ func csharpExtensionAcceptsArgCount(e *graph.Edge, c *graph.Node) bool {
 // through its declaring class (`BagExt.Add(bag)`) rather than on a
 // receiver value (`bag.Add()`).
 //
-// The extractor stamps receiver_name only for a bare receiver that no
-// local, parameter or builtin in scope explains — so a receiver_name
-// equal to the candidate's own declaring class is a type reference, not
-// a shadowing variable. Any receiver the extractor DID type is a value
-// by construction, and carries no receiver_name at all.
+// The extractor stamps receiver_name only for a receiver that no local,
+// parameter, builtin or chain walk explains — so a receiver_name whose
+// trailing segment is the candidate's own declaring class is a type
+// reference, not a shadowing variable. Any receiver the extractor DID
+// type is a value by construction, and carries no receiver_name at all.
+//
+// The trailing segment is what matters because the class may be written
+// namespace-qualified: `Lib.BagExt.Add(bag)` and `BagExt.Add(bag)` are
+// the same call and must reach the same overload.
 func csharpCallIsStaticForm(e *graph.Edge, c *graph.Node) bool {
 	recv, _ := e.Meta["receiver_name"].(string)
 	if recv == "" {
 		return false
+	}
+	if i := strings.LastIndex(recv, "."); i >= 0 {
+		recv = recv[i+1:]
 	}
 	owner, _ := c.Meta["receiver"].(string)
 	return owner != "" && recv == owner

--- a/internal/resolver/csharp_static_form_qualified_test.go
+++ b/internal/resolver/csharp_static_form_qualified_test.go
@@ -1,0 +1,51 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// A static-form extension call passes the receiver as its first argument,
+// so the arity window must NOT discount the `this` slot. That distinction
+// rides on the receiver's spelling, which the extractor stamps only when
+// nothing else could type the receiver — and a namespace-qualified
+// receiver took the chain-walker branch instead, so it arrived carrying
+// no spelling at all.
+//
+// The binder then read `Lib.BagExt.Add(bag)` as extension form, subtracted
+// a slot the argument list had actually filled, and bound the two-parameter
+// overload. `BagExt.Add(bag)` — the same call, written unqualified — bound
+// the correct one, so the two spellings disagreed.
+func TestResolveCSharpExtension_QualifiedStaticFormPicksSameOverload(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Ext.cs": `using System;
+namespace Lib {
+    public interface IBag { }
+    public class Opts { }
+    public static class BagExt {
+        public static IBag Add(this IBag bag) { return bag; }
+        public static IBag Add(this IBag bag, Action<Opts> configure) { return bag; }
+    }
+}`,
+		"Caller.cs": `using Lib;
+namespace App {
+    public class Runner {
+        public void Simple(IBag b) { BagExt.Add(b); }
+        public void Qualified(IBag b) { Lib.BagExt.Add(b); }
+        public void QualifiedTwo(IBag b) { Lib.BagExt.Add(b, x => { }); }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	const oneParam = "Ext.cs::BagExt.Add"
+	const twoParam = "Ext.cs::BagExt.Add_L7"
+
+	assert.Equal(t, oneParam, namedCallTarget(t, g, "Caller.cs::Runner.Simple", "Add"),
+		"control: the unqualified static form already worked")
+	assert.Equal(t, oneParam, namedCallTarget(t, g, "Caller.cs::Runner.Qualified", "Add"),
+		"the same call written namespace-qualified must reach the same overload")
+	assert.Equal(t, twoParam, namedCallTarget(t, g, "Caller.cs::Runner.QualifiedTwo", "Add"),
+		"a qualified static-form call with a real second argument is the two-parameter overload")
+}

--- a/internal/resolver/go_generic_call_ambiguity_test.go
+++ b/internal/resolver/go_generic_call_ambiguity_test.go
@@ -86,3 +86,54 @@ func Run() {
 	assert.Contains(t, targets, "app/lib.go::OneArg",
 		"a generic call with exactly one value argument resolves to its declaration")
 }
+
+// The package-scope argument above covers a var and a func sharing a
+// name. It does NOT cover two cases that are ordinary Go:
+//
+//   - a func-valued STRUCT FIELD, which lives in the type's namespace and
+//     may freely share a name with a method on some other type;
+//   - a LOCAL variable shadowing a package-scope function name.
+//
+// Both spell an index-then-call exactly like a generic instantiation, and
+// before the instantiation marker existed the ordinary name tiers bound
+// them: `t.handlers[k]()` landed on an unrelated `Other.handlers`, and a
+// shadowed `Handler[k]()` landed on the package's `Handler` at the
+// ast_resolved tier. Requiring a real type-parameter list on the target
+// is what separates the instantiation from both impostors.
+func TestResolveGo_IndexedFieldAndLocalShadowDoNotBind(t *testing.T) {
+	g := buildMultiLangGraph(t, map[string]string{
+		"app/a.go": `package app
+
+type Other struct{}
+
+func (o Other) handlers() {}
+
+func Handler() {}
+
+type T struct {
+	handlers map[string]func()
+}
+
+func (t T) Dispatch(k string) {
+	t.handlers[k]()
+}
+
+func LocalShadow(k string) {
+	Handler := map[string]func(){}
+	Handler[k]()
+}
+`,
+	})
+	New(g).ResolveAll()
+
+	for _, caller := range []string{"app/a.go::T.Dispatch", "app/a.go::LocalShadow"} {
+		for _, e := range g.GetOutEdges(caller) {
+			if e.Kind != graph.EdgeCalls {
+				continue
+			}
+			assert.True(t, graph.IsUnresolvedTarget(e.To),
+				"%s: indexing a func value is not a generic call, so it must not bind (got %s)",
+				caller, e.To)
+		}
+	}
+}

--- a/internal/resolver/repo_language_lookup.go
+++ b/internal/resolver/repo_language_lookup.go
@@ -302,11 +302,55 @@ func (r *Resolver) cachedFindNodesByNameInRepoForEdge(name, repo string, edge *g
 	if r.nodesByRepoLanguageName != nil {
 		if byName, ok := r.nodesByRepoLanguageName[scope]; ok {
 			if hits, warmed := byName[name]; warmed {
-				return hits
+				return genericInstantiationOnly(edge, hits)
 			}
 		}
 	}
-	return graph.FindNodesByNamesInRepoLanguages(r.graph, []string{name}, scope.repo, languages)[name]
+	return genericInstantiationOnly(edge,
+		graph.FindNodesByNamesInRepoLanguages(r.graph, []string{name}, scope.repo, languages)[name])
+}
+
+// genericInstantiationOnly narrows a call edge's candidates when the
+// extractor marked it as an explicit generic instantiation.
+//
+// Some grammars spell an instantiation exactly like something unrelated:
+// Go parses `Zero[int]()` the same as indexing a func-valued map or
+// struct field, and `One[int](1)` the same as a conversion to a generic
+// type. Emitting all three is what recovers the real generic calls, but
+// it also hands the ordinary name tiers candidates a genuine index or
+// conversion should never reach — and those tiers bound them, pointing
+// `t.handlers[k]()` at an unrelated same-named method.
+//
+// A true instantiation can only target a declaration that DECLARES type
+// parameters. Requiring that is exact rather than heuristic, and it is
+// what separates the call from both impostors: a func-valued field and a
+// shadowing local name nothing generic. Narrowing only — an unmarked
+// edge, or one whose candidates carry no evidence either way, is
+// returned untouched. An empty result leaves the edge unresolved, which
+// is the correct answer for an index or a conversion.
+//
+// The returned slice is never the cached input when it filters, so the
+// shared name cache is not mutated.
+func genericInstantiationOnly(edge *graph.Edge, hits []*graph.Node) []*graph.Node {
+	if edge == nil || edge.Meta == nil || len(hits) == 0 {
+		return hits
+	}
+	if marked, _ := edge.Meta[graph.MetaGenericInstantiation].(bool); !marked {
+		return hits
+	}
+	out := make([]*graph.Node, 0, len(hits))
+	for _, n := range hits {
+		if n == nil || n.Meta == nil {
+			continue
+		}
+		if n.Kind != graph.KindFunction && n.Kind != graph.KindMethod {
+			continue
+		}
+		if tp, ok := n.Meta["type_params"]; ok && tp != nil {
+			out = append(out, n)
+		}
+	}
+	return out
 }
 
 // cachedFindExternNodesByName keeps explicit extern candidates isolated by the


### PR DESCRIPTION
Two wrong-edge regressions from #536 and #538. Both turn a previously *missing* edge into a confidently *wrong* one, which is the worse failure and the exact thing those PRs argued they were avoiding. Found by auditing the merged changes rather than by a report.

Both reproduced on current `main` before fixing.

## 1. C#: a namespace-qualified static-form call binds the wrong overload

A static-form extension call (`BagExt.Add(bag)`) passes the receiver as its *first argument*, so the arity window must not discount the `this` slot. #536 handled that by stamping the receiver's spelling — but only in the branch reached after the local / parameter / builtin lookups all miss. A **namespace-qualified** receiver takes the chain-walker branch before that, so it arrived carrying no spelling, the binder read the call as extension form, and it subtracted a slot the argument list had already filled.

Measured on `main`:

```
Runner.Simple     BagExt.Add(b)       -> BagExt.Add     (param_count=1)  ✅
Runner.Qualified  Lib.BagExt.Add(b)   -> BagExt.Add_L7  (param_count=2)  ❌
```

The same call, written two ways, reaching two different overloads. Before #536 both were unresolved, so this is a regression rather than a pre-existing gap.

A qualified receiver the chain walker could not type now carries the same evidence, and `csharpCallIsStaticForm` compares the **trailing segment**, so `Lib.BagExt.Add` and `BagExt.Add` agree.

## 2. Go: indexing a func value binds to an unrelated declaration

#538's generic-call patterns match `Zero[int]()`, and Go spells indexing a func-valued map or field identically. The safety argument was that a package-scope name is a func, a var *or* a type and never two. That is true — and it covers neither of these:

- a func-valued **struct field**, which lives in the type's namespace and may freely share a name with another type's method;
- a **local** shadowing a package-scope function name.

Measured on `main`:

```
T.Dispatch    t.handlers[k]()                        -> Other.handlers  conf=0.70  ❌
LocalShadow   Handler := map[...]; Handler[k]()       -> Handler         conf=0.90  ❌ (ast_resolved)
```

`t.handlers[k]()` binding to an unrelated type's method is the worst of the two — it is a plausible-looking edge with no relationship to the code.

### The fix uses the one property the impostors cannot fake

A real instantiation can only target a declaration that **declares type parameters**. So the extractor marks the call shapes it could not disambiguate (`graph.MetaGenericInstantiation`), and the resolver binds such an edge only to a generic declaration.

That runs at `cachedFindNodesByNameInRepoForEdge` — the shared candidate lookup every name tier goes through — so no tier can bypass it. It narrows only: an unmarked edge is untouched, and an empty result leaves the call unresolved, which is the correct answer for an index or a conversion. Go function and method nodes already carried `Meta["type_params"]`, so no new extraction evidence was needed on the declaration side.

Real generic calls still resolve — `TestResolveGo_GenericCallResolvesAcrossFiles` (added in #538) still passes, including the cross-file single-value-argument form.

## Versions

Both `csharp` and `go` extractor versions are bumped. Existing indexes carry the wrong edges, and only a re-extraction removes them.

## Verification

`go test ./internal/...` exit 0 across 136 packages, zero failures; `golangci-lint` 0 issues. Three regression tests added, each failing before this change:
`QualifiedStaticFormPicksSameOverload`, `IndexedFieldAndLocalShadowDoNotBind`, plus the pre-existing ambiguity and cross-file generic tests still passing.

## Related

The same audit turned up six pre-existing gaps, filed separately: #559 #560 #561 #562 #563 #564.
