### PR TITLE
fix(mcp): validate batch edit discriminators

### DIFF
--- a/internal/mcp/batch_edit_validation_test.go
+++ b/internal/mcp/batch_edit_validation_test.go
@@ -1,0 +1,146 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+func unmarshalBatchEditError(t *testing.T, result *mcpgo.CallToolResult) map[string]any {
+	t.Helper()
+	require.True(t, result.IsError)
+	require.NotEmpty(t, result.Content)
+	text, ok := result.Content[0].(mcpgo.TextContent)
+	require.True(t, ok, "expected TextContent, got %T", result.Content[0])
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal([]byte(text.Text), &payload))
+	return payload
+}
+
+func TestParseBatchEditsInfersCompleteLegacyShapes(t *testing.T) {
+	branches := batchEditItemsSchema()["oneOf"].([]any)
+	fileRequired := branches[1].(map[string]any)["required"].([]any)
+	require.NotContains(t, fileRequired, "op", "schema must admit the same complete legacy file shape as the runtime")
+
+	structured, err := parseBatchEdits([]any{map[string]any{
+		"path": "a.go", "old_string": "before", "new_string": "",
+	}})
+	require.NoError(t, err)
+	require.Len(t, structured, 1)
+	require.Equal(t, "edit_file", structured[0].Op)
+
+	legacy, err := parseBatchEdits(`[{"id":"pkg/a.go::A","old_source":"before","new_source":""}]`)
+	require.NoError(t, err)
+	require.Len(t, legacy, 1)
+	require.Equal(t, "edit_symbol", legacy[0].Op)
+}
+
+func TestParseBatchEditsRejectsUnknownOpInLegacyJSONString(t *testing.T) {
+	_, err := parseBatchEdits(`[{"op":"replace_file","path":"a.go","old_string":"before","new_string":"after"}]`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "edits[0]")
+	require.Contains(t, err.Error(), `unknown op "replace_file"`)
+	require.Contains(t, err.Error(), "edit_file, edit_symbol")
+}
+
+func TestParseBatchEditsRejectsAmbiguousAndIncompleteShapes(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		item map[string]any
+		want string
+	}{
+		{
+			name: "mixed",
+			item: map[string]any{
+				"path": "a.go", "old_string": "before", "new_string": "after",
+				"id": "pkg/a.go::A", "old_source": "before", "new_source": "after",
+			},
+			want: "mixes edit_file and edit_symbol fields",
+		},
+		{
+			name: "incomplete-file",
+			item: map[string]any{"old_string": "before", "new_string": "after"},
+			want: "incomplete edit_file shape",
+		},
+		{
+			name: "unrecognized-alias",
+			item: map[string]any{"file": "a.go"},
+			want: "does not match a supported batch edit shape",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := parseBatchEdits([]any{test.item})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "edits[0]")
+			require.Contains(t, err.Error(), test.want)
+			require.Contains(t, err.Error(), `{"op":"edit_file"`)
+			require.Contains(t, err.Error(), `{"op":"edit_symbol"`)
+		})
+	}
+}
+
+func TestBatchEditUnknownDiscriminatorIsStructuredAndWritesNothing(t *testing.T) {
+	srv, root := setupTestServer(t)
+	path := filepath.Join(root, "batch-invalid-op.txt")
+	require.NoError(t, os.WriteFile(path, []byte("alpha beta\n"), 0o644))
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"edits": []any{
+			map[string]any{
+				"op": "edit_file", "path": path,
+				"old_string": "alpha", "new_string": "ALPHA",
+			},
+			map[string]any{
+				"op": "replace_file", "path": path,
+				"old_string": "beta", "new_string": "BETA",
+			},
+		},
+	}
+	result, err := srv.handleBatchEdit(context.Background(), req)
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	payload := unmarshalBatchEditError(t, result)
+	require.Equal(t, "invalid_argument", payload["error_code"])
+	require.Contains(t, payload["message"], `unknown op "replace_file"`)
+	data := payload["data"].(map[string]any)
+	require.Equal(t, float64(1), data["item_index"])
+	require.ElementsMatch(t, []any{"edit_file", "edit_symbol"}, data["accepted_values"])
+	require.Len(t, data["accepted_shapes"], 2)
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "alpha beta\n", string(content), "invalid item must reject the whole batch before the first write")
+}
+
+func TestFacadeEditBatchRejectsNestedFileSelector(t *testing.T) {
+	srv, root := setupTestServer(t)
+	srv.facades.capture(mcpgo.NewTool("batch_edit"), srv.handleBatchEdit)
+	path := filepath.Join(root, "facade-invalid-shape.txt")
+	require.NoError(t, os.WriteFile(path, []byte("before\n"), 0o644))
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"operation": "batch",
+		"changes": []any{map[string]any{
+			"target":     map[string]any{"file": path},
+			"old_string": "before", "new_string": "after",
+		}},
+	}
+	result, err := srv.handleFacade(context.Background(), "edit", req)
+	require.NoError(t, err)
+	require.True(t, result.IsError)
+	payload := unmarshalBatchEditError(t, result)
+	require.Equal(t, "invalid_argument", payload["error_code"])
+	require.Contains(t, payload["message"], "edits[0]")
+	require.Contains(t, payload["message"], "incomplete edit_file shape")
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, "before\n", string(content))
+}

--- a/internal/mcp/batch_transaction.go
+++ b/internal/mcp/batch_transaction.go
@@ -206,7 +206,7 @@ func (s *Server) planBatchTransaction(ctx context.Context, edits []batchEditItem
 					plan.absPath, plan.file = absPath, relPath
 				}
 			}
-		default:
+		case "edit_symbol":
 			switch {
 			case edit.SymbolID == "":
 				plan.err = "edit_symbol op requires id"
@@ -238,6 +238,8 @@ func (s *Server) planBatchTransaction(ctx context.Context, edits []batchEditItem
 					plan.order = 20
 				}
 			}
+		default:
+			plan.err = fmt.Sprintf("unsupported batch edit op %q", plan.op)
 		}
 		plans = append(plans, plan)
 	}
@@ -763,7 +765,7 @@ func (s *Server) handleAtomicBatchEdit(ctx context.Context, req mcp.CallToolRequ
 
 	edits, err := parseBatchEdits(rawEdits)
 	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
+		return batchEditInvalidArgumentResult(err), nil
 	}
 	if len(edits) == 0 {
 		return mcp.NewToolResultError("edits array is empty"), nil

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -3686,8 +3686,9 @@ func (s *Server) handleGetSymbolHistory(ctx context.Context, req mcp.CallToolReq
 // batchEditItem is one operation in a batch_edit call. It is a discriminated
 // union over `op`: an edit_symbol op carries {id, old_source, new_source}; an
 // edit_file op carries {path, old_string, new_string, replace_all?}. When `op`
-// is omitted it is inferred (edit_file when a path is present, else edit_symbol)
-// so the legacy homogeneous {id, old_source, new_source} payload still works.
+// is omitted it is inferred only from one complete, unambiguous field set, so
+// both legacy item shapes remain supported without silently misclassifying
+// malformed payloads.
 type batchEditItem struct {
 	Op string `json:"op,omitempty"`
 	// edit_symbol
@@ -3701,12 +3702,11 @@ type batchEditItem struct {
 	ReplaceAll bool   `json:"replace_all,omitempty"`
 }
 
-// kind resolves the operation kind for an item: an explicit, recognised `op`
-// wins; otherwise edit_file is inferred when a path is present, else
-// edit_symbol.
+// kind returns a normalized operation kind. Runtime payloads are normalized by
+// parseBatchEdits; preserving an explicit unknown value here ensures internal
+// callers also fail closed instead of silently becoming edit_symbol.
 func (it batchEditItem) kind() string {
-	switch it.Op {
-	case "edit_file", "edit_symbol":
+	if it.Op != "" {
 		return it.Op
 	}
 	if it.Path != "" {
@@ -3757,21 +3757,94 @@ func batchEditItemsSchema() map[string]any {
 				"type":        "object",
 				"description": "Replace a string in any file (imports, config, comments — non-symbol edits).",
 				"properties": map[string]any{
-					"op":          map[string]any{"const": "edit_file", "description": "Operation kind. Required to select a file edit."},
+					"op":          map[string]any{"const": "edit_file", "description": "Operation kind (optional; inferred as edit_file when omitted and the complete file field set is present)."},
 					"path":        map[string]any{"type": "string", "description": "File path (repo-relative or absolute)."},
 					"old_string":  map[string]any{"type": "string", "description": "Exact text to replace; must be unique unless replace_all is set. CRLF/LF line-ending differences against the file are tolerated."},
 					"new_string":  map[string]any{"type": "string", "description": "Replacement text."},
 					"replace_all": map[string]any{"type": "boolean", "description": "Replace every occurrence instead of requiring uniqueness."},
 				},
-				"required": []any{"op", "path", "old_string", "new_string"},
+				"required": []any{"path", "old_string", "new_string"},
 			},
 		},
 	}
 }
 
+var batchEditAcceptedShapes = [2]string{
+	`{"op":"edit_file","path":"<file>","old_string":"<text>","new_string":"<text>"}`,
+	`{"op":"edit_symbol","id":"<symbol_id>","old_source":"<source>","new_source":"<source>"}`,
+}
+
+type batchEditArgumentError struct {
+	index  int
+	reason string
+}
+
+func (e *batchEditArgumentError) Error() string {
+	return fmt.Sprintf("edits[%d]: %s; accepted shapes: %s or %s", e.index, e.reason, batchEditAcceptedShapes[0], batchEditAcceptedShapes[1])
+}
+
+func batchEditHasAny(fields map[string]json.RawMessage, names ...string) bool {
+	for _, name := range names {
+		if _, ok := fields[name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func missingBatchEditFields(fields map[string]json.RawMessage, names ...string) []string {
+	missing := make([]string, 0, len(names))
+	for _, name := range names {
+		if _, ok := fields[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	return missing
+}
+
+func classifyBatchEditItem(fields map[string]json.RawMessage, op string) (string, error) {
+	hasFileFields := batchEditHasAny(fields, "path", "old_string", "new_string", "replace_all")
+	hasSymbolFields := batchEditHasAny(fields, "id", "old_source", "new_source")
+
+	if _, explicit := fields["op"]; explicit {
+		switch op {
+		case "edit_file", "edit_symbol":
+		default:
+			return "", fmt.Errorf("unknown op %q (accepted values: edit_file, edit_symbol)", op)
+		}
+	}
+	if hasFileFields && hasSymbolFields {
+		return "", fmt.Errorf("item mixes edit_file and edit_symbol fields")
+	}
+
+	kind := op
+	if kind == "" {
+		switch {
+		case hasFileFields:
+			kind = "edit_file"
+		case hasSymbolFields:
+			kind = "edit_symbol"
+		default:
+			return "", fmt.Errorf("item does not match a supported batch edit shape")
+		}
+	}
+
+	var missing []string
+	if kind == "edit_file" {
+		missing = missingBatchEditFields(fields, "path", "old_string", "new_string")
+	} else {
+		missing = missingBatchEditFields(fields, "id", "old_source", "new_source")
+	}
+	if len(missing) > 0 {
+		return "", fmt.Errorf("incomplete %s shape (missing: %s)", kind, strings.Join(missing, ", "))
+	}
+	return kind, nil
+}
+
 // parseBatchEdits accepts the `edits` argument as either a structured JSON
 // array (the typed-schema path) or a JSON-encoded string of the same array
-// (the legacy path), and decodes it into batch edit items.
+// (the legacy path). It validates every item's discriminator and complete field
+// set before returning anything to the transaction layer.
 func parseBatchEdits(raw any) ([]batchEditItem, error) {
 	var data []byte
 	switch v := raw.(type) {
@@ -3786,11 +3859,44 @@ func parseBatchEdits(raw any) ([]batchEditItem, error) {
 		}
 		data = b
 	}
-	var edits []batchEditItem
-	if err := json.Unmarshal(data, &edits); err != nil {
+
+	var rawItems []json.RawMessage
+	if err := json.Unmarshal(data, &rawItems); err != nil {
 		return nil, fmt.Errorf("invalid edits JSON: %v", err)
 	}
+	edits := make([]batchEditItem, 0, len(rawItems))
+	for i, rawItem := range rawItems {
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(rawItem, &fields); err != nil {
+			return nil, &batchEditArgumentError{index: i, reason: "item must be an object: " + err.Error()}
+		}
+		var edit batchEditItem
+		if err := json.Unmarshal(rawItem, &edit); err != nil {
+			return nil, &batchEditArgumentError{index: i, reason: "invalid item fields: " + err.Error()}
+		}
+		kind, err := classifyBatchEditItem(fields, edit.Op)
+		if err != nil {
+			return nil, &batchEditArgumentError{index: i, reason: err.Error()}
+		}
+		edit.Op = kind
+		edits = append(edits, edit)
+	}
 	return edits, nil
+}
+
+func batchEditInvalidArgumentResult(err error) *mcp.CallToolResult {
+	data := map[string]any{
+		"accepted_values": []string{"edit_file", "edit_symbol"},
+		"accepted_shapes": batchEditAcceptedShapes[:],
+	}
+	if itemErr, ok := err.(*batchEditArgumentError); ok {
+		data["item_index"] = itemErr.index
+	}
+	return NewStructuredErrorResult(StructuredError{
+		ErrorCode: ErrCodeInvalidArgument,
+		Message:   err.Error(),
+		Data:      data,
+	})
 }
 
 func (s *Server) handleBatchEdit(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {


### PR DESCRIPTION
Closes #566.

## What changed

- validate every `batch_edit` item from its raw JSON keys before transaction admission
- reject unknown `op` values plus mixed, missing, and incomplete field sets with structured `invalid_argument` details
- report the original `edits[index]`, accepted discriminator values, and both accepted item shapes
- infer an omitted `op` only for a complete, unambiguous legacy file or symbol shape, and align the advertised schema with that compatibility path
- keep the transaction planner fail-closed for any internal caller that bypasses request decoding

## Before / after

Before the fix, the fail-first coverage showed that an explicit `op: "replace_file"` reached normal transaction handling instead of returning a tool error, mixed/incomplete items decoded successfully, and complete legacy file items were not normalized.

After the fix, discriminator validation completes for the entire array before a transaction is admitted. A malformed later item therefore cannot allow an earlier valid item to write. Existing transaction preflight tests continue to assert `disk_status: "unchanged"` / zero writes.

## Tests

- `go test ./internal/mcp -run "Test(ParseBatchEdits|BatchEditUnknownDiscriminator|FacadeEditBatch|AtomicBatchPreflightFailureWritesNothing|BatchEditPreflightsAllItemsBeforeFirstWrite)" -count=1`
- `go vet ./internal/mcp`
- `git diff --check`

`go test ./internal/mcp -count=1` was also run on Windows. The new/focused tests pass, while the package-wide run retains unrelated platform/parser baseline failures (for example POSIX file-URI expectations, symlink privilege, mode preservation, and existing typed-anchor fixtures). `golangci-lint run` could not load packages in this Windows worktree and reported `no go files to analyze`; CI remains the authoritative Linux lint run.