### PR TITLE
fix(search): stop the rerank tokenizer panicking on trailing multi-byte uppercase runes

### DIFF
--- a/internal/search/rerank/tokens.go
+++ b/internal/search/rerank/tokens.go
@@ -3,6 +3,7 @@ package rerank
 import (
 	"strings"
 	"unicode"
+	"unicode/utf8"
 )
 
 // tokenize lowercases and splits a string on non-alphanumeric and
@@ -45,9 +46,9 @@ func tokenize(s string) []string {
 				// SCREAMING → Camel split: keep the last upper as
 				// the start of the next token: HTTPHeader → HTTP +
 				// Header.
-				if unicode.IsUpper(r) && unicode.IsUpper(prev) && i+1 < len(s) {
-					next := []rune(s[i:])[1]
-					if unicode.IsLower(next) {
+				if unicode.IsUpper(r) && unicode.IsUpper(prev) {
+					next, size := utf8.DecodeRuneInString(s[i+utf8.RuneLen(r):])
+					if size > 0 && unicode.IsLower(next) {
 						flush()
 					}
 				}

--- a/internal/search/rerank/tokens_test.go
+++ b/internal/search/rerank/tokens_test.go
@@ -1,0 +1,33 @@
+package rerank
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTokenize(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"ParseHTTPHeader", []string{"parse", "http", "header"}},
+		{"validate_user_token", []string{"validate", "user", "token"}},
+		{"HTTPHeader", []string{"http", "header"}},
+		{"простой текст", []string{"простой", "текст"}},
+		// A word ending in consecutive uppercase runes where the last
+		// one is multi-byte used to panic with "index out of range [1]
+		// with length 1": the lookahead guard compared byte offsets, so
+		// []rune(s[i:]) could hold a single rune.
+		{"ТЕКСТ", []string{"текст"}},
+		{"ПРОСТОЙ ТЕКСТ", []string{"простой", "текст"}},
+		{"CAFÉ", []string{"café"}},
+		// SCREAMING → Camel split still works across a multi-byte run.
+		{"ЖКХStatus", []string{"жкх", "status"}},
+	}
+	for _, tc := range cases {
+		if got := tokenize(tc.in); !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("tokenize(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

A community user reported `explore` failing with:

```
tool "explore" internal error: runtime error: index out of range [1] with length 1
```

for the plain-text query `простой текст` on v0.63.2, and read it as a corrupted index. The index was fine — this is a per-request panic in the rerank tokenizer, caught by the tool firewall.

## Root cause

`tokenize`'s SCREAMING→Camel lookahead in `internal/search/rerank/tokens.go` guarded with `i+1 < len(s)` — a **byte** comparison (`i` comes from `range s`) — before reading `[]rune(s[i:])[1]`. When a word ends in consecutive uppercase letters whose last rune is multi-byte (`ТЕКСТ`, `ПРОСТОЙ`, `CAFÉ`), the byte guard passes but the suffix decodes to a single rune, so the index panics with exactly the reported message.

The query itself was lowercase and harmless: `rerank.Tokenize` also runs over **retrieved candidate text**, so any repo containing all-caps non-ASCII words (Russian docs/strings in this case) trips it. Corpus-dependent, which is why it never reproduced on ASCII-only codebases.

## Fix

Decode the lookahead rune with `utf8.DecodeRuneInString(s[i+utf8.RuneLen(r):])` instead of materialising the suffix as a rune slice. This also drops the O(n) allocation per boundary check.

## Tests

New `tokens_test.go`: the three panic inputs, the split-across-multibyte case (`ЖКХStatus` → `жкх`, `status`), and the existing ASCII behaviors (`ParseHTTPHeader`, `validate_user_token`, `HTTPHeader`). `go test -race ./internal/search/rerank/` and `golangci-lint` are green.