### PR TITLE
fix(mcp): let explicit file reads escape stale localization state

### DIFF
--- a/internal/hooks/explicit_file_policy_test.go
+++ b/internal/hooks/explicit_file_policy_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestRulePreambleRoutesExplicitFileReadsDirectly(t *testing.T) {
 	got := rulePreamble()
-	direct := `read(operation:"file", target:{file:"<path>"})`
+	direct := `read(operation:"file", target:{file:"<path>"}, options:{new_user_task:true})`
 	localize := "`mcp__gortex__explore` (never a bare `explore`) with `operation:\"localize\"`"
 
 	if !strings.Contains(got, "explicitly named file") || !strings.Contains(got, direct) {

--- a/internal/hooks/sessionstart.go
+++ b/internal/hooks/sessionstart.go
@@ -418,7 +418,7 @@ func hasPathPrefix(path, prefix string) bool {
 // — this is just enough that an agent in the very first turn knows
 // to reach for graph tools first.
 func rulePreamble() string {
-	return "**Rule:** For an explicitly named file that the user asks you to read, review, or summarize, call `read(operation:\"file\", target:{file:\"<path>\"})` directly; do not start localization. " +
+	return "**Rule:** For an explicitly named file that the user asks you to read, review, or summarize, on the first direct file read caused by a new user request call `read(operation:\"file\", target:{file:\"<path>\"}, options:{new_user_task:true})`; do not start localization. " +
 		"Otherwise choose by requested output: when the requested output is files, symbols, or supporting evidence, call the mounted tool `mcp__gortex__explore` (never a bare `explore`) with `operation:\"localize\"`; it returns terminal evidence. " +
 		"Its localize task may be concise, but must faithfully preserve the issue title and every user-supplied technical identifier, path, literal, error, symptom, and stated hypothesis; never invent a causal hypothesis. " +
 		"A clearly framed problem section may be restored exactly at execution only for a clearly lossy model task, so evidence can reflect details beyond a concise tool argument. " +

--- a/internal/hooks/sessionstart_test.go
+++ b/internal/hooks/sessionstart_test.go
@@ -28,6 +28,7 @@ func TestRulePreambleRoutesByOutcomeAndPreservesExactIdentifiers(t *testing.T) {
 	briefing := rulePreamble()
 	for _, required := range []string{
 		"For an explicitly named file",
+		"options:{new_user_task:true}",
 		"choose by requested output",
 		"requested output is files, symbols, or supporting evidence",
 		"localize task may be concise",

--- a/internal/mcp/explicit_file_policy_test.go
+++ b/internal/mcp/explicit_file_policy_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestCodingAgentInstructionsRouteExplicitFileReadsDirectly(t *testing.T) {
-	direct := `read(operation:"file", target:{file:"<path>"})`
+	direct := `read(operation:"file", target:{file:"<path>"}, options:{new_user_task:true})`
 	localize := `explore(operation:"localize")`
 	directAt := strings.Index(codingAgentInstructions, direct)
 	localizeAt := strings.Index(codingAgentInstructions, localize)

--- a/internal/mcp/facade_schema.go
+++ b/internal/mcp/facade_schema.go
@@ -130,6 +130,12 @@ func facadePublicCapabilitySchema(
 		}
 		addCandidate(facadePublicPath{field: field}, value, true)
 	}
+	// new_user_task is a facade control field, not a legacy read_file
+	// argument. Keep the exact operation schema aligned with tools/list even
+	// though the legacy schema and minimal request example cannot discover it.
+	if spec.Facade == "read" && spec.Operation == "file" {
+		addCandidate(facadePublicPath{container: "options", field: "new_user_task"}, false, true)
+	}
 
 	// Stable documented top-level aliases are available only when the actual
 	// normalizer lowers them into a field captured by this operation.

--- a/internal/mcp/facade_tools.go
+++ b/internal/mcp/facade_tools.go
@@ -118,7 +118,14 @@ func facadeToolDefinitionWithOperations(name string, operations []string) mcpgo.
 	case "search":
 		opts = []mcpgo.ToolOption{operation, mcpgo.WithString("query"), options, output}
 	case "read":
-		opts = []mcpgo.ToolOption{operation, target, freeObject("context", "Read window or source-context controls."), options, output}
+		opts = []mcpgo.ToolOption{
+			operation, target, freeObject("context", "Read window or source-context controls."),
+			mcpgo.WithObject("options",
+				mcpgo.Description("Set new_user_task=true only on the first read.file call caused by a new user request. Never set it to retry, continue the current request, or bypass answer_ready."),
+				mcpgo.AdditionalProperties(true),
+			),
+			output,
+		}
 	case "relations", "trace":
 		opts = []mcpgo.ToolOption{operation, freeObject("target", "Primary file or symbol target."), freeObject("to", "Optional destination target."), options, output}
 	case "analyze":
@@ -174,6 +181,16 @@ func facadeToolDefinitionWithOperations(name string, operations []string) mcpgo.
 	opts = append(opts, output)
 	opts = append([]mcpgo.ToolOption{mcpgo.WithDescription(desc), annotation}, opts...)
 	tool := mcpgo.NewTool(name, opts...)
+	if name == "read" {
+		if optionsSchema, ok := tool.InputSchema.Properties["options"].(map[string]any); ok {
+			optionsSchema["properties"] = map[string]any{
+				"new_user_task": map[string]any{
+					"type":        "boolean",
+					"description": "True only for the first read.file call caused by a new user request.",
+				},
+			}
+		}
+	}
 	if targetSchema, ok := tool.InputSchema.Properties["target"].(map[string]any); ok {
 		// The public facade validator already requires one selector. Encode that
 		// contract in tools/list as well so a caller can construct its first read
@@ -417,13 +434,15 @@ func localizationReadStructuredPayload(content []mcpgo.Content, completion local
 }
 
 func parseLocalizationNewUserBoundary(facade, operation string, arguments map[string]any) (bool, *mcpgo.CallToolResult) {
+	boundaryAllowed := (facade == "explore" && (operation == "task" || operation == "localize")) ||
+		(facade == "read" && operation == "file")
 	rawOptions, present := arguments["options"]
 	if !present || rawOptions == nil {
 		return false, nil
 	}
 	options, ok := rawOptions.(map[string]any)
 	if !ok {
-		if facade != "explore" || (operation != "task" && operation != "localize") {
+		if !boundaryAllowed {
 			return false, nil
 		}
 		return false, NewStructuredErrorResult(StructuredError{
@@ -444,10 +463,10 @@ func parseLocalizationNewUserBoundary(facade, operation string, arguments map[st
 			Data:      map[string]any{"field": "options.new_user_task", "operation": operation},
 		})
 	}
-	if facade != "explore" || (operation != "task" && operation != "localize") {
+	if !boundaryAllowed {
 		return false, NewStructuredErrorResult(StructuredError{
 			ErrorCode: ErrCodeInvalidArgument,
-			Message:   "options.new_user_task is valid only on the first explore.task or explore.localize call of a new user request",
+			Message:   "options.new_user_task is valid only on the first explore.task, explore.localize, or read.file call of a new user request",
 			Data:      map[string]any{"field": "options.new_user_task", "facade": facade, "operation": operation},
 		})
 	}
@@ -482,12 +501,14 @@ func (s *Server) handleFacade(ctx context.Context, facade string, req mcpgo.Call
 		return invalidBoundary, nil
 	}
 	newUserExploreFlow := facade == "explore" && newUserTask && (operation == "task" || operation == "localize")
+	newUserReadFlow := facade == "read" && operation == "file" && newUserTask
+	newUserBoundaryFlow := newUserExploreFlow || newUserReadFlow
 	// Parse enough of an explicit new-task boundary to validate it, then apply
 	// the cheap terminal gate before operation lookup, shorthand resolution,
 	// overlay construction, and legacy dispatch. Non-navigation facades never
 	// enter this gate.
 	recoveryGeneration := uint64(0)
-	if !newUserExploreFlow {
+	if !newUserBoundaryFlow {
 		var blocked *mcpgo.CallToolResult
 		blocked, recoveryGeneration = terminal.interceptAnswerReady(facade, operation, req.GetArguments())
 		if blocked != nil {
@@ -546,23 +567,28 @@ func (s *Server) handleFacade(ctx context.Context, facade string, req mcpgo.Call
 		publishLocalizationAuthReceipt(localizationAuthToken, invalid)
 		return invalid, nil
 	}
-	// Every localize call and an explicit new-user task call starts a
-	// transactional reservation. Task text never implies a boundary. A task
-	// boundary stages inactive navigation so later diagnosis calls are admitted
-	// only after the first explore call succeeds.
-	transactionalExploreFlow := freshLocalizeFlow || newUserExploreFlow
-	localizeReservation := uint64(0)
-	localizeFinished := false
-	if transactionalExploreFlow {
+	// Every localize call and explicit new-user task boundary starts a
+	// transactional reservation. Task text and directed-read arguments never
+	// imply a boundary on their own. A diagnosis or read boundary stages inactive
+	// navigation and replaces the prior contract only after the first call succeeds.
+	transactionalBoundaryFlow := freshLocalizeFlow || newUserBoundaryFlow
+	boundaryTask := req.GetString("task", "")
+	if newUserReadFlow {
+		target, _ := input["target"].(map[string]any)
+		boundaryTask = "read.file " + strings.TrimSpace(fmt.Sprint(target["file"]))
+	}
+	taskBoundaryReservation := uint64(0)
+	taskBoundaryFinished := false
+	if transactionalBoundaryFlow {
 		var blocked *mcpgo.CallToolResult
-		localizeReservation, blocked = terminal.beginLocalize(req.GetString("task", ""), newUserTask)
+		taskBoundaryReservation, blocked = terminal.beginLocalize(boundaryTask, newUserTask)
 		if blocked != nil {
 			s.recordFacadeTelemetry(facade, operation, facadeOutcomeBlocked, time.Since(started))
 			publishLocalizationAuthReceipt(localizationAuthToken, blocked)
 			return blocked, nil
 		}
 		if !freshLocalizeFlow {
-			terminal.keepOpenForTask(req.GetString("task", ""))
+			terminal.keepOpenForTask(boundaryTask)
 		}
 	}
 	localizationReadReservation := uint64(0)
@@ -571,12 +597,12 @@ func (s *Server) handleFacade(ctx context.Context, facade string, req mcpgo.Call
 		if localizationReadReservation != 0 {
 			terminal.finishReservedReadTokenWithDigest(localizationReadReservation, localizationReadSucceeded, nil, false)
 		}
-		if localizeReservation != 0 && !localizeFinished {
+		if taskBoundaryReservation != 0 && !taskBoundaryFinished {
 			// Errors and panics roll back to the previous completion contract.
-			terminal.finishLocalize(localizeReservation, false)
+			terminal.finishLocalize(taskBoundaryReservation, false)
 		}
 	}()
-	if !transactionalExploreFlow {
+	if !transactionalBoundaryFlow {
 		blocked, reservation := terminal.authorizeWithToken(facade, operation, req.GetArguments())
 		if blocked != nil {
 			s.recordFacadeTelemetry(facade, operation, facadeOutcomeBlocked, time.Since(started))
@@ -611,9 +637,9 @@ func (s *Server) handleFacade(ctx context.Context, facade string, req mcpgo.Call
 			result, err = decorateExhaustedLocalizationReadFailure(result, err, completion, spec)
 		}
 	}
-	if transactionalExploreFlow {
-		terminal.finishLocalize(localizeReservation, succeeded)
-		localizeFinished = true
+	if transactionalBoundaryFlow {
+		terminal.finishLocalize(taskBoundaryReservation, succeeded)
+		taskBoundaryFinished = true
 	}
 	publishLocalizationAuthReceipt(localizationAuthToken, result)
 	return result, err

--- a/internal/mcp/facade_tools_test.go
+++ b/internal/mcp/facade_tools_test.go
@@ -123,19 +123,26 @@ func TestCompactToolsListIsStaticAndBudgeted(t *testing.T) {
 	require.NoError(t, json.Unmarshal(raw, &parsed))
 	require.Len(t, parsed.Result.Tools, 21)
 	foundExplore := false
+	foundRead := false
 	for _, tool := range parsed.Result.Tools {
 		require.True(t, isFacadeToolName(tool.Name), "legacy tool leaked into facade-v1: %s", tool.Name)
-		if tool.Name != "explore" {
-			continue
+		switch tool.Name {
+		case "explore":
+			foundExplore = true
+			operation := tool.InputSchema.Properties["operation"].(map[string]any)
+			require.Contains(t, operation["enum"], "localize")
+			require.Contains(t, operation["enum"], "task")
+			require.Contains(t, operation["description"], "Use localize")
+			require.Contains(t, operation["description"], "Use task only")
+		case "read":
+			foundRead = true
+			options := tool.InputSchema.Properties["options"].(map[string]any)
+			require.Contains(t, options["description"], "new_user_task=true")
+			require.Contains(t, options["description"], "read.file")
 		}
-		foundExplore = true
-		operation := tool.InputSchema.Properties["operation"].(map[string]any)
-		require.Contains(t, operation["enum"], "localize")
-		require.Contains(t, operation["enum"], "task")
-		require.Contains(t, operation["description"], "Use localize")
-		require.Contains(t, operation["description"], "Use task only")
 	}
 	require.True(t, foundExplore, "runtime tools/list omitted explore")
+	require.True(t, foundRead, "runtime tools/list omitted read")
 }
 
 func TestFacadeSchemasAcceptUniversalCLIOutput(t *testing.T) {
@@ -532,11 +539,11 @@ func TestCodingAgentInstructionsStayTerseAndDirective(t *testing.T) {
 	srv := &Server{}
 	got := srv.stateAwareInstructionsForClient("", "generic-harness")
 	require.Equal(t, codingAgentInstructions, got)
-	require.Less(t, len(got), 500)
+	require.Less(t, len(got), 550)
 	for _, implementationTerm := range []string{"codex", "facade", "version", "preset", "tools/list", "tools_search"} {
 		require.NotContains(t, strings.ToLower(got), implementationTerm)
 	}
-	for _, directive := range []string{"MUST use Gortex MCP", "Explicit file read/review", `read(operation:"file", target:{file:"<path>"})`, "do not localize", "Unknown file/symbol/evidence", `explore(operation:"localize")`, "completion.required_action", "stop at answer_ready", "Diagnosis/change", `explore(operation:"task")`, `change(operation:"impact")`, "Mutate only via edit/refactor", `change(operation:"detect")`, "capabilities only if fields unknown"} {
+	for _, directive := range []string{"MUST use Gortex MCP", "First explicit-file read per new user request", `read(operation:"file", target:{file:"<path>"}, options:{new_user_task:true})`, "do not localize", "Unknown file/symbol/evidence", `explore(operation:"localize")`, "completion.required_action", "stop at answer_ready", "Diagnosis/change", `explore(operation:"task")`, `change(operation:"impact")`, "Mutate only via edit/refactor", `change(operation:"detect")`, "capabilities only if fields unknown"} {
 		require.Contains(t, got, directive)
 	}
 }
@@ -1047,7 +1054,14 @@ func TestFacadeCapabilitiesReturnsOperationSchema(t *testing.T) {
 	require.Equal(t, "file", out["operation"])
 	require.Equal(t, true, out["available"])
 	require.NotEmpty(t, out["schema_hash"])
-	require.NotNil(t, out["input_schema"])
+	inputSchema, ok := out["input_schema"].(map[string]any)
+	require.True(t, ok)
+	schemaProperties := inputSchema["properties"].(map[string]any)
+	options := schemaProperties["options"].(map[string]any)
+	optionProperties := options["properties"].(map[string]any)
+	boundary := optionProperties["new_user_task"].(map[string]any)
+	require.Equal(t, "boolean", boundary["type"])
+	require.Contains(t, boundary["description"], "first read.file")
 	shape, ok := out["request_shape"].(map[string]any)
 	require.True(t, ok)
 	require.Equal(t, "read", shape["tool"])
@@ -1469,6 +1483,11 @@ func TestFacadeReadSchemaAdvertisesExactlyOneTargetSelector(t *testing.T) {
 	require.Equal(t, 1, target["maxProperties"])
 	require.Contains(t, target["description"], "exactly one selector")
 	require.Contains(t, target["description"], "symbol for one source symbol")
+	options := tool.InputSchema.Properties["options"].(map[string]any)
+	properties := options["properties"].(map[string]any)
+	boundary := properties["new_user_task"].(map[string]any)
+	require.Equal(t, "boolean", boundary["type"])
+	require.Contains(t, boundary["description"], "first read.file")
 }
 
 func TestFacadeReadSelectorCardinalityDefaultsAndAliases(t *testing.T) {

--- a/internal/mcp/localization_terminal.go
+++ b/internal/mcp/localization_terminal.go
@@ -1346,8 +1346,9 @@ func localizationRecoveryRejectedResult(completion localizationCompletion, facad
 // An inactive session admits its first localization without a boundary flag.
 // Once a contract exists, only the first explore call for a genuinely new user
 // request may cross it, and the caller must say so explicitly. Localize stages
-// its returned completion; task stages inactive navigation. The old contract
-// remains live until finishLocalize commits the successful replacement.
+// its returned completion; task and explicit direct-read boundaries stage
+// inactive navigation. The old contract remains live until finishLocalize
+// commits the successful replacement.
 func (s *localizationTerminalState) beginLocalize(task string, newUserTask bool) (uint64, *mcpgo.CallToolResult) {
 	if s == nil {
 		return 0, nil

--- a/internal/mcp/localization_terminal_test.go
+++ b/internal/mcp/localization_terminal_test.go
@@ -85,13 +85,23 @@ func TestHandleFacadeValidatesMalformedExplicitNewUserBoundary(t *testing.T) {
 		{
 			name: "boundary on unsupported explore operation",
 			args: map[string]any{"operation": "outline", "task": "Locate Bar", "options": map[string]any{"new_user_task": true}},
-			want: "valid only on the first explore.task or explore.localize",
+			want: "valid only on the first explore.task, explore.localize, or read.file",
+		},
+		{
+			name:   "boundary on unsupported read operation",
+			facade: "read",
+			args: map[string]any{
+				"operation": "source",
+				"target":    map[string]any{"symbol": "pkg/a.go::A"},
+				"options":   map[string]any{"new_user_task": true},
+			},
+			want: "valid only on the first explore.task, explore.localize, or read.file",
 		},
 		{
 			name:   "boundary on another facade",
 			facade: "search",
 			args:   map[string]any{"operation": "symbols", "query": "Run", "options": map[string]any{"new_user_task": true}},
-			want:   "valid only on the first explore.task or explore.localize",
+			want:   "valid only on the first explore.task, explore.localize, or read.file",
 		},
 		{
 			name: "boundary without task",
@@ -627,6 +637,129 @@ func TestHandleFacadeExplicitNewUserTaskCrossesTerminalBoundary(t *testing.T) {
 	if state != localizationStateInactive || digest != nil || completion.digest != nil || completion.FinalResponse != "" {
 		t.Fatalf("new user task leaked prior terminal replay: state=%q digest=%#v completion=%#v", state, digest, completion)
 	}
+}
+
+func TestHandleFacadeExplicitNewUserReadCrossesTerminalBoundary(t *testing.T) {
+	registry := newFacadeRegistry()
+	calls := 0
+	registry.capture(mcpgo.NewTool("read_file", mcpgo.WithString("path", mcpgo.Required())), func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		calls++
+		if got := req.GetString("path", ""); got != "specs/localization-close-the-grep-gap.md" {
+			t.Fatalf("read path = %q", got)
+		}
+		return mcpgo.NewToolResultText("spec contents"), nil
+	})
+	server := &Server{facades: registry, localization: newLocalizationTerminalState(), sessions: newSessionMap()}
+	ctx := WithSessionID(context.Background(), "explicit-read-boundary")
+	terminal := server.localizationFor(ctx)
+	prior := newLocalizationCompletion(true, "")
+	prior.digest = testEvidenceDigest()
+	terminal.armForTask(prior, "Locate Foo")
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Name = "read"
+	req.Params.Arguments = map[string]any{
+		"operation": "file",
+		"target":    map[string]any{"file": "specs/localization-close-the-grep-gap.md"},
+	}
+	replayed, err := server.handleFacade(ctx, "read", req)
+	if err != nil || calls != 0 {
+		t.Fatalf("ordinary read escaped terminal state: result=%#v err=%v calls=%d", replayed, err, calls)
+	}
+	requireLocalizationTerminalReplay(t, replayed, "read", "file")
+
+	req.Params.Arguments.(map[string]any)["options"] = map[string]any{"new_user_task": true}
+	result, err := server.handleFacade(ctx, "read", req)
+	if err != nil || result == nil || result.IsError || calls != 1 {
+		t.Fatalf("explicit read boundary = (%#v, %v), calls=%d", result, err, calls)
+	}
+	if text, _ := singleTextContent(result); text != "spec contents" {
+		t.Fatalf("explicit read boundary text = %q", text)
+	}
+	if blocked := terminal.block("search", "symbols", nil); blocked != nil {
+		t.Fatalf("successful direct read retained prior terminal state: %#v", blocked)
+	}
+	terminal.mu.Lock()
+	fingerprint := terminal.taskFingerprint
+	state := terminal.state
+	digest := terminal.digest
+	terminal.mu.Unlock()
+	if fingerprint != "read.file specs/localization-close-the-grep-gap.md" || state != localizationStateInactive || digest != nil {
+		t.Fatalf("direct read boundary state = fingerprint %q, state %q, digest %#v", fingerprint, state, digest)
+	}
+}
+
+func TestHandleFacadeNewUserReadValidatesBeforeTerminalReplay(t *testing.T) {
+	registry := newFacadeRegistry()
+	calls := 0
+	registry.capture(mcpgo.NewTool("read_file"), func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		calls++
+		return mcpgo.NewToolResultText("unexpected"), nil
+	})
+	server := &Server{facades: registry, localization: newLocalizationTerminalState(), sessions: newSessionMap()}
+	ctx := WithSessionID(context.Background(), "invalid-read-boundary")
+	terminal := server.localizationFor(ctx)
+	prior := newLocalizationCompletion(true, "")
+	prior.digest = testEvidenceDigest()
+	terminal.armForTask(prior, "Locate Foo")
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Name = "read"
+	req.Params.Arguments = map[string]any{
+		"operation": "file",
+		"target": map[string]any{
+			"file": "specs/localization-close-the-grep-gap.md",
+			"repo": "gortex-bench",
+		},
+		"options": map[string]any{"new_user_task": true},
+	}
+	result, err := server.handleFacade(ctx, "read", req)
+	if err != nil || result == nil || !result.IsError {
+		t.Fatalf("invalid direct read boundary = (%#v, %v), want selector error", result, err)
+	}
+	text, _ := singleTextContent(result)
+	if !strings.Contains(text, "target must contain exactly one selector") || strings.Contains(text, "LOCALIZATION:") {
+		t.Fatalf("invalid direct read boundary text = %q", text)
+	}
+	if calls != 0 {
+		t.Fatalf("invalid direct read dispatched %d legacy call(s)", calls)
+	}
+	if blocked := terminal.block("search", "symbols", nil); blocked == nil {
+		t.Fatal("invalid direct read boundary cleared the prior terminal contract")
+	}
+}
+
+func TestHandleFacadeFailedNewUserReadRollsBackTerminalState(t *testing.T) {
+	registry := newFacadeRegistry()
+	calls := 0
+	registry.capture(mcpgo.NewTool("read_file"), func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		calls++
+		return mcpgo.NewToolResultError("read failed"), nil
+	})
+	server := &Server{facades: registry, localization: newLocalizationTerminalState(), sessions: newSessionMap()}
+	ctx := WithSessionID(context.Background(), "failed-read-boundary")
+	terminal := server.localizationFor(ctx)
+	prior := newLocalizationCompletion(true, "")
+	prior.digest = testEvidenceDigest()
+	terminal.armForTask(prior, "Locate Foo")
+
+	req := mcpgo.CallToolRequest{}
+	req.Params.Name = "read"
+	req.Params.Arguments = map[string]any{
+		"operation": "file",
+		"target":    map[string]any{"file": "missing.md"},
+		"options":   map[string]any{"new_user_task": true},
+	}
+	result, err := server.handleFacade(ctx, "read", req)
+	if err != nil || result == nil || !result.IsError || calls != 1 {
+		t.Fatalf("failed direct read boundary = (%#v, %v), calls=%d", result, err, calls)
+	}
+	delete(req.Params.Arguments.(map[string]any), "options")
+	replayed, err := server.handleFacade(ctx, "read", req)
+	if err != nil || calls != 1 {
+		t.Fatalf("failed boundary did not restore terminal state: result=%#v err=%v calls=%d", replayed, err, calls)
+	}
+	requireLocalizationTerminalReplay(t, replayed, "read", "file")
 }
 
 func TestHandleFacadeExactReadCommitsOnlyOnSuccess(t *testing.T) {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1303,7 +1303,7 @@ const serverInstructions = `Gortex is a code-intelligence graph server — it in
 // codingAgentInstructions is intentionally terse because some MCP hosts repeat
 // initialize instructions beside every rendered tool. It describes what to do,
 // not how the server versions or implements its tool surface.
-const codingAgentInstructions = `MUST use Gortex MCP. Explicit file read/review: read(operation:"file", target:{file:"<path>"}); do not localize. Unknown file/symbol/evidence: explore(operation:"localize"); obey completion.required_action; stop at answer_ready. Diagnosis/change: explore(operation:"task"); one follow-up max. Pre-edit: change(operation:"impact"); signature: change(operation:"verify"). Mutate only via edit/refactor. Post-edit: change(operation:"detect"), tests/guards/contract. capabilities only if fields unknown.`
+const codingAgentInstructions = `MUST use Gortex MCP. First explicit-file read per new user request: read(operation:"file", target:{file:"<path>"}, options:{new_user_task:true}); do not localize. Unknown file/symbol/evidence: explore(operation:"localize"); obey completion.required_action; stop at answer_ready. Diagnosis/change: explore(operation:"task"); 1 follow-up. Pre-edit: change(operation:"impact"); signature: change(operation:"verify"). Mutate only via edit/refactor. Post-edit: change(operation:"detect"), tests/guards/contract. capabilities only if fields unknown.`
 
 // ServerInstructionsUntracked is the inactive-state `instructions` variant
 // returned when a session's cwd is not covered by any tracked repo. Rather than

--- a/internal/profiles/bodies.go
+++ b/internal/profiles/bodies.go
@@ -39,7 +39,7 @@ A Gortex daemon is configured machine-wide via the §gortex§ MCP server. Whenev
 // sectionExploreOpener positions the one-shot localization verb as
 // the opening move (standard rendering; the lean profile carries its
 // own condensed line).
-var sectionExploreOpener = bt(`For an explicitly named file to read/review/summarize, call §read(operation:"file", target:{file:"<path>"})§ directly; do not start localization. When the file, symbol, or evidence must be discovered, call §explore(operation:"localize")§ and obey §completion.required_action§; after §answer_ready§ answer from §completion.final_response§ and make no further tool calls. For diagnosis or requested changes, call §explore(operation:"task")§, make at most one focused follow-up, then proceed to impact, edit, and test.
+var sectionExploreOpener = bt(`For an explicitly named file to read/review/summarize, on the first direct file read caused by a new user request call §read(operation:"file", target:{file:"<path>"}, options:{new_user_task:true})§; do not start localization. When the file, symbol, or evidence must be discovered, call §explore(operation:"localize")§ and obey §completion.required_action§; after §answer_ready§ answer from §completion.final_response§ and make no further tool calls. For diagnosis or requested changes, call §explore(operation:"task")§, make at most one focused follow-up, then proceed to impact, edit, and test.
 
 `)
 
@@ -48,7 +48,7 @@ var sectionExploreOpener = bt(`For an explicitly named file to read/review/summa
 // can actually call; exact operation schemas remain on demand.
 var sectionCompactWorkflow = bt(`For every coding task:
 
-1. For an explicitly named file to read/review/summarize, call §read(operation:"file", target:{file:"<path>"})§ directly; do not start localization. When the file, symbol, or evidence must be discovered, call §explore(operation:"localize")§ and obey §completion.required_action§; after §answer_ready§, answer from §completion.final_response§ and stop. For diagnosis or modification, call §explore(operation:"task")§.
+1. Named-file read/review/summarize: first new-task call §read(operation:"file", target:{file:"<path>"}, options:{new_user_task:true})§; do not localize. When the file, symbol, or evidence must be discovered, call §explore(operation:"localize")§ and obey §completion.required_action§; after §answer_ready§, answer from §completion.final_response§ and stop. For diagnosis or modification, call §explore(operation:"task")§.
 2. In a diagnosis/change flow, make at most one follow-up call on one unresolved symbol with §search§, §read§, §relations§, or §trace§, then continue to step 3. Never reopen indexed source with Read/Grep/Glob or shell equivalents.
 3. Before mutation, call §change(operation:"impact")§; for a signature change, also call §change(operation:"verify")§ with the proposed signature. Mutate only with §edit§ or §refactor§. After mutation, call §change(operation:"detect")§, then use its symbol IDs with §change(operation:"tests")§, §change(operation:"guards")§, and §change(operation:"contract")§.
 4. Call §capabilities§ only when you need the exact fields for an operation.
@@ -65,7 +65,7 @@ var sectionCompactMemory = bt(`Use §recall§ before revisiting prior work. Call
 
 var sectionFullRuleTable = bt(`| Instead of...                       | Use...                                   |
 |-------------------------------------|------------------------------------------|
-| Explicitly named file to read / review / summarize | §read(operation:"file", target:{file:"<path>"})§ directly |
+| Explicitly named file to read / review / summarize | First new-task read: §read(operation:"file", target:{file:"<path>"}, options:{new_user_task:true})§ |
 | Unknown file / symbol / evidence / "where is X" | §explore(operation:"localize")§; obey §completion§ |
 | Diagnosing or changing code           | §explore(operation:"task")§, then impact/edit/test |
 | §Grep§ / §grep§ / §rg§ for a symbol | §search_symbols§ (BM25 + camelCase-aware) |

--- a/internal/profiles/explicit_file_policy_test.go
+++ b/internal/profiles/explicit_file_policy_test.go
@@ -11,7 +11,7 @@ func TestPolicyBodiesRouteExplicitFileReadsDirectly(t *testing.T) {
 		"compact workflow": sectionCompactWorkflow,
 		"full rule table":  sectionFullRuleTable,
 	}
-	direct := `read(operation:"file", target:{file:"<path>"})`
+	direct := `read(operation:"file", target:{file:"<path>"}, options:{new_user_task:true})`
 	localize := `explore(operation:"localize")`
 
 	for name, body := range bodies {


### PR DESCRIPTION
## Summary

- Add `read.file` support for `options.new_user_task` to cross a stale localization `answer_ready` boundary.
- Reset localization state only after a successful read; failed reads preserve the prior terminal result.
- Preserve existing same-task terminal replay when the option is absent.
- Align MCP schemas, capability metadata, and agent guidance with the new boundary behavior.
- Add regression coverage for successful resets, transactional failure handling, replay behavior, and invalid multi-selector targets.

## Verification

Passed:

- `go test ./internal/mcp ./internal/hooks ./internal/profiles`
- Focused race-enabled tests
- `git diff --check`

`go test ./...` still encounters unrelated environment failures involving live-daemon writes to the user query-log cache and nested `.claude/worktrees` crossing the graph fence.
