### PR TITLE
fix(cpp): emit nested qualified call edges

### DIFF
--- a/internal/parser/languages/cpp.go
+++ b/internal/parser/languages/cpp.go
@@ -88,19 +88,12 @@ const qCppAll = `
       field: (template_method
         name: (field_identifier) @callm.method))) @callm.expr
 
-  ; Namespace-qualified free calls. std::move(x), ns::helper() and their
-  ; templated forms parse the callee as a qualified_identifier, which the
-  ; bare-identifier pattern cannot match — so every :: call was dropped
-  ; too, generics or not. Rust already carries the equivalent
-  ; scoped_identifier pattern; the trailing name is what the call names.
+  ; Namespace-qualified free calls. Capture the complete qualified_identifier
+  ; instead of fixing the query to one nesting depth: a::b::c() nests another
+  ; qualified_identifier in its name field, and the trailing identifier is
+  ; recovered structurally in cppQualifiedCallName.
   (call_expression
-    function: (qualified_identifier
-      name: (identifier) @call.name)) @call.expr
-
-  (call_expression
-    function: (qualified_identifier
-      name: (template_function
-        name: (identifier) @call.name))) @call.expr
+    function: (qualified_identifier) @callq.name) @callq.expr
 ]
 `
 
@@ -196,6 +189,18 @@ func (e *CppExtractor) Extract(filePath string, src []byte) (*parser.ExtractionR
 					line:     expr.StartLine + 1,
 					isMember: true,
 					receiver: cppCallReceiverText(expr.Node, src),
+					argTypes: extractCppCallArgTypes(expr.Node, src),
+				})
+
+			case m.Captures["callq.expr"] != nil:
+				expr := m.Captures["callq.expr"]
+				name := cppQualifiedCallName(m.Captures["callq.name"].Node, src)
+				if name == "" {
+					return
+				}
+				calls = append(calls, cppDeferredCall{
+					name:     name,
+					line:     expr.StartLine + 1,
 					argTypes: extractCppCallArgTypes(expr.Node, src),
 				})
 
@@ -686,6 +691,25 @@ func cppInnerDeclarator(decl *sitter.Node) *sitter.Node {
 		}
 	}
 	return nil
+}
+
+// cppQualifiedCallName follows a qualified call's name field until it reaches
+// the trailing identifier. tree-sitter-cpp nests another qualified_identifier
+// there for every additional :: segment; a templated tail adds one
+// template_function wrapper. Unknown shapes return no evidence rather than
+// inventing a callee name.
+func cppQualifiedCallName(node *sitter.Node, src []byte) string {
+	for depth := 0; node != nil && depth < 64; depth++ {
+		switch node.Type() {
+		case "identifier", "field_identifier":
+			return node.Content(src)
+		case "qualified_identifier", "template_function":
+			node = node.ChildByFieldName("name")
+		default:
+			return ""
+		}
+	}
+	return ""
 }
 
 // lastIdentifier extracts the last identifier from a qualified_identifier.

--- a/internal/parser/languages/cpp_generic_call_test.go
+++ b/internal/parser/languages/cpp_generic_call_test.go
@@ -37,6 +37,12 @@ func TestCppExtractor_QualifiedCallEmitsEdge(t *testing.T) {
 	src := []byte(`void run() {
   ns::helper();
   ns::templated<int>();
+  ns::Type::method();
+  ns::Type::templated<int>();
+  a::b::c::function();
+  a::b::c::templated<int>();
+  std::chrono::duration_cast<int>(value);
+  boost::asio::post(ex);
 }
 `)
 	res, err := NewCppExtractor().Extract("demo.cpp", src)
@@ -47,4 +53,16 @@ func TestCppExtractor_QualifiedCallEmitsEdge(t *testing.T) {
 		"the trailing name is what a qualified call names")
 	assert.Contains(t, byLine[3], "unresolved::templated",
 		"a templated qualified call names the same trailing identifier")
+	assert.Contains(t, byLine[4], "unresolved::method",
+		"a three-segment qualified call names its trailing identifier")
+	assert.Contains(t, byLine[5], "unresolved::templated",
+		"a three-segment templated call names its trailing identifier")
+	assert.Contains(t, byLine[6], "unresolved::function",
+		"qualification depth must not cap call extraction")
+	assert.Contains(t, byLine[7], "unresolved::templated",
+		"template extraction must not be capped by qualification depth")
+	assert.Contains(t, byLine[8], "unresolved::duration_cast",
+		"standard-library nested calls must remain visible")
+	assert.Contains(t, byLine[9], "unresolved::post",
+		"library namespace depth must not hide free calls")
 }


### PR DESCRIPTION
## Summary

- capture the complete C++ qualified_identifier instead of matching one fixed nesting depth
- follow qualified_identifier and template_function name fields to recover the trailing callee
- cover depth-2, depth-3, depth-4, templated, std::chrono, and boost::asio call sites

## Testing

- go test ./internal/parser/languages -run Cpp -count=1 -timeout=10m
- go test -race ./internal/parser/languages -run TestCppExtractor focused patterns -count=1 -timeout=10m
- go build ./internal/parser/languages
- git diff --check

## Local Windows baseline

The full languages package remains red only in three existing subprocess extractor assertions. go vet also retains the existing grammar_load_windows.go:33 unsafe.Pointer warning. Neither path is touched by this PR.

Fixes #561