### PR TITLE
fix(mcp): harden unindexed rename recovery

### DIFF
--- a/internal/indexer/extract_source.go
+++ b/internal/indexer/extract_source.go
@@ -14,10 +14,12 @@ import (
 // interactive recovery must not turn one MCP request into an unbounded parse.
 const maxAdHocExtractSourceBytes = 1 << 20 // 1 MiB
 
-// ExtractSource parses caller-owned bytes through the indexer's normal
-// admission, minified-content, timeout, panic-recovery, and optional
-// crash-isolation path without mutating graph state. The caller owns the
-// returned result and must call ReleaseTree when it is no longer needed.
+// ExtractSource parses caller-owned bytes through bounded admission,
+// minified-content, timeout, panic-recovery, and optional crash isolation
+// without mutating graph state. Preparation must preserve raw byte and line
+// coordinates; configured command transforms are refused because they may
+// synthesize declarations that cannot safely anchor an edit of the raw file.
+// The caller owns the result and must call ReleaseTree when finished.
 func (idx *Indexer) ExtractSource(ctx context.Context, filePath string, src []byte) (*parser.ExtractionResult, error) {
 	if idx == nil || idx.registry == nil {
 		return nil, fmt.Errorf("indexer source extraction is unavailable")
@@ -36,7 +38,15 @@ func (idx *Indexer) ExtractSource(ctx context.Context, filePath string, src []by
 		return nil, fmt.Errorf("source exceeds bounded extraction limit (%d bytes)", limit)
 	}
 
-	language, ok := idx.registry.DetectLanguageContent(filePath, src)
+	path := filePath
+	if !filepath.IsAbs(path) && idx.rootPath != "" {
+		path = filepath.Join(idx.rootPath, filepath.FromSlash(filePath))
+	}
+	prepared, err := idx.transforms.prepareCoordinateStable(path, src)
+	if err != nil {
+		return nil, fmt.Errorf("coordinate-stable source preparation: %w", err)
+	}
+	language, ok := idx.effectiveLanguage(path, prepared)
 	if !ok {
 		return nil, fmt.Errorf("unsupported source language for %s", filePath)
 	}
@@ -44,7 +54,10 @@ func (idx *Indexer) ExtractSource(ctx context.Context, filePath string, src []by
 	if !ok {
 		return nil, fmt.Errorf("no extractor registered for %s", language)
 	}
-	prepared := parser.ApplyPreParse(extractor, src)
+	prepared = parser.ApplyPreParse(extractor, prepared)
+	if !sameSourceCoordinates(src, prepared) {
+		return nil, fmt.Errorf("extractor pre-parse rewrite does not preserve source coordinates")
+	}
 	if int64(len(prepared)) > limit {
 		return nil, fmt.Errorf("prepared source exceeds bounded extraction limit (%d bytes)", limit)
 	}
@@ -55,12 +68,16 @@ func (idx *Indexer) ExtractSource(ctx context.Context, filePath string, src []by
 		pool, quarantine = idx.sharedParsePool()
 	}
 	nativeAdmission := newNativeParseExtractionAdmission(0, nil, idx.nativeParseAdmission.Load())
-	path := filePath
-	if !filepath.IsAbs(path) && idx.rootPath != "" {
-		path = filepath.Join(idx.rootPath, filepath.FromSlash(filePath))
+	rawLease, err := acquireParseAdmission(
+		ctx, int64(len(prepared)), 0, nil, idx.parseAdmission.Load(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("source admission: %w", err)
 	}
-	result, skipped, err := idx.extractFileCtx(
-		ctx, nativeAdmission, pool, quarantine,
+	defer rawLease.Release()
+
+	result, skipped, err := idx.extractFileCtxWithRawLease(
+		ctx, nativeAdmission, rawLease, pool, quarantine,
 		path, filePath, language, extractor, prepared,
 	)
 	if err != nil {

--- a/internal/indexer/extract_source_test.go
+++ b/internal/indexer/extract_source_test.go
@@ -1,0 +1,118 @@
+package indexer
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+func newExtractSourceTestIndexer(t *testing.T, cfg config.IndexConfig) *Indexer {
+	t.Helper()
+	registry := parser.NewRegistry()
+	registry.Register(languages.NewGoExtractor())
+	idx := New(graph.New(), registry, cfg, zap.NewNop())
+	t.Cleanup(idx.Close)
+	return idx
+}
+
+func TestExtractSourcePreservesRawCoordinates(t *testing.T) {
+	cfg := config.Default()
+	idx := newExtractSourceTestIndexer(t, cfg.Index)
+	source := append([]byte{0xef, 0xbb, 0xbf}, []byte("package main\n\nfunc Late() {}\n")...)
+
+	result, err := idx.ExtractSource(t.Context(), "late.go", source)
+	require.NoError(t, err)
+	defer result.ReleaseTree()
+
+	for _, node := range result.Nodes {
+		if strings.HasSuffix(node.ID, "::Late") {
+			require.Equal(t, 3, node.StartLine)
+			return
+		}
+	}
+	t.Fatal("Late declaration was not extracted")
+}
+
+func TestExtractSourceRefusesCommandTransforms(t *testing.T) {
+	cfg := config.Default()
+	cfg.Index.Transforms = []config.TransformRule{{
+		Name:       "must-not-run",
+		Extensions: []string{".go"},
+		Command:    []string{"gortex-test-transform-must-not-run"},
+	}}
+	idx := newExtractSourceTestIndexer(t, cfg.Index)
+
+	result, err := idx.ExtractSource(t.Context(), "late.go", []byte("package main\n\nfunc Late() {}\n"))
+	require.Nil(t, result)
+	require.ErrorContains(t, err, "does not guarantee coordinate preservation")
+}
+
+type unstablePreParserExtractor struct{}
+
+func (unstablePreParserExtractor) Language() string     { return "unstable" }
+func (unstablePreParserExtractor) Extensions() []string { return []string{".unstable"} }
+func (unstablePreParserExtractor) Extract(string, []byte) (*parser.ExtractionResult, error) {
+	return &parser.ExtractionResult{}, nil
+}
+func (unstablePreParserExtractor) PreParse(src []byte) []byte {
+	return append(append([]byte(nil), src...), 'x')
+}
+
+func TestExtractSourceRefusesUnstablePreParser(t *testing.T) {
+	registry := parser.NewRegistry()
+	registry.Register(unstablePreParserExtractor{})
+	cfg := config.Default()
+	idx := New(graph.New(), registry, cfg.Index, zap.NewNop())
+	t.Cleanup(idx.Close)
+
+	result, err := idx.ExtractSource(t.Context(), "late.unstable", []byte("source\n"))
+	require.Nil(t, result)
+	require.ErrorContains(t, err, "pre-parse rewrite does not preserve source coordinates")
+}
+
+func TestExtractSourceCancellationReleasesRawAdmissionWaiter(t *testing.T) {
+	cfg := config.Default()
+	idx := newExtractSourceTestIndexer(t, cfg.Index)
+	budget := newParseAdmissionBudget(1)
+	idx.parseAdmission.Store(budget)
+
+	held, err := acquireParseAdmission(t.Context(), 1, 0, nil, budget)
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(t.Context())
+	errCh := make(chan error, 1)
+	go func() {
+		result, extractErr := idx.ExtractSource(ctx, "late.go", []byte("package main\n\nfunc Late() {}\n"))
+		if result != nil {
+			result.ReleaseTree()
+		}
+		errCh <- extractErr
+	}()
+
+	require.Eventually(t, func() bool {
+		budget.mu.Lock()
+		defer budget.mu.Unlock()
+		return len(budget.waiters) == 1
+	}, time.Second, time.Millisecond)
+	cancel()
+
+	select {
+	case extractErr := <-errCh:
+		require.ErrorIs(t, extractErr, context.Canceled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("ExtractSource did not observe admission cancellation")
+	}
+	held.Release()
+	budget.mu.Lock()
+	defer budget.mu.Unlock()
+	require.Zero(t, budget.used)
+	require.Empty(t, budget.waiters)
+}

--- a/internal/indexer/transform.go
+++ b/internal/indexer/transform.go
@@ -119,6 +119,71 @@ func (p *transformPipeline) run(path string, src []byte) []byte {
 	return out
 }
 
+// prepareCoordinateStable applies only source preparation whose output keeps
+// a one-to-one byte and line mapping to the caller-owned bytes. Unindexed
+// rename recovery edits the raw file, so an arbitrary command transform may
+// not synthesize or relocate a declaration and still be advertised as a
+// declaration-only fallback.
+func (p *transformPipeline) prepareCoordinateStable(path string, src []byte) ([]byte, error) {
+	if p == nil {
+		return src, nil
+	}
+	out := src
+	for _, transform := range p.prePass {
+		if !transform.matches(path) {
+			continue
+		}
+		rewritten := transform.rewrite(path, out)
+		if !sameSourceCoordinates(out, rewritten) {
+			return nil, fmt.Errorf("pre-parse transform %q does not preserve source coordinates", transform.name())
+		}
+		out = rewritten
+	}
+	for _, transform := range p.transforms {
+		if !transform.matches(path) {
+			continue
+		}
+		switch transform.(type) {
+		case bomStripTransform:
+			var err error
+			out, err = neutralizeSourceBOM(out)
+			if err != nil {
+				return nil, err
+			}
+		default:
+			return nil, fmt.Errorf("source transform %q does not guarantee coordinate preservation", transform.name())
+		}
+	}
+	return out, nil
+}
+
+func sameSourceCoordinates(raw, prepared []byte) bool {
+	if len(raw) != len(prepared) {
+		return false
+	}
+	for i := range raw {
+		rawBreak := raw[i] == '\n' || raw[i] == '\r'
+		preparedBreak := prepared[i] == '\n' || prepared[i] == '\r'
+		if (rawBreak || preparedBreak) && raw[i] != prepared[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func neutralizeSourceBOM(src []byte) ([]byte, error) {
+	switch {
+	case bytes.HasPrefix(src, []byte{0xef, 0xbb, 0xbf}):
+		out := bytes.Clone(src)
+		copy(out[:3], []byte("   "))
+		return out, nil
+	case bytes.HasPrefix(src, []byte{0xff, 0xfe}), bytes.HasPrefix(src, []byte{0xfe, 0xff}):
+		return nil, fmt.Errorf("UTF-16 BOM cannot be prepared without changing source coordinates")
+	default:
+		return src, nil
+	}
+}
+
 // languageFor returns the language a transform re-types path to, or ""
 // when no transform claims it. Lets a file whose extension is not
 // natively indexed (e.g. .pdf) still reach an extractor.

--- a/internal/mcp/rename_apply.go
+++ b/internal/mcp/rename_apply.go
@@ -9,6 +9,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/indexer"
 )
 
 // renameEdit is one planned single-line replacement in a coordinated rename.
@@ -45,6 +46,10 @@ func (s *Server) unindexedRenameRecovery(ctx context.Context, id, newName string
 	}
 
 	file := s.graphPathSpelling(relPath)
+	owner, relPath := s.indexerForRel(file)
+	if owner == nil || relPath == "" {
+		return nil
+	}
 	if indexed := s.engineFor(ctx).GetFileSymbols(file); indexed != nil && indexed.TotalNodes > 0 {
 		return nil
 	}
@@ -53,7 +58,7 @@ func (s *Server) unindexedRenameRecovery(ctx context.Context, id, newName string
 	if err != nil {
 		return nil
 	}
-	extracted, err := s.indexer.ExtractSource(ctx, relPath, content)
+	extracted, err := owner.ExtractSource(ctx, relPath, content)
 	if err != nil || extracted == nil {
 		return nil
 	}
@@ -77,7 +82,7 @@ func (s *Server) unindexedRenameRecovery(ctx context.Context, id, newName string
 	}
 
 	oldLine, newLine, ok := s.verifiedDeclarationRename(
-		ctx, relPath, content, declarationLine, requestedSymbol, declarationName, newName,
+		ctx, owner, relPath, content, declarationLine, requestedSymbol, declarationName, newName,
 	)
 	if !ok {
 		return nil
@@ -129,6 +134,7 @@ const (
 // rather than at its name.
 func (s *Server) verifiedDeclarationRename(
 	ctx context.Context,
+	owner *indexer.Indexer,
 	relPath string,
 	content []byte,
 	declarationLine int,
@@ -175,7 +181,7 @@ func (s *Server) verifiedDeclarationRename(
 		candidateLines[declarationLine-1] = candidateLine
 		candidateContent := []byte(strings.Join(candidateLines, ""))
 
-		candidate, err := s.indexer.ExtractSource(ctx, relPath, candidateContent)
+		candidate, err := owner.ExtractSource(ctx, relPath, candidateContent)
 		if err == nil && candidate != nil {
 			originalPresent := false
 			expectedAtDeclaration := 0

--- a/internal/mcp/rename_recovery_test.go
+++ b/internal/mcp/rename_recovery_test.go
@@ -10,6 +10,13 @@ import (
 
 	mcplib "github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/search"
 )
 
 func decodeRenameErrorResp(t *testing.T, res *mcplib.CallToolResult) map[string]any {
@@ -205,6 +212,80 @@ func TestRenameSymbol_SymlinkRecoveryIsRefused(t *testing.T) {
 	info, err := os.Lstat(linkPath)
 	require.NoError(t, err)
 	require.NotZero(t, info.Mode()&os.ModeSymlink)
+}
+
+func setupMultiRepoRenameRecoveryServer(
+	t *testing.T,
+	repoYAML string,
+	baseCfg *config.IndexConfig,
+) (*Server, string) {
+	t.Helper()
+	repo := setupMiniRepo(t, "repo-a")
+	if repoYAML != "" {
+		require.NoError(t, os.WriteFile(filepath.Join(repo, ".gortex.yaml"), []byte(repoYAML), 0o644))
+	}
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	global := &config.GlobalConfig{Repos: []config.RepoEntry{{Path: repo, Name: "repo-a"}}}
+	global.SetConfigPath(configPath)
+	require.NoError(t, global.Save())
+	manager, err := config.NewConfigManager(configPath)
+	require.NoError(t, err)
+
+	registry := testRegistry()
+	store := graph.New()
+	multi := indexer.NewMultiIndexer(store, registry, search.NewBM25(), manager, zap.NewNop())
+	_, err = multi.IndexAll()
+	require.NoError(t, err)
+
+	var base *indexer.Indexer
+	if baseCfg != nil {
+		base = indexer.New(store, registry, *baseCfg, zap.NewNop())
+		t.Cleanup(base.Close)
+	}
+	srv := NewServer(query.NewEngine(store), store, base, nil, zap.NewNop(), nil, MultiRepoOptions{
+		ConfigManager: manager,
+		MultiIndexer:  multi,
+	})
+	return srv, repo
+}
+
+func TestRenameSymbol_UnindexedRecoveryUsesOwningRepoIndexer(t *testing.T) {
+	srv, repo := setupMultiRepoRenameRecoveryServer(t, "", nil)
+	const source = "package main\n\nfunc Late() {}\n"
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "late.go"), []byte(source), 0o644))
+
+	res := callToolByName(t, srv, context.Background(), "rename_symbol", map[string]any{
+		"id": "repo-a/late.go::Late", "new_name": "Renamed",
+	})
+	resp := decodeRenameErrorResp(t, res)
+	require.Equal(t, "symbol_not_indexed", resp["error_code"])
+	recovery := resp["data"].(map[string]any)
+	fallback := recovery["safe_fallback"].(map[string]any)
+	request := fallback["request"].(map[string]any)
+	require.Equal(t, "repo-a/late.go", request["target"].(map[string]any)["file"])
+}
+
+func TestRenameSymbol_UnindexedRecoveryHonorsOwningRepoLimit(t *testing.T) {
+	base := config.Default().Index
+	base.MaxFileSize = 0
+	srv, repo := setupMultiRepoRenameRecoveryServer(t, "index:\n  max_file_size: 16\n", &base)
+	const source = "package main\n\nfunc Restricted() {}\n"
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "late.go"), []byte(source), 0o644))
+
+	owner, ownerRel := srv.indexerForRel("repo-a/late.go")
+	require.NotNil(t, owner)
+	result, err := owner.ExtractSource(t.Context(), ownerRel, []byte(source))
+	require.Nil(t, result)
+	require.ErrorContains(t, err, "bounded extraction limit (16 bytes)")
+
+	res := callToolByName(t, srv, context.Background(), "rename_symbol", map[string]any{
+		"id": "repo-a/late.go::Restricted", "new_name": "Renamed",
+	})
+	require.True(t, res.IsError)
+	text := toolResultText(res)
+	require.Contains(t, text, "symbol not found: repo-a/late.go::Restricted")
+	require.NotContains(t, text, "safe_fallback")
 }
 
 func TestRenameSymbol_InvalidTargetStaysNotFound(t *testing.T) {


### PR DESCRIPTION
## Summary

- route unindexed rename recovery through the repository indexer that owns the target file
- restore the current bounded extraction path with raw/native admission and coordinate-stable preprocessing
- refuse arbitrary command transforms when a declaration-only raw edit cannot be proven safe
- cover multi-repo ownership, repo-specific file limits, transform refusal, BOM coordinates, and admission cancellation

## Validation

- `go test -race ./internal/indexer ./internal/mcp`
- `go vet ./internal/indexer ./internal/mcp`
- `git diff --check`
- `go test ./...` (all packages passed except the existing `cmd/gortex` post-test real-user-state guard, which observed a write to `~/.gortex/cache/query-log.jsonl` after that package itself printed PASS)

Follow-up to #574.