### PR TITLE
fix: stop spawning a child process per file, and bound the codex version probe

### DIFF
--- a/internal/agents/codex/adapter.go
+++ b/internal/agents/codex/adapter.go
@@ -13,6 +13,7 @@
 package codex
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -21,10 +22,12 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/zzet/gortex/internal/agents"
 	"github.com/zzet/gortex/internal/agents/internalutil"
 	"github.com/zzet/gortex/internal/mcp"
+	"github.com/zzet/gortex/internal/platform"
 	"github.com/zzet/gortex/internal/version"
 )
 
@@ -400,13 +403,27 @@ func codexStartupTimeoutAtLeast(value any, minimum int) bool {
 	}
 }
 
+// codexVersionProbeTimeout bounds the `codex --version` probe. A version
+// banner is instant; anything slower is a wedged binary, and without a
+// deadline the probe blocks the install indefinitely and leaks a child
+// process that never exits. Failing the probe is cheap — the caller reads
+// an error as "unknown install" and keeps direct tool exposure on.
+// Overridable so the timeout test does not have to sleep for the real one.
+var codexVersionProbeTimeout = 5 * time.Second
+
 // codexVersionOutput is a seam for hermetic adapter tests.
 var codexVersionOutput = func() ([]byte, error) {
 	path, err := exec.LookPath("codex")
 	if err != nil {
 		return nil, err
 	}
-	return exec.Command(path, "--version").Output()
+	ctx, cancel := context.WithTimeout(context.Background(), codexVersionProbeTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, path, "--version")
+	// The probe also runs from surfaces with no console of their own; without
+	// this, Windows hands the child a fresh console window.
+	platform.ConfigureBackgroundCommand(cmd)
+	return cmd.Output()
 }
 
 func codexSupportsDirectToolNamespaces() (supported bool, detectedVersion string) {

--- a/internal/agents/codex/adapter_version_probe_test.go
+++ b/internal/agents/codex/adapter_version_probe_test.go
@@ -1,0 +1,63 @@
+package codex
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestCodexVersionOutput_TimesOut pins the deadline on the `codex --version`
+// probe. A wedged binary previously blocked the caller forever and left a
+// child process behind that never exited; the probe must give up and report
+// an error instead.
+func TestCodexVersionOutput_TimesOut(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake binary is a POSIX shell script")
+	}
+
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "codex")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\nsleep 60\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+
+	original := codexVersionProbeTimeout
+	codexVersionProbeTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { codexVersionProbeTimeout = original })
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := codexVersionOutput()
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("hung probe returned success; want a timeout error")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("probe did not honour its deadline")
+	}
+}
+
+// TestCodexSupportsDirectToolNamespaces_TreatsProbeFailureAsCurrent documents
+// the posture the timeout relies on: a probe that fails for any reason —
+// including the new deadline — leaves direct tool exposure enabled rather
+// than silently downgrading the install.
+func TestCodexSupportsDirectToolNamespaces_TreatsProbeFailureAsCurrent(t *testing.T) {
+	original := codexVersionOutput
+	codexVersionOutput = func() ([]byte, error) { return nil, os.ErrDeadlineExceeded }
+	t.Cleanup(func() { codexVersionOutput = original })
+
+	supported, detected := codexSupportsDirectToolNamespaces()
+	if !supported {
+		t.Error("probe failure disabled direct tool namespaces")
+	}
+	if detected != "" {
+		t.Errorf("detected version = %q, want empty on probe failure", detected)
+	}
+}

--- a/internal/churn/churn.go
+++ b/internal/churn/churn.go
@@ -31,7 +31,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os/exec"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -378,9 +378,6 @@ func stripRepoPrefix(filePath, repoRoot string) string {
 	if !strings.Contains(filePath, "/") {
 		return filePath
 	}
-	if _, err := exec.LookPath("git"); err != nil {
-		return filePath
-	}
 	abs := filepath.Join(repoRoot, filePath)
 	if fileExists(abs) {
 		return filePath
@@ -394,9 +391,16 @@ func stripRepoPrefix(filePath, repoRoot string) string {
 	return filePath
 }
 
+// fileExists is split out so tests can stub it. os.Stat follows symlinks,
+// and Mode().IsRegular matches the previous `test -f` semantics without
+// spawning a process for every lookup. Shelling out here cost one child
+// process per indexed file on every enrichment pass, and was outright
+// wrong on Windows, where there is no `test` executable: every lookup
+// failed, so multi-repo paths were never stripped and the enricher
+// silently produced no churn data.
 var fileExists = func(path string) bool {
-	cmd := exec.Command("test", "-f", path)
-	return cmd.Run() == nil
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular()
 }
 
 // runGit shells out and returns trimmed stdout, or "" on error. Used

--- a/internal/churn/churn_test.go
+++ b/internal/churn/churn_test.go
@@ -203,3 +203,61 @@ func currentBranch(t *testing.T, dir string) string {
 	}
 	return strings.TrimSpace(string(out))
 }
+
+// TestStripRepoPrefix_NeedsNoExternalBinaries pins the fix for the
+// subprocess fan-out: resolving whether a path exists is a filesystem
+// question, and answering it must not depend on anything being on PATH.
+// The previous implementation gated on `exec.LookPath("git")` and then
+// shelled out to `test -f` once per indexed file, so on a host where
+// neither resolves — every Windows box, since there is no `test`
+// executable — the prefix was never stripped and the enricher silently
+// produced no churn data.
+func TestStripRepoPrefix_NeedsNoExternalBinaries(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "internal"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "internal", "foo.go")
+	if err := os.WriteFile(target, []byte("package internal\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Nothing is resolvable on PATH — the old implementation bailed here.
+	t.Setenv("PATH", "")
+
+	if got := stripRepoPrefix("myrepo/internal/foo.go", root); got != "internal/foo.go" {
+		t.Errorf("prefixed path: got %q, want %q", got, "internal/foo.go")
+	}
+	if got := stripRepoPrefix("internal/foo.go", root); got != "internal/foo.go" {
+		t.Errorf("repo-relative path: got %q, want %q", got, "internal/foo.go")
+	}
+	// A path that resolves under neither spelling is returned untouched.
+	if got := stripRepoPrefix("myrepo/internal/absent.go", root); got != "myrepo/internal/absent.go" {
+		t.Errorf("unresolvable path: got %q, want it unchanged", got)
+	}
+}
+
+// TestFileExists_MatchesTestF keeps the os.Stat replacement honest about
+// the `test -f` semantics it replaced: regular files only, symlinks
+// followed, directories and missing paths rejected.
+func TestFileExists_MatchesTestF(t *testing.T) {
+	dir := t.TempDir()
+	regular := filepath.Join(dir, "regular")
+	if err := os.WriteFile(regular, []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !fileExists(regular) {
+		t.Error("regular file reported missing")
+	}
+	if fileExists(dir) {
+		t.Error("directory reported as a regular file")
+	}
+	if fileExists(filepath.Join(dir, "missing")) {
+		t.Error("missing path reported as a regular file")
+	}
+
+	link := filepath.Join(dir, "regular-link")
+	if err := os.Symlink(regular, link); err == nil && !fileExists(link) {
+		t.Error("symlink to a regular file reported missing")
+	}
+}


### PR DESCRIPTION
Investigated #581 and fixed the two real defects it surfaced.

## On the reported `findstr.exe`

Gortex never invokes `findstr`. It is not in the source, and there is no grep/ripgrep search fallback to degrade into: `search_text` is a trigram index inside the daemon, and every code-search path is in-process. The one `rg` shell-out in the tree is a benchmark baseline adapter under `bench/`, which the daemon does not link.

So the report's specific attribution does not hold. But the shape it describes — a daemon fanning out short-lived children with no console suppression and no deadline — is real, and two instances of it are fixed here.

## 1. `churn` spawned `test -f` once per indexed file

`stripRepoPrefix` answered "does this path exist" by shelling out:

```go
var fileExists = func(path string) bool {
	cmd := exec.Command("test", "-f", path)
	return cmd.Run() == nil
}
```

The identical helper in `internal/blame` was already converted to `os.Stat`, and its comment says so explicitly — *"without spawning a process for every lookup"*. This copy was missed, so `internal/churn` kept the old behaviour.

Consequences:

- **Process fan-out.** One child process per indexed file per enrichment   pass. On the ~105k-node workspace in the issue that is thousands of spawns to answer a question `os.Stat` answers inline. The call site   never went through `platform.ConfigureBackgroundCommand`, so on Windows each child also gets its own console window — matching the reported symptom of console windows appearing during activity, concurrent with the `git` fan-out.
- **Silently wrong on Windows.** There is no `test` executable on Windows, so every lookup failed, multi-repo paths were never stripped, and the enricher produced no churn data at all.

`os.Stat` + `Mode().IsRegular()` reproduces the `test -f` semantics exactly (regular files only, symlinks followed) and needs nothing on PATH. The `exec.LookPath("git")` gate goes with it — path stripping does not depend on git being installed, and `EnrichGraph` already fails at its `rev-parse` before reaching this code when git is absent.

## 2. `codex --version` probe could hang forever

The Codex adapter ran `exec.Command(path, "--version").Output()` with no deadline. A version banner is instant, so any delay means a wedged binary — and the unbounded call blocks the install indefinitely while leaving a child that never exits. That is the issue's suggested fix #2, and the process signature it describes (zero CPU since start, never
exits).

Now bounded by a 5s `CommandContext` deadline and routed through `ConfigureBackgroundCommand`. The failure posture is unchanged and already correct: a probe error reads as "unknown install" and leaves direct tool exposure on, so the deadline degrades into the existing safe default rather than silently downgrading the install.

## Not changed

- **`CREATE_NO_WINDOW` on every spawn site.** Already handled — 17 call sites route through `platform.ConfigureBackgroundCommand`, including every `git` invocation (`gitcmd.Run`), LSP servers, and the LLM subprocess providers. The two sites fixed here were the daemon-side gaps.
- **Fail loudly when ripgrep is missing.** Not applicable: Gortex does not require or use ripgrep at runtime.
- **The 10 concurrent `gortex.exe` processes.** Left alone — no defect identified, and the reporter flagged it without claiming one. Worth a separate issue if it recurs with process-tree evidence.

## Verification

Both tests were confirmed to fail against the pre-fix code:

- `TestStripRepoPrefix_NeedsNoExternalBinaries` fails with `got "myrepo/internal/foo.go", want "internal/foo.go"` — the exact Windows breakage, reproduced on any platform by emptying PATH rather than by relying on `test` happening to exist on POSIX CI.
- `TestCodexVersionOutput_TimesOut` does not compile pre-fix; there was no deadline to assert on.

`go build ./...`, `go vet`, `golangci-lint run` (0 issues), and
`go test -race` across `internal/churn`, `internal/blame`,
`internal/agents/...`, and `cmd/gortex` all pass. `internal/churn`,
`internal/blame`, and `internal/platform` also cross-compile for
`GOOS=windows`.

Closes #581
