### PR TITLE
fix(mcp): cut the facade repository-selector cost and explain its refusals

### DIFF
--- a/docs/mcp-facade-v1.md
+++ b/docs/mcp-facade-v1.md
@@ -194,16 +194,13 @@ Each facade advertises only its high-frequency stable fields. A read request ill
 ```json
 {
   "target": {"file": "internal/mcp/server.go"},
-  "context": {"start_line": 100, "end_line": 180},
-  "options": {"repo": "gortex"},
-  "output": {
-    "format": "json",
-    "max_bytes": 20000,
-    "cursor": "opaque",
-    "fields": "path,content"
-  }
+  "context": {"compress_bodies": true},
+  "options": {"offset": 100, "limit": 80},
+  "output": {"max_bytes": 20000}
 }
 ```
+
+Every field above is published by `read.file`. Containers are closed per operation, so an envelope is only portable across operations to the extent that `capabilities(...detail="schema")` says it is — `read.file` takes a line window as `options.offset`/`options.limit`, while another operation may spell the same intent differently or not accept it at all.
 
 The dispatcher flattens the advertised `arguments`, `options`, `source`, `context`, `guard`, and `output` objects into the selected legacy handler's arguments. Common top-level fields win where the adapter defines a friendly alias. Operation-specific fields that are not worth mounting in every model turn remain discoverable through `capabilities`.
 
@@ -229,6 +226,8 @@ Examples are `{"file":"internal/mcp/server.go"}` and `{"symbol":"Server.addTool"
 High-frequency fields are direct and typed. In particular, `edit` advertises `match`, `replacement`, `content`, `guard`, `changes`, and `dry_run` at the top level. `refactor` similarly advertises `new_name`, `destination`, and `dry_run`. The adapter translates friendly fields such as `match`/`replacement` into the selected legacy handler's vocabulary.
 
 Cold domain tools accept an `arguments` object; common tools may additionally accept `options`, `source`, or `context`. Repository/project/scope fields use the operation schema returned by `capabilities` and are passed through to the handler. `output` is a stable open object for response shaping such as `format`, `max_bytes`, `limit`, `cursor`, and `fields`; adding another response control does not change the outer tool schema. Cursors remain opaque.
+
+A repository-selector field — `repo`, `repo_path`, `repository`, or `repository_path`, in any letter case, at the top level or in any container — MUST be refused with `invalid_argument` when the selected operation cannot consume it. Silently dropping it answers about the active repository while the caller believes another one was addressed, which is a wrong answer the caller cannot detect, and on a write operation it is a write to the wrong repository. Most operations accept no repository selector at all and run against the active project; their refusal carries `data.reason = "no_repository_selector"` and names `workspace_admin.set_active_project` as the way to change scope. An operation that does publish one names it in `data.suggested_field` — `options.repo` for the common domains, `arguments.repo` for cold domains. `capabilities(...detail="schema")` is authoritative for which selector, if any, an operation accepts.
 
 ### 8.4 Response compatibility and metadata
 

--- a/internal/mcp/facade_container_validation_test.go
+++ b/internal/mcp/facade_container_validation_test.go
@@ -143,6 +143,48 @@ func TestFacadeRepositoryValidationLeavesNonSelectorCompatibilityAlone(t *testin
 	}))
 }
 
+// Most operations publish no repository selector at all. Refusing one with a
+// bare "unknown field" leaves the caller retrying spellings that can never be
+// accepted, so the refusal has to say that no selector exists and how to change
+// scope instead.
+func TestFacadeRepositoryValidationExplainsOperationsWithoutASelector(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	spec, ok := srv.facades.operation("read", "file")
+	require.True(t, ok)
+	require.Empty(t, srv.facadePublicRepositoryField(spec), "read.file publishes no repository selector")
+
+	result := srv.validateFacadeInput(spec, map[string]any{
+		"operation": "file",
+		"target":    map[string]any{"file": "main.go"},
+		"options":   map[string]any{"repo": "other-repo"},
+	})
+	require.NotNil(t, result)
+	require.True(t, result.IsError)
+
+	var structured StructuredError
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(result)), &structured))
+	require.Equal(t, ErrCodeInvalidArgument, structured.ErrorCode)
+	require.Equal(t, "options.repo", structured.Data["field"])
+	require.Equal(t, "no_repository_selector", structured.Data["reason"])
+	require.NotContains(t, structured.Data, "suggested_field", "there is no selector to suggest")
+	require.Contains(t, structured.Message, "read.file accepts no repository selector")
+	require.Contains(t, structured.Message, "workspace_admin.set_active_project")
+
+	// An operation that does publish one keeps pointing at it.
+	detect, ok := srv.facades.operation("change", "detect")
+	require.True(t, ok)
+	rejected := srv.validateFacadeInput(detect, map[string]any{
+		"operation": "detect",
+		"source":    map[string]any{"repo_path": "/work/other-repo"},
+	})
+	require.NotNil(t, rejected)
+	var suggested StructuredError
+	require.NoError(t, json.Unmarshal([]byte(toolResultText(rejected)), &suggested))
+	require.Equal(t, "options.repo", suggested.Data["suggested_field"])
+	require.NotContains(t, suggested.Data, "reason")
+}
+
 func TestFacadeRepositoryValidationRejectsInvalidCanonicalSelectors(t *testing.T) {
 	srv, _ := setupTestServer(t)
 

--- a/internal/mcp/facade_registry.go
+++ b/internal/mcp/facade_registry.go
@@ -50,6 +50,10 @@ type facadeRegistry struct {
 	byFacade map[string]map[string]facadeOperationSpec
 	byLegacy map[string][]facadeOperationSpec
 	captured map[string]capturedFacadeTool
+	// repoFields memoizes facadePublicRepositoryField, whose input is the
+	// captured tool set. capture drops it so a late registration is never
+	// answered from a pre-registration result.
+	repoFields sync.Map
 }
 
 func newFacadeRegistry() *facadeRegistry {
@@ -82,6 +86,26 @@ func (r *facadeRegistry) capture(tool mcpgo.Tool, handler server.ToolHandlerFunc
 	r.mu.Lock()
 	r.captured[tool.Name] = capturedFacadeTool{tool: tool, handler: handler}
 	r.mu.Unlock()
+	r.repoFields.Clear()
+}
+
+func (r *facadeRegistry) cachedRepositoryField(key string) (string, bool) {
+	if r == nil {
+		return "", false
+	}
+	cached, ok := r.repoFields.Load(key)
+	if !ok {
+		return "", false
+	}
+	field, ok := cached.(string)
+	return field, ok
+}
+
+func (r *facadeRegistry) cacheRepositoryField(key, field string) {
+	if r == nil {
+		return
+	}
+	r.repoFields.Store(key, field)
 }
 
 func (r *facadeRegistry) operation(facade, operation string) (facadeOperationSpec, bool) {

--- a/internal/mcp/facade_repository_selector_cost_test.go
+++ b/internal/mcp/facade_repository_selector_cost_test.go
@@ -1,0 +1,77 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+// stubFacadeLegacy re-captures a legacy handler under its real schema so a
+// measurement sees facade plumbing only, without the handler's own work.
+func stubFacadeLegacy(t *testing.T, srv *Server, legacy string) {
+	t.Helper()
+	existing, ok := srv.facades.legacy(legacy)
+	require.True(t, ok, "legacy tool %s must be captured", legacy)
+	srv.facades.capture(existing.tool, func(_ context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		return mcpgo.NewToolResultText("{}"), nil
+	})
+}
+
+func facadeRequest(facade string, args map[string]any) mcpgo.CallToolRequest {
+	req := mcpgo.CallToolRequest{}
+	req.Params.Name = facade
+	req.Params.Arguments = args
+	return req
+}
+
+// Resolving the operation's published repository selector builds the whole
+// public capability schema, which re-materialises the immutable operation table
+// and re-probes every legacy property. Doing that per request made a call
+// carrying the canonical selector cost ~40x the allocations of the same call
+// without one. The selector path must stay in the same order of magnitude as
+// the plain path.
+func TestFacadeRepositorySelectorDoesNotDominateDispatchCost(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	stubFacadeLegacy(t, srv, "detect_changes")
+
+	measure := func(args map[string]any) float64 {
+		req := facadeRequest("change", args)
+		return testing.AllocsPerRun(50, func() {
+			_, _ = srv.handleFacade(context.Background(), "change", req)
+		})
+	}
+
+	plain := measure(map[string]any{"operation": "detect"})
+	selector := measure(map[string]any{
+		"operation": "detect",
+		"options":   map[string]any{"repo": "repo-a"},
+	})
+
+	// 4x leaves generous headroom over the ~1.6x this actually costs while
+	// still failing loudly on an uncached schema build (~40x).
+	require.LessOrEqual(t, selector, plain*4,
+		"selector dispatch allocated %.0f vs %.0f without a selector — the published-schema lookup is being rebuilt per request",
+		selector, plain)
+}
+
+// The memo is keyed on the captured tool set, so a handler registered after the
+// first lookup must not be answered from the pre-registration result.
+func TestFacadeRepositorySelectorCacheDropsOnLateRegistration(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	spec, ok := srv.facades.operation("change", "detect")
+	require.True(t, ok)
+
+	noop := func(_ context.Context, _ mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		return mcpgo.NewToolResultText("{}"), nil
+	}
+	srv.facades.capture(mcpgo.NewTool("detect_changes", mcpgo.WithString("scope")), noop)
+	require.Empty(t, srv.facadePublicRepositoryField(spec),
+		"a handler that declares no repo must publish no repository selector")
+
+	srv.facades.capture(mcpgo.NewTool("detect_changes",
+		mcpgo.WithString("scope"), mcpgo.WithString("repo")), noop)
+	require.Equal(t, "options.repo", srv.facadePublicRepositoryField(spec),
+		"the late registration declares repo, so the memoized answer must be dropped")
+}

--- a/internal/mcp/facade_tools.go
+++ b/internal/mcp/facade_tools.go
@@ -1575,6 +1575,12 @@ func (s *Server) validateFacadeRepositoryFields(spec facadeOperationSpec, input 
 			if canonicalPath != "" {
 				data["suggested_field"] = canonicalPath
 				message += fmt.Sprintf("; use %s to select a repository", canonicalPath)
+			} else {
+				// Refusing without saying why leaves the caller retrying
+				// spellings of a selector this operation will never accept.
+				data["reason"] = "no_repository_selector"
+				message += fmt.Sprintf("; %s.%s accepts no repository selector and runs against the active project"+
+					" — switch it with workspace_admin.set_active_project", spec.Facade, spec.Operation)
 			}
 			return NewStructuredErrorResult(StructuredError{
 				ErrorCode: ErrCodeInvalidArgument,
@@ -1606,7 +1612,27 @@ func (s *Server) facadeFieldConsumed(spec facadeOperationSpec, containerName, fi
 	return false
 }
 
+// facadePublicRepositoryField reports where the operation's published schema
+// exposes its repository selector, as a dotted path, or "" when the operation
+// has none.
+//
+// Building the published schema re-materialises the immutable operation table
+// and re-runs the lowering probe for every legacy property, which costs two
+// orders of magnitude more than the rest of facade dispatch. The answer depends
+// only on the spec and the captured legacy schema, so it is memoized per
+// registry and invalidated whenever a late registration changes what is
+// captured.
 func (s *Server) facadePublicRepositoryField(spec facadeOperationSpec) string {
+	key := spec.Facade + "." + spec.Operation
+	if cached, ok := s.facades.cachedRepositoryField(key); ok {
+		return cached
+	}
+	field := s.resolveFacadePublicRepositoryField(spec)
+	s.facades.cacheRepositoryField(key, field)
+	return field
+}
+
+func (s *Server) resolveFacadePublicRepositoryField(spec facadeOperationSpec) string {
 	capability := s.facadeCapability(spec, true)
 	schema, _ := capability["input_schema"].(map[string]any)
 	properties, _ := schema["properties"].(map[string]any)


### PR DESCRIPTION
## Summary

Follow-up to #553, which closed the silent wrong-repository fallback behind #549. Four commits: two fix what that merge shipped with, two close the residual it left open.

### 1. The published-schema lookup ran per request

`facadePublicRepositoryField` builds the operation's whole public capability schema, which re-materialises the immutable operation table and re-probes every legacy property. It ran on every call carrying a repository selector — including `options.repo`, the canonical one. Memoized on the registry and dropped whenever `capture` changes the captured set, since optional handlers register after `NewServer` and a pre-registration answer must not survive.

| call | before | after |
| --- | --- | --- |
| `change.detect`, no selector | 1,488 ns / 1,128 B / 17 allocs | 1,380 ns / 1,128 B / 17 allocs |
| `change.detect` + `options.repo` | 89,707 ns / 160,884 B / 659 allocs | 2,416 ns / 2,200 B / 27 allocs |
| `read.file` + `options.repo` | 118,789 ns / 174,940 B / 832 allocs | 3,461 ns / 2,865 B / 39 allocs |

`alloc_space` attributed 62% of the removed cost to `facadeCanonicalOperationNames` → `facadeOperationSpecs` → `addFacadeGroup`, plus 16% to regexp compilation.

### 2. Refusals on operations with no selector said nothing useful

Most operations publish no repository selector; those refusals read `unknown field "options.repo"`, which looks like a typo and invites retrying spellings that can never be accepted. The refusal now names the operation, points at `workspace_admin.set_active_project`, and carries `reason: "no_repository_selector"`. The facade specification's own §8.1 envelope passed `options.repo` to `read.file`, which `read.file` does not accept and the server now refuses — replaced with an envelope whose every field `read.file` publishes.

### 3. The guard matched four names, so the same bug had other doors

`options.workspace`, `options.root`, `options.cwd`, `options.repo_root`, `options.worktree` and friends were still silently dropped, and on `edit.file` that is a write to the wrong repository reported as success — the same failure the four-name guard was added to close, reachable by writing the intent a different way. The class now covers the spellings a caller may reasonably reach for. Membership is by name; refusal is still decided per operation by the consumption probe, so an operation that genuinely reads `workspace` or `root` keeps receiving it. `path` and `scope` stay out — on this surface they name a file or a working-tree scope far more often than a repository.

### 4. The edit facade's aliases were eating another handler's vocabulary

`match`/`replacement` are the `edit` facade's caller-facing names for the legacy `old_string`/`new_string` pair, and the lowering rewrote them on **every** facade. `edit_memory` declares `replacement` itself, so `remember.edit_memory`'s replacement text was renamed into a field that handler does not declare: the memory was edited with no replacement text and the call reported success, while the published schema advertised `arguments.replacement`. Now only the facade that publishes the pair translates it.

## Measured

Every reachable operation × 7 locations (top level + 6 containers) × the whole 342-name facade vocabulary — 378,094 rows — against merged main:

| | rows |
| --- | --- |
| consumed before, refused now (regressions) | **0** |
| silently dropped before, refused now | **10,353** |
| consumed rows preserved | 7,547 |
| newly reaching the handler (item 4) | 7 |

The nine-door `edit.file` write probe refuses every spelling at every location with the target file unchanged; `options.workspace` — the door this PR opened with — is now closed.

## Tests

Five guards, each mutation-verified to go red when its mechanism is removed: the allocation bound on the selector path, memo invalidation on late registration, the `no_repository_selector` guidance, refusal of every invented spelling before a write, and `remember.edit_memory` receiving its own vocabulary. Plus drift pins: the alias predicate against the facade definitions, and the deliberate exclusion of `path`/`scope`.

## Verification

- `go test -race ./internal/mcp` — pass (127 s)
- `golangci-lint run ./internal/mcp/...` — 0 issues
- `go vet ./internal/mcp`, `go build ./cmd/gortex/`, `git diff --check` — pass

## Known limit, recorded rather than implied

Fields **outside** the target-selector class that an operation does not consume are still forwarded and ignored. Refusing those generically needs an enumeration of every server-side reader, and the handler, the response layer and facade middleware each read the normalized arguments: `output.format`, `options.new_user_task` and `options.fields` are each honoured by a reader no handler schema mentions. I built that generic rule, measured it, and it refused working calls in exactly those places — an incomplete enumeration trades a silent-drop bug for a broken feature. The specification now states the limit instead of implying a guarantee that does not hold.

Refs #549
