### PR TITLE
Skills and hooks for Codex, OpenCode and GitHub Copilot CLI

### DIFF
--- a/.github/workflows/init-smoke.yml
+++ b/.github/workflows/init-smoke.yml
@@ -68,6 +68,9 @@ jobs:
           mkdir -p "$RUNNER_TEMP/repo/.omp"
           # OpenClaw
           mkdir -p "$RUNNER_TEMP/home/.openclaw"
+          # GitHub Copilot CLI — the standalone `copilot` binary, not the
+          # VS Code extension the `vscode` adapter targets.
+          mkdir -p "$RUNNER_TEMP/home/.copilot"
 
       - name: Run gortex init --dry-run --json
         id: run
@@ -88,9 +91,12 @@ jobs:
           agents = {a["name"]: a for a in data["agents"]}
           expected = [
               "claude-code", "aider", "cline", "codex", "continue",
-              "cursor", "gemini", "kilocode", "kiro", "oh-my-pi", "opencode",
-              "openclaw", "vscode", "windsurf", "zed",
+              "copilot-cli", "cursor", "gemini", "kilocode", "kiro",
+              "oh-my-pi", "opencode", "openclaw", "vscode", "windsurf", "zed",
               # "antigravity" always true when HOME is set; not a detection test.
+              # hermes, kimi and pi have no sentinel here yet — the list is
+              # hand-maintained, so a new adapter is only covered once it is
+              # added in both places above.
           ]
           failed = []
           for name in expected:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ High-quality parsing 257 languages/grammars through tree-sitter AST analysis, in
 - **Cross-repo by default** — N repos in one graph; contracts, references, and call chains span repo boundaries with evidence-gated resolution, contract matching, impact analysis, per-session isolation → [docs/multi-repo.md](docs/multi-repo.md)
 - **Extreamly fast analysis** — a precomputed depth-3 reach index turns blast-radius queries into O(seeds × reach) map lookups. Safe to ask "what breaks if I change this?" on every edit. No dozens of tool calls to grasp context.
 - **Zero external dependencies** — single binary, everything in-process. No network, no model download to get started. Install, start daemon, use.
-- **Agent integrations (19)** — `gortex init` configures every detected coding assistant on the machine → [docs/agents.md](docs/agents.md)
+- **Agent integrations (20)** — `gortex init` configures every detected coding assistant on the machine → [docs/agents.md](docs/agents.md)
 - **100+ MCP tools, 16 resources, 3 prompts** — symbol lookup, call chains, blast radius, dataflow, clone detection, refactoring, code actions → [docs/mcp.md](docs/mcp.md)
 - **Semantic search default-on** — baked GloVe-50d (3.8 MB embedded), store-native FTS5/BM25 + vector with adaptive alpha fusion, zero deps; opt-in MiniLM / Ollama / OpenAI → [docs/semantic-search.md](docs/semantic-search.md)
 - **Speculative execution** — `preview_edit` / `simulate_chain` answer "what would change if I applied this WorkspaceEdit?" without touching disk
@@ -162,7 +162,7 @@ Data flow, graph schema (node and edge kinds, multi-repo fields, test taxonomy),
 | Optional LLM features | [llm.md](docs/llm.md) |
 | LSP integration | [lsp.md](docs/lsp.md) |
 | Per-community skills & agent usage | [skills.md](docs/skills.md) |
-| AI agent adapters (19) | [agents.md](docs/agents.md) |
+| AI agent adapters (20) | [agents.md](docs/agents.md) |
 | Supported languages (257) | [languages.md](docs/languages.md) |
 | Token savings | [savings.md](docs/savings.md) |
 | GCX1 wire format | [wire-format.md](docs/wire-format.md) |

--- a/cmd/gortex/agents_render_test.go
+++ b/cmd/gortex/agents_render_test.go
@@ -6,8 +6,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/claudecode"
 )
 
 // updateAgentRender regenerates the committed agent-render goldens.
@@ -68,4 +70,246 @@ func TestAgentsRenderGolden(t *testing.T) {
 			t.Errorf("stale golden %s has no matching adapter — delete it or restore the adapter", e.Name())
 		}
 	}
+}
+
+// realHomeBeforeSandbox is the developer's actual home directory,
+// captured during package-variable initialisation — which runs before
+// TestMain installs the process-wide testenv sandbox that replaces
+// $HOME. The render hermeticity guard needs the real path: after
+// SandboxProcess, os.UserHomeDir() reports the sandbox and could not
+// tell a genuine escape from a contained write.
+var realHomeBeforeSandbox = func() string {
+	h, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return h
+}()
+
+// neutraliseClaudeConfigDirOverride clears the process-wide Claude
+// config-root seam for the duration of a test. The seam outranks
+// $CLAUDE_CONFIG_DIR, so a value left behind by an earlier test (or by
+// a future caller of `gortex install --claude-config-dir` in the same
+// process) would send the ModeGlobal render somewhere the sandbox
+// cannot see — the manifest's home/ section would silently render
+// empty. The render itself cannot clear it: claudecode imports
+// internal/agents, so internal/agents cannot import claudecode.
+func neutraliseClaudeConfigDirOverride(t *testing.T) {
+	t.Helper()
+	claudecode.SetConfigDirOverride("")
+	t.Cleanup(func() { claudecode.SetConfigDirOverride("") })
+}
+
+// renderAllAdapters is the one-line render every guard below shares.
+func renderAllAdapters(t *testing.T) map[string]string {
+	t.Helper()
+	manifests, err := agents.RenderManifest(buildRegistry().All())
+	if err != nil {
+		t.Fatalf("render adapters: %v", err)
+	}
+	return manifests
+}
+
+// manifestKeys extracts the `=== <key> ===` headers from a manifest.
+func manifestKeys(manifest string) []string {
+	var keys []string
+	for _, line := range strings.Split(manifest, "\n") {
+		if strings.HasPrefix(line, "=== ") && strings.HasSuffix(line, " ===") {
+			keys = append(keys, strings.TrimSuffix(strings.TrimPrefix(line, "=== "), " ==="))
+		}
+	}
+	return keys
+}
+
+// TestAgentsRenderIsHermetic proves the drift fence cannot write
+// outside its sandbox. It matters because the fence now renders
+// ModeGlobal, whose whole job is writing user-level files: an escape
+// would corrupt the developer's real home AND hide itself, because the
+// bytes that left the sandbox are exactly the ones missing from the
+// manifest's home/ section.
+//
+// The environment below is hostile on purpose. Every variable is one a
+// developer may legitimately have exported, and each one used to be a
+// live escape hatch or a determinism hole.
+func TestAgentsRenderIsHermetic(t *testing.T) {
+	neutraliseClaudeConfigDirOverride(t)
+
+	decoy := t.TempDir()
+	claudeDecoy := filepath.Join(decoy, "claude-config-dir")
+	kimiDecoy := filepath.Join(decoy, "kimi-code-home")
+	t.Setenv("CLAUDE_CONFIG_DIR", claudeDecoy)
+	t.Setenv("KIMI_CODE_HOME", kimiDecoy)
+	t.Setenv("GORTEX_CODEX_HOOK_MODE", "suppress")
+	t.Setenv("GORTEX_INSTRUCTIONS_PROFILE", "full")
+
+	manifests := renderAllAdapters(t)
+
+	// 1. The decoy config roots must be untouched: if either had won,
+	//    the adapter's user-level artifacts would have landed there.
+	for _, dir := range []string{claudeDecoy, kimiDecoy} {
+		if _, err := os.Stat(dir); !os.IsNotExist(err) {
+			t.Errorf("render escaped the sandbox into %s (stat err: %v) — the config-dir env pin is not holding", dir, err)
+		}
+	}
+
+	// 2. No manifest may name the developer's real home. A leaked
+	//    absolute path means something resolved a path outside the
+	//    sandbox, whether or not it managed to write there.
+	if realHomeBeforeSandbox != "" {
+		for name, m := range manifests {
+			if strings.Contains(m, realHomeBeforeSandbox) {
+				t.Errorf("%s manifest references the real home %q", name, realHomeBeforeSandbox)
+			}
+		}
+	}
+
+	// 3. Nothing under the real home that the render *could* have
+	//    written may have been created by this run. Every user-level
+	//    manifest key is checked against its real-home counterpart, so
+	//    the guard extends itself automatically as adapters grow new
+	//    user-level surfaces.
+	if realHomeBeforeSandbox != "" {
+		checked := map[string]bool{}
+		for name, m := range manifests {
+			for _, key := range manifestKeys(m) {
+				rel, ok := homeRelativeManifestKey(key)
+				if !ok || checked[rel] {
+					continue
+				}
+				checked[rel] = true
+				path := filepath.Join(realHomeBeforeSandbox, filepath.FromSlash(rel))
+				info, err := os.Lstat(path)
+				if err != nil {
+					continue // absent is the expected state
+				}
+				if info.ModTime().After(renderGuardStart) {
+					t.Errorf("%s: %s was modified during the render — the sandbox leaked into the real home\n"+
+						"(false positive only if another process wrote that path during this test)", name, path)
+				}
+			}
+		}
+	}
+
+	// 4. The pinned variables are restored exactly as the test set them.
+	for k, want := range map[string]string{
+		"CLAUDE_CONFIG_DIR":           claudeDecoy,
+		"KIMI_CODE_HOME":              kimiDecoy,
+		"GORTEX_CODEX_HOOK_MODE":      "suppress",
+		"GORTEX_INSTRUCTIONS_PROFILE": "full",
+	} {
+		if got := os.Getenv(k); got != want {
+			t.Errorf("%s = %q after the render, want it restored to %q", k, got, want)
+		}
+	}
+}
+
+// renderGuardStart is captured before any test runs, so the
+// hermeticity guard can distinguish "this file was already here" from
+// "this render just wrote it".
+var renderGuardStart = time.Now().Add(-time.Second)
+
+// homeRelativeManifestKey maps a `<mode>/home/<rel>` manifest key to
+// <rel>, and reports false for repo-root keys (which have no real-home
+// counterpart).
+func homeRelativeManifestKey(key string) (string, bool) {
+	for _, prefix := range []string{"project/home/", "global/home/"} {
+		if strings.HasPrefix(key, prefix) {
+			return strings.TrimPrefix(key, prefix), true
+		}
+	}
+	return "", false
+}
+
+// TestAgentsRenderIsDeterministic pins the fence against the ambient
+// environment. Both variables below are read at render time — codex
+// bakes $GORTEX_CODEX_HOOK_MODE into its hook command, and
+// profiles.ActiveName honours $GORTEX_INSTRUCTIONS_PROFILE, which
+// selects the user-level skill set — so without the render's env pins
+// the goldens would encode whichever posture the regenerating
+// developer happened to export, and CI would then fail on a diff
+// nobody can explain.
+func TestAgentsRenderIsDeterministic(t *testing.T) {
+	neutraliseClaudeConfigDirOverride(t)
+
+	t.Setenv("GORTEX_CODEX_HOOK_MODE", "suppress")
+	t.Setenv("GORTEX_INSTRUCTIONS_PROFILE", "full")
+	first := renderAllAdapters(t)
+
+	t.Setenv("GORTEX_CODEX_HOOK_MODE", "rewrite")
+	t.Setenv("GORTEX_INSTRUCTIONS_PROFILE", "localization")
+	second := renderAllAdapters(t)
+
+	for name, got := range second {
+		if want, ok := first[name]; !ok {
+			t.Errorf("%s rendered only once across two runs", name)
+		} else if got != want {
+			t.Errorf("%s manifest depends on the ambient environment: it changed when "+
+				"$GORTEX_CODEX_HOOK_MODE / $GORTEX_INSTRUCTIONS_PROFILE changed", name)
+		}
+	}
+
+	// And the codex hook command must carry the shipped default posture,
+	// not the "suppress"/"rewrite" the environment asked for.
+	codex, ok := first["codex"]
+	if !ok {
+		t.Fatal("no codex manifest")
+	}
+	if !strings.Contains(codex, "--agent=codex --mode=enrich") {
+		t.Errorf("codex hook command does not carry the fixed default posture --mode=enrich")
+	}
+	for _, leaked := range []string{"--mode=suppress", "--mode=rewrite", "--mode=deny"} {
+		if strings.Contains(codex, leaked) {
+			t.Errorf("codex manifest carries %q from the ambient environment", leaked)
+		}
+	}
+}
+
+// TestAgentsRenderFenceCoverage is the positive counterpart to the
+// goldens: it asserts the fence still *sees* the surfaces it was
+// widened to cover. Without it, a change that quietly narrows the
+// sandbox Env again — dropping InstallHooks, the generated-skill
+// fixture, or the ModeGlobal pass — would sail through as a golden
+// regeneration, which is exactly how the previous blind spot appeared.
+func TestAgentsRenderFenceCoverage(t *testing.T) {
+	neutraliseClaudeConfigDirOverride(t)
+	manifests := renderAllAdapters(t)
+
+	claude, ok := manifests["claude-code"]
+	if !ok {
+		t.Fatal("no claude-code manifest")
+	}
+	for _, want := range []string{
+		// ModeGlobal user-level artifacts.
+		"=== global/home/.claude/skills/",
+		"=== global/home/.claude/CLAUDE.md ===",
+		// Lifecycle hooks, both scopes.
+		"=== project/root/.claude/settings.local.json ===",
+		"=== global/home/.claude/settings.local.json ===",
+		// Generated per-community skills.
+		"=== project/root/.claude/skills/generated/gortex-example-one/SKILL.md ===",
+		"=== project/root/.claude/skills/generated/gortex-example-two/SKILL.md ===",
+	} {
+		if !strings.Contains(claude, want) {
+			t.Errorf("claude-code manifest lost fence coverage for %q", want)
+		}
+	}
+
+	// Every adapter must render something in both modes; a mode that
+	// renders nothing at all is the signature of a narrowed fence.
+	var projectOnly []string
+	for name, m := range manifests {
+		if !strings.Contains(m, "=== project/") {
+			t.Errorf("%s rendered no project-mode artifacts", name)
+		}
+		if !strings.Contains(m, "=== global/") {
+			projectOnly = append(projectOnly, name)
+		}
+	}
+	// Some adapters legitimately have no user-level surface, so this is
+	// reported rather than failed — but every adapter that has one must
+	// keep it visible.
+	if len(projectOnly) == len(manifests) {
+		t.Error("no adapter rendered a global-mode artifact — the ModeGlobal pass is not reaching adapters")
+	}
+	t.Logf("adapters with no ModeGlobal artifacts: %v", projectOnly)
 }

--- a/cmd/gortex/docs_counts_test.go
+++ b/cmd/gortex/docs_counts_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// docs_counts_test.go pins the adapter count printed in the docs to the
+// registry itself.
+//
+// Three separate files advertise how many agent integrations ship, and
+// all three had drifted — the docs still said nineteen while the
+// registry had grown. A count nobody can verify is worse than no count:
+// a reader who spots one stale number stops trusting the rest of the
+// page. Deriving it here means the next adapter fails this test until
+// its author updates every place that claims a total.
+
+// countedDocs maps a repo-relative doc to the phrasing it uses for the
+// adapter total. Each entry must contain the numeral, so a single
+// substring check covers all three without parsing prose.
+var countedDocs = []struct {
+	path    string
+	context string // human hint printed on failure
+}{
+	{"docs/agents.md", "\"NN adapters ship today\" in the intro"},
+	{"docs/skills.md", "\"NN other AI coding assistants\" under Usage with other agents"},
+	{"README.md", "\"Agent integrations (NN)\" and the docs table row"},
+}
+
+func TestDocsAdapterCountMatchesRegistry(t *testing.T) {
+	want := len(buildRegistry().All())
+	if want == 0 {
+		t.Fatal("buildRegistry() returned no adapters — the guard would pass vacuously")
+	}
+
+	root := repoRootForDocs(t)
+	for _, doc := range countedDocs {
+		t.Run(doc.path, func(t *testing.T) {
+			body, err := os.ReadFile(filepath.Join(root, doc.path))
+			if err != nil {
+				t.Fatalf("read %s: %v", doc.path, err)
+			}
+			// docs/skills.md counts the OTHER assistants — every adapter
+			// except claude-code, which the page describes separately.
+			n := want
+			if doc.path == "docs/skills.md" {
+				n = want - 1
+			}
+			if !strings.Contains(string(body), fmt.Sprint(n)) {
+				t.Errorf("%s does not mention the adapter count %d; update %s", doc.path, n, doc.context)
+			}
+		})
+	}
+}
+
+// repoRootForDocs walks up from the test's working directory (cmd/gortex)
+// to the module root, so the guard works from any invocation directory.
+func repoRootForDocs(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("no go.mod found above the test working directory")
+		}
+		dir = parent
+	}
+}

--- a/cmd/gortex/doctor_runtime.go
+++ b/cmd/gortex/doctor_runtime.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/zzet/gortex/internal/agents/claudecode"
 	"github.com/zzet/gortex/internal/agents/codex"
+	"github.com/zzet/gortex/internal/agents/copilotcli"
+	"github.com/zzet/gortex/internal/agents/opencode"
 	"github.com/zzet/gortex/internal/doctor"
 	"github.com/zzet/gortex/internal/hooks"
 	"github.com/zzet/gortex/internal/savings"
@@ -105,7 +107,7 @@ func collectRuntime(home string, days int) doctorRuntime {
 		Savings:  collectSavings(since),
 	}
 	for _, probe := range doctorAgentProbes(home) {
-		out.Agents = append(out.Agents, probe(since, activity, now))
+		out.Agents = append(out.Agents, probe.run(since, activity, now))
 	}
 	if doctorRedact {
 		out.Hooks.Path = doctorPath(out.Hooks.Path)
@@ -113,15 +115,31 @@ func collectRuntime(home string, days int) doctorRuntime {
 	return out
 }
 
-// agentProbe collects one agent's runtime slice.
-type agentProbe func(since time.Time, activity hooks.EffectivenessSummary, now time.Time) doctorAgentRuntime
+// agentProbe collects one agent's runtime slice. The agent name is carried
+// beside the closure rather than only inside it so the coverage guard in
+// doctor_runtime_test.go can enumerate what doctor speaks about without
+// running a probe — a probe reads the real home and scans session
+// transcripts, which is not something a unit test should be doing.
+type agentProbe struct {
+	agent string
+	run   func(since time.Time, activity hooks.EffectivenessSummary, now time.Time) doctorAgentRuntime
+}
 
 // doctorAgentProbes returns a probe per agent doctor can speak about. Adding
 // an agent here is the whole cost of covering it — the finding rules, the
 // per-agent log partition, and the renderer are all already generic.
+//
+// The `agent` string is not cosmetic: it is the key the invocation log is
+// partitioned by (hooks.EffectivenessSummary.ForAgent), and the writer side
+// stamps whatever `gortex hook --agent=<x>` was invoked with, normalised
+// through hooks.SetAgent. A probe naming an agent the hook handler does not
+// report reads zero runs forever and turns a healthy install into a
+// permanent "configured but none has run" blocker, so each entry below uses
+// the adapter's own Name constant — the same value the adapters bake into
+// their hook command lines.
 func doctorAgentProbes(home string) []agentProbe {
 	return []agentProbe{
-		func(since time.Time, activity hooks.EffectivenessSummary, now time.Time) doctorAgentRuntime {
+		{agent: codex.Name, run: func(since time.Time, activity hooks.EffectivenessSummary, now time.Time) doctorAgentRuntime {
 			state := codex.Inspect(home)
 			return buildAgentRuntime(agentRuntimeInput{
 				agent:      codex.Name,
@@ -138,8 +156,8 @@ func doctorAgentProbes(home string) []agentProbe {
 				trustRemedy:   codex.TrustRemedy,
 				adoption:      doctor.ScanCodexSessions(doctor.CodexHome(), since, 10),
 			}, activity, now)
-		},
-		func(since time.Time, activity hooks.EffectivenessSummary, now time.Time) doctorAgentRuntime {
+		}},
+		{agent: hooks.AgentClaudeCode, run: func(since time.Time, activity hooks.EffectivenessSummary, now time.Time) doctorAgentRuntime {
 			state := claudecode.Inspect(home)
 			return buildAgentRuntime(agentRuntimeInput{
 				agent:      hooks.AgentClaudeCode,
@@ -151,7 +169,58 @@ func doctorAgentProbes(home string) []agentProbe {
 				},
 				adoption: doctor.ScanClaudeSessions(doctor.ClaudeHome(), since, 10),
 			}, activity, now)
-		},
+		}},
+		{agent: copilotcli.Name, run: func(since time.Time, activity hooks.EffectivenessSummary, now time.Time) doctorAgentRuntime {
+			state := copilotcli.Inspect(home)
+			return buildAgentRuntime(agentRuntimeInput{
+				agent:      copilotcli.Name,
+				hookEvents: copilotcli.HookEvents,
+				install: doctorAgentInstall{
+					ConfigPath: state.ConfigPath, ConfigPresent: state.ConfigPresent,
+					MCPServer: state.MCPServer, Hooks: state.Hooks,
+					InstructionsPath: state.InstructionsPath, InstructionsWired: state.InstructionsWired,
+				},
+				// No per-hook trust gate: the Copilot CLI runs whatever is in
+				// hooks/*.json, so "configured but never ran" here means the
+				// hook is broken rather than unapproved, and pointing the user
+				// at an approval flow that does not exist would be worse than
+				// the generic remedy.
+				//
+				// STOP-LINE: no adoption scan. Copilot CLI keeps its session
+				// history in ~/.copilot/session-store.db — SQLite with an
+				// undocumented, unversioned schema and no export path.
+				// Reverse-engineering private tables buys a number that
+				// silently turns into zeros after any patch release, so the
+				// Adoption slice stays at its zero value on purpose and
+				// doctor reports "adoption could not be measured".
+			}, activity, now)
+		}},
+		{agent: opencode.Name, run: func(since time.Time, activity hooks.EffectivenessSummary, now time.Time) doctorAgentRuntime {
+			state := opencode.Inspect(home)
+			return buildAgentRuntime(agentRuntimeInput{
+				agent: opencode.Name,
+				// Three events, not four: opencode.HookEvents deliberately
+				// omits PostToolUse because the plugin's after-hook never
+				// shells the bridge and so can never log a run.
+				hookEvents: opencode.HookEvents,
+				install: doctorAgentInstall{
+					ConfigPath: state.ConfigPath, ConfigPresent: state.ConfigPresent,
+					MCPServer: state.MCPServer, Hooks: state.Hooks,
+					// No InstructionsPath: OpenCode has no user-level rules
+					// file Gortex writes (its routing block is per-repo in
+					// AGENTS.md), and naming one would produce a permanent
+					// "no Gortex rule block" warning about a file nothing
+					// ever writes.
+				},
+				// No per-hook trust gate — the plugin runs as soon as
+				// OpenCode loads it.
+				//
+				// STOP-LINE: no adoption scan. OpenCode keeps no session log
+				// Gortex can read, so there is no transcript to count tool
+				// calls from. Passing no adoption data is the honest answer;
+				// inventing one would be a fabricated metric.
+			}, activity, now)
+		}},
 	}
 }
 
@@ -292,10 +361,18 @@ func printDoctorRuntime(w io.Writer, r doctorRuntime) {
 
 func printAgentRuntime(w io.Writer, a doctorAgentRuntime, summary hooks.EffectivenessSummary) {
 	fmt.Fprintf(w, "\n  %s — install\n", a.Agent)
-	if !a.Install.ConfigPresent {
-		fmt.Fprintf(w, "    %s %s missing\n", glyphAbsent, a.Install.ConfigPath)
-	} else {
+	if a.Install.ConfigPresent {
 		fmt.Fprintf(w, "    %s mcp server registered\n", mark(a.Install.MCPServer))
+	} else {
+		fmt.Fprintf(w, "    %s %s missing\n", glyphAbsent, a.Install.ConfigPath)
+	}
+	// Hook lines print whenever the config carries them OR hooks are wired
+	// at all. The second half is not redundant: OpenCode has no hook
+	// configuration to read back — its hook surface is the bridge plugin,
+	// which lives nowhere near ConfigPath — so gating on ConfigPresent
+	// would render a fully wired OpenCode install as one line about a
+	// missing opencode.json and nothing else.
+	if a.Install.ConfigPresent || anyHookConfigured(a.Install.Hooks) {
 		for _, event := range a.HookEvents {
 			fmt.Fprintf(w, "    %s hook %-17s %d configured\n", mark(a.Install.Hooks[event] > 0), event, a.Install.Hooks[event])
 		}
@@ -429,6 +506,17 @@ func doctorTruncate(s string, n int) string {
 		return s
 	}
 	return s[:n]
+}
+
+// anyHookConfigured reports whether the agent declares at least one Gortex
+// hook, regardless of which file (if any) that declaration lives in.
+func anyHookConfigured(hooks map[string]int) bool {
+	for _, n := range hooks {
+		if n > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func mark(ok bool) string {

--- a/cmd/gortex/doctor_runtime_test.go
+++ b/cmd/gortex/doctor_runtime_test.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/claudecode"
+	"github.com/zzet/gortex/internal/agents/codex"
+	"github.com/zzet/gortex/internal/agents/copilotcli"
+	"github.com/zzet/gortex/internal/agents/opencode"
+	"github.com/zzet/gortex/internal/hooks"
+	"github.com/zzet/gortex/internal/testenv"
+)
+
+// doctorAgentProbes is hand-maintained, and the failure mode of a
+// hand-maintained list is silence: an adapter that grows an Inspect and is
+// never added here reports nothing at all, which reads to the user as
+// "Gortex has nothing to say about this agent" rather than "doctor forgot
+// about it". Deriving the expectation from the source tree is what turns
+// the omission into a red build instead.
+var (
+	inspectDecl   = regexp.MustCompile(`(?m)^func Inspect\(`)
+	adapterNameRe = regexp.MustCompile(`(?m)^(?:const\s+)?[ \t]*Name\s*=\s*"([^"]+)"`)
+)
+
+func TestDoctorProbesEveryAdapterThatExposesInspect(t *testing.T) {
+	adaptersDir := filepath.Join(repoRootForDocs(t), "internal", "agents")
+	entries, err := os.ReadDir(adaptersDir)
+	if err != nil {
+		t.Fatalf("read %s: %v", adaptersDir, err)
+	}
+
+	// package directory → adapter Name, for every package with an Inspect.
+	want := map[string]string{}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		files, err := filepath.Glob(filepath.Join(adaptersDir, e.Name(), "*.go"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		hasInspect, name := false, ""
+		for _, f := range files {
+			if strings.HasSuffix(f, "_test.go") {
+				continue
+			}
+			body, err := os.ReadFile(f)
+			if err != nil {
+				t.Fatalf("read %s: %v", f, err)
+			}
+			if inspectDecl.Match(body) {
+				hasInspect = true
+			}
+			if name == "" {
+				if m := adapterNameRe.FindSubmatch(body); m != nil {
+					name = string(m[1])
+				}
+			}
+		}
+		if !hasInspect {
+			continue
+		}
+		if name == "" {
+			t.Fatalf("internal/agents/%s exposes Inspect but declares no Name constant", e.Name())
+		}
+		want[e.Name()] = name
+	}
+
+	// A scan that matched nothing would make the guard pass vacuously.
+	for _, required := range []string{"claudecode", "codex", "copilotcli", "opencode"} {
+		if _, ok := want[required]; !ok {
+			t.Fatalf("the source scan missed internal/agents/%s — the guard would pass vacuously", required)
+		}
+	}
+
+	probed := map[string]bool{}
+	for _, probe := range doctorAgentProbes("") {
+		probed[probe.agent] = true
+	}
+	for pkg, name := range want {
+		if !probed[name] {
+			t.Errorf("internal/agents/%s exposes Inspect but doctorAgentProbes has no probe for %q; "+
+				"add one so `gortex doctor` can speak about it", pkg, name)
+		}
+	}
+}
+
+// TestDoctorProbeAgentNamesMatchTheHookWriter closes the loop the probe
+// list cannot close on its own.
+//
+// The invocation log is partitioned per agent, and the writer stamps
+// whatever `gortex hook --agent=<x>` resolves to through hooks.SetAgent.
+// A probe that reads a key the writer never stamps sees zero runs forever
+// — and doctor turns zero runs into a BLOCKER, so the failure presents as
+// "your hooks never ran" on a machine where they run every turn.
+func TestDoctorProbeAgentNamesMatchTheHookWriter(t *testing.T) {
+	t.Cleanup(func() { hooks.SetAgent("") })
+	for _, probe := range doctorAgentProbes("") {
+		// SetAgent normalises the flag value; the probe's key must be a
+		// fixed point of that normalisation.
+		hooks.SetAgent(probe.agent)
+		if got := hooks.ActiveAgent(); got != probe.agent {
+			t.Errorf("probe reads %q but `gortex hook --agent=%s` records %q", probe.agent, probe.agent, got)
+		}
+	}
+	// Claude Code is the one agent whose hook command carries no --agent
+	// flag at all (telemetry.go: rewriting it would invalidate Codex-style
+	// hook trust for no gain), so the empty default has to resolve to the
+	// same key its probe reads.
+	hooks.SetAgent("")
+	if got := hooks.ActiveAgent(); got != hooks.AgentClaudeCode {
+		t.Errorf("the empty --agent default records %q, want %q", got, hooks.AgentClaudeCode)
+	}
+}
+
+// TestDoctorRuntimeReportsInstallStateForEveryHost runs the real
+// ModeGlobal installs into a sandbox home and then asks doctor what it
+// sees, so the probes are exercised against what the writers actually
+// wrote rather than a hand-built fixture.
+func TestDoctorRuntimeReportsInstallStateForEveryHost(t *testing.T) {
+	home := t.TempDir()
+	testenv.SandboxAt(t, home)
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	claudecode.SetConfigDirOverride("")
+
+	env := agents.Env{
+		Root:                      t.TempDir(),
+		Home:                      home,
+		HookCommand:               "/tmp/test-gortex hook",
+		Mode:                      agents.ModeGlobal,
+		InstallHooks:              true,
+		InstallGlobalInstructions: true,
+		InstructionsDir:           filepath.Join(home, ".gortex", "instructions"),
+	}
+	for _, a := range []agents.Adapter{claudecode.New(), codex.New(), copilotcli.New(), opencode.New()} {
+		if _, err := a.Apply(env, agents.ApplyOpts{ForceDetect: true}); err != nil {
+			t.Fatalf("%s apply: %v", a.Name(), err)
+		}
+	}
+
+	runtime := collectRuntime(home, 7)
+	byAgent := map[string]doctorAgentRuntime{}
+	for _, a := range runtime.Agents {
+		byAgent[a.Agent] = a
+	}
+
+	for _, tc := range []struct {
+		agent     string
+		wantMCP   bool
+		hookProof string // the file that must name this agent's --agent value
+	}{
+		{codex.Name, true, filepath.Join(home, ".codex", "config.toml")},
+		{hooks.AgentClaudeCode, true, ""},
+		{copilotcli.Name, true, filepath.Join(home, ".copilot", "hooks", "gortex.json")},
+		// OpenCode registers no user-level MCP server: `gortex init` puts
+		// the stanza in the repo's own opencode.json.
+		{opencode.Name, false, opencode.PluginPath(home)},
+	} {
+		t.Run(tc.agent, func(t *testing.T) {
+			got, ok := byAgent[tc.agent]
+			if !ok {
+				t.Fatalf("doctor reported nothing for %s", tc.agent)
+			}
+			if got.Install.MCPServer != tc.wantMCP {
+				t.Errorf("MCPServer = %v, want %v", got.Install.MCPServer, tc.wantMCP)
+			}
+			if len(got.HookEvents) == 0 {
+				t.Fatal("no hook events declared")
+			}
+			for _, event := range got.HookEvents {
+				if got.Install.Hooks[event] == 0 {
+					t.Errorf("hook %s reported 0 configured after a real install", event)
+				}
+			}
+			if tc.hookProof == "" {
+				return
+			}
+			// The other half of the agent-name contract: the adapter must
+			// bake the very string the probe reads into its hook command,
+			// or the probe reads an empty partition of the log forever.
+			body, err := os.ReadFile(tc.hookProof)
+			if err != nil {
+				t.Fatalf("read %s: %v", tc.hookProof, err)
+			}
+			if !strings.Contains(string(body), "--agent="+tc.agent) {
+				t.Errorf("%s does not invoke `gortex hook --agent=%s`", tc.hookProof, tc.agent)
+			}
+		})
+	}
+
+	// The stop-line: neither new host has a session transcript Gortex can
+	// read, so their adoption slice stays at its zero value rather than
+	// carrying an invented number.
+	for _, agent := range []string{copilotcli.Name, opencode.Name} {
+		if got := byAgent[agent].Adoption; got.FilesFound != 0 || got.GortexCalls != 0 {
+			t.Errorf("%s reports adoption data it cannot have: %+v", agent, got)
+		}
+	}
+
+	// --json has to carry all four; it is what CI consumers read.
+	blob, err := json.Marshal(map[string]any{"runtime": runtime})
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+	for _, agent := range []string{codex.Name, hooks.AgentClaudeCode, copilotcli.Name, opencode.Name} {
+		if !strings.Contains(string(blob), `"agent":"`+agent+`"`) {
+			t.Errorf("the --json report never names %s", agent)
+		}
+	}
+}

--- a/cmd/gortex/hook.go
+++ b/cmd/gortex/hook.go
@@ -14,7 +14,7 @@ var (
 
 var hookCmd = &cobra.Command{
 	Use:    "hook",
-	Short:  "Agent hook handler (Claude Code by default; --agent for Gemini / Antigravity / Hermes / Kimi)",
+	Short:  "Agent hook handler (Claude Code by default; --agent for Codex / Copilot CLI / Kimi / Hermes / Pi / OpenCode / Gemini / Antigravity)",
 	Hidden: true, // Not for direct user invocation.
 	Run: func(_ *cobra.Command, _ []string) {
 		// --agent selects the hook wire protocol. Empty (the default) is the
@@ -22,10 +22,10 @@ var hookCmd = &cobra.Command{
 		// remaining external agents share the hookSpecificOutput.additionalContext
 		// wire shape.
 		// Attribute every telemetry row this process writes to the harness that
-	// invoked it, before any handler runs.
-	hooks.SetAgent(hookAgent)
+		// invoked it, before any handler runs.
+		hooks.SetAgent(hookAgent)
 
-	switch hookAgent {
+		switch hookAgent {
 		case "hermes":
 			// Hermes (NousResearch hermes-agent) sends
 			// snake_case events and expects an action/message decision shape, so
@@ -37,6 +37,20 @@ var hookCmd = &cobra.Command{
 			// shells `gortex hook --agent=pi`, sending a normalized event
 			// envelope on stdin and applying the PiDecision read back.
 			hooks.RunPi(hookPort, hooks.ParseMode(hookMode))
+			return
+		case "opencode":
+			// OpenCode has no hook configuration at all — its Gortex plugin
+			// (JS) shells `gortex hook --agent=opencode` from
+			// tool.execute.before / permission.ask / chat.message and applies
+			// the BridgeDecision read back, so it shares Pi's bridge core.
+			hooks.RunOpenCode(hookPort, hooks.ParseMode(hookMode))
+			return
+		case "copilot-cli":
+			// GitHub Copilot CLI: camelCase lifecycle events and a flat,
+			// per-event stdout shape (permissionDecision / modifiedPrompt /
+			// additionalContext) rather than Claude's hookSpecificOutput
+			// envelope, over a lowercase tool vocabulary of its own.
+			hooks.RunCopilot(hookPort, hooks.ParseMode(hookMode))
 			return
 		case "codex":
 			// Codex defaults to advisory context. Explicit postures add hard
@@ -65,6 +79,6 @@ func init() {
 	hookCmd.Flags().StringVar(&hookMode, "mode", "",
 		"hook posture: Claude defaults to deny and accepts deny|enrich|consult-unlock|nudge; Codex defaults to enrich and accepts enrich|deny|rewrite|suppress")
 	hookCmd.Flags().StringVar(&hookAgent, "agent", "",
-		"hook wire protocol: empty/'claude' (Claude Code lifecycle hooks), 'codex' (Codex Bash/MCP/apply_patch hooks), 'kimi' (Kimi Code CLI hooks), 'hermes' (NousResearch hermes-agent hooks), 'pi' (Pi extension bridge), or 'gemini'/'antigravity'. Default (empty) is Claude Code.")
+		"hook wire protocol: empty/'claude' (Claude Code lifecycle hooks), 'codex' (Codex Bash/MCP/apply_patch hooks), 'copilot-cli' (GitHub Copilot CLI hooks), 'kimi' (Kimi Code CLI hooks), 'hermes' (NousResearch hermes-agent hooks), 'pi' (Pi extension bridge), 'opencode' (OpenCode plugin bridge), or 'gemini'/'antigravity'. Default (empty) is Claude Code.")
 	rootCmd.AddCommand(hookCmd)
 }

--- a/cmd/gortex/init.go
+++ b/cmd/gortex/init.go
@@ -19,6 +19,7 @@ import (
 	"github.com/zzet/gortex/internal/agents/cline"
 	"github.com/zzet/gortex/internal/agents/codex"
 	"github.com/zzet/gortex/internal/agents/continuedev"
+	"github.com/zzet/gortex/internal/agents/copilotcli"
 	"github.com/zzet/gortex/internal/agents/cursor"
 	"github.com/zzet/gortex/internal/agents/gemini"
 	"github.com/zzet/gortex/internal/agents/hermes"
@@ -126,6 +127,7 @@ func buildRegistry() *agents.Registry {
 	r.Register(cline.New())
 	r.Register(codex.New())
 	r.Register(continuedev.New())
+	r.Register(copilotcli.New())
 	r.Register(gemini.New())
 	r.Register(hermes.New())
 	r.Register(kimi.New())

--- a/cmd/gortex/init_wizard.go
+++ b/cmd/gortex/init_wizard.go
@@ -26,6 +26,9 @@ var agentLabels = map[string]string{
 	"cline":       "Cline",
 	"codex":       "Codex CLI",
 	"continue":    "Continue.dev",
+	// Distinct from "vscode" below: that adapter is Copilot inside VS
+	// Code, this one is the standalone `copilot` terminal binary.
+	"copilot-cli": "GitHub Copilot CLI",
 	"gemini":      "Gemini CLI",
 	"hermes":      "Hermes",
 	"kimi":        "Kimi Code CLI",
@@ -50,6 +53,7 @@ var agentDetails = map[string]string{
 	"cline":       ".clinerules + cline_mcp_settings.json",
 	"codex":       "AGENTS.md + config.toml hooks",
 	"continue":    ".continue/config.json",
+	"copilot-cli": "~/.copilot/mcp-config.json + copilot-instructions.md",
 	"gemini":      ".gemini/settings.json",
 	"hermes":      "~/.hermes/config.yaml + profiles + skills",
 	"kimi":        ".kimi-code/mcp.json · user hook via install",

--- a/cmd/gortex/init_wizard_test.go
+++ b/cmd/gortex/init_wizard_test.go
@@ -164,6 +164,43 @@ func TestInitWizard_HookModeSelectCycles(t *testing.T) {
 	assert.Equal(t, "deny", m.options.Selects[0].Value(), "left cycles back")
 }
 
+// TestInitWizard_CopilotCLISurvivesLabelRoundTrip pins the silent-drop
+// trap in collectChoices: the wizard renders a checklist of *labels* and
+// maps them back to slugs through agentLabels, so a slug that is
+// registered but missing from that table still renders (title-cased) and
+// then vanishes on confirmation — the user's pick never runs. It also
+// pins that the CLI adapter's label is distinguishable from the VS Code
+// one, since two identical labels would collide in the same reverse map.
+func TestInitWizard_CopilotCLISurvivesLabelRoundTrip(t *testing.T) {
+	registered := []agents.Adapter{
+		&fakeAdapter{name: "claude-code", detected: true},
+		&fakeAdapter{name: "copilot-cli", detected: true},
+		&fakeAdapter{name: "vscode", detected: true},
+	}
+	detected := map[string]bool{"claude-code": true, "copilot-cli": true, "vscode": true}
+
+	m := newInitWizardModel(".", registered, detected, defaultDefaults())
+	assert.Contains(t, m.collectPickedLabels(), "GitHub Copilot CLI")
+	assert.NotEqual(t, agentLabel("vscode"), agentLabel("copilot-cli"),
+		"the CLI and the VS Code host must not share a label — the label→slug map is keyed by label")
+
+	m.collectChoices()
+	assert.Contains(t, m.pickedAgents, "copilot-cli",
+		"copilot-cli must survive the label→slug round-trip; a missing agentLabels entry drops it silently")
+	assert.Contains(t, m.pickedAgents, "vscode")
+}
+
+// TestInitWizard_EveryRegisteredAdapterHasALabel generalises the trap
+// above: any adapter reachable from buildRegistry must be in agentLabels,
+// or the wizard will offer it and then discard the pick.
+func TestInitWizard_EveryRegisteredAdapterHasALabel(t *testing.T) {
+	for _, a := range buildRegistry().All() {
+		if _, ok := agentLabels[a.Name()]; !ok {
+			t.Errorf("adapter %q is registered but missing from agentLabels — collectChoices would drop the user's pick", a.Name())
+		}
+	}
+}
+
 func TestInitWizard_ViewIncludesBannerAndStepLine(t *testing.T) {
 	m := newInitWizardModel("/tmp/demo", sampleRegistered(), sampleDetected(), defaultDefaults())
 

--- a/cmd/gortex/init_wizard_test.go
+++ b/cmd/gortex/init_wizard_test.go
@@ -95,10 +95,10 @@ func TestInitWizard_AdvancesThroughStepsAndCollectsChoices(t *testing.T) {
 	m := newInitWizardModel(".", sampleRegistered(), sampleDetected(), defaultDefaults())
 
 	// Step 1: agents — toggle codex on, then advance.
-	m = pressKey(m, "j")     // cursor → cursor
-	m = pressKey(m, "j")     // → aider
-	m = pressKey(m, "j")     // → codex
-	m = pressKey(m, " ")     // pick codex
+	m = pressKey(m, "j") // cursor → cursor
+	m = pressKey(m, "j") // → aider
+	m = pressKey(m, "j") // → codex
+	m = pressKey(m, " ") // pick codex
 	m = pressSpecial(m, tea.KeyEnter)
 	assert.Equal(t, stepOptions, m.step)
 

--- a/cmd/gortex/instructions.go
+++ b/cmd/gortex/instructions.go
@@ -12,6 +12,7 @@ import (
 	"github.com/zzet/gortex/internal/agents/claudecode"
 	"github.com/zzet/gortex/internal/agents/codex"
 	"github.com/zzet/gortex/internal/agents/copilotcli"
+	"github.com/zzet/gortex/internal/agents/hermes"
 	"github.com/zzet/gortex/internal/agents/opencode"
 	"github.com/zzet/gortex/internal/profiles"
 )
@@ -51,6 +52,7 @@ var hostSkillSyncs = []struct {
 	{"codex", codex.SyncSkills},
 	{"opencode", opencode.SyncSkills},
 	{"copilot cli", copilotcli.SyncSkills},
+	{"hermes", hermes.SyncSkills},
 }
 
 // instructions.go is the `gortex instructions` command tree — the CLI

--- a/cmd/gortex/instructions.go
+++ b/cmd/gortex/instructions.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -10,6 +11,8 @@ import (
 	"github.com/zzet/gortex/internal/agents"
 	"github.com/zzet/gortex/internal/agents/claudecode"
 	"github.com/zzet/gortex/internal/agents/codex"
+	"github.com/zzet/gortex/internal/agents/copilotcli"
+	"github.com/zzet/gortex/internal/agents/opencode"
 	"github.com/zzet/gortex/internal/profiles"
 )
 
@@ -20,6 +23,34 @@ import (
 func fileContains(path, needle string) bool {
 	data, err := os.ReadFile(path)
 	return err == nil && strings.Contains(string(data), needle)
+}
+
+// hostSkillSyncs is every host whose installed skill tree a profile
+// switch has to reshape. Each entry reconciles that host's own root
+// against the profile's subset, and each already knows how to enforce
+// the one rule that matters: a skill the user edited is kept, never
+// deleted to satisfy a profile.
+//
+// The table lives here, in cmd, deliberately. Routing the other hosts
+// through claudecode would make one adapter depend on three others and
+// invert exactly the direction internal/agents/skillpack was extracted
+// to protect (adapters -> skillpack, never adapter -> adapter). The
+// orchestrator is the layer allowed to know about all of them.
+//
+// Only Claude Code's entry installs missing skills on a machine that
+// never ran `gortex install`; the three newer hosts no-op when their
+// skills root is absent. That asymmetry is intentional — it preserves
+// the behaviour `instructions switch` has always had for Claude Code
+// while keeping a switch from conjuring a Codex / OpenCode / Copilot
+// surface the user never asked for.
+var hostSkillSyncs = []struct {
+	name string
+	sync func(w io.Writer, home string, allowed []string, opts agents.ApplyOpts) ([]agents.FileAction, error)
+}{
+	{"claude code", claudecode.SyncGlobalSkills},
+	{"codex", codex.SyncSkills},
+	{"opencode", opencode.SyncSkills},
+	{"copilot cli", copilotcli.SyncSkills},
 }
 
 // instructions.go is the `gortex instructions` command tree — the CLI
@@ -120,15 +151,21 @@ func runInstructionsSwitch(cmd *cobra.Command, args []string) error {
 	}
 	cmd.Printf("Switched to the %q instruction profile (active copy: %s/%s).\n", p.Name, dir, profiles.ActiveFileName)
 
-	// Reconcile the installed skills with the profile's subset. Best
-	// effort: a missing home or an unwritable skills dir downgrades to
-	// a warning, the profile switch itself has already landed.
+	// Reconcile the installed skills with the profile's subset, on every
+	// skill-aware host — a profile that keeps three playbooks is a lie
+	// if the other eighteen are still sitting in Codex's or OpenCode's
+	// picker. Best effort: a missing home or an unwritable skills dir
+	// downgrades to a warning, the profile switch itself has already
+	// landed.
 	if home, err := os.UserHomeDir(); err == nil && home != "" {
-		actions, err := claudecode.SyncGlobalSkills(cmd.ErrOrStderr(), home, p.Skills, agents.ApplyOpts{})
-		if err != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "warning: skills sync incomplete: %v\n", err)
-		} else {
-			installed, removed := 0, 0
+		installed, removed := 0, 0
+		for _, host := range hostSkillSyncs {
+			actions, err := host.sync(cmd.ErrOrStderr(), home, p.Skills, agents.ApplyOpts{})
+			if err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s skills sync incomplete: %v\n", host.name, err)
+			}
+			// Counted even on error: the actions returned before the
+			// failure describe files that really did change.
 			for _, a := range actions {
 				switch a.Action {
 				case agents.ActionCreate:
@@ -137,9 +174,9 @@ func runInstructionsSwitch(cmd *cobra.Command, args []string) error {
 					removed++
 				}
 			}
-			if installed+removed > 0 {
-				cmd.Printf("Skills reconciled: %d installed, %d removed.\n", installed, removed)
-			}
+		}
+		if installed+removed > 0 {
+			cmd.Printf("Skills reconciled: %d installed, %d removed.\n", installed, removed)
 		}
 		// Nudge when the pointer block was never installed — the
 		// profile only reaches agents through the @-include.

--- a/cmd/gortex/instructions_test.go
+++ b/cmd/gortex/instructions_test.go
@@ -4,11 +4,16 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/claudecode"
+	"github.com/zzet/gortex/internal/agents/codex"
+	"github.com/zzet/gortex/internal/agents/opencode"
 	"github.com/zzet/gortex/internal/profiles"
 	"github.com/zzet/gortex/internal/testenv"
 )
@@ -33,6 +38,178 @@ func captureCmd() (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
 	cmd.SetOut(out)
 	cmd.SetErr(errOut)
 	return cmd, out, errOut
+}
+
+// installedSkillIDs lists the skill directories under root that still
+// hold a SKILL.md — what a host would actually load, as opposed to what
+// directories happen to exist.
+func installedSkillIDs(t *testing.T, root string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(root)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("read dir %s: %v", root, err)
+	}
+	var out []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(root, e.Name(), "SKILL.md")); err == nil {
+			out = append(out, e.Name())
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestInstructionsSwitchReshapesEverySkillHost is the regression guard
+// for the bug this wiring closes: `instructions switch` used to prune
+// only ~/.claude/skills, so a user who picked a three-skill profile kept
+// the full twenty-one-playbook surface on every other host they had
+// installed — the profile was a lie everywhere but Claude Code.
+//
+// The sandbox seeds three hosts by running each adapter's own sync with
+// a nil subset (the install path), so the seeded bytes are exactly what
+// that host ships and the prune decision is exercised for real rather
+// than against a fixture.
+func TestInstructionsSwitchReshapesEverySkillHost(t *testing.T) {
+	home, _ := sandboxInstructionsEnv(t)
+	// Both of these relocate a host's config root when exported, and the
+	// sandbox home reads as the machine's real home, so a developer's own
+	// value would redirect the prune outside the sandbox.
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	t.Setenv("COPILOT_HOME", "")
+
+	claudeRoot := filepath.Join(home, ".claude", "skills")
+	codexRoot := filepath.Join(home, ".agents", "skills")
+	opencodeRoot := filepath.Join(home, ".config", "opencode", "skills")
+
+	// Seed each host's full pack. The two newer adapters no-op unless
+	// their root already exists — a switch must never install a host —
+	// so the directory is created first, exactly as `gortex install`
+	// would have left it.
+	for _, root := range []string{codexRoot, opencodeRoot} {
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, seed := range []struct {
+		name string
+		sync func(w *bytes.Buffer, home string) error
+	}{
+		{"claude code", func(w *bytes.Buffer, home string) error {
+			_, err := claudecode.SyncGlobalSkills(w, home, nil, agents.ApplyOpts{})
+			return err
+		}},
+		{"codex", func(w *bytes.Buffer, home string) error {
+			_, err := codex.SyncSkills(w, home, nil, agents.ApplyOpts{})
+			return err
+		}},
+		{"opencode", func(w *bytes.Buffer, home string) error {
+			_, err := opencode.SyncSkills(w, home, nil, agents.ApplyOpts{})
+			return err
+		}},
+	} {
+		if err := seed.sync(&bytes.Buffer{}, home); err != nil {
+			t.Fatalf("seed %s: %v", seed.name, err)
+		}
+	}
+
+	full := installedSkillIDs(t, claudeRoot)
+	if len(full) < 4 {
+		t.Fatalf("seeded pack is %v — too small for a subset to prove anything", full)
+	}
+	for _, root := range []string{codexRoot, opencodeRoot} {
+		if got := installedSkillIDs(t, root); len(got) != len(full) {
+			t.Fatalf("%s seeded with %d skills, want the full pack (%d)", root, len(got), len(full))
+		}
+	}
+
+	// One playbook the user rewrote, outside the target profile. It must
+	// survive on every host: enforcing a profile is worth deleting files
+	// Gortex wrote, never a file the user did.
+	const mine = "---\nname: gortex-rename\ndescription: mine\n---\nmy own steps\n"
+	for _, root := range []string{claudeRoot, codexRoot, opencodeRoot} {
+		if err := os.WriteFile(filepath.Join(root, "gortex-rename", "SKILL.md"), []byte(mine), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cmd, out, _ := captureCmd()
+	if err := runInstructionsSwitch(cmd, []string{"localization"}); err != nil {
+		t.Fatalf("switch: %v", err)
+	}
+
+	loc, _ := profiles.ByName("localization")
+	if loc.Skills == nil {
+		t.Fatal("the localization profile no longer carries a skills subset — this test proves nothing")
+	}
+	want := append([]string(nil), loc.Skills...)
+	want = append(want, "gortex-rename") // kept: customised
+	sort.Strings(want)
+
+	for _, root := range []string{claudeRoot, codexRoot, opencodeRoot} {
+		if got := installedSkillIDs(t, root); strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Errorf("%s holds %v after the switch, want %v", root, got, want)
+		}
+		path := filepath.Join(root, "gortex-rename", "SKILL.md")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("%s: customised skill was deleted to satisfy a profile: %v", path, err)
+			continue
+		}
+		if string(data) != mine {
+			t.Errorf("%s: customised skill was rewritten:\n%s", path, data)
+		}
+	}
+
+	if !strings.Contains(out.String(), "Skills reconciled") {
+		t.Errorf("switch must report the reconciliation, got:\n%s", out.String())
+	}
+
+	// Switching back must restore the full pack on every host. A profile
+	// that can only ever shrink the surface would make `localization` a
+	// one-way door, and the user's customised playbook still has to
+	// survive the return trip.
+	cmd, _, _ = captureCmd()
+	if err := runInstructionsSwitch(cmd, []string{"core"}); err != nil {
+		t.Fatalf("switch back: %v", err)
+	}
+	for _, root := range []string{claudeRoot, codexRoot, opencodeRoot} {
+		if got := installedSkillIDs(t, root); strings.Join(got, ",") != strings.Join(full, ",") {
+			t.Errorf("%s holds %v after switching back to core, want the full pack %v", root, got, full)
+		}
+		if got, err := os.ReadFile(filepath.Join(root, "gortex-rename", "SKILL.md")); err != nil || string(got) != mine {
+			t.Errorf("%s: customised skill did not survive the round trip (err=%v)", root, err)
+		}
+	}
+}
+
+// TestInstructionsSwitchLeavesUninstalledHostsAlone: most machines run
+// one or two of the supported hosts. A switch must not materialise a
+// Codex / OpenCode / Copilot skills tree the user never asked for, and
+// must not error because those trees are absent.
+func TestInstructionsSwitchLeavesUninstalledHostsAlone(t *testing.T) {
+	home, _ := sandboxInstructionsEnv(t)
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	t.Setenv("COPILOT_HOME", "")
+
+	cmd, _, _ := captureCmd()
+	if err := runInstructionsSwitch(cmd, []string{"localization"}); err != nil {
+		t.Fatalf("switch: %v", err)
+	}
+	for _, root := range []string{
+		filepath.Join(home, ".agents", "skills"),
+		filepath.Join(home, ".config", "opencode", "skills"),
+		filepath.Join(home, ".copilot", "skills"),
+	} {
+		if _, err := os.Stat(root); !os.IsNotExist(err) {
+			t.Errorf("switch created %s on a machine with no such host (stat err = %v)", root, err)
+		}
+	}
 }
 
 func TestInstructionsSwitchListShowRegen(t *testing.T) {

--- a/cmd/gortex/testdata/agent-render/aider.txt
+++ b/cmd/gortex/testdata/agent-render/aider.txt
@@ -1,8 +1,8 @@
-=== root/.aiderignore ===
+=== project/root/.aiderignore ===
 # Added by `gortex init` — Gortex cache artifacts are not source
 .gortex/
 *.gortex-cache
-=== root/CONVENTIONS.md ===
+=== project/root/CONVENTIONS.md ===
 <!-- gortex:communities:start -->
 - [example-community](.claude/skills/example/SKILL.md) — example routing block
 

--- a/cmd/gortex/testdata/agent-render/antigravity.txt
+++ b/cmd/gortex/testdata/agent-render/antigravity.txt
@@ -1,4 +1,4 @@
-=== home/.gemini/antigravity/knowledge/gortex-workflow/artifacts/gortex-instructions.md ===
+=== project/home/.gemini/antigravity/knowledge/gortex-workflow/artifacts/gortex-instructions.md ===
 ---
 type: "Knowledge Item"
 description: "Mandatory Gortex public-tool workflow"
@@ -23,12 +23,12 @@ Common calls:
 If the Gortex server is configured but these tools are missing from the callable MCP tools, report a Gortex MCP integration failure and stop. Do not start a daemon or switch to a CLI/shell fallback.
 
 Use `recall` before revisiting prior work and `remember` immediately for durable decisions, invariants, or gotchas.
-=== home/.gemini/antigravity/knowledge/gortex-workflow/metadata.json ===
+=== project/home/.gemini/antigravity/knowledge/gortex-workflow/metadata.json ===
 {
   "summary": "MANDATORY: Use native Gortex MCP tools for indexed code. If configured tools are missing, report an MCP integration failure; do not start a daemon or use a CLI fallback.",
   "references": ["artifacts/gortex-instructions.md"]
 }
-=== home/.gemini/antigravity/mcp_config.json ===
+=== project/home/.gemini/antigravity/mcp_config.json ===
 {
   "mcpServers": {
     "gortex": {
@@ -42,7 +42,83 @@ Use `recall` before revisiting prior work and `remember` immediately for durable
     }
   }
 }
-=== home/.gemini/settings.json ===
+=== project/home/.gemini/settings.json ===
+{
+  "hooks": {
+    "AfterTool": [
+      {
+        "hooks": [
+          {
+            "command": "gortex hook --agent antigravity",
+            "description": "Gortex graph context + stale-index hint",
+            "name": "gortex",
+            "timeout": 10000,
+            "type": "command"
+          }
+        ],
+        "matcher": "run_shell_command|search_file_content|glob"
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "gortex hook --agent antigravity",
+            "description": "Gortex session orientation",
+            "name": "gortex",
+            "timeout": 10000,
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  }
+}
+=== global/home/.gemini/antigravity/knowledge/gortex-workflow/artifacts/gortex-instructions.md ===
+---
+type: "Knowledge Item"
+description: "Mandatory Gortex public-tool workflow"
+---
+
+## MANDATORY: Use Gortex MCP tools instead of Read/Grep
+
+For every coding task:
+
+1. Call `explore` first with the complete task. Work from the returned source and call paths; do not reopen them with file or shell tools.
+2. Inspect indexed code only with `search`, `read`, `relations`, and `trace`. Never use Read/Grep/Glob or shell equivalents for indexed source.
+3. Before mutation, call `change(operation:"impact")`; for a signature change, also call `change(operation:"verify")` with the proposed signature. Mutate only with `edit` or `refactor`. After mutation, call `change(operation:"detect")`, then use its symbol IDs with `change(operation:"tests")`, `change(operation:"guards")`, and `change(operation:"contract")`.
+4. Call `capabilities` only when you need the exact fields for an operation.
+
+Common calls:
+
+- `search({operation:"symbols", query:"<name or concept>"})`
+- `read({target:{symbol:"<file>::<Name|Recv.Name>"}})`
+- `relations({operation:"usages", target:{symbol:"<id>"}})`
+- `edit({target:{file:"<path>"}, match:"<old>", replacement:"<new>"})`
+
+If the Gortex server is configured but these tools are missing from the callable MCP tools, report a Gortex MCP integration failure and stop. Do not start a daemon or switch to a CLI/shell fallback.
+
+Use `recall` before revisiting prior work and `remember` immediately for durable decisions, invariants, or gotchas.
+=== global/home/.gemini/antigravity/knowledge/gortex-workflow/metadata.json ===
+{
+  "summary": "MANDATORY: Use native Gortex MCP tools for indexed code. If configured tools are missing, report an MCP integration failure; do not start a daemon or use a CLI fallback.",
+  "references": ["artifacts/gortex-instructions.md"]
+}
+=== global/home/.gemini/antigravity/mcp_config.json ===
+{
+  "mcpServers": {
+    "gortex": {
+      "args": [
+        "mcp"
+      ],
+      "command": "gortex",
+      "env": {
+        "GORTEX_INDEX_WORKERS": "8"
+      }
+    }
+  }
+}
+=== global/home/.gemini/settings.json ===
 {
   "hooks": {
     "AfterTool": [

--- a/cmd/gortex/testdata/agent-render/claude-code.txt
+++ b/cmd/gortex/testdata/agent-render/claude-code.txt
@@ -1,4 +1,4 @@
-=== root/.claude/settings.json ===
+=== project/root/.claude/settings.json ===
 {
   "permissions": {
     "allow": [
@@ -16,7 +16,128 @@
     ]
   }
 }
-=== root/.mcp.json ===
+=== project/root/.claude/settings.local.json ===
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "gortex hook",
+            "statusMessage": "Watching for Gortex localization completion...",
+            "timeout": 3000,
+            "type": "command"
+          }
+        ],
+        "matcher": "mcp__gortex__explore|mcp__gortex__search|mcp__gortex__read|mcp__gortex__relations|mcp__gortex__trace|mcp__gortex__analyze|mcp__plugin_gortex_gortex__explore|mcp__plugin_gortex_gortex__search|mcp__plugin_gortex_gortex__read|mcp__plugin_gortex_gortex__relations|mcp__plugin_gortex_gortex__trace|mcp__plugin_gortex_gortex__analyze"
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "command": "gortex hook",
+            "statusMessage": "Injecting Gortex orientation snapshot...",
+            "timeout": 3000,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "gortex hook",
+            "statusMessage": "Enforcing Gortex graph access policy...",
+            "timeout": 3000,
+            "type": "command"
+          }
+        ],
+        "matcher": "*"
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "gortex hook",
+            "statusMessage": "Loading Gortex graph orientation...",
+            "timeout": 3000,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "command": "gortex hook",
+            "statusMessage": "Running Gortex post-task diagnostics...",
+            "timeout": 5000,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "command": "gortex hook",
+            "statusMessage": "Starting an isolated Gortex subagent turn...",
+            "timeout": 3000,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "command": "gortex hook",
+            "statusMessage": "Clearing Gortex subagent turn state...",
+            "timeout": 3000,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "command": "gortex hook",
+            "statusMessage": "Surfacing relevant Gortex symbols...",
+            "timeout": 3000,
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  }
+}
+=== project/root/.claude/skills/generated/gortex-example-one/SKILL.md ===
+---
+name: gortex-example-one
+description: Example generated community skill used by the render drift fence.
+---
+
+# example-one
+
+Routing stub for the example-one community.
+=== project/root/.claude/skills/generated/gortex-example-two/SKILL.md ===
+---
+name: gortex-example-two
+description: Example generated community skill used by the render drift fence.
+---
+
+# example-two
+
+Routing stub for the example-two community.
+=== project/root/.mcp.json ===
 {
   "mcpServers": {
     "gortex": {
@@ -30,10 +151,1076 @@
     }
   }
 }
-=== root/AGENTS.md ===
+=== project/root/AGENTS.md ===
 <!-- gortex:communities:start -->
 - [example-community](.claude/skills/example/SKILL.md) — example routing block
 
 <!-- gortex:communities:end -->
-=== root/CLAUDE.md ===
+=== project/root/CLAUDE.md ===
 @AGENTS.md
+=== global/home/.claude.json ===
+{
+  "mcpServers": {
+    "gortex": {
+      "args": [
+        "mcp"
+      ],
+      "command": "gortex",
+      "env": {}
+    }
+  }
+}
+=== global/home/.claude/CLAUDE.md ===
+<!-- gortex:rules:start -->
+## MANDATORY: Use Gortex MCP tools instead of Read/Grep/Glob
+
+The machine-wide Gortex rules load from the active instruction profile, imported below:
+
+@$HOME/.gortex/instructions/active.md
+
+Switch guidance depth with `gortex instructions switch <core|localization|full>` (`list` shows all) — applies to NEW sessions only.
+
+<!-- gortex:rules:end -->
+=== global/home/.claude/agents/gortex-impact.md ===
+---
+name: gortex-impact
+description: "Assess a change's blast radius, contracts, guards, and tests."
+tools: mcp__gortex__capabilities, mcp__gortex__explore, mcp__gortex__search, mcp__gortex__read, mcp__gortex__relations, mcp__gortex__trace, mcp__gortex__analyze, mcp__gortex__change, mcp__gortex__recall, mcp__gortex__workspace
+---
+
+Convert the delegated change into a concise, graph-grounded impact report. Do not mutate files.
+
+1. Resolve the working set with `explore`; use `search` and `read` only to disambiguate targets.
+2. Call `change` with `operation: "impact"`. For signature changes also call `operation: "verify"`.
+3. Use `relations` for callers, usages, and dependents; use `analyze` with `kind: "contracts"` when a boundary may change.
+4. Call `change` with `operation: "guards"` and `operation: "tests"`.
+5. Call `capabilities` with `detail: "schema"` if an operation's exact arguments are not visible.
+
+Return: one-line safe/risky/breaking verdict; broken callers, contracts, or guards with file:line; then exact tests to run.
+=== global/home/.claude/agents/gortex-search.md ===
+---
+name: gortex-search
+description: "Locate code, trace call paths, or map architecture in a fresh context."
+tools: mcp__gortex__capabilities, mcp__gortex__explore, mcp__gortex__search, mcp__gortex__read, mcp__gortex__relations, mcp__gortex__trace, mcp__gortex__analyze, mcp__gortex__recall, mcp__gortex__workspace
+---
+
+Answer the delegated code-navigation question using only Gortex.
+
+1. Call `explore` with `operation: "task"` and the delegated task.
+2. Use `search` with `operation: "symbols"` for names or `operation: "text"` for exact literals.
+3. Use `read` with `operation: "source"` or `operation: "summary"`; do not request unrelated whole files.
+4. Use `relations` for callers, usages, dependencies, dependents, or implementations. Use `trace` for call chains and dataflow.
+5. Use `analyze` for architecture, communities, processes, or a named graph analysis.
+6. Call `capabilities` with `detail: "schema"` if an operation's exact arguments are not visible.
+
+Return the answer first, then symbol IDs and file:line evidence, then caveats. Do not dump raw tool output.
+=== global/home/.claude/commands/gortex-add-test.md ===
+# Add Tests with Gortex
+
+1. Localize the behavior with `explore`.
+2. Confirm the specific gap with `change({operation: "tests", source: {symbols: ["<id>"]}})`. Use repository-wide `analyze({kind: "untested"})` or path-scoped `analyze({kind: "coverage_gaps", options: {path_prefix: "<path>"}})` only for broader coverage discovery.
+3. Inspect callers with `relations({operation: "callers", target: {symbol: "<id>"}})` and request targets with `change({operation: "tests", source: {symbols: ["<id>"]}})`.
+4. Add the narrowest test with `edit({operation: "file", target: {file: "<existing test path>"}, ...})`; use operation `write` for a new test file.
+5. Run the test, then require `change` operations `detect` and `guards`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/commands/gortex-architecture-review.md ===
+# Review Architecture with Gortex
+
+1. Build the map with `explore({operation: "outline"})` and `analyze` kinds `architecture` and `communities`.
+2. Measure boundaries with `analyze({kind: "coupling"})` and cycles with `analyze({kind: "cycles"})`.
+3. Trace representative paths with `trace` and inspect public boundaries with `analyze({kind: "contracts", options: {action: "list"}})`.
+4. Deliver observed structure, intended structure, violations, consequences, and prioritized changes. Cite graph evidence for every finding.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/commands/gortex-co-change.md ===
+# Analyze Co-Change with Gortex
+
+1. Resolve the anchor with `search({operation: "symbols", query: "<name>"})`.
+2. Call symbol-scoped `analyze({kind: "co_change", target: {symbol: "<id>"}})` and repository-wide `analyze({kind: "churn"})`.
+3. Compare structural coupling through `relations` operations `cluster` and `dependents`.
+4. Report strong historical pairs, graph-confirmed dependencies, likely hidden coupling, and an actionable boundary or guard.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/commands/gortex-cross-repo-usage.md ===
+# Find Cross-Repository Usage with Gortex
+
+1. Confirm tracked repositories with `workspace({operation: "repos"})`.
+2. Resolve the provider symbol with `search({operation: "symbols", query: "<name>", options: {repo: "<provider>"}})`.
+3. Call `relations({operation: "usages", target: {symbol: "<id>"}})` and group results by repository.
+4. Add `analyze({kind: "cross_repo", options: {repo: "<provider>"}})` for repository boundaries and `analyze({kind: "contracts", options: {action: "bridge", mode: "impact", symbol: "<id>"}})` for wire-level consumers.
+5. Report indexed coverage and name any untracked repositories as an explicit gap.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/commands/gortex-dataflow-trace.md ===
+# Trace Data Flow with Gortex
+
+1. Call `explore({operation: "task", task: "trace <value> from <source> to <sink>"})`.
+2. Resolve endpoints with `search({operation: "symbols", query: "<source or sink>"})`.
+3. Use `trace({operation: "flow", target: {symbol: "<source-id>"}, to: {symbol: "<sink-id>"}})`. Use operation `taint` when source/sink security semantics matter.
+4. Cross-check control flow with operation `call_chain` when the data-flow graph has a gap.
+5. Report each hop with its symbol ID and confidence; distinguish no path from incomplete indexing.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/commands/gortex-debug.md ===
+# Debug with Gortex
+
+1. Localize the exact symptom with `explore({operation: "task", task: "<error and observed behavior>"})`.
+2. For a literal error, call `search({operation: "text", query: "<exact text>"})`. For a name, use operation `symbols`.
+3. Walk toward the cause with `relations({operation: "callers", target: {symbol: "<id>"}})` and `trace({operation: "call_chain", target: {symbol: "<id>"}})`. Use `flow` or `taint` only after resolving both `target` and `to` endpoints.
+4. Confirm repository-wide error propagation with `analyze({kind: "error_surface"})`; use `options.repo` to narrow a multi-repository workspace.
+5. Before fixing, run `change({operation: "impact", source: {symbols: ["<id>"]}})`. After fixing, run `change` operations `detect`, `tests`, and `guards`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/commands/gortex-episode-replay.md ===
+# Replay a Change Episode with Gortex
+
+1. Run `analyze({kind: "replay", options: {from: "<start>", to: "<end>"}})` for the requested window.
+2. Project the relevant diff with `change({operation: "detect", source: {scope: "<scope>"}})`.
+3. Surface decisions with `recall({operation: "surface", arguments: {task: "<episode>"}})`.
+4. Trace important before/after paths using `trace` and identify which change altered behavior.
+5. Produce a timestamped narrative with evidence links, impact, missed signals, and remaining uncertainty.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/commands/gortex-explore.md ===
+# Explore a Codebase with Gortex
+
+1. Call `explore({operation: "task", task: "<question>"})`.
+2. Read only a returned anchor with `read({target: {symbol: "<id>"}})`.
+3. Choose the needed relationship (`callers`, `usages`, or `dependencies`), for example `relations({operation: "callers", target: {symbol: "<id>"}})`; use `trace({operation: "call_chain", target: {symbol: "<id>"}})` for execution order.
+4. Answer with the execution path, file locations, symbol IDs, and any graph uncertainty.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/commands/gortex-extract-function.md ===
+# Extract a Function with Gortex
+
+1. Inspect the file with `read({operation: "editing_context", target: {file: "<path>"}})`.
+2. Resolve the selected range with `change({operation: "ranges", source: {file: "<path>", range: {...}}})`.
+3. Request extraction actions with `change({operation: "code_actions", source: {file: "<path>", range: {...}}})`.
+4. Apply the selected action through `refactor({operation: "apply_code_action", target: {file: "<path>"}, options: {...}})`.
+5. Run `change` operations `detect`, `tests`, `guards`, and `contract`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/commands/gortex-fix-all.md ===
+# Fix Diagnostics with Gortex
+
+1. Read diagnostics using `change({operation: "diagnostics", source: {file: "<path>"}})`.
+2. Fetch applicable fixes with `change({operation: "code_actions", source: {file: "<path>"}})`.
+3. Apply one reviewed action with `refactor({operation: "apply_code_action", target: {file: "<path>"}, options: {...}})`, or use operation `fix_all` only when the user asked for all safe fixes.
+4. Re-run diagnostics, then run `change` operations `detect` and `tests`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/commands/gortex-guide.md ===
+# Gortex Guide
+
+Use this sequence for codebase work:
+
+1. `explore({operation: "task", task: "<goal or bug>"})` — localize the task and obtain the working set.
+2. `search({operation: "symbols", query: "<name>"})` or `search({operation: "text", query: "<literal>"})` — resolve a precise anchor.
+3. `read({operation: "source", target: {symbol: "<id>"}})` — read only the source needed.
+4. `relations({operation: "usages", target: {symbol: "<id>"}})` or `trace({operation: "call_chain", target: {symbol: "<id>"}})` — follow verified graph edges.
+5. `change({operation: "impact", source: {symbols: ["<id>"]}})` — assess a planned change.
+6. Apply with `edit` or `refactor`, then run `change` operations `detect`, `guards`, and `tests`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/commands/gortex-impact.md ===
+# Assess Change Impact with Gortex
+
+1. Resolve the target with `search({operation: "symbols", query: "<name>"})`.
+2. Query `relations` operations `usages`, `dependents`, and `implementations` for the resolved symbol.
+3. Call `change({operation: "impact", source: {symbols: ["<id>"]}})`; add operation `api_impact` for a public API.
+4. For a signature change, require `change({operation: "verify", source: {changes: [{symbol_id: "<id>", new_signature: "<signature>"}]}})`.
+5. Report direct callers, transitive risk, interfaces, contracts, and the tests returned by `change({operation: "tests", source: {symbols: ["<id>"]}})`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/commands/gortex-incident-investigation.md ===
+# Investigate an Incident with Gortex
+
+1. Paste the exact symptom into `explore({operation: "task", task: "<alert, error, and time window>"})`.
+2. Search exact error text with `search({operation: "text", query: "<literal>"})`.
+3. Walk `relations` operation `callers` and `trace` operations `call_chain`, `flow`, or `taint` from symptom toward cause.
+4. Correlate repository-wide `analyze({kind: "recent_changes"})` with symbol-scoped `recall({operation: "surface", arguments: {symbol_ids: "<id>", task: "<symptom>"}})`.
+5. Separate evidence, hypothesis, and unknowns. Gate any fix through `change` before and after the mutation.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/commands/gortex-onboarding.md ===
+# Onboard to a Repository with Gortex
+
+1. Call `explore({operation: "outline"})`, then `explore({operation: "task", task: "explain the repository's main responsibilities and entry points"})`.
+2. Run `analyze` with kinds `architecture`, `communities`, and `processes`.
+3. Trace one representative request or job with `trace({operation: "call_chain", target: {symbol: "<entry-id>"}})`.
+4. Read only the key returned symbols. Deliver a concise map of entry points, boundaries, data flow, tests, and operational risks.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/commands/gortex-pr-review-agent.md ===
+# Review a Change as a Sub-Agent
+
+## MCP-capable harness
+
+Native Gortex MCP is mandatory. Call `review({operation: "run", source: {scope: "<scope>"}})`, then use `change` operations `guards`, `tests`, and `contract`. When the proposed signature is known, run operation `verify` before mutation. If the configured callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or use the Bash path below.
+
+## Bash-only harness
+
+Use this path only when the harness has no MCP transport by design:
+
+```bash
+gortex review --audience agent --format json
+```
+
+In either mode, return `VERDICT: clean` or `VERDICT: findings` followed by actionable findings with severity and `file:line`. Do not replace graph-backed review with ad-hoc `git diff` inspection.
+=== global/home/.claude/commands/gortex-pr-review.md ===
+# Review a Change with Gortex
+
+1. Project the working tree with `change({operation: "detect", source: {scope: "unstaged"}})`; use `staged` or `compare` only when that is the requested review scope.
+2. Build review context with `review({operation: "run", source: {scope: "<scope>"}})` and operation `diff_context` when per-file context is needed.
+3. Require `change` operations `guards`, `tests`, and `contract`. When the proposed signature is known, run operation `verify` before mutation.
+4. Check wire boundaries with `analyze({kind: "contracts", options: {action: "check"}})` when APIs or events changed.
+5. Report only actionable findings with severity, `file:line`, evidence, consequence, and correction. State an explicit clean verdict when none remain.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/commands/gortex-quality-audit.md ===
+# Audit Repository Quality with Gortex
+
+1. Establish scope with `workspace({operation: "info"})` and `explore({operation: "outline"})`.
+2. Run `analyze` for `health`, `dead_code`, `hotspots`, `cycles`, and `clones`.
+3. Validate high-risk findings with `read` and `relations`; do not report an unverified heuristic as a fact.
+4. Rank findings by evidence, impact, and remediation cost. Include exact paths, symbol IDs, and a smallest-first action plan.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/commands/gortex-refactor.md ===
+# Refactor with Gortex
+
+1. Call `explore({operation: "task", task: "<refactor goal>"})` and resolve every target with `search`.
+2. Run `change({operation: "impact", source: {symbols: ["<id>"]}})`. Before altering a signature, also run `change({operation: "verify", source: {changes: [{symbol_id: "<id>", new_signature: "<signature>"}]}})`.
+3. Choose exactly one `refactor` operation: `rename`, `move`, `inline`, `delete`, or `apply_code_action`. For example: `refactor({operation: "rename", target: {symbol: "<id>"}, new_name: "<name>"})`.
+4. Require `change` operations `detect`, `tests`, `guards`, and `contract` after the mutation. Resolve every violation before finishing.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/commands/gortex-rename.md ===
+# Rename a Symbol with Gortex
+
+1. Resolve exactly one symbol with `search({operation: "symbols", query: "<old name>"})`.
+2. Enumerate references and implementations with `relations` operations `usages` and `implementations`.
+3. Run `change({operation: "impact", source: {symbols: ["<id>"]}})`. For a public signature rename, also run `change({operation: "verify", source: {changes: [{symbol_id: "<id>", new_signature: "<signature with new name>"}]}})`.
+4. Preview with `refactor({operation: "rename", target: {symbol: "<id>"}, new_name: "<new>", dry_run: true})`, then repeat it with `dry_run: false` to apply.
+5. Require `change` operations `detect`, `guards`, and `tests`; confirm no old usages remain.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/commands/gortex-safe-edit.md ===
+# Make a Safe Edit with Gortex
+
+1. Localize with `explore` and inspect `read({operation: "editing_context", target: {file: "<path>"}})`.
+2. Run `change({operation: "impact", source: {symbols: ["<id>"]}})` before editing.
+3. Choose `edit` operation `file`, `symbol`, or `batch`. Preview with `dry_run: true`; after review, repeat the same guarded request with `dry_run: false`. Use `change({operation: "simulate", source: {steps: "<WorkspaceEdit JSON array>"}})` for a multi-step semantic edit.
+4. Run `change` operations `detect`, `tests`, `guards`, and `contract`. Signature verification belongs before mutation with the proposed signature.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/settings.json ===
+{
+  "permissions": {
+    "allow": [
+      "mcp__gortex__analyze",
+      "mcp__gortex__capabilities",
+      "mcp__gortex__change",
+      "mcp__gortex__explore",
+      "mcp__gortex__read",
+      "mcp__gortex__recall",
+      "mcp__gortex__relations",
+      "mcp__gortex__response",
+      "mcp__gortex__search",
+      "mcp__gortex__trace",
+      "mcp__gortex__workspace"
+    ]
+  }
+}
+=== global/home/.claude/settings.local.json ===
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "gortex hook",
+            "statusMessage": "Watching for Gortex localization completion...",
+            "timeout": 3000,
+            "type": "command"
+          }
+        ],
+        "matcher": "mcp__gortex__explore|mcp__gortex__search|mcp__gortex__read|mcp__gortex__relations|mcp__gortex__trace|mcp__gortex__analyze|mcp__plugin_gortex_gortex__explore|mcp__plugin_gortex_gortex__search|mcp__plugin_gortex_gortex__read|mcp__plugin_gortex_gortex__relations|mcp__plugin_gortex_gortex__trace|mcp__plugin_gortex_gortex__analyze"
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "command": "gortex hook",
+            "statusMessage": "Injecting Gortex orientation snapshot...",
+            "timeout": 3000,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "gortex hook",
+            "statusMessage": "Enforcing Gortex graph access policy...",
+            "timeout": 3000,
+            "type": "command"
+          }
+        ],
+        "matcher": "*"
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "gortex hook",
+            "statusMessage": "Loading Gortex graph orientation...",
+            "timeout": 3000,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "command": "gortex hook",
+            "statusMessage": "Running Gortex post-task diagnostics...",
+            "timeout": 5000,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "command": "gortex hook",
+            "statusMessage": "Starting an isolated Gortex subagent turn...",
+            "timeout": 3000,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "command": "gortex hook",
+            "statusMessage": "Clearing Gortex subagent turn state...",
+            "timeout": 3000,
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "command": "gortex hook",
+            "statusMessage": "Surfacing relevant Gortex symbols...",
+            "timeout": 3000,
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  }
+}
+=== global/home/.claude/skills/gortex-add-test/SKILL.md ===
+---
+name: gortex-add-test
+description: "Add tests for under-tested code and coverage gaps."
+---
+# Add Tests with Gortex
+
+1. Localize the behavior with `explore`.
+2. Confirm the specific gap with `change({operation: "tests", source: {symbols: ["<id>"]}})`. Use repository-wide `analyze({kind: "untested"})` or path-scoped `analyze({kind: "coverage_gaps", options: {path_prefix: "<path>"}})` only for broader coverage discovery.
+3. Inspect callers with `relations({operation: "callers", target: {symbol: "<id>"}})` and request targets with `change({operation: "tests", source: {symbols: ["<id>"]}})`.
+4. Add the narrowest test with `edit({operation: "file", target: {file: "<existing test path>"}, ...})`; use operation `write` for a new test file.
+5. Run the test, then require `change` operations `detect` and `guards`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/skills/gortex-architecture-review/SKILL.md ===
+---
+name: gortex-architecture-review
+description: "Graph-grounded architectural read of a repo."
+---
+# Review Architecture with Gortex
+
+1. Build the map with `explore({operation: "outline"})` and `analyze` kinds `architecture` and `communities`.
+2. Measure boundaries with `analyze({kind: "coupling"})` and cycles with `analyze({kind: "cycles"})`.
+3. Trace representative paths with `trace` and inspect public boundaries with `analyze({kind: "contracts", options: {action: "list"}})`.
+4. Deliver observed structure, intended structure, violations, consequences, and prioritized changes. Cite graph evidence for every finding.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/skills/gortex-cli/SKILL.md ===
+---
+name: gortex-cli
+description: "Bash-only mirror of Gortex MCP tools for harnesses without MCP support."
+---
+# Gortex from a Bash-Only Harness
+
+Use this skill only in a harness that has no MCP transport by design. If a Gortex MCP server is configured but its callable tools are missing, report an integration failure; do not use this skill as a fallback.
+
+Every public MCP tool has the same name through `gortex call`:
+
+```bash
+gortex call explore --arg task='locate the authentication flow'
+gortex call search --arg operation=symbols --arg query=UserStore
+gortex call read --arg target='{"symbol":"internal/store.go::UserStore"}'
+gortex call relations --arg operation=usages --arg target='{"symbol":"internal/store.go::UserStore"}'
+gortex call change --arg operation=impact --arg target='{"symbol":"internal/store.go::UserStore"}'
+gortex call edit --arg target='{"file":"internal/store.go"}' --arg match='old text' --arg replacement='new text'
+gortex call change --arg operation=detect --arg source='{"scope":"all"}'
+```
+
+For an exact operation schema:
+
+```bash
+gortex call capabilities --arg domain=read --arg operation=source --arg detail=schema
+```
+
+The required order is `explore` → targeted `search/read/relations/trace` → pre-change `change` → `edit/refactor` → post-change `change`. Do not use shell file reads or search as a substitute.
+=== global/home/.claude/skills/gortex-co-change/SKILL.md ===
+---
+name: gortex-co-change
+description: "Find what changes together and hidden coupling."
+---
+# Analyze Co-Change with Gortex
+
+1. Resolve the anchor with `search({operation: "symbols", query: "<name>"})`.
+2. Call symbol-scoped `analyze({kind: "co_change", target: {symbol: "<id>"}})` and repository-wide `analyze({kind: "churn"})`.
+3. Compare structural coupling through `relations` operations `cluster` and `dependents`.
+4. Report strong historical pairs, graph-confirmed dependencies, likely hidden coupling, and an actionable boundary or guard.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/skills/gortex-cross-repo-usage/SKILL.md ===
+---
+name: gortex-cross-repo-usage
+description: "Find who uses a symbol across all consumer repos."
+---
+# Find Cross-Repository Usage with Gortex
+
+1. Confirm tracked repositories with `workspace({operation: "repos"})`.
+2. Resolve the provider symbol with `search({operation: "symbols", query: "<name>", options: {repo: "<provider>"}})`.
+3. Call `relations({operation: "usages", target: {symbol: "<id>"}})` and group results by repository.
+4. Add `analyze({kind: "cross_repo", options: {repo: "<provider>"}})` for repository boundaries and `analyze({kind: "contracts", options: {action: "bridge", mode: "impact", symbol: "<id>"}})` for wire-level consumers.
+5. Report indexed coverage and name any untracked repositories as an explicit gap.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/skills/gortex-dataflow-trace/SKILL.md ===
+---
+name: gortex-dataflow-trace
+description: "Trace where a value flows through the code."
+---
+# Trace Data Flow with Gortex
+
+1. Call `explore({operation: "task", task: "trace <value> from <source> to <sink>"})`.
+2. Resolve endpoints with `search({operation: "symbols", query: "<source or sink>"})`.
+3. Use `trace({operation: "flow", target: {symbol: "<source-id>"}, to: {symbol: "<sink-id>"}})`. Use operation `taint` when source/sink security semantics matter.
+4. Cross-check control flow with operation `call_chain` when the data-flow graph has a gap.
+5. Report each hop with its symbol ID and confidence; distinguish no path from incomplete indexing.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/skills/gortex-debug/SKILL.md ===
+---
+name: gortex-debug
+description: "Debug a bug, trace an error, or find why something fails."
+---
+# Debug with Gortex
+
+1. Localize the exact symptom with `explore({operation: "task", task: "<error and observed behavior>"})`.
+2. For a literal error, call `search({operation: "text", query: "<exact text>"})`. For a name, use operation `symbols`.
+3. Walk toward the cause with `relations({operation: "callers", target: {symbol: "<id>"}})` and `trace({operation: "call_chain", target: {symbol: "<id>"}})`. Use `flow` or `taint` only after resolving both `target` and `to` endpoints.
+4. Confirm repository-wide error propagation with `analyze({kind: "error_surface"})`; use `options.repo` to narrow a multi-repository workspace.
+5. Before fixing, run `change({operation: "impact", source: {symbols: ["<id>"]}})`. After fixing, run `change` operations `detect`, `tests`, and `guards`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/skills/gortex-episode-replay/SKILL.md ===
+---
+name: gortex-episode-replay
+description: "Reconstruct what changed in a window (postmortem, release, PR)."
+---
+# Replay a Change Episode with Gortex
+
+1. Run `analyze({kind: "replay", options: {from: "<start>", to: "<end>"}})` for the requested window.
+2. Project the relevant diff with `change({operation: "detect", source: {scope: "<scope>"}})`.
+3. Surface decisions with `recall({operation: "surface", arguments: {task: "<episode>"}})`.
+4. Trace important before/after paths using `trace` and identify which change altered behavior.
+5. Produce a timestamped narrative with evidence links, impact, missed signals, and remaining uncertainty.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/skills/gortex-explore/SKILL.md ===
+---
+name: gortex-explore
+description: "Understand how code works or trace an execution flow."
+---
+# Explore a Codebase with Gortex
+
+1. Call `explore({operation: "task", task: "<question>"})`.
+2. Read only a returned anchor with `read({target: {symbol: "<id>"}})`.
+3. Choose the needed relationship (`callers`, `usages`, or `dependencies`), for example `relations({operation: "callers", target: {symbol: "<id>"}})`; use `trace({operation: "call_chain", target: {symbol: "<id>"}})` for execution order.
+4. Answer with the execution path, file locations, symbol IDs, and any graph uncertainty.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/skills/gortex-extract-function/SKILL.md ===
+---
+name: gortex-extract-function
+description: "Extract code into a function or method via LSP refactor."
+---
+# Extract a Function with Gortex
+
+1. Inspect the file with `read({operation: "editing_context", target: {file: "<path>"}})`.
+2. Resolve the selected range with `change({operation: "ranges", source: {file: "<path>", range: {...}}})`.
+3. Request extraction actions with `change({operation: "code_actions", source: {file: "<path>", range: {...}}})`.
+4. Apply the selected action through `refactor({operation: "apply_code_action", target: {file: "<path>"}, options: {...}})`.
+5. Run `change` operations `detect`, `tests`, `guards`, and `contract`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/skills/gortex-fix-all/SKILL.md ===
+---
+name: gortex-fix-all
+description: "Clear LSP diagnostics — one error, a file, or source.fixAll."
+---
+# Fix Diagnostics with Gortex
+
+1. Read diagnostics using `change({operation: "diagnostics", source: {file: "<path>"}})`.
+2. Fetch applicable fixes with `change({operation: "code_actions", source: {file: "<path>"}})`.
+3. Apply one reviewed action with `refactor({operation: "apply_code_action", target: {file: "<path>"}, options: {...}})`, or use operation `fix_all` only when the user asked for all safe fixes.
+4. Re-run diagnostics, then run `change` operations `detect` and `tests`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/skills/gortex-guide/SKILL.md ===
+---
+name: gortex-guide
+description: "Gortex reference: available tools, graph schema, and workflow."
+---
+# Gortex Guide
+
+Use this sequence for codebase work:
+
+1. `explore({operation: "task", task: "<goal or bug>"})` — localize the task and obtain the working set.
+2. `search({operation: "symbols", query: "<name>"})` or `search({operation: "text", query: "<literal>"})` — resolve a precise anchor.
+3. `read({operation: "source", target: {symbol: "<id>"}})` — read only the source needed.
+4. `relations({operation: "usages", target: {symbol: "<id>"}})` or `trace({operation: "call_chain", target: {symbol: "<id>"}})` — follow verified graph edges.
+5. `change({operation: "impact", source: {symbols: ["<id>"]}})` — assess a planned change.
+6. Apply with `edit` or `refactor`, then run `change` operations `detect`, `guards`, and `tests`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/skills/gortex-impact/SKILL.md ===
+---
+name: gortex-impact
+description: "Assess what breaks if you change X before editing it."
+---
+# Assess Change Impact with Gortex
+
+1. Resolve the target with `search({operation: "symbols", query: "<name>"})`.
+2. Query `relations` operations `usages`, `dependents`, and `implementations` for the resolved symbol.
+3. Call `change({operation: "impact", source: {symbols: ["<id>"]}})`; add operation `api_impact` for a public API.
+4. For a signature change, require `change({operation: "verify", source: {changes: [{symbol_id: "<id>", new_signature: "<signature>"}]}})`.
+5. Report direct callers, transitive risk, interfaces, contracts, and the tests returned by `change({operation: "tests", source: {symbols: ["<id>"]}})`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/skills/gortex-incident-investigation/SKILL.md ===
+---
+name: gortex-incident-investigation
+description: "Walk a production symptom back to its root cause."
+---
+# Investigate an Incident with Gortex
+
+1. Paste the exact symptom into `explore({operation: "task", task: "<alert, error, and time window>"})`.
+2. Search exact error text with `search({operation: "text", query: "<literal>"})`.
+3. Walk `relations` operation `callers` and `trace` operations `call_chain`, `flow`, or `taint` from symptom toward cause.
+4. Correlate repository-wide `analyze({kind: "recent_changes"})` with symbol-scoped `recall({operation: "surface", arguments: {symbol_ids: "<id>", task: "<symptom>"}})`.
+5. Separate evidence, hypothesis, and unknowns. Gate any fix through `change` before and after the mutation.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/skills/gortex-onboarding/SKILL.md ===
+---
+name: gortex-onboarding
+description: "Structured tour of an unfamiliar repo."
+---
+# Onboard to a Repository with Gortex
+
+1. Call `explore({operation: "outline"})`, then `explore({operation: "task", task: "explain the repository's main responsibilities and entry points"})`.
+2. Run `analyze` with kinds `architecture`, `communities`, and `processes`.
+3. Trace one representative request or job with `trace({operation: "call_chain", target: {symbol: "<entry-id>"}})`.
+4. Read only the key returned symbols. Deliver a concise map of entry points, boundaries, data flow, tests, and operational risks.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/skills/gortex-pr-review-agent/SKILL.md ===
+---
+name: gortex-pr-review-agent
+description: "Coding-agent review verdict via the gortex review verb."
+---
+# Review a Change as a Sub-Agent
+
+## MCP-capable harness
+
+Native Gortex MCP is mandatory. Call `review({operation: "run", source: {scope: "<scope>"}})`, then use `change` operations `guards`, `tests`, and `contract`. When the proposed signature is known, run operation `verify` before mutation. If the configured callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or use the Bash path below.
+
+## Bash-only harness
+
+Use this path only when the harness has no MCP transport by design:
+
+```bash
+gortex review --audience agent --format json
+```
+
+In either mode, return `VERDICT: clean` or `VERDICT: findings` followed by actionable findings with severity and `file:line`. Do not replace graph-backed review with ad-hoc `git diff` inspection.
+=== global/home/.claude/skills/gortex-pr-review/SKILL.md ===
+---
+name: gortex-pr-review
+description: "Graph-grounded review of a pending change or PR."
+---
+# Review a Change with Gortex
+
+1. Project the working tree with `change({operation: "detect", source: {scope: "unstaged"}})`; use `staged` or `compare` only when that is the requested review scope.
+2. Build review context with `review({operation: "run", source: {scope: "<scope>"}})` and operation `diff_context` when per-file context is needed.
+3. Require `change` operations `guards`, `tests`, and `contract`. When the proposed signature is known, run operation `verify` before mutation.
+4. Check wire boundaries with `analyze({kind: "contracts", options: {action: "check"}})` when APIs or events changed.
+5. Report only actionable findings with severity, `file:line`, evidence, consequence, and correction. State an explicit clean verdict when none remain.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/skills/gortex-quality-audit/SKILL.md ===
+---
+name: gortex-quality-audit
+description: "Repo-scale quality scan — dead code, hotspots, clones."
+---
+# Audit Repository Quality with Gortex
+
+1. Establish scope with `workspace({operation: "info"})` and `explore({operation: "outline"})`.
+2. Run `analyze` for `health`, `dead_code`, `hotspots`, `cycles`, and `clones`.
+3. Validate high-risk findings with `read` and `relations`; do not report an unverified heuristic as a fact.
+4. Rank findings by evidence, impact, and remediation cost. Include exact paths, symbol IDs, and a smallest-first action plan.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/skills/gortex-refactor/SKILL.md ===
+---
+name: gortex-refactor
+description: "Rename, extract, split, or restructure code safely."
+---
+# Refactor with Gortex
+
+1. Call `explore({operation: "task", task: "<refactor goal>"})` and resolve every target with `search`.
+2. Run `change({operation: "impact", source: {symbols: ["<id>"]}})`. Before altering a signature, also run `change({operation: "verify", source: {changes: [{symbol_id: "<id>", new_signature: "<signature>"}]}})`.
+3. Choose exactly one `refactor` operation: `rename`, `move`, `inline`, `delete`, or `apply_code_action`. For example: `refactor({operation: "rename", target: {symbol: "<id>"}, new_name: "<name>"})`.
+4. Require `change` operations `detect`, `tests`, `guards`, and `contract` after the mutation. Resolve every violation before finishing.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/skills/gortex-rename/SKILL.md ===
+---
+name: gortex-rename
+description: "Rename a symbol and update every reference atomically."
+---
+# Rename a Symbol with Gortex
+
+1. Resolve exactly one symbol with `search({operation: "symbols", query: "<old name>"})`.
+2. Enumerate references and implementations with `relations` operations `usages` and `implementations`.
+3. Run `change({operation: "impact", source: {symbols: ["<id>"]}})`. For a public signature rename, also run `change({operation: "verify", source: {changes: [{symbol_id: "<id>", new_signature: "<signature with new name>"}]}})`.
+4. Preview with `refactor({operation: "rename", target: {symbol: "<id>"}, new_name: "<new>", dry_run: true})`, then repeat it with `dry_run: false` to apply.
+5. Require `change` operations `detect`, `guards`, and `tests`; confirm no old usages remain.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.claude/skills/gortex-safe-edit/SKILL.md ===
+---
+name: gortex-safe-edit
+description: "Preview an edit's blast radius on the shadow graph before writing."
+---
+# Make a Safe Edit with Gortex
+
+1. Localize with `explore` and inspect `read({operation: "editing_context", target: {file: "<path>"}})`.
+2. Run `change({operation: "impact", source: {symbols: ["<id>"]}})` before editing.
+3. Choose `edit` operation `file`, `symbol`, or `batch`. Preview with `dry_run: true`; after review, repeat the same guarded request with `dry_run: false`. Use `change({operation: "simulate", source: {steps: "<WorkspaceEdit JSON array>"}})` for a multi-step semantic edit.
+4. Run `change` operations `detect`, `tests`, `guards`, and `contract`. Signature verification belongs before mutation with the proposed signature.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.gortex/instructions/active.md ===
+## MANDATORY: Use Gortex MCP tools instead of Read/Grep/Glob
+
+A Gortex daemon is configured machine-wide via the `gortex` MCP server. Whenever you operate on indexed source (any repo the daemon tracks — check `gortex daemon status`), you MUST prefer graph queries over file reads. Hook posture is configurable; follow every Gortex hook instruction even when raw file tools remain callable.
+
+For every coding task:
+
+1. Named-file read/review/summarize: first new-task call `read(operation:"file", target:{file:"<path>"}, options:{new_user_task:true})`; do not localize. When the file, symbol, or evidence must be discovered, call `explore(operation:"localize")` and obey `completion.required_action`; after `answer_ready`, answer from `completion.final_response` and stop. For diagnosis or modification, call `explore(operation:"task")`.
+2. In a diagnosis/change flow, make at most one follow-up call on one unresolved symbol with `search`, `read`, `relations`, or `trace`, then continue to step 3. Never reopen indexed source with Read/Grep/Glob or shell equivalents.
+3. Before mutation, call `change(operation:"impact")`; for a signature change, also call `change(operation:"verify")` with the proposed signature. Mutate only with `edit` or `refactor`. After mutation, call `change(operation:"detect")`, then use its symbol IDs with `change(operation:"tests")`, `change(operation:"guards")`, and `change(operation:"contract")`.
+4. Call `capabilities` only when you need the exact fields for an operation.
+
+Common calls: `search(operation:"symbols", query:"<name>")` · `read(target:{symbol:"<id>"})` · `relations(operation:"usages", target:{symbol:"<id>"})`.
+
+If the Gortex server is configured but these tools are missing from the callable MCP tools, report a Gortex MCP integration failure and stop. Do not start a daemon or switch to a CLI/shell fallback.
+
+Use `recall` before revisiting prior work. Call `remember` immediately for a durable decision, invariant, constraint, or gotcha.
+
+## Reference and discovery
+
+- **`gortex://guide` resource** (or the `gortex guide [topic]` CLI) is the full reference: LLM-provider matrix, capabilities catalog, analyze / search_ast catalogs, token-economy detail, MCP resources, session-start checklist. Read it on demand — it is not pre-paid here.
+- **`capabilities`** — request an exact operation schema only when the compact tool description is insufficient; ordinary coding requires no tool discovery or promotion.
+- MCP startup manages daemon availability. If the configured server or its tools are unavailable, report a Gortex MCP integration failure; do not start a daemon manually. "cwd is not covered by any tracked repo" means graph tools are unavailable there.
+- **Instruction profiles** — this block is the active `core` profile. `gortex instructions list` shows the others (`core` balanced default · `localization` lean · `full` maximum guidance); switch with `gortex instructions switch <name>` — applies to NEW sessions only (instructions, tools/list, and skills all load at session start).
+=== global/home/.gortex/instructions/core.md ===
+## MANDATORY: Use Gortex MCP tools instead of Read/Grep/Glob
+
+A Gortex daemon is configured machine-wide via the `gortex` MCP server. Whenever you operate on indexed source (any repo the daemon tracks — check `gortex daemon status`), you MUST prefer graph queries over file reads. Hook posture is configurable; follow every Gortex hook instruction even when raw file tools remain callable.
+
+For every coding task:
+
+1. Named-file read/review/summarize: first new-task call `read(operation:"file", target:{file:"<path>"}, options:{new_user_task:true})`; do not localize. When the file, symbol, or evidence must be discovered, call `explore(operation:"localize")` and obey `completion.required_action`; after `answer_ready`, answer from `completion.final_response` and stop. For diagnosis or modification, call `explore(operation:"task")`.
+2. In a diagnosis/change flow, make at most one follow-up call on one unresolved symbol with `search`, `read`, `relations`, or `trace`, then continue to step 3. Never reopen indexed source with Read/Grep/Glob or shell equivalents.
+3. Before mutation, call `change(operation:"impact")`; for a signature change, also call `change(operation:"verify")` with the proposed signature. Mutate only with `edit` or `refactor`. After mutation, call `change(operation:"detect")`, then use its symbol IDs with `change(operation:"tests")`, `change(operation:"guards")`, and `change(operation:"contract")`.
+4. Call `capabilities` only when you need the exact fields for an operation.
+
+Common calls: `search(operation:"symbols", query:"<name>")` · `read(target:{symbol:"<id>"})` · `relations(operation:"usages", target:{symbol:"<id>"})`.
+
+If the Gortex server is configured but these tools are missing from the callable MCP tools, report a Gortex MCP integration failure and stop. Do not start a daemon or switch to a CLI/shell fallback.
+
+Use `recall` before revisiting prior work. Call `remember` immediately for a durable decision, invariant, constraint, or gotcha.
+
+## Reference and discovery
+
+- **`gortex://guide` resource** (or the `gortex guide [topic]` CLI) is the full reference: LLM-provider matrix, capabilities catalog, analyze / search_ast catalogs, token-economy detail, MCP resources, session-start checklist. Read it on demand — it is not pre-paid here.
+- **`capabilities`** — request an exact operation schema only when the compact tool description is insufficient; ordinary coding requires no tool discovery or promotion.
+- MCP startup manages daemon availability. If the configured server or its tools are unavailable, report a Gortex MCP integration failure; do not start a daemon manually. "cwd is not covered by any tracked repo" means graph tools are unavailable there.
+- **Instruction profiles** — this block is the active `core` profile. `gortex instructions list` shows the others (`core` balanced default · `localization` lean · `full` maximum guidance); switch with `gortex instructions switch <name>` — applies to NEW sessions only (instructions, tools/list, and skills all load at session start).
+=== global/home/.gortex/instructions/full.md ===
+## MANDATORY: Use Gortex MCP tools instead of Read/Grep/Glob
+
+A Gortex daemon is configured machine-wide via the `gortex` MCP server. Whenever you operate on indexed source (any repo the daemon tracks — check `gortex daemon status`), you MUST prefer graph queries over file reads. Hook posture is configurable; follow every Gortex hook instruction even when raw file tools remain callable.
+
+For an explicitly named file to read/review/summarize, on the first direct file read caused by a new user request call `read(operation:"file", target:{file:"<path>"}, options:{new_user_task:true})`; do not start localization. When the file, symbol, or evidence must be discovered, call `explore(operation:"localize")` and obey `completion.required_action`; after `answer_ready` answer from `completion.final_response` and make no further tool calls. For diagnosis or requested changes, call `explore(operation:"task")`, make at most one focused follow-up, then proceed to impact, edit, and test.
+
+| Instead of...                       | Use...                                   |
+|-------------------------------------|------------------------------------------|
+| Explicitly named file to read / review / summarize | First new-task read: `read(operation:"file", target:{file:"<path>"}, options:{new_user_task:true})` |
+| Unknown file / symbol / evidence / "where is X" | `explore(operation:"localize")`; obey `completion` |
+| Diagnosing or changing code           | `explore(operation:"task")`, then impact/edit/test |
+| `Grep` / `grep` / `rg` for a symbol | `search_symbols` (BM25 + camelCase-aware) |
+| `Grep` for references               | `find_usages` (zero false positives)     |
+| Reading / grepping to find callers  | `get_callers` / `get_call_chain`         |
+| `Glob` over source files            | `get_repo_outline` / `search_symbols`    |
+| `Read` a file for one symbol        | `get_symbol_source` (`compress_bodies:true` for the signature only) |
+| `Read` to understand a file         | `get_file_summary` / `get_editing_context` |
+| `Read` a non-indexed / raw file     | `read_file`                              |
+| `Read` several symbols' bodies at once | `batch_symbols` (one call, many bodies) |
+| Multiple reads to explore a task    | `smart_context` (one call)               |
+| `Edit` / `Write` source             | `edit_file` / `write_file` / `edit_symbol` / `rename_symbol` / `batch_edit` |
+
+**Native MCP required:** if a configured Gortex tool is missing from the callable MCP tools, report a Gortex MCP integration failure and stop. Do not start a daemon or use a CLI/shell fallback.
+
+Graph queries *narrow scope*; they do not replace reading the implementation. For the symbol you are about to change or depend on — especially behavior-critical code (migrations, retry / fallback / error-recovery paths, concurrency, compatibility shims) — read the real body with `get_symbol_source` and do NOT pass `compress_bodies:true`, which elides the branches that carry the risk. `format:"gcx"` (compact wire, ~27% fewer tokens) and `compress_bodies:true` (body-eliding) exist on the read / list tools; the parameter legend is in the MCP server instructions.
+
+## MANDATORY: Session + development memory
+
+The graph remembers code; these tools remember **why you made a call**. They are behavior-critical — run each at its trigger, not "optionally":
+
+- **Session start / after a compaction** — call `distill_session` first: prior top symbols, pinned notes, decisions, recent excerpts. Seed your mental model before reading any file.
+- **Immediately after `smart_context`** — call `surface_memories task:"<task>" symbol_ids:"<top hits>"`: cross-session invariants / gotchas / decisions anchored to your working set. If it returns nothing, don't probe further.
+- **At every decision** — pick an approach, reject an alternative, hit a non-obvious constraint, or commit to an invariant → `save_note tags:"decision" body:"<what+why>"`. Mention symbol IDs (`pkg/foo.go::Bar`) in the body for auto-linking; `pinned:true` for load-bearing notes.
+- **When you learn a durable fact worth teaching the team** — `store_memory kind:"<invariant|gotcha|convention|decision|constraint|incident>" body:"<what+why>" symbol_ids:"<id>" importance:5`. `save_note` is the per-session scratchpad; `store_memory` is the workspace-wide store every future agent inherits. Supersede a stale memory with `supersedes:"<old-id>"`.
+- **Before editing a symbol you've touched before** — `query_notes symbol_id:"<id>"` / `query_memories symbol_id:"<id>"` surface prior decisions and "do not change this without …" warnings.
+
+**Save / store:** decisions, non-obvious constraints, invariants, follow-ups, incident learnings, bug reproductions. **Skip:** play-by-play the diff already shows, anything derivable from the graph, content already in CLAUDE.md.
+
+## Reference and discovery
+
+- **`gortex://guide` resource** (or the `gortex guide [topic]` CLI) is the full reference: LLM-provider matrix, capabilities catalog, analyze / search_ast catalogs, token-economy detail, MCP resources, session-start checklist. Read it on demand — it is not pre-paid here.
+- **`tools_search`** — under this profile the server publishes the full documented dev-cycle preset (~34 workhorse tools) eagerly; the long tail still loads by keyword via `tools_search` (every tool stays callable by name).
+- MCP startup manages daemon availability. If the configured server or its tools are unavailable, report a Gortex MCP integration failure; do not start a daemon manually. "cwd is not covered by any tracked repo" means graph tools are unavailable there.
+- **Instruction profiles** — this block is the active `full` profile. `gortex instructions list` shows the others (`core` balanced default · `localization` lean · `full` maximum guidance); switch with `gortex instructions switch <name>` — applies to NEW sessions only (instructions, tools/list, and skills all load at session start).
+=== global/home/.gortex/instructions/localization.md ===
+## MANDATORY: Use Gortex MCP tools instead of Read/Grep/Glob
+
+A machine-wide `gortex` MCP server indexes this code. You MUST prefer graph queries over file reads. Hook posture is configurable; follow every Gortex hook instruction even when raw file tools remain callable.
+
+For every coding task:
+
+1. Named-file read/review/summarize: first new-task call `read(operation:"file", target:{file:"<path>"}, options:{new_user_task:true})`; do not localize. When the file, symbol, or evidence must be discovered, call `explore(operation:"localize")` and obey `completion.required_action`; after `answer_ready`, answer from `completion.final_response` and stop. For diagnosis or modification, call `explore(operation:"task")`.
+2. In a diagnosis/change flow, make at most one follow-up call on one unresolved symbol with `search`, `read`, `relations`, or `trace`, then continue to step 3. Never reopen indexed source with Read/Grep/Glob or shell equivalents.
+3. Before mutation, call `change(operation:"impact")`; for a signature change, also call `change(operation:"verify")` with the proposed signature. Mutate only with `edit` or `refactor`. After mutation, call `change(operation:"detect")`, then use its symbol IDs with `change(operation:"tests")`, `change(operation:"guards")`, and `change(operation:"contract")`.
+4. Call `capabilities` only when you need the exact fields for an operation.
+
+Common calls: `search(operation:"symbols", query:"<name>")` · `read(target:{symbol:"<id>"})` · `relations(operation:"usages", target:{symbol:"<id>"})`.
+
+If the Gortex server is configured but these tools are missing from the callable MCP tools, report a Gortex MCP integration failure and stop. Do not start a daemon or switch to a CLI/shell fallback.
+
+Use `recall` before revisiting prior work. Call `remember` immediately for a durable decision, invariant, constraint, or gotcha.
+
+**Reference:** call `capabilities` for an exact operation schema; use `gortex://guide` only for deeper background.
+- **Profiles:** active `localization`. Broader guidance: `gortex instructions switch core` (or `full`; `list` shows all) — NEW sessions only.

--- a/cmd/gortex/testdata/agent-render/cline.txt
+++ b/cmd/gortex/testdata/agent-render/cline.txt
@@ -1,4 +1,4 @@
-=== root/.clinerules/gortex-communities.md ===
+=== project/root/.clinerules/gortex-communities.md ===
 <!-- gortex:communities:start -->
 - [example-community](.claude/skills/example/SKILL.md) — example routing block
 

--- a/cmd/gortex/testdata/agent-render/codex.txt
+++ b/cmd/gortex/testdata/agent-render/codex.txt
@@ -569,6 +569,37 @@ Use `recall` before revisiting prior work. Call `remember` immediately for a dur
 - **Instruction profiles** — this block is the active `core` profile. `gortex instructions list` shows the others (`core` balanced default · `localization` lean · `full` maximum guidance); switch with `gortex instructions switch <name>` — applies to NEW sessions only (instructions, tools/list, and skills all load at session start).
 
 <!-- gortex:rules:end -->
+=== global/home/.codex/agents/gortex-impact.toml ===
+name = "gortex-impact"
+description = "Assess a change's blast radius, contracts, guards, and tests."
+sandbox_mode = "read-only"
+developer_instructions = '''
+Convert the delegated change into a concise, graph-grounded impact report. Do not mutate files.
+
+1. Resolve the working set with `explore`; use `search` and `read` only to disambiguate targets.
+2. Call `change` with `operation: "impact"`. For signature changes also call `operation: "verify"`.
+3. Use `relations` for callers, usages, and dependents; use `analyze` with `kind: "contracts"` when a boundary may change.
+4. Call `change` with `operation: "guards"` and `operation: "tests"`.
+5. Call `capabilities` with `detail: "schema"` if an operation's exact arguments are not visible.
+
+Return: one-line safe/risky/breaking verdict; broken callers, contracts, or guards with file:line; then exact tests to run.
+'''
+=== global/home/.codex/agents/gortex-search.toml ===
+name = "gortex-search"
+description = "Locate code, trace call paths, or map architecture in a fresh context."
+sandbox_mode = "read-only"
+developer_instructions = '''
+Answer the delegated code-navigation question using only Gortex.
+
+1. Call `explore` with `operation: "task"` and the delegated task.
+2. Use `search` with `operation: "symbols"` for names or `operation: "text"` for exact literals.
+3. Use `read` with `operation: "source"` or `operation: "summary"`; do not request unrelated whole files.
+4. Use `relations` for callers, usages, dependencies, dependents, or implementations. Use `trace` for call chains and dataflow.
+5. Use `analyze` for architecture, communities, processes, or a named graph analysis.
+6. Call `capabilities` with `detail: "schema"` if an operation's exact arguments are not visible.
+
+Return the answer first, then symbol IDs and file:line evidence, then caveats. Do not dump raw tool output.
+'''
 === global/home/.codex/config.toml ===
 [features]
 [features.code_mode]

--- a/cmd/gortex/testdata/agent-render/continue.txt
+++ b/cmd/gortex/testdata/agent-render/continue.txt
@@ -1,4 +1,4 @@
-=== root/.continue/mcpServers/gortex.json ===
+=== project/root/.continue/mcpServers/gortex.json ===
 {
   "mcpServers": {
     "gortex": {
@@ -12,7 +12,7 @@
     }
   }
 }
-=== root/.continue/rules/gortex-communities.md ===
+=== project/root/.continue/rules/gortex-communities.md ===
 <!-- gortex:communities:start -->
 - [example-community](.claude/skills/example/SKILL.md) — example routing block
 

--- a/cmd/gortex/testdata/agent-render/copilot-cli.txt
+++ b/cmd/gortex/testdata/agent-render/copilot-cli.txt
@@ -1,62 +1,24 @@
-=== project/home/.codex/config.toml ===
-[features]
-[features.code_mode]
-direct_only_tool_namespaces = ['mcp__gortex', 'gortex']
+=== project/home/.copilot/mcp-config.json ===
+{
+  "mcpServers": {
+    "gortex": {
+      "args": [
+        "mcp"
+      ],
+      "command": "gortex",
+      "env": {
+        "GORTEX_INDEX_WORKERS": "8"
+      },
+      "type": "local"
+    }
+  }
+}
+=== project/root/.github/copilot-instructions.md ===
+<!-- gortex:communities:start -->
+- [example-community](.claude/skills/example/SKILL.md) — example routing block
 
-[hooks]
-[[hooks.PostToolUse]]
-matcher = '^(Bash|apply_patch)$'
-
-[[hooks.PostToolUse.hooks]]
-command = 'gortex hook --agent=codex --mode=enrich'
-statusMessage = 'Loading Gortex post-tool context...'
-timeout = 5
-type = 'command'
-
-[[hooks.PreToolUse]]
-matcher = '^Bash$'
-
-[[hooks.PreToolUse.hooks]]
-command = 'gortex hook --agent=codex --mode=enrich'
-statusMessage = 'Loading Gortex Bash guidance...'
-timeout = 5
-type = 'command'
-
-[[hooks.PreToolUse]]
-matcher = '^mcp__gortex__read$'
-
-[[hooks.PreToolUse.hooks]]
-command = 'gortex hook --agent=codex --mode=enrich'
-statusMessage = 'Loading Gortex read guidance...'
-timeout = 5
-type = 'command'
-
-[[hooks.SessionStart]]
-matcher = 'startup|resume|clear|compact'
-
-[[hooks.SessionStart.hooks]]
-command = 'gortex hook --agent=codex --mode=enrich'
-statusMessage = 'Loading Gortex graph orientation...'
-timeout = 5
-type = 'command'
-
-[[hooks.UserPromptSubmit]]
-[[hooks.UserPromptSubmit.hooks]]
-command = 'gortex hook --agent=codex --mode=enrich'
-statusMessage = 'Surfacing Gortex graph context for your prompt...'
-timeout = 5
-type = 'command'
-
-[mcp_servers]
-[mcp_servers.gortex]
-args = ['mcp']
-command = 'gortex'
-required = true
-startup_timeout_sec = 90
-
-[mcp_servers.gortex.env]
-GORTEX_INDEX_WORKERS = '8'
-=== project/root/.agents/skills/gortex-example-one/SKILL.md ===
+<!-- gortex:communities:end -->
+=== project/root/.github/skills/gortex-example-one/SKILL.md ===
 ---
 name: gortex-example-one
 description: Example generated community skill used by the render drift fence.
@@ -65,7 +27,7 @@ description: Example generated community skill used by the render drift fence.
 # example-one
 
 Routing stub for the example-one community.
-=== project/root/.agents/skills/gortex-example-two/SKILL.md ===
+=== project/root/.github/skills/gortex-example-two/SKILL.md ===
 ---
 name: gortex-example-two
 description: Example generated community skill used by the render drift fence.
@@ -74,475 +36,38 @@ description: Example generated community skill used by the render drift fence.
 # example-two
 
 Routing stub for the example-two community.
-=== project/root/AGENTS.md ===
-<!-- gortex:communities:start -->
-- [example-community](.claude/skills/example/SKILL.md) — example routing block
-
-<!-- gortex:communities:end -->
-=== global/home/.agents/skills/gortex-add-test/SKILL.md ===
----
-name: gortex-add-test
-description: "Add tests for under-tested code and coverage gaps."
----
-
-# Add Tests with Gortex
-
-1. Localize the behavior with `explore`.
-2. Confirm the specific gap with `change({operation: "tests", source: {symbols: ["<id>"]}})`. Use repository-wide `analyze({kind: "untested"})` or path-scoped `analyze({kind: "coverage_gaps", options: {path_prefix: "<path>"}})` only for broader coverage discovery.
-3. Inspect callers with `relations({operation: "callers", target: {symbol: "<id>"}})` and request targets with `change({operation: "tests", source: {symbols: ["<id>"]}})`.
-4. Add the narrowest test with `edit({operation: "file", target: {file: "<existing test path>"}, ...})`; use operation `write` for a new test file.
-5. Run the test, then require `change` operations `detect` and `guards`.
-
-## Required behavior
-
-- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
-- Do not substitute shell reads, file search, or Git plumbing.
-- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
-- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
-- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
-- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== global/home/.agents/skills/gortex-architecture-review/SKILL.md ===
----
-name: gortex-architecture-review
-description: "Graph-grounded architectural read of a repo."
----
-
-# Review Architecture with Gortex
-
-1. Build the map with `explore({operation: "outline"})` and `analyze` kinds `architecture` and `communities`.
-2. Measure boundaries with `analyze({kind: "coupling"})` and cycles with `analyze({kind: "cycles"})`.
-3. Trace representative paths with `trace` and inspect public boundaries with `analyze({kind: "contracts", options: {action: "list"}})`.
-4. Deliver observed structure, intended structure, violations, consequences, and prioritized changes. Cite graph evidence for every finding.
-
-## Required behavior
-
-- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
-- Do not substitute shell reads, file search, or Git plumbing.
-- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
-- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
-- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
-- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== global/home/.agents/skills/gortex-cli/SKILL.md ===
----
-name: gortex-cli
-description: "Bash-only mirror of Gortex MCP tools for harnesses without MCP support."
----
-
-# Gortex from a Bash-Only Harness
-
-Use this skill only in a harness that has no MCP transport by design. If a Gortex MCP server is configured but its callable tools are missing, report an integration failure; do not use this skill as a fallback.
-
-Every public MCP tool has the same name through `gortex call`:
-
-```bash
-gortex call explore --arg task='locate the authentication flow'
-gortex call search --arg operation=symbols --arg query=UserStore
-gortex call read --arg target='{"symbol":"internal/store.go::UserStore"}'
-gortex call relations --arg operation=usages --arg target='{"symbol":"internal/store.go::UserStore"}'
-gortex call change --arg operation=impact --arg target='{"symbol":"internal/store.go::UserStore"}'
-gortex call edit --arg target='{"file":"internal/store.go"}' --arg match='old text' --arg replacement='new text'
-gortex call change --arg operation=detect --arg source='{"scope":"all"}'
-```
-
-For an exact operation schema:
-
-```bash
-gortex call capabilities --arg domain=read --arg operation=source --arg detail=schema
-```
-
-The required order is `explore` → targeted `search/read/relations/trace` → pre-change `change` → `edit/refactor` → post-change `change`. Do not use shell file reads or search as a substitute.
-=== global/home/.agents/skills/gortex-co-change/SKILL.md ===
----
-name: gortex-co-change
-description: "Find what changes together and hidden coupling."
----
-
-# Analyze Co-Change with Gortex
-
-1. Resolve the anchor with `search({operation: "symbols", query: "<name>"})`.
-2. Call symbol-scoped `analyze({kind: "co_change", target: {symbol: "<id>"}})` and repository-wide `analyze({kind: "churn"})`.
-3. Compare structural coupling through `relations` operations `cluster` and `dependents`.
-4. Report strong historical pairs, graph-confirmed dependencies, likely hidden coupling, and an actionable boundary or guard.
-
-## Required behavior
-
-- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
-- Do not substitute shell reads, file search, or Git plumbing.
-- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
-- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
-- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
-- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== global/home/.agents/skills/gortex-cross-repo-usage/SKILL.md ===
----
-name: gortex-cross-repo-usage
-description: "Find who uses a symbol across all consumer repos."
----
-
-# Find Cross-Repository Usage with Gortex
-
-1. Confirm tracked repositories with `workspace({operation: "repos"})`.
-2. Resolve the provider symbol with `search({operation: "symbols", query: "<name>", options: {repo: "<provider>"}})`.
-3. Call `relations({operation: "usages", target: {symbol: "<id>"}})` and group results by repository.
-4. Add `analyze({kind: "cross_repo", options: {repo: "<provider>"}})` for repository boundaries and `analyze({kind: "contracts", options: {action: "bridge", mode: "impact", symbol: "<id>"}})` for wire-level consumers.
-5. Report indexed coverage and name any untracked repositories as an explicit gap.
-
-## Required behavior
-
-- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
-- Do not substitute shell reads, file search, or Git plumbing.
-- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
-- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
-- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
-- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== global/home/.agents/skills/gortex-dataflow-trace/SKILL.md ===
----
-name: gortex-dataflow-trace
-description: "Trace where a value flows through the code."
----
-
-# Trace Data Flow with Gortex
-
-1. Call `explore({operation: "task", task: "trace <value> from <source> to <sink>"})`.
-2. Resolve endpoints with `search({operation: "symbols", query: "<source or sink>"})`.
-3. Use `trace({operation: "flow", target: {symbol: "<source-id>"}, to: {symbol: "<sink-id>"}})`. Use operation `taint` when source/sink security semantics matter.
-4. Cross-check control flow with operation `call_chain` when the data-flow graph has a gap.
-5. Report each hop with its symbol ID and confidence; distinguish no path from incomplete indexing.
-
-## Required behavior
-
-- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
-- Do not substitute shell reads, file search, or Git plumbing.
-- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
-- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
-- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
-- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== global/home/.agents/skills/gortex-debug/SKILL.md ===
----
-name: gortex-debug
-description: "Debug a bug, trace an error, or find why something fails."
----
-
-# Debug with Gortex
-
-1. Localize the exact symptom with `explore({operation: "task", task: "<error and observed behavior>"})`.
-2. For a literal error, call `search({operation: "text", query: "<exact text>"})`. For a name, use operation `symbols`.
-3. Walk toward the cause with `relations({operation: "callers", target: {symbol: "<id>"}})` and `trace({operation: "call_chain", target: {symbol: "<id>"}})`. Use `flow` or `taint` only after resolving both `target` and `to` endpoints.
-4. Confirm repository-wide error propagation with `analyze({kind: "error_surface"})`; use `options.repo` to narrow a multi-repository workspace.
-5. Before fixing, run `change({operation: "impact", source: {symbols: ["<id>"]}})`. After fixing, run `change` operations `detect`, `tests`, and `guards`.
-
-## Required behavior
-
-- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
-- Do not substitute shell reads, file search, or Git plumbing.
-- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
-- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
-- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
-- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== global/home/.agents/skills/gortex-episode-replay/SKILL.md ===
----
-name: gortex-episode-replay
-description: "Reconstruct what changed in a window (postmortem, release, PR)."
----
-
-# Replay a Change Episode with Gortex
-
-1. Run `analyze({kind: "replay", options: {from: "<start>", to: "<end>"}})` for the requested window.
-2. Project the relevant diff with `change({operation: "detect", source: {scope: "<scope>"}})`.
-3. Surface decisions with `recall({operation: "surface", arguments: {task: "<episode>"}})`.
-4. Trace important before/after paths using `trace` and identify which change altered behavior.
-5. Produce a timestamped narrative with evidence links, impact, missed signals, and remaining uncertainty.
-
-## Required behavior
-
-- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
-- Do not substitute shell reads, file search, or Git plumbing.
-- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
-- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
-- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
-- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== global/home/.agents/skills/gortex-explore/SKILL.md ===
----
-name: gortex-explore
-description: "Understand how code works or trace an execution flow."
----
-
-# Explore a Codebase with Gortex
-
-1. Call `explore({operation: "task", task: "<question>"})`.
-2. Read only a returned anchor with `read({target: {symbol: "<id>"}})`.
-3. Choose the needed relationship (`callers`, `usages`, or `dependencies`), for example `relations({operation: "callers", target: {symbol: "<id>"}})`; use `trace({operation: "call_chain", target: {symbol: "<id>"}})` for execution order.
-4. Answer with the execution path, file locations, symbol IDs, and any graph uncertainty.
-
-## Required behavior
-
-- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
-- Do not substitute shell reads, file search, or Git plumbing.
-- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
-- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
-- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
-- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== global/home/.agents/skills/gortex-extract-function/SKILL.md ===
----
-name: gortex-extract-function
-description: "Extract code into a function or method via LSP refactor."
----
-
-# Extract a Function with Gortex
-
-1. Inspect the file with `read({operation: "editing_context", target: {file: "<path>"}})`.
-2. Resolve the selected range with `change({operation: "ranges", source: {file: "<path>", range: {...}}})`.
-3. Request extraction actions with `change({operation: "code_actions", source: {file: "<path>", range: {...}}})`.
-4. Apply the selected action through `refactor({operation: "apply_code_action", target: {file: "<path>"}, options: {...}})`.
-5. Run `change` operations `detect`, `tests`, `guards`, and `contract`.
-
-## Required behavior
-
-- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
-- Do not substitute shell reads, file search, or Git plumbing.
-- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
-- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
-- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
-- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== global/home/.agents/skills/gortex-fix-all/SKILL.md ===
----
-name: gortex-fix-all
-description: "Clear LSP diagnostics — one error, a file, or source.fixAll."
----
-
-# Fix Diagnostics with Gortex
-
-1. Read diagnostics using `change({operation: "diagnostics", source: {file: "<path>"}})`.
-2. Fetch applicable fixes with `change({operation: "code_actions", source: {file: "<path>"}})`.
-3. Apply one reviewed action with `refactor({operation: "apply_code_action", target: {file: "<path>"}, options: {...}})`, or use operation `fix_all` only when the user asked for all safe fixes.
-4. Re-run diagnostics, then run `change` operations `detect` and `tests`.
-
-## Required behavior
-
-- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
-- Do not substitute shell reads, file search, or Git plumbing.
-- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
-- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
-- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
-- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== global/home/.agents/skills/gortex-guide/SKILL.md ===
----
-name: gortex-guide
-description: "Gortex reference: available tools, graph schema, and workflow."
----
-
-# Gortex Guide
-
-Use this sequence for codebase work:
-
-1. `explore({operation: "task", task: "<goal or bug>"})` — localize the task and obtain the working set.
-2. `search({operation: "symbols", query: "<name>"})` or `search({operation: "text", query: "<literal>"})` — resolve a precise anchor.
-3. `read({operation: "source", target: {symbol: "<id>"}})` — read only the source needed.
-4. `relations({operation: "usages", target: {symbol: "<id>"}})` or `trace({operation: "call_chain", target: {symbol: "<id>"}})` — follow verified graph edges.
-5. `change({operation: "impact", source: {symbols: ["<id>"]}})` — assess a planned change.
-6. Apply with `edit` or `refactor`, then run `change` operations `detect`, `guards`, and `tests`.
-
-## Required behavior
-
-- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
-- Do not substitute shell reads, file search, or Git plumbing.
-- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
-- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
-- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
-- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== global/home/.agents/skills/gortex-impact/SKILL.md ===
+=== global/home/.copilot/agents/gortex-impact.agent.md ===
 ---
 name: gortex-impact
-description: "Assess what breaks if you change X before editing it."
+description: "Assess a change's blast radius, contracts, guards, and tests."
 ---
 
-# Assess Change Impact with Gortex
+Convert the delegated change into a concise, graph-grounded impact report. Do not mutate files.
 
-1. Resolve the target with `search({operation: "symbols", query: "<name>"})`.
-2. Query `relations` operations `usages`, `dependents`, and `implementations` for the resolved symbol.
-3. Call `change({operation: "impact", source: {symbols: ["<id>"]}})`; add operation `api_impact` for a public API.
-4. For a signature change, require `change({operation: "verify", source: {changes: [{symbol_id: "<id>", new_signature: "<signature>"}]}})`.
-5. Report direct callers, transitive risk, interfaces, contracts, and the tests returned by `change({operation: "tests", source: {symbols: ["<id>"]}})`.
+1. Resolve the working set with `explore`; use `search` and `read` only to disambiguate targets.
+2. Call `change` with `operation: "impact"`. For signature changes also call `operation: "verify"`.
+3. Use `relations` for callers, usages, and dependents; use `analyze` with `kind: "contracts"` when a boundary may change.
+4. Call `change` with `operation: "guards"` and `operation: "tests"`.
+5. Call `capabilities` with `detail: "schema"` if an operation's exact arguments are not visible.
 
-## Required behavior
-
-- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
-- Do not substitute shell reads, file search, or Git plumbing.
-- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
-- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
-- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
-- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== global/home/.agents/skills/gortex-incident-investigation/SKILL.md ===
+Return: one-line safe/risky/breaking verdict; broken callers, contracts, or guards with file:line; then exact tests to run.
+=== global/home/.copilot/agents/gortex-search.agent.md ===
 ---
-name: gortex-incident-investigation
-description: "Walk a production symptom back to its root cause."
+name: gortex-search
+description: "Locate code, trace call paths, or map architecture in a fresh context."
 ---
 
-# Investigate an Incident with Gortex
+Answer the delegated code-navigation question using only Gortex.
 
-1. Paste the exact symptom into `explore({operation: "task", task: "<alert, error, and time window>"})`.
-2. Search exact error text with `search({operation: "text", query: "<literal>"})`.
-3. Walk `relations` operation `callers` and `trace` operations `call_chain`, `flow`, or `taint` from symptom toward cause.
-4. Correlate repository-wide `analyze({kind: "recent_changes"})` with symbol-scoped `recall({operation: "surface", arguments: {symbol_ids: "<id>", task: "<symptom>"}})`.
-5. Separate evidence, hypothesis, and unknowns. Gate any fix through `change` before and after the mutation.
+1. Call `explore` with `operation: "task"` and the delegated task.
+2. Use `search` with `operation: "symbols"` for names or `operation: "text"` for exact literals.
+3. Use `read` with `operation: "source"` or `operation: "summary"`; do not request unrelated whole files.
+4. Use `relations` for callers, usages, dependencies, dependents, or implementations. Use `trace` for call chains and dataflow.
+5. Use `analyze` for architecture, communities, processes, or a named graph analysis.
+6. Call `capabilities` with `detail: "schema"` if an operation's exact arguments are not visible.
 
-## Required behavior
-
-- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
-- Do not substitute shell reads, file search, or Git plumbing.
-- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
-- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
-- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
-- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== global/home/.agents/skills/gortex-onboarding/SKILL.md ===
----
-name: gortex-onboarding
-description: "Structured tour of an unfamiliar repo."
----
-
-# Onboard to a Repository with Gortex
-
-1. Call `explore({operation: "outline"})`, then `explore({operation: "task", task: "explain the repository's main responsibilities and entry points"})`.
-2. Run `analyze` with kinds `architecture`, `communities`, and `processes`.
-3. Trace one representative request or job with `trace({operation: "call_chain", target: {symbol: "<entry-id>"}})`.
-4. Read only the key returned symbols. Deliver a concise map of entry points, boundaries, data flow, tests, and operational risks.
-
-## Required behavior
-
-- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
-- Do not substitute shell reads, file search, or Git plumbing.
-- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
-- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
-- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
-- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== global/home/.agents/skills/gortex-pr-review-agent/SKILL.md ===
----
-name: gortex-pr-review-agent
-description: "Coding-agent review verdict via the gortex review verb."
----
-
-# Review a Change as a Sub-Agent
-
-## MCP-capable harness
-
-Native Gortex MCP is mandatory. Call `review({operation: "run", source: {scope: "<scope>"}})`, then use `change` operations `guards`, `tests`, and `contract`. When the proposed signature is known, run operation `verify` before mutation. If the configured callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or use the Bash path below.
-
-## Bash-only harness
-
-Use this path only when the harness has no MCP transport by design:
-
-```bash
-gortex review --audience agent --format json
-```
-
-In either mode, return `VERDICT: clean` or `VERDICT: findings` followed by actionable findings with severity and `file:line`. Do not replace graph-backed review with ad-hoc `git diff` inspection.
-=== global/home/.agents/skills/gortex-pr-review/SKILL.md ===
----
-name: gortex-pr-review
-description: "Graph-grounded review of a pending change or PR."
----
-
-# Review a Change with Gortex
-
-1. Project the working tree with `change({operation: "detect", source: {scope: "unstaged"}})`; use `staged` or `compare` only when that is the requested review scope.
-2. Build review context with `review({operation: "run", source: {scope: "<scope>"}})` and operation `diff_context` when per-file context is needed.
-3. Require `change` operations `guards`, `tests`, and `contract`. When the proposed signature is known, run operation `verify` before mutation.
-4. Check wire boundaries with `analyze({kind: "contracts", options: {action: "check"}})` when APIs or events changed.
-5. Report only actionable findings with severity, `file:line`, evidence, consequence, and correction. State an explicit clean verdict when none remain.
-
-## Required behavior
-
-- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
-- Do not substitute shell reads, file search, or Git plumbing.
-- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
-- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
-- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
-- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== global/home/.agents/skills/gortex-quality-audit/SKILL.md ===
----
-name: gortex-quality-audit
-description: "Repo-scale quality scan — dead code, hotspots, clones."
----
-
-# Audit Repository Quality with Gortex
-
-1. Establish scope with `workspace({operation: "info"})` and `explore({operation: "outline"})`.
-2. Run `analyze` for `health`, `dead_code`, `hotspots`, `cycles`, and `clones`.
-3. Validate high-risk findings with `read` and `relations`; do not report an unverified heuristic as a fact.
-4. Rank findings by evidence, impact, and remediation cost. Include exact paths, symbol IDs, and a smallest-first action plan.
-
-## Required behavior
-
-- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
-- Do not substitute shell reads, file search, or Git plumbing.
-- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
-- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
-- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
-- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== global/home/.agents/skills/gortex-refactor/SKILL.md ===
----
-name: gortex-refactor
-description: "Rename, extract, split, or restructure code safely."
----
-
-# Refactor with Gortex
-
-1. Call `explore({operation: "task", task: "<refactor goal>"})` and resolve every target with `search`.
-2. Run `change({operation: "impact", source: {symbols: ["<id>"]}})`. Before altering a signature, also run `change({operation: "verify", source: {changes: [{symbol_id: "<id>", new_signature: "<signature>"}]}})`.
-3. Choose exactly one `refactor` operation: `rename`, `move`, `inline`, `delete`, or `apply_code_action`. For example: `refactor({operation: "rename", target: {symbol: "<id>"}, new_name: "<name>"})`.
-4. Require `change` operations `detect`, `tests`, `guards`, and `contract` after the mutation. Resolve every violation before finishing.
-
-## Required behavior
-
-- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
-- Do not substitute shell reads, file search, or Git plumbing.
-- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
-- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
-- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
-- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== global/home/.agents/skills/gortex-rename/SKILL.md ===
----
-name: gortex-rename
-description: "Rename a symbol and update every reference atomically."
----
-
-# Rename a Symbol with Gortex
-
-1. Resolve exactly one symbol with `search({operation: "symbols", query: "<old name>"})`.
-2. Enumerate references and implementations with `relations` operations `usages` and `implementations`.
-3. Run `change({operation: "impact", source: {symbols: ["<id>"]}})`. For a public signature rename, also run `change({operation: "verify", source: {changes: [{symbol_id: "<id>", new_signature: "<signature with new name>"}]}})`.
-4. Preview with `refactor({operation: "rename", target: {symbol: "<id>"}, new_name: "<new>", dry_run: true})`, then repeat it with `dry_run: false` to apply.
-5. Require `change` operations `detect`, `guards`, and `tests`; confirm no old usages remain.
-
-## Required behavior
-
-- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
-- Do not substitute shell reads, file search, or Git plumbing.
-- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
-- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
-- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
-- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== global/home/.agents/skills/gortex-safe-edit/SKILL.md ===
----
-name: gortex-safe-edit
-description: "Preview an edit's blast radius on the shadow graph before writing."
----
-
-# Make a Safe Edit with Gortex
-
-1. Localize with `explore` and inspect `read({operation: "editing_context", target: {file: "<path>"}})`.
-2. Run `change({operation: "impact", source: {symbols: ["<id>"]}})` before editing.
-3. Choose `edit` operation `file`, `symbol`, or `batch`. Preview with `dry_run: true`; after review, repeat the same guarded request with `dry_run: false`. Use `change({operation: "simulate", source: {steps: "<WorkspaceEdit JSON array>"}})` for a multi-step semantic edit.
-4. Run `change` operations `detect`, `tests`, `guards`, and `contract`. Signature verification belongs before mutation with the proposed signature.
-
-## Required behavior
-
-- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
-- Do not substitute shell reads, file search, or Git plumbing.
-- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
-- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
-- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
-- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== global/home/.codex/AGENTS.md ===
+Return the answer first, then symbol IDs and file:line evidence, then caveats. Do not dump raw tool output.
+=== global/home/.copilot/copilot-instructions.md ===
 <!-- gortex:rules:start -->
 ## MANDATORY: Use Gortex MCP tools instead of Read/Grep/Glob
 
@@ -569,61 +94,505 @@ Use `recall` before revisiting prior work. Call `remember` immediately for a dur
 - **Instruction profiles** — this block is the active `core` profile. `gortex instructions list` shows the others (`core` balanced default · `localization` lean · `full` maximum guidance); switch with `gortex instructions switch <name>` — applies to NEW sessions only (instructions, tools/list, and skills all load at session start).
 
 <!-- gortex:rules:end -->
-=== global/home/.codex/config.toml ===
-[features]
-[features.code_mode]
-direct_only_tool_namespaces = ['mcp__gortex', 'gortex']
+=== global/home/.copilot/hooks/gortex.json ===
+{
+  "disableAllHooks": false,
+  "hooks": {
+    "postToolUse": [
+      {
+        "bash": "gortex hook --agent=copilot-cli",
+        "cwd": ".",
+        "matcher": "^(?:bash|create|edit|glob|grep|powershell|rg|view)$",
+        "powershell": "gortex hook --agent=copilot-cli",
+        "timeoutSec": 10,
+        "type": "command"
+      }
+    ],
+    "preToolUse": [
+      {
+        "bash": "gortex hook --agent=copilot-cli",
+        "cwd": ".",
+        "matcher": "^(?:bash|create|edit|glob|grep|powershell|rg|view)$",
+        "powershell": "gortex hook --agent=copilot-cli",
+        "timeoutSec": 10,
+        "type": "command"
+      }
+    ],
+    "sessionStart": [
+      {
+        "bash": "gortex hook --agent=copilot-cli",
+        "cwd": ".",
+        "powershell": "gortex hook --agent=copilot-cli",
+        "timeoutSec": 10,
+        "type": "command"
+      }
+    ],
+    "userPromptSubmitted": [
+      {
+        "bash": "gortex hook --agent=copilot-cli",
+        "cwd": ".",
+        "powershell": "gortex hook --agent=copilot-cli",
+        "timeoutSec": 10,
+        "type": "command"
+      }
+    ]
+  },
+  "version": 1
+}
+=== global/home/.copilot/mcp-config.json ===
+{
+  "mcpServers": {
+    "gortex": {
+      "args": [
+        "mcp"
+      ],
+      "command": "gortex",
+      "env": {
+        "GORTEX_INDEX_WORKERS": "8"
+      },
+      "type": "local"
+    }
+  }
+}
+=== global/home/.copilot/skills/gortex-add-test/SKILL.md ===
+---
+name: gortex-add-test
+description: "Add tests for under-tested code and coverage gaps."
+---
+# Add Tests with Gortex
 
-[hooks]
-[[hooks.PostToolUse]]
-matcher = '^(Bash|apply_patch)$'
+1. Localize the behavior with `explore`.
+2. Confirm the specific gap with `change({operation: "tests", source: {symbols: ["<id>"]}})`. Use repository-wide `analyze({kind: "untested"})` or path-scoped `analyze({kind: "coverage_gaps", options: {path_prefix: "<path>"}})` only for broader coverage discovery.
+3. Inspect callers with `relations({operation: "callers", target: {symbol: "<id>"}})` and request targets with `change({operation: "tests", source: {symbols: ["<id>"]}})`.
+4. Add the narrowest test with `edit({operation: "file", target: {file: "<existing test path>"}, ...})`; use operation `write` for a new test file.
+5. Run the test, then require `change` operations `detect` and `guards`.
 
-[[hooks.PostToolUse.hooks]]
-command = 'gortex hook --agent=codex --mode=enrich'
-statusMessage = 'Loading Gortex post-tool context...'
-timeout = 5
-type = 'command'
+## Required behavior
 
-[[hooks.PreToolUse]]
-matcher = '^Bash$'
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.copilot/skills/gortex-architecture-review/SKILL.md ===
+---
+name: gortex-architecture-review
+description: "Graph-grounded architectural read of a repo."
+---
+# Review Architecture with Gortex
 
-[[hooks.PreToolUse.hooks]]
-command = 'gortex hook --agent=codex --mode=enrich'
-statusMessage = 'Loading Gortex Bash guidance...'
-timeout = 5
-type = 'command'
+1. Build the map with `explore({operation: "outline"})` and `analyze` kinds `architecture` and `communities`.
+2. Measure boundaries with `analyze({kind: "coupling"})` and cycles with `analyze({kind: "cycles"})`.
+3. Trace representative paths with `trace` and inspect public boundaries with `analyze({kind: "contracts", options: {action: "list"}})`.
+4. Deliver observed structure, intended structure, violations, consequences, and prioritized changes. Cite graph evidence for every finding.
 
-[[hooks.PreToolUse]]
-matcher = '^mcp__gortex__read$'
+## Required behavior
 
-[[hooks.PreToolUse.hooks]]
-command = 'gortex hook --agent=codex --mode=enrich'
-statusMessage = 'Loading Gortex read guidance...'
-timeout = 5
-type = 'command'
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.copilot/skills/gortex-cli/SKILL.md ===
+---
+name: gortex-cli
+description: "Bash-only mirror of Gortex MCP tools for harnesses without MCP support."
+---
+# Gortex from a Bash-Only Harness
 
-[[hooks.SessionStart]]
-matcher = 'startup|resume|clear|compact'
+Use this skill only in a harness that has no MCP transport by design. If a Gortex MCP server is configured but its callable tools are missing, report an integration failure; do not use this skill as a fallback.
 
-[[hooks.SessionStart.hooks]]
-command = 'gortex hook --agent=codex --mode=enrich'
-statusMessage = 'Loading Gortex graph orientation...'
-timeout = 5
-type = 'command'
+Every public MCP tool has the same name through `gortex call`:
 
-[[hooks.UserPromptSubmit]]
-[[hooks.UserPromptSubmit.hooks]]
-command = 'gortex hook --agent=codex --mode=enrich'
-statusMessage = 'Surfacing Gortex graph context for your prompt...'
-timeout = 5
-type = 'command'
+```bash
+gortex call explore --arg task='locate the authentication flow'
+gortex call search --arg operation=symbols --arg query=UserStore
+gortex call read --arg target='{"symbol":"internal/store.go::UserStore"}'
+gortex call relations --arg operation=usages --arg target='{"symbol":"internal/store.go::UserStore"}'
+gortex call change --arg operation=impact --arg target='{"symbol":"internal/store.go::UserStore"}'
+gortex call edit --arg target='{"file":"internal/store.go"}' --arg match='old text' --arg replacement='new text'
+gortex call change --arg operation=detect --arg source='{"scope":"all"}'
+```
 
-[mcp_servers]
-[mcp_servers.gortex]
-args = ['mcp']
-command = 'gortex'
-required = true
-startup_timeout_sec = 90
+For an exact operation schema:
 
-[mcp_servers.gortex.env]
-GORTEX_INDEX_WORKERS = '8'
+```bash
+gortex call capabilities --arg domain=read --arg operation=source --arg detail=schema
+```
+
+The required order is `explore` → targeted `search/read/relations/trace` → pre-change `change` → `edit/refactor` → post-change `change`. Do not use shell file reads or search as a substitute.
+=== global/home/.copilot/skills/gortex-co-change/SKILL.md ===
+---
+name: gortex-co-change
+description: "Find what changes together and hidden coupling."
+---
+# Analyze Co-Change with Gortex
+
+1. Resolve the anchor with `search({operation: "symbols", query: "<name>"})`.
+2. Call symbol-scoped `analyze({kind: "co_change", target: {symbol: "<id>"}})` and repository-wide `analyze({kind: "churn"})`.
+3. Compare structural coupling through `relations` operations `cluster` and `dependents`.
+4. Report strong historical pairs, graph-confirmed dependencies, likely hidden coupling, and an actionable boundary or guard.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.copilot/skills/gortex-cross-repo-usage/SKILL.md ===
+---
+name: gortex-cross-repo-usage
+description: "Find who uses a symbol across all consumer repos."
+---
+# Find Cross-Repository Usage with Gortex
+
+1. Confirm tracked repositories with `workspace({operation: "repos"})`.
+2. Resolve the provider symbol with `search({operation: "symbols", query: "<name>", options: {repo: "<provider>"}})`.
+3. Call `relations({operation: "usages", target: {symbol: "<id>"}})` and group results by repository.
+4. Add `analyze({kind: "cross_repo", options: {repo: "<provider>"}})` for repository boundaries and `analyze({kind: "contracts", options: {action: "bridge", mode: "impact", symbol: "<id>"}})` for wire-level consumers.
+5. Report indexed coverage and name any untracked repositories as an explicit gap.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.copilot/skills/gortex-dataflow-trace/SKILL.md ===
+---
+name: gortex-dataflow-trace
+description: "Trace where a value flows through the code."
+---
+# Trace Data Flow with Gortex
+
+1. Call `explore({operation: "task", task: "trace <value> from <source> to <sink>"})`.
+2. Resolve endpoints with `search({operation: "symbols", query: "<source or sink>"})`.
+3. Use `trace({operation: "flow", target: {symbol: "<source-id>"}, to: {symbol: "<sink-id>"}})`. Use operation `taint` when source/sink security semantics matter.
+4. Cross-check control flow with operation `call_chain` when the data-flow graph has a gap.
+5. Report each hop with its symbol ID and confidence; distinguish no path from incomplete indexing.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.copilot/skills/gortex-debug/SKILL.md ===
+---
+name: gortex-debug
+description: "Debug a bug, trace an error, or find why something fails."
+---
+# Debug with Gortex
+
+1. Localize the exact symptom with `explore({operation: "task", task: "<error and observed behavior>"})`.
+2. For a literal error, call `search({operation: "text", query: "<exact text>"})`. For a name, use operation `symbols`.
+3. Walk toward the cause with `relations({operation: "callers", target: {symbol: "<id>"}})` and `trace({operation: "call_chain", target: {symbol: "<id>"}})`. Use `flow` or `taint` only after resolving both `target` and `to` endpoints.
+4. Confirm repository-wide error propagation with `analyze({kind: "error_surface"})`; use `options.repo` to narrow a multi-repository workspace.
+5. Before fixing, run `change({operation: "impact", source: {symbols: ["<id>"]}})`. After fixing, run `change` operations `detect`, `tests`, and `guards`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.copilot/skills/gortex-episode-replay/SKILL.md ===
+---
+name: gortex-episode-replay
+description: "Reconstruct what changed in a window (postmortem, release, PR)."
+---
+# Replay a Change Episode with Gortex
+
+1. Run `analyze({kind: "replay", options: {from: "<start>", to: "<end>"}})` for the requested window.
+2. Project the relevant diff with `change({operation: "detect", source: {scope: "<scope>"}})`.
+3. Surface decisions with `recall({operation: "surface", arguments: {task: "<episode>"}})`.
+4. Trace important before/after paths using `trace` and identify which change altered behavior.
+5. Produce a timestamped narrative with evidence links, impact, missed signals, and remaining uncertainty.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.copilot/skills/gortex-explore/SKILL.md ===
+---
+name: gortex-explore
+description: "Understand how code works or trace an execution flow."
+---
+# Explore a Codebase with Gortex
+
+1. Call `explore({operation: "task", task: "<question>"})`.
+2. Read only a returned anchor with `read({target: {symbol: "<id>"}})`.
+3. Choose the needed relationship (`callers`, `usages`, or `dependencies`), for example `relations({operation: "callers", target: {symbol: "<id>"}})`; use `trace({operation: "call_chain", target: {symbol: "<id>"}})` for execution order.
+4. Answer with the execution path, file locations, symbol IDs, and any graph uncertainty.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.copilot/skills/gortex-extract-function/SKILL.md ===
+---
+name: gortex-extract-function
+description: "Extract code into a function or method via LSP refactor."
+---
+# Extract a Function with Gortex
+
+1. Inspect the file with `read({operation: "editing_context", target: {file: "<path>"}})`.
+2. Resolve the selected range with `change({operation: "ranges", source: {file: "<path>", range: {...}}})`.
+3. Request extraction actions with `change({operation: "code_actions", source: {file: "<path>", range: {...}}})`.
+4. Apply the selected action through `refactor({operation: "apply_code_action", target: {file: "<path>"}, options: {...}})`.
+5. Run `change` operations `detect`, `tests`, `guards`, and `contract`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.copilot/skills/gortex-fix-all/SKILL.md ===
+---
+name: gortex-fix-all
+description: "Clear LSP diagnostics — one error, a file, or source.fixAll."
+---
+# Fix Diagnostics with Gortex
+
+1. Read diagnostics using `change({operation: "diagnostics", source: {file: "<path>"}})`.
+2. Fetch applicable fixes with `change({operation: "code_actions", source: {file: "<path>"}})`.
+3. Apply one reviewed action with `refactor({operation: "apply_code_action", target: {file: "<path>"}, options: {...}})`, or use operation `fix_all` only when the user asked for all safe fixes.
+4. Re-run diagnostics, then run `change` operations `detect` and `tests`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.copilot/skills/gortex-guide/SKILL.md ===
+---
+name: gortex-guide
+description: "Gortex reference: available tools, graph schema, and workflow."
+---
+# Gortex Guide
+
+Use this sequence for codebase work:
+
+1. `explore({operation: "task", task: "<goal or bug>"})` — localize the task and obtain the working set.
+2. `search({operation: "symbols", query: "<name>"})` or `search({operation: "text", query: "<literal>"})` — resolve a precise anchor.
+3. `read({operation: "source", target: {symbol: "<id>"}})` — read only the source needed.
+4. `relations({operation: "usages", target: {symbol: "<id>"}})` or `trace({operation: "call_chain", target: {symbol: "<id>"}})` — follow verified graph edges.
+5. `change({operation: "impact", source: {symbols: ["<id>"]}})` — assess a planned change.
+6. Apply with `edit` or `refactor`, then run `change` operations `detect`, `guards`, and `tests`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.copilot/skills/gortex-impact/SKILL.md ===
+---
+name: gortex-impact
+description: "Assess what breaks if you change X before editing it."
+---
+# Assess Change Impact with Gortex
+
+1. Resolve the target with `search({operation: "symbols", query: "<name>"})`.
+2. Query `relations` operations `usages`, `dependents`, and `implementations` for the resolved symbol.
+3. Call `change({operation: "impact", source: {symbols: ["<id>"]}})`; add operation `api_impact` for a public API.
+4. For a signature change, require `change({operation: "verify", source: {changes: [{symbol_id: "<id>", new_signature: "<signature>"}]}})`.
+5. Report direct callers, transitive risk, interfaces, contracts, and the tests returned by `change({operation: "tests", source: {symbols: ["<id>"]}})`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.copilot/skills/gortex-incident-investigation/SKILL.md ===
+---
+name: gortex-incident-investigation
+description: "Walk a production symptom back to its root cause."
+---
+# Investigate an Incident with Gortex
+
+1. Paste the exact symptom into `explore({operation: "task", task: "<alert, error, and time window>"})`.
+2. Search exact error text with `search({operation: "text", query: "<literal>"})`.
+3. Walk `relations` operation `callers` and `trace` operations `call_chain`, `flow`, or `taint` from symptom toward cause.
+4. Correlate repository-wide `analyze({kind: "recent_changes"})` with symbol-scoped `recall({operation: "surface", arguments: {symbol_ids: "<id>", task: "<symptom>"}})`.
+5. Separate evidence, hypothesis, and unknowns. Gate any fix through `change` before and after the mutation.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.copilot/skills/gortex-onboarding/SKILL.md ===
+---
+name: gortex-onboarding
+description: "Structured tour of an unfamiliar repo."
+---
+# Onboard to a Repository with Gortex
+
+1. Call `explore({operation: "outline"})`, then `explore({operation: "task", task: "explain the repository's main responsibilities and entry points"})`.
+2. Run `analyze` with kinds `architecture`, `communities`, and `processes`.
+3. Trace one representative request or job with `trace({operation: "call_chain", target: {symbol: "<entry-id>"}})`.
+4. Read only the key returned symbols. Deliver a concise map of entry points, boundaries, data flow, tests, and operational risks.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.copilot/skills/gortex-pr-review-agent/SKILL.md ===
+---
+name: gortex-pr-review-agent
+description: "Coding-agent review verdict via the gortex review verb."
+---
+# Review a Change as a Sub-Agent
+
+## MCP-capable harness
+
+Native Gortex MCP is mandatory. Call `review({operation: "run", source: {scope: "<scope>"}})`, then use `change` operations `guards`, `tests`, and `contract`. When the proposed signature is known, run operation `verify` before mutation. If the configured callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or use the Bash path below.
+
+## Bash-only harness
+
+Use this path only when the harness has no MCP transport by design:
+
+```bash
+gortex review --audience agent --format json
+```
+
+In either mode, return `VERDICT: clean` or `VERDICT: findings` followed by actionable findings with severity and `file:line`. Do not replace graph-backed review with ad-hoc `git diff` inspection.
+=== global/home/.copilot/skills/gortex-pr-review/SKILL.md ===
+---
+name: gortex-pr-review
+description: "Graph-grounded review of a pending change or PR."
+---
+# Review a Change with Gortex
+
+1. Project the working tree with `change({operation: "detect", source: {scope: "unstaged"}})`; use `staged` or `compare` only when that is the requested review scope.
+2. Build review context with `review({operation: "run", source: {scope: "<scope>"}})` and operation `diff_context` when per-file context is needed.
+3. Require `change` operations `guards`, `tests`, and `contract`. When the proposed signature is known, run operation `verify` before mutation.
+4. Check wire boundaries with `analyze({kind: "contracts", options: {action: "check"}})` when APIs or events changed.
+5. Report only actionable findings with severity, `file:line`, evidence, consequence, and correction. State an explicit clean verdict when none remain.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.copilot/skills/gortex-quality-audit/SKILL.md ===
+---
+name: gortex-quality-audit
+description: "Repo-scale quality scan — dead code, hotspots, clones."
+---
+# Audit Repository Quality with Gortex
+
+1. Establish scope with `workspace({operation: "info"})` and `explore({operation: "outline"})`.
+2. Run `analyze` for `health`, `dead_code`, `hotspots`, `cycles`, and `clones`.
+3. Validate high-risk findings with `read` and `relations`; do not report an unverified heuristic as a fact.
+4. Rank findings by evidence, impact, and remediation cost. Include exact paths, symbol IDs, and a smallest-first action plan.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.copilot/skills/gortex-refactor/SKILL.md ===
+---
+name: gortex-refactor
+description: "Rename, extract, split, or restructure code safely."
+---
+# Refactor with Gortex
+
+1. Call `explore({operation: "task", task: "<refactor goal>"})` and resolve every target with `search`.
+2. Run `change({operation: "impact", source: {symbols: ["<id>"]}})`. Before altering a signature, also run `change({operation: "verify", source: {changes: [{symbol_id: "<id>", new_signature: "<signature>"}]}})`.
+3. Choose exactly one `refactor` operation: `rename`, `move`, `inline`, `delete`, or `apply_code_action`. For example: `refactor({operation: "rename", target: {symbol: "<id>"}, new_name: "<name>"})`.
+4. Require `change` operations `detect`, `tests`, `guards`, and `contract` after the mutation. Resolve every violation before finishing.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.copilot/skills/gortex-rename/SKILL.md ===
+---
+name: gortex-rename
+description: "Rename a symbol and update every reference atomically."
+---
+# Rename a Symbol with Gortex
+
+1. Resolve exactly one symbol with `search({operation: "symbols", query: "<old name>"})`.
+2. Enumerate references and implementations with `relations` operations `usages` and `implementations`.
+3. Run `change({operation: "impact", source: {symbols: ["<id>"]}})`. For a public signature rename, also run `change({operation: "verify", source: {changes: [{symbol_id: "<id>", new_signature: "<signature with new name>"}]}})`.
+4. Preview with `refactor({operation: "rename", target: {symbol: "<id>"}, new_name: "<new>", dry_run: true})`, then repeat it with `dry_run: false` to apply.
+5. Require `change` operations `detect`, `guards`, and `tests`; confirm no old usages remain.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.copilot/skills/gortex-safe-edit/SKILL.md ===
+---
+name: gortex-safe-edit
+description: "Preview an edit's blast radius on the shadow graph before writing."
+---
+# Make a Safe Edit with Gortex
+
+1. Localize with `explore` and inspect `read({operation: "editing_context", target: {file: "<path>"}})`.
+2. Run `change({operation: "impact", source: {symbols: ["<id>"]}})` before editing.
+3. Choose `edit` operation `file`, `symbol`, or `batch`. Preview with `dry_run: true`; after review, repeat the same guarded request with `dry_run: false`. Use `change({operation: "simulate", source: {steps: "<WorkspaceEdit JSON array>"}})` for a multi-step semantic edit.
+4. Run `change` operations `detect`, `tests`, `guards`, and `contract`. Signature verification belongs before mutation with the proposed signature.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.

--- a/cmd/gortex/testdata/agent-render/cursor.txt
+++ b/cmd/gortex/testdata/agent-render/cursor.txt
@@ -1,4 +1,4 @@
-=== root/.cursor/mcp.json ===
+=== project/root/.cursor/mcp.json ===
 {
   "mcpServers": {
     "gortex": {
@@ -12,7 +12,7 @@
     }
   }
 }
-=== root/.cursor/rules/gortex-communities.mdc ===
+=== project/root/.cursor/rules/gortex-communities.mdc ===
 ---
 description: Gortex code intelligence — prefer graph tools over file reads
 alwaysApply: true
@@ -22,7 +22,7 @@ alwaysApply: true
 - [example-community](.claude/skills/example/SKILL.md) — example routing block
 
 <!-- gortex:communities:end -->
-=== root/.cursor/rules/gortex-workflow.mdc ===
+=== project/root/.cursor/rules/gortex-workflow.mdc ===
 ---
 description: Gortex code intelligence — prefer graph tools over file reads
 alwaysApply: true
@@ -41,3 +41,17 @@ Use Gortex MCP tools for indexed code. This is mandatory.
 If the configured Gortex tools are missing from the callable MCP tools, report a Gortex MCP integration failure and stop. Do not start a daemon or use a CLI/shell fallback.
 
 Use **recall** before editing known code and **remember** for durable decisions or invariants.
+=== global/home/.cursor/mcp.json ===
+{
+  "mcpServers": {
+    "gortex": {
+      "args": [
+        "mcp"
+      ],
+      "command": "gortex",
+      "env": {
+        "GORTEX_INDEX_WORKERS": "8"
+      }
+    }
+  }
+}

--- a/cmd/gortex/testdata/agent-render/gemini.txt
+++ b/cmd/gortex/testdata/agent-render/gemini.txt
@@ -1,4 +1,4 @@
-=== root/.gemini/settings.json ===
+=== project/root/.gemini/settings.json ===
 {
   "hooks": {
     "AfterTool": [
@@ -41,8 +41,51 @@
     }
   }
 }
-=== root/GEMINI.md ===
+=== project/root/GEMINI.md ===
 <!-- gortex:communities:start -->
 - [example-community](.claude/skills/example/SKILL.md) — example routing block
 
 <!-- gortex:communities:end -->
+=== global/home/.gemini/settings.json ===
+{
+  "hooks": {
+    "AfterTool": [
+      {
+        "hooks": [
+          {
+            "command": "gortex hook --agent gemini",
+            "description": "Gortex graph context + stale-index hint",
+            "name": "gortex",
+            "timeout": 10000,
+            "type": "command"
+          }
+        ],
+        "matcher": "run_shell_command|search_file_content|glob"
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "gortex hook --agent gemini",
+            "description": "Gortex session orientation",
+            "name": "gortex",
+            "timeout": 10000,
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "mcpServers": {
+    "gortex": {
+      "args": [
+        "mcp"
+      ],
+      "command": "gortex",
+      "env": {
+        "GORTEX_INDEX_WORKERS": "8"
+      }
+    }
+  }
+}

--- a/cmd/gortex/testdata/agent-render/hermes.txt
+++ b/cmd/gortex/testdata/agent-render/hermes.txt
@@ -1,4 +1,4 @@
-=== home/.hermes/config.yaml ===
+=== project/home/.hermes/config.yaml ===
 mcp_servers:
   gortex:
     command: gortex
@@ -7,7 +7,15 @@ mcp_servers:
     timeout: 120
 platform_toolsets:
   cli: true
-=== home/.hermes/skills/analysis/gortex-architecture-review/SKILL.md ===
+hooks:
+  pre_tool_call:
+    - matcher: "read_file|terminal"
+      command: "gortex hook --agent hermes"
+      timeout: 5
+  pre_llm_call:
+    - command: "gortex hook --agent hermes"
+      timeout: 5
+=== project/home/.hermes/skills/analysis/gortex-architecture-review/SKILL.md ===
 ---
 name: gortex-architecture-review
 description: "Graph-grounded architectural read of a repo."
@@ -34,7 +42,7 @@ metadata:
 - Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
 - Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
 - Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== home/.hermes/skills/analysis/gortex-co-change/SKILL.md ===
+=== project/home/.hermes/skills/analysis/gortex-co-change/SKILL.md ===
 ---
 name: gortex-co-change
 description: "Find what changes together and hidden coupling."
@@ -61,7 +69,7 @@ metadata:
 - Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
 - Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
 - Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== home/.hermes/skills/analysis/gortex-episode-replay/SKILL.md ===
+=== project/home/.hermes/skills/analysis/gortex-episode-replay/SKILL.md ===
 ---
 name: gortex-episode-replay
 description: "Reconstruct what changed in a window (postmortem, release, PR)."
@@ -89,7 +97,7 @@ metadata:
 - Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
 - Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
 - Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== home/.hermes/skills/analysis/gortex-impact/SKILL.md ===
+=== project/home/.hermes/skills/analysis/gortex-impact/SKILL.md ===
 ---
 name: gortex-impact
 description: "Assess what breaks if you change X before editing it."
@@ -117,7 +125,7 @@ metadata:
 - Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
 - Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
 - Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== home/.hermes/skills/analysis/gortex-pr-review-agent/SKILL.md ===
+=== project/home/.hermes/skills/analysis/gortex-pr-review-agent/SKILL.md ===
 ---
 name: gortex-pr-review-agent
 description: "Coding-agent review verdict via the gortex review verb."
@@ -144,7 +152,7 @@ gortex review --audience agent --format json
 ```
 
 In either mode, return `VERDICT: clean` or `VERDICT: findings` followed by actionable findings with severity and `file:line`. Do not replace graph-backed review with ad-hoc `git diff` inspection.
-=== home/.hermes/skills/analysis/gortex-pr-review/SKILL.md ===
+=== project/home/.hermes/skills/analysis/gortex-pr-review/SKILL.md ===
 ---
 name: gortex-pr-review
 description: "Graph-grounded review of a pending change or PR."
@@ -172,7 +180,7 @@ metadata:
 - Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
 - Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
 - Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== home/.hermes/skills/analysis/gortex-quality-audit/SKILL.md ===
+=== project/home/.hermes/skills/analysis/gortex-quality-audit/SKILL.md ===
 ---
 name: gortex-quality-audit
 description: "Repo-scale quality scan — dead code, hotspots, clones."
@@ -199,7 +207,7 @@ metadata:
 - Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
 - Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
 - Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== home/.hermes/skills/code-intelligence/gortex-cli/SKILL.md ===
+=== project/home/.hermes/skills/code-intelligence/gortex-cli/SKILL.md ===
 ---
 name: gortex-cli
 description: "Bash-only mirror of Gortex MCP tools for harnesses without MCP support."
@@ -234,7 +242,7 @@ gortex call capabilities --arg domain=read --arg operation=source --arg detail=s
 ```
 
 The required order is `explore` → targeted `search/read/relations/trace` → pre-change `change` → `edit/refactor` → post-change `change`. Do not use shell file reads or search as a substitute.
-=== home/.hermes/skills/code-intelligence/gortex/SKILL.md ===
+=== project/home/.hermes/skills/code-intelligence/gortex/SKILL.md ===
 ---
 name: gortex
 description: "Use Gortex for indexed-code exploration, reads, relationships, impact checks, edits, and refactors."
@@ -286,7 +294,7 @@ Use `workspace` for local index, repository, and project state. Use `workspace_a
 - `/gortex-refactor`
 - `/gortex-rename`
 - `/gortex-safe-edit`
-=== home/.hermes/skills/debugging/gortex-debug/SKILL.md ===
+=== project/home/.hermes/skills/debugging/gortex-debug/SKILL.md ===
 ---
 name: gortex-debug
 description: "Debug a bug, trace an error, or find why something fails."
@@ -314,7 +322,7 @@ metadata:
 - Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
 - Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
 - Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== home/.hermes/skills/debugging/gortex-incident-investigation/SKILL.md ===
+=== project/home/.hermes/skills/debugging/gortex-incident-investigation/SKILL.md ===
 ---
 name: gortex-incident-investigation
 description: "Walk a production symptom back to its root cause."
@@ -342,7 +350,7 @@ metadata:
 - Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
 - Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
 - Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== home/.hermes/skills/navigation/gortex-cross-repo-usage/SKILL.md ===
+=== project/home/.hermes/skills/navigation/gortex-cross-repo-usage/SKILL.md ===
 ---
 name: gortex-cross-repo-usage
 description: "Find who uses a symbol across all consumer repos."
@@ -370,7 +378,7 @@ metadata:
 - Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
 - Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
 - Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== home/.hermes/skills/navigation/gortex-dataflow-trace/SKILL.md ===
+=== project/home/.hermes/skills/navigation/gortex-dataflow-trace/SKILL.md ===
 ---
 name: gortex-dataflow-trace
 description: "Trace where a value flows through the code."
@@ -398,7 +406,7 @@ metadata:
 - Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
 - Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
 - Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== home/.hermes/skills/navigation/gortex-explore/SKILL.md ===
+=== project/home/.hermes/skills/navigation/gortex-explore/SKILL.md ===
 ---
 name: gortex-explore
 description: "Understand how code works or trace an execution flow."
@@ -425,7 +433,7 @@ metadata:
 - Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
 - Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
 - Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== home/.hermes/skills/navigation/gortex-onboarding/SKILL.md ===
+=== project/home/.hermes/skills/navigation/gortex-onboarding/SKILL.md ===
 ---
 name: gortex-onboarding
 description: "Structured tour of an unfamiliar repo."
@@ -452,7 +460,7 @@ metadata:
 - Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
 - Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
 - Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== home/.hermes/skills/refactoring/gortex-extract-function/SKILL.md ===
+=== project/home/.hermes/skills/refactoring/gortex-extract-function/SKILL.md ===
 ---
 name: gortex-extract-function
 description: "Extract code into a function or method via LSP refactor."
@@ -480,7 +488,7 @@ metadata:
 - Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
 - Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
 - Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== home/.hermes/skills/refactoring/gortex-fix-all/SKILL.md ===
+=== project/home/.hermes/skills/refactoring/gortex-fix-all/SKILL.md ===
 ---
 name: gortex-fix-all
 description: "Clear LSP diagnostics — one error, a file, or source.fixAll."
@@ -507,7 +515,7 @@ metadata:
 - Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
 - Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
 - Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== home/.hermes/skills/refactoring/gortex-refactor/SKILL.md ===
+=== project/home/.hermes/skills/refactoring/gortex-refactor/SKILL.md ===
 ---
 name: gortex-refactor
 description: "Rename, extract, split, or restructure code safely."
@@ -534,7 +542,7 @@ metadata:
 - Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
 - Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
 - Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== home/.hermes/skills/refactoring/gortex-rename/SKILL.md ===
+=== project/home/.hermes/skills/refactoring/gortex-rename/SKILL.md ===
 ---
 name: gortex-rename
 description: "Rename a symbol and update every reference atomically."
@@ -562,7 +570,7 @@ metadata:
 - Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
 - Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
 - Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== home/.hermes/skills/refactoring/gortex-safe-edit/SKILL.md ===
+=== project/home/.hermes/skills/refactoring/gortex-safe-edit/SKILL.md ===
 ---
 name: gortex-safe-edit
 description: "Preview an edit's blast radius on the shadow graph before writing."
@@ -589,7 +597,634 @@ metadata:
 - Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
 - Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
 - Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
-=== home/.hermes/skills/testing/gortex-add-test/SKILL.md ===
+=== project/home/.hermes/skills/testing/gortex-add-test/SKILL.md ===
+---
+name: gortex-add-test
+description: "Add tests for under-tested code and coverage gaps."
+version: 1.0.0
+metadata:
+  hermes:
+    tags: [code-intelligence, mcp, add-test]
+    category: testing
+    platforms: [linux, macos, windows]
+    related_skills: [gortex]
+---
+# Add Tests with Gortex
+
+1. Localize the behavior with `explore`.
+2. Confirm the specific gap with `change({operation: "tests", source: {symbols: ["<id>"]}})`. Use repository-wide `analyze({kind: "untested"})` or path-scoped `analyze({kind: "coverage_gaps", options: {path_prefix: "<path>"}})` only for broader coverage discovery.
+3. Inspect callers with `relations({operation: "callers", target: {symbol: "<id>"}})` and request targets with `change({operation: "tests", source: {symbols: ["<id>"]}})`.
+4. Add the narrowest test with `edit({operation: "file", target: {file: "<existing test path>"}, ...})`; use operation `write` for a new test file.
+5. Run the test, then require `change` operations `detect` and `guards`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.hermes/config.yaml ===
+mcp_servers:
+  gortex:
+    command: gortex
+    args: [mcp]
+    connect_timeout: 60
+    timeout: 120
+platform_toolsets:
+  cli: true
+hooks:
+  pre_tool_call:
+    - matcher: "read_file|terminal"
+      command: "gortex hook --agent hermes"
+      timeout: 5
+  pre_llm_call:
+    - command: "gortex hook --agent hermes"
+      timeout: 5
+=== global/home/.hermes/skills/analysis/gortex-architecture-review/SKILL.md ===
+---
+name: gortex-architecture-review
+description: "Graph-grounded architectural read of a repo."
+version: 1.0.0
+metadata:
+  hermes:
+    tags: [code-intelligence, mcp, architecture-review]
+    category: analysis
+    platforms: [linux, macos, windows]
+    related_skills: [gortex]
+---
+# Review Architecture with Gortex
+
+1. Build the map with `explore({operation: "outline"})` and `analyze` kinds `architecture` and `communities`.
+2. Measure boundaries with `analyze({kind: "coupling"})` and cycles with `analyze({kind: "cycles"})`.
+3. Trace representative paths with `trace` and inspect public boundaries with `analyze({kind: "contracts", options: {action: "list"}})`.
+4. Deliver observed structure, intended structure, violations, consequences, and prioritized changes. Cite graph evidence for every finding.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.hermes/skills/analysis/gortex-co-change/SKILL.md ===
+---
+name: gortex-co-change
+description: "Find what changes together and hidden coupling."
+version: 1.0.0
+metadata:
+  hermes:
+    tags: [code-intelligence, mcp, co-change]
+    category: analysis
+    platforms: [linux, macos, windows]
+    related_skills: [gortex]
+---
+# Analyze Co-Change with Gortex
+
+1. Resolve the anchor with `search({operation: "symbols", query: "<name>"})`.
+2. Call symbol-scoped `analyze({kind: "co_change", target: {symbol: "<id>"}})` and repository-wide `analyze({kind: "churn"})`.
+3. Compare structural coupling through `relations` operations `cluster` and `dependents`.
+4. Report strong historical pairs, graph-confirmed dependencies, likely hidden coupling, and an actionable boundary or guard.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.hermes/skills/analysis/gortex-episode-replay/SKILL.md ===
+---
+name: gortex-episode-replay
+description: "Reconstruct what changed in a window (postmortem, release, PR)."
+version: 1.0.0
+metadata:
+  hermes:
+    tags: [code-intelligence, mcp, episode-replay]
+    category: analysis
+    platforms: [linux, macos, windows]
+    related_skills: [gortex]
+---
+# Replay a Change Episode with Gortex
+
+1. Run `analyze({kind: "replay", options: {from: "<start>", to: "<end>"}})` for the requested window.
+2. Project the relevant diff with `change({operation: "detect", source: {scope: "<scope>"}})`.
+3. Surface decisions with `recall({operation: "surface", arguments: {task: "<episode>"}})`.
+4. Trace important before/after paths using `trace` and identify which change altered behavior.
+5. Produce a timestamped narrative with evidence links, impact, missed signals, and remaining uncertainty.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.hermes/skills/analysis/gortex-impact/SKILL.md ===
+---
+name: gortex-impact
+description: "Assess what breaks if you change X before editing it."
+version: 1.0.0
+metadata:
+  hermes:
+    tags: [code-intelligence, mcp, impact]
+    category: analysis
+    platforms: [linux, macos, windows]
+    related_skills: [gortex]
+---
+# Assess Change Impact with Gortex
+
+1. Resolve the target with `search({operation: "symbols", query: "<name>"})`.
+2. Query `relations` operations `usages`, `dependents`, and `implementations` for the resolved symbol.
+3. Call `change({operation: "impact", source: {symbols: ["<id>"]}})`; add operation `api_impact` for a public API.
+4. For a signature change, require `change({operation: "verify", source: {changes: [{symbol_id: "<id>", new_signature: "<signature>"}]}})`.
+5. Report direct callers, transitive risk, interfaces, contracts, and the tests returned by `change({operation: "tests", source: {symbols: ["<id>"]}})`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.hermes/skills/analysis/gortex-pr-review-agent/SKILL.md ===
+---
+name: gortex-pr-review-agent
+description: "Coding-agent review verdict via the gortex review verb."
+version: 1.0.0
+metadata:
+  hermes:
+    tags: [code-intelligence, mcp, pr-review-agent]
+    category: analysis
+    platforms: [linux, macos, windows]
+    related_skills: [gortex]
+---
+# Review a Change as a Sub-Agent
+
+## MCP-capable harness
+
+Native Gortex MCP is mandatory. Call `review({operation: "run", source: {scope: "<scope>"}})`, then use `change` operations `guards`, `tests`, and `contract`. When the proposed signature is known, run operation `verify` before mutation. If the configured callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or use the Bash path below.
+
+## Bash-only harness
+
+Use this path only when the harness has no MCP transport by design:
+
+```bash
+gortex review --audience agent --format json
+```
+
+In either mode, return `VERDICT: clean` or `VERDICT: findings` followed by actionable findings with severity and `file:line`. Do not replace graph-backed review with ad-hoc `git diff` inspection.
+=== global/home/.hermes/skills/analysis/gortex-pr-review/SKILL.md ===
+---
+name: gortex-pr-review
+description: "Graph-grounded review of a pending change or PR."
+version: 1.0.0
+metadata:
+  hermes:
+    tags: [code-intelligence, mcp, pr-review]
+    category: analysis
+    platforms: [linux, macos, windows]
+    related_skills: [gortex]
+---
+# Review a Change with Gortex
+
+1. Project the working tree with `change({operation: "detect", source: {scope: "unstaged"}})`; use `staged` or `compare` only when that is the requested review scope.
+2. Build review context with `review({operation: "run", source: {scope: "<scope>"}})` and operation `diff_context` when per-file context is needed.
+3. Require `change` operations `guards`, `tests`, and `contract`. When the proposed signature is known, run operation `verify` before mutation.
+4. Check wire boundaries with `analyze({kind: "contracts", options: {action: "check"}})` when APIs or events changed.
+5. Report only actionable findings with severity, `file:line`, evidence, consequence, and correction. State an explicit clean verdict when none remain.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.hermes/skills/analysis/gortex-quality-audit/SKILL.md ===
+---
+name: gortex-quality-audit
+description: "Repo-scale quality scan — dead code, hotspots, clones."
+version: 1.0.0
+metadata:
+  hermes:
+    tags: [code-intelligence, mcp, quality-audit]
+    category: analysis
+    platforms: [linux, macos, windows]
+    related_skills: [gortex]
+---
+# Audit Repository Quality with Gortex
+
+1. Establish scope with `workspace({operation: "info"})` and `explore({operation: "outline"})`.
+2. Run `analyze` for `health`, `dead_code`, `hotspots`, `cycles`, and `clones`.
+3. Validate high-risk findings with `read` and `relations`; do not report an unverified heuristic as a fact.
+4. Rank findings by evidence, impact, and remediation cost. Include exact paths, symbol IDs, and a smallest-first action plan.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.hermes/skills/code-intelligence/gortex-cli/SKILL.md ===
+---
+name: gortex-cli
+description: "Bash-only mirror of Gortex MCP tools for harnesses without MCP support."
+version: 1.0.0
+metadata:
+  hermes:
+    tags: [code-intelligence, mcp, cli]
+    category: code-intelligence
+    platforms: [linux, macos, windows]
+    related_skills: [gortex]
+---
+# Gortex from a Bash-Only Harness
+
+Use this skill only in a harness that has no MCP transport by design. If a Gortex MCP server is configured but its callable tools are missing, report an integration failure; do not use this skill as a fallback.
+
+Every public MCP tool has the same name through `gortex call`:
+
+```bash
+gortex call explore --arg task='locate the authentication flow'
+gortex call search --arg operation=symbols --arg query=UserStore
+gortex call read --arg target='{"symbol":"internal/store.go::UserStore"}'
+gortex call relations --arg operation=usages --arg target='{"symbol":"internal/store.go::UserStore"}'
+gortex call change --arg operation=impact --arg target='{"symbol":"internal/store.go::UserStore"}'
+gortex call edit --arg target='{"file":"internal/store.go"}' --arg match='old text' --arg replacement='new text'
+gortex call change --arg operation=detect --arg source='{"scope":"all"}'
+```
+
+For an exact operation schema:
+
+```bash
+gortex call capabilities --arg domain=read --arg operation=source --arg detail=schema
+```
+
+The required order is `explore` → targeted `search/read/relations/trace` → pre-change `change` → `edit/refactor` → post-change `change`. Do not use shell file reads or search as a substitute.
+=== global/home/.hermes/skills/code-intelligence/gortex/SKILL.md ===
+---
+name: gortex
+description: "Use Gortex for indexed-code exploration, reads, relationships, impact checks, edits, and refactors."
+version: 1.0.0
+metadata:
+  hermes:
+    tags: [code-intelligence, code-search, navigation, refactoring, mcp]
+    category: code-intelligence
+    platforms: [linux, macos, windows]
+    related_skills: [gortex-add-test, gortex-architecture-review, gortex-cli, gortex-co-change, gortex-cross-repo-usage, gortex-dataflow-trace, gortex-debug, gortex-episode-replay, gortex-explore, gortex-extract-function, gortex-fix-all, gortex-impact, gortex-incident-investigation, gortex-onboarding, gortex-pr-review, gortex-pr-review-agent, gortex-quality-audit, gortex-refactor, gortex-rename, gortex-safe-edit]
+---
+
+# Gortex code intelligence
+
+Use Gortex MCP tools for indexed code. This is mandatory.
+
+1. Start every coding task with `explore` using `operation: "task"` and the task text.
+2. Use `search` for symbols, text, files, or AST shapes. Use `read` for source, summaries, files, or editing context.
+3. Use `relations` for usages, callers, dependencies, dependents, and implementations. Use `trace` for call chains and dataflow.
+4. Before mutation, call `change` with `operation: "impact"`; for a signature change, also call operation `verify` with the proposed signature.
+5. Mutate only with `edit` or `refactor`. After mutation, call `change` operations `detect`, `tests`, `guards`, and `contract`.
+6. Call `capabilities` with `domain`, `operation`, and `detail: "schema"` when exact arguments are not visible.
+
+Do not replace graph reads or searches with terminal commands. If the configured Gortex tools are missing from the callable MCP tools, report a Gortex MCP integration failure and stop; do not start a daemon or use a CLI/shell fallback.
+
+Use `workspace` for local index, repository, and project state. Use `workspace_admin` only when the user asks to change that state. Use `recall` before editing known code and `remember` for durable decisions or invariants.
+
+## Task playbooks (slash commands)
+
+`gortex install` also registers these per-task playbooks as Hermes slash commands. Reach for the one that matches your task:
+
+- `/gortex-add-test`
+- `/gortex-architecture-review`
+- `/gortex-cli`
+- `/gortex-co-change`
+- `/gortex-cross-repo-usage`
+- `/gortex-dataflow-trace`
+- `/gortex-debug`
+- `/gortex-episode-replay`
+- `/gortex-explore`
+- `/gortex-extract-function`
+- `/gortex-fix-all`
+- `/gortex-impact`
+- `/gortex-incident-investigation`
+- `/gortex-onboarding`
+- `/gortex-pr-review`
+- `/gortex-pr-review-agent`
+- `/gortex-quality-audit`
+- `/gortex-refactor`
+- `/gortex-rename`
+- `/gortex-safe-edit`
+=== global/home/.hermes/skills/debugging/gortex-debug/SKILL.md ===
+---
+name: gortex-debug
+description: "Debug a bug, trace an error, or find why something fails."
+version: 1.0.0
+metadata:
+  hermes:
+    tags: [code-intelligence, mcp, debug]
+    category: debugging
+    platforms: [linux, macos, windows]
+    related_skills: [gortex]
+---
+# Debug with Gortex
+
+1. Localize the exact symptom with `explore({operation: "task", task: "<error and observed behavior>"})`.
+2. For a literal error, call `search({operation: "text", query: "<exact text>"})`. For a name, use operation `symbols`.
+3. Walk toward the cause with `relations({operation: "callers", target: {symbol: "<id>"}})` and `trace({operation: "call_chain", target: {symbol: "<id>"}})`. Use `flow` or `taint` only after resolving both `target` and `to` endpoints.
+4. Confirm repository-wide error propagation with `analyze({kind: "error_surface"})`; use `options.repo` to narrow a multi-repository workspace.
+5. Before fixing, run `change({operation: "impact", source: {symbols: ["<id>"]}})`. After fixing, run `change` operations `detect`, `tests`, and `guards`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.hermes/skills/debugging/gortex-incident-investigation/SKILL.md ===
+---
+name: gortex-incident-investigation
+description: "Walk a production symptom back to its root cause."
+version: 1.0.0
+metadata:
+  hermes:
+    tags: [code-intelligence, mcp, incident-investigation]
+    category: debugging
+    platforms: [linux, macos, windows]
+    related_skills: [gortex]
+---
+# Investigate an Incident with Gortex
+
+1. Paste the exact symptom into `explore({operation: "task", task: "<alert, error, and time window>"})`.
+2. Search exact error text with `search({operation: "text", query: "<literal>"})`.
+3. Walk `relations` operation `callers` and `trace` operations `call_chain`, `flow`, or `taint` from symptom toward cause.
+4. Correlate repository-wide `analyze({kind: "recent_changes"})` with symbol-scoped `recall({operation: "surface", arguments: {symbol_ids: "<id>", task: "<symptom>"}})`.
+5. Separate evidence, hypothesis, and unknowns. Gate any fix through `change` before and after the mutation.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.hermes/skills/navigation/gortex-cross-repo-usage/SKILL.md ===
+---
+name: gortex-cross-repo-usage
+description: "Find who uses a symbol across all consumer repos."
+version: 1.0.0
+metadata:
+  hermes:
+    tags: [code-intelligence, mcp, cross-repo-usage]
+    category: navigation
+    platforms: [linux, macos, windows]
+    related_skills: [gortex]
+---
+# Find Cross-Repository Usage with Gortex
+
+1. Confirm tracked repositories with `workspace({operation: "repos"})`.
+2. Resolve the provider symbol with `search({operation: "symbols", query: "<name>", options: {repo: "<provider>"}})`.
+3. Call `relations({operation: "usages", target: {symbol: "<id>"}})` and group results by repository.
+4. Add `analyze({kind: "cross_repo", options: {repo: "<provider>"}})` for repository boundaries and `analyze({kind: "contracts", options: {action: "bridge", mode: "impact", symbol: "<id>"}})` for wire-level consumers.
+5. Report indexed coverage and name any untracked repositories as an explicit gap.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.hermes/skills/navigation/gortex-dataflow-trace/SKILL.md ===
+---
+name: gortex-dataflow-trace
+description: "Trace where a value flows through the code."
+version: 1.0.0
+metadata:
+  hermes:
+    tags: [code-intelligence, mcp, dataflow-trace]
+    category: navigation
+    platforms: [linux, macos, windows]
+    related_skills: [gortex]
+---
+# Trace Data Flow with Gortex
+
+1. Call `explore({operation: "task", task: "trace <value> from <source> to <sink>"})`.
+2. Resolve endpoints with `search({operation: "symbols", query: "<source or sink>"})`.
+3. Use `trace({operation: "flow", target: {symbol: "<source-id>"}, to: {symbol: "<sink-id>"}})`. Use operation `taint` when source/sink security semantics matter.
+4. Cross-check control flow with operation `call_chain` when the data-flow graph has a gap.
+5. Report each hop with its symbol ID and confidence; distinguish no path from incomplete indexing.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.hermes/skills/navigation/gortex-explore/SKILL.md ===
+---
+name: gortex-explore
+description: "Understand how code works or trace an execution flow."
+version: 1.0.0
+metadata:
+  hermes:
+    tags: [code-intelligence, mcp, explore]
+    category: navigation
+    platforms: [linux, macos, windows]
+    related_skills: [gortex]
+---
+# Explore a Codebase with Gortex
+
+1. Call `explore({operation: "task", task: "<question>"})`.
+2. Read only a returned anchor with `read({target: {symbol: "<id>"}})`.
+3. Choose the needed relationship (`callers`, `usages`, or `dependencies`), for example `relations({operation: "callers", target: {symbol: "<id>"}})`; use `trace({operation: "call_chain", target: {symbol: "<id>"}})` for execution order.
+4. Answer with the execution path, file locations, symbol IDs, and any graph uncertainty.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.hermes/skills/navigation/gortex-onboarding/SKILL.md ===
+---
+name: gortex-onboarding
+description: "Structured tour of an unfamiliar repo."
+version: 1.0.0
+metadata:
+  hermes:
+    tags: [code-intelligence, mcp, onboarding]
+    category: navigation
+    platforms: [linux, macos, windows]
+    related_skills: [gortex]
+---
+# Onboard to a Repository with Gortex
+
+1. Call `explore({operation: "outline"})`, then `explore({operation: "task", task: "explain the repository's main responsibilities and entry points"})`.
+2. Run `analyze` with kinds `architecture`, `communities`, and `processes`.
+3. Trace one representative request or job with `trace({operation: "call_chain", target: {symbol: "<entry-id>"}})`.
+4. Read only the key returned symbols. Deliver a concise map of entry points, boundaries, data flow, tests, and operational risks.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.hermes/skills/refactoring/gortex-extract-function/SKILL.md ===
+---
+name: gortex-extract-function
+description: "Extract code into a function or method via LSP refactor."
+version: 1.0.0
+metadata:
+  hermes:
+    tags: [code-intelligence, mcp, extract-function]
+    category: refactoring
+    platforms: [linux, macos, windows]
+    related_skills: [gortex]
+---
+# Extract a Function with Gortex
+
+1. Inspect the file with `read({operation: "editing_context", target: {file: "<path>"}})`.
+2. Resolve the selected range with `change({operation: "ranges", source: {file: "<path>", range: {...}}})`.
+3. Request extraction actions with `change({operation: "code_actions", source: {file: "<path>", range: {...}}})`.
+4. Apply the selected action through `refactor({operation: "apply_code_action", target: {file: "<path>"}, options: {...}})`.
+5. Run `change` operations `detect`, `tests`, `guards`, and `contract`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.hermes/skills/refactoring/gortex-fix-all/SKILL.md ===
+---
+name: gortex-fix-all
+description: "Clear LSP diagnostics — one error, a file, or source.fixAll."
+version: 1.0.0
+metadata:
+  hermes:
+    tags: [code-intelligence, mcp, fix-all]
+    category: refactoring
+    platforms: [linux, macos, windows]
+    related_skills: [gortex]
+---
+# Fix Diagnostics with Gortex
+
+1. Read diagnostics using `change({operation: "diagnostics", source: {file: "<path>"}})`.
+2. Fetch applicable fixes with `change({operation: "code_actions", source: {file: "<path>"}})`.
+3. Apply one reviewed action with `refactor({operation: "apply_code_action", target: {file: "<path>"}, options: {...}})`, or use operation `fix_all` only when the user asked for all safe fixes.
+4. Re-run diagnostics, then run `change` operations `detect` and `tests`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.hermes/skills/refactoring/gortex-refactor/SKILL.md ===
+---
+name: gortex-refactor
+description: "Rename, extract, split, or restructure code safely."
+version: 1.0.0
+metadata:
+  hermes:
+    tags: [code-intelligence, mcp, refactor]
+    category: refactoring
+    platforms: [linux, macos, windows]
+    related_skills: [gortex]
+---
+# Refactor with Gortex
+
+1. Call `explore({operation: "task", task: "<refactor goal>"})` and resolve every target with `search`.
+2. Run `change({operation: "impact", source: {symbols: ["<id>"]}})`. Before altering a signature, also run `change({operation: "verify", source: {changes: [{symbol_id: "<id>", new_signature: "<signature>"}]}})`.
+3. Choose exactly one `refactor` operation: `rename`, `move`, `inline`, `delete`, or `apply_code_action`. For example: `refactor({operation: "rename", target: {symbol: "<id>"}, new_name: "<name>"})`.
+4. Require `change` operations `detect`, `tests`, `guards`, and `contract` after the mutation. Resolve every violation before finishing.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.hermes/skills/refactoring/gortex-rename/SKILL.md ===
+---
+name: gortex-rename
+description: "Rename a symbol and update every reference atomically."
+version: 1.0.0
+metadata:
+  hermes:
+    tags: [code-intelligence, mcp, rename]
+    category: refactoring
+    platforms: [linux, macos, windows]
+    related_skills: [gortex]
+---
+# Rename a Symbol with Gortex
+
+1. Resolve exactly one symbol with `search({operation: "symbols", query: "<old name>"})`.
+2. Enumerate references and implementations with `relations` operations `usages` and `implementations`.
+3. Run `change({operation: "impact", source: {symbols: ["<id>"]}})`. For a public signature rename, also run `change({operation: "verify", source: {changes: [{symbol_id: "<id>", new_signature: "<signature with new name>"}]}})`.
+4. Preview with `refactor({operation: "rename", target: {symbol: "<id>"}, new_name: "<new>", dry_run: true})`, then repeat it with `dry_run: false` to apply.
+5. Require `change` operations `detect`, `guards`, and `tests`; confirm no old usages remain.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.hermes/skills/refactoring/gortex-safe-edit/SKILL.md ===
+---
+name: gortex-safe-edit
+description: "Preview an edit's blast radius on the shadow graph before writing."
+version: 1.0.0
+metadata:
+  hermes:
+    tags: [code-intelligence, mcp, safe-edit]
+    category: refactoring
+    platforms: [linux, macos, windows]
+    related_skills: [gortex]
+---
+# Make a Safe Edit with Gortex
+
+1. Localize with `explore` and inspect `read({operation: "editing_context", target: {file: "<path>"}})`.
+2. Run `change({operation: "impact", source: {symbols: ["<id>"]}})` before editing.
+3. Choose `edit` operation `file`, `symbol`, or `batch`. Preview with `dry_run: true`; after review, repeat the same guarded request with `dry_run: false`. Use `change({operation: "simulate", source: {steps: "<WorkspaceEdit JSON array>"}})` for a multi-step semantic edit.
+4. Run `change` operations `detect`, `tests`, `guards`, and `contract`. Signature verification belongs before mutation with the proposed signature.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.hermes/skills/testing/gortex-add-test/SKILL.md ===
 ---
 name: gortex-add-test
 description: "Add tests for under-tested code and coverage gaps."

--- a/cmd/gortex/testdata/agent-render/kilocode.txt
+++ b/cmd/gortex/testdata/agent-render/kilocode.txt
@@ -1,4 +1,4 @@
-=== root/.kilocoderules ===
+=== project/root/.kilocoderules ===
 <!-- gortex:communities:start -->
 - [example-community](.claude/skills/example/SKILL.md) — example routing block
 

--- a/cmd/gortex/testdata/agent-render/kimi.txt
+++ b/cmd/gortex/testdata/agent-render/kimi.txt
@@ -1,4 +1,38 @@
-=== root/.kimi-code/mcp.json ===
+=== project/root/.kimi-code/mcp.json ===
+{
+  "mcpServers": {
+    "gortex": {
+      "args": [
+        "mcp"
+      ],
+      "command": "gortex",
+      "env": {
+        "GORTEX_INDEX_WORKERS": "8"
+      }
+    }
+  }
+}
+=== global/home/.kimi-code/config.toml ===
+[[hooks]]
+command = 'gortex hook --agent=kimi'
+event = 'UserPromptSubmit'
+timeout = 5
+
+[[hooks]]
+command = 'gortex hook --agent=kimi'
+event = 'PreToolUse'
+timeout = 5
+
+[[hooks]]
+command = 'gortex hook --agent=kimi'
+event = 'Stop'
+timeout = 30
+
+[[hooks]]
+command = 'gortex hook --agent=kimi'
+event = 'SubagentStart'
+timeout = 15
+=== global/home/.kimi-code/mcp.json ===
 {
   "mcpServers": {
     "gortex": {

--- a/cmd/gortex/testdata/agent-render/kiro.txt
+++ b/cmd/gortex/testdata/agent-render/kiro.txt
@@ -1,4 +1,4 @@
-=== root/.kiro/hooks/gortex-post-edit.json ===
+=== project/root/.kiro/hooks/gortex-post-edit.json ===
 {
   "name": "Gortex: Post-Edit Check",
   "version": "1.0.0",
@@ -12,7 +12,7 @@
     "prompt": "Call Gortex change with operation detect for unstaged changes. Use its affected symbol IDs with operations tests, guards, and contract; run the selected tests and report every result."
   }
 }
-=== root/.kiro/hooks/gortex-pre-read.json ===
+=== project/root/.kiro/hooks/gortex-pre-read.json ===
 {
   "name": "Gortex: Enrich Source Read",
   "version": "1.0.0",
@@ -23,7 +23,7 @@
     "prompt": "For indexed source code, use Gortex read with operation editing_context or source instead of a raw file read. Skip generated files, metadata, documentation, configuration, and non-source assets."
   }
 }
-=== root/.kiro/hooks/gortex-smart-context.json ===
+=== project/root/.kiro/hooks/gortex-smart-context.json ===
 {
   "name": "Gortex: Task Context",
   "version": "1.0.0",
@@ -34,7 +34,7 @@
     "prompt": "For a coding task, call Gortex explore with operation task and the user's task text before reading or searching files. Skip this only for non-coding conversation."
   }
 }
-=== root/.kiro/settings/mcp.json ===
+=== project/root/.kiro/settings/mcp.json ===
 {
   "mcpServers": {
     "gortex": {
@@ -62,7 +62,7 @@
     }
   }
 }
-=== root/.kiro/steering/gortex-debug.md ===
+=== project/root/.kiro/steering/gortex-debug.md ===
 ---
 inclusion: manual
 ---
@@ -74,7 +74,7 @@ inclusion: manual
 3. Use `relations({operation:"callers", ...})` and `trace({operation:"call_chain", ...})` to follow execution.
 4. Use `trace` with `flow` or `taint` when the bug concerns values crossing helpers.
 5. Read only the suspect symbols, then state the root cause and evidence.
-=== root/.kiro/steering/gortex-explore.md ===
+=== project/root/.kiro/steering/gortex-explore.md ===
 ---
 inclusion: manual
 ---
@@ -86,7 +86,7 @@ inclusion: manual
 3. Read only the needed source with `read` (`source`/`summary`/`editing_context`).
 4. Prove relationships with `relations` or execution paths with `trace`.
 5. Return symbol IDs, file:line locations, and the shortest evidence needed.
-=== root/.kiro/steering/gortex-impact.md ===
+=== project/root/.kiro/steering/gortex-impact.md ===
 ---
 inclusion: manual
 ---
@@ -98,7 +98,7 @@ inclusion: manual
 3. For signature changes, call `change` with `operation:"verify"`.
 4. Check `relations` usages/dependents and `analyze` contracts when boundaries are involved.
 5. Call `change` with `operation:"tests"` and report concrete tests.
-=== root/.kiro/steering/gortex-refactor.md ===
+=== project/root/.kiro/steering/gortex-refactor.md ===
 ---
 inclusion: manual
 ---
@@ -110,7 +110,7 @@ inclusion: manual
 3. Use `refactor` for rename, move, inline, delete, or code actions. Use `edit` for file, symbol, batch, or new-file changes.
 4. After writing, call `change` operations `detect`, `tests`, `guards`, and `contract`.
 5. Run the project tests selected by the graph.
-=== root/.kiro/steering/gortex-workflow.md ===
+=== project/root/.kiro/steering/gortex-workflow.md ===
 ---
 inclusion: always
 ---
@@ -129,3 +129,31 @@ Use Gortex MCP tools for indexed code. This is mandatory.
 Do not replace graph reads or searches with shell commands. If the configured Gortex tools are missing from the callable MCP tools, report a Gortex MCP integration failure and stop; do not start a daemon or use a CLI/shell fallback.
 
 For durable context, use `recall` (`surface`/`notes`/`memories`) before editing known code and `remember` (`note`/`memory`) for decisions and invariants.
+=== global/home/.kiro/settings/mcp.json ===
+{
+  "mcpServers": {
+    "gortex": {
+      "args": [
+        "mcp"
+      ],
+      "autoApprove": [
+        "analyze",
+        "capabilities",
+        "change",
+        "explore",
+        "read",
+        "recall",
+        "relations",
+        "response",
+        "search",
+        "trace",
+        "workspace"
+      ],
+      "command": "gortex",
+      "disabled": false,
+      "env": {
+        "GORTEX_INDEX_WORKERS": "8"
+      }
+    }
+  }
+}

--- a/cmd/gortex/testdata/agent-render/oh-my-pi.txt
+++ b/cmd/gortex/testdata/agent-render/oh-my-pi.txt
@@ -1,4 +1,4 @@
-=== root/.omp/mcp.json ===
+=== project/root/.omp/mcp.json ===
 {
   "mcpServers": {
     "gortex": {

--- a/cmd/gortex/testdata/agent-render/openclaw.txt
+++ b/cmd/gortex/testdata/agent-render/openclaw.txt
@@ -1,4 +1,20 @@
-=== home/.openclaw/openclaw.json ===
+=== project/home/.openclaw/openclaw.json ===
+{
+  "mcp": {
+    "servers": {
+      "gortex": {
+        "args": [
+          "mcp"
+        ],
+        "command": "gortex",
+        "env": {
+          "GORTEX_INDEX_WORKERS": "8"
+        }
+      }
+    }
+  }
+}
+=== global/home/.openclaw/openclaw.json ===
 {
   "mcp": {
     "servers": {

--- a/cmd/gortex/testdata/agent-render/opencode.txt
+++ b/cmd/gortex/testdata/agent-render/opencode.txt
@@ -1,9 +1,27 @@
-=== root/AGENTS.md ===
+=== project/root/.opencode/skills/gortex-example-one/SKILL.md ===
+---
+name: gortex-example-one
+description: Example generated community skill used by the render drift fence.
+---
+
+# example-one
+
+Routing stub for the example-one community.
+=== project/root/.opencode/skills/gortex-example-two/SKILL.md ===
+---
+name: gortex-example-two
+description: Example generated community skill used by the render drift fence.
+---
+
+# example-two
+
+Routing stub for the example-two community.
+=== project/root/AGENTS.md ===
 <!-- gortex:communities:start -->
 - [example-community](.claude/skills/example/SKILL.md) — example routing block
 
 <!-- gortex:communities:end -->
-=== root/opencode.json ===
+=== project/root/opencode.json ===
 {
   "$schema": "https://opencode.ai/config.json",
   "mcp": {
@@ -20,3 +38,1183 @@
     }
   }
 }
+=== global/home/.config/opencode/commands/gortex-add-test.md ===
+---
+description: "Add tests for under-tested code and coverage gaps."
+---
+
+# Add Tests with Gortex
+
+1. Localize the behavior with `explore`.
+2. Confirm the specific gap with `change({operation: "tests", source: {symbols: ["<id>"]}})`. Use repository-wide `analyze({kind: "untested"})` or path-scoped `analyze({kind: "coverage_gaps", options: {path_prefix: "<path>"}})` only for broader coverage discovery.
+3. Inspect callers with `relations({operation: "callers", target: {symbol: "<id>"}})` and request targets with `change({operation: "tests", source: {symbols: ["<id>"]}})`.
+4. Add the narrowest test with `edit({operation: "file", target: {file: "<existing test path>"}, ...})`; use operation `write` for a new test file.
+5. Run the test, then require `change` operations `detect` and `guards`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/commands/gortex-architecture-review.md ===
+---
+description: "Graph-grounded architectural read of a repo."
+---
+
+# Review Architecture with Gortex
+
+1. Build the map with `explore({operation: "outline"})` and `analyze` kinds `architecture` and `communities`.
+2. Measure boundaries with `analyze({kind: "coupling"})` and cycles with `analyze({kind: "cycles"})`.
+3. Trace representative paths with `trace` and inspect public boundaries with `analyze({kind: "contracts", options: {action: "list"}})`.
+4. Deliver observed structure, intended structure, violations, consequences, and prioritized changes. Cite graph evidence for every finding.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/commands/gortex-co-change.md ===
+---
+description: "Find what changes together and hidden coupling."
+---
+
+# Analyze Co-Change with Gortex
+
+1. Resolve the anchor with `search({operation: "symbols", query: "<name>"})`.
+2. Call symbol-scoped `analyze({kind: "co_change", target: {symbol: "<id>"}})` and repository-wide `analyze({kind: "churn"})`.
+3. Compare structural coupling through `relations` operations `cluster` and `dependents`.
+4. Report strong historical pairs, graph-confirmed dependencies, likely hidden coupling, and an actionable boundary or guard.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/commands/gortex-cross-repo-usage.md ===
+---
+description: "Find who uses a symbol across all consumer repos."
+---
+
+# Find Cross-Repository Usage with Gortex
+
+1. Confirm tracked repositories with `workspace({operation: "repos"})`.
+2. Resolve the provider symbol with `search({operation: "symbols", query: "<name>", options: {repo: "<provider>"}})`.
+3. Call `relations({operation: "usages", target: {symbol: "<id>"}})` and group results by repository.
+4. Add `analyze({kind: "cross_repo", options: {repo: "<provider>"}})` for repository boundaries and `analyze({kind: "contracts", options: {action: "bridge", mode: "impact", symbol: "<id>"}})` for wire-level consumers.
+5. Report indexed coverage and name any untracked repositories as an explicit gap.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/commands/gortex-dataflow-trace.md ===
+---
+description: "Trace where a value flows through the code."
+---
+
+# Trace Data Flow with Gortex
+
+1. Call `explore({operation: "task", task: "trace <value> from <source> to <sink>"})`.
+2. Resolve endpoints with `search({operation: "symbols", query: "<source or sink>"})`.
+3. Use `trace({operation: "flow", target: {symbol: "<source-id>"}, to: {symbol: "<sink-id>"}})`. Use operation `taint` when source/sink security semantics matter.
+4. Cross-check control flow with operation `call_chain` when the data-flow graph has a gap.
+5. Report each hop with its symbol ID and confidence; distinguish no path from incomplete indexing.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/commands/gortex-debug.md ===
+---
+description: "Debug a bug, trace an error, or find why something fails."
+---
+
+# Debug with Gortex
+
+1. Localize the exact symptom with `explore({operation: "task", task: "<error and observed behavior>"})`.
+2. For a literal error, call `search({operation: "text", query: "<exact text>"})`. For a name, use operation `symbols`.
+3. Walk toward the cause with `relations({operation: "callers", target: {symbol: "<id>"}})` and `trace({operation: "call_chain", target: {symbol: "<id>"}})`. Use `flow` or `taint` only after resolving both `target` and `to` endpoints.
+4. Confirm repository-wide error propagation with `analyze({kind: "error_surface"})`; use `options.repo` to narrow a multi-repository workspace.
+5. Before fixing, run `change({operation: "impact", source: {symbols: ["<id>"]}})`. After fixing, run `change` operations `detect`, `tests`, and `guards`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/commands/gortex-episode-replay.md ===
+---
+description: "Reconstruct what changed in a window (postmortem, release, PR)."
+---
+
+# Replay a Change Episode with Gortex
+
+1. Run `analyze({kind: "replay", options: {from: "<start>", to: "<end>"}})` for the requested window.
+2. Project the relevant diff with `change({operation: "detect", source: {scope: "<scope>"}})`.
+3. Surface decisions with `recall({operation: "surface", arguments: {task: "<episode>"}})`.
+4. Trace important before/after paths using `trace` and identify which change altered behavior.
+5. Produce a timestamped narrative with evidence links, impact, missed signals, and remaining uncertainty.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/commands/gortex-explore.md ===
+---
+description: "Understand how code works or trace an execution flow."
+---
+
+# Explore a Codebase with Gortex
+
+1. Call `explore({operation: "task", task: "<question>"})`.
+2. Read only a returned anchor with `read({target: {symbol: "<id>"}})`.
+3. Choose the needed relationship (`callers`, `usages`, or `dependencies`), for example `relations({operation: "callers", target: {symbol: "<id>"}})`; use `trace({operation: "call_chain", target: {symbol: "<id>"}})` for execution order.
+4. Answer with the execution path, file locations, symbol IDs, and any graph uncertainty.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/commands/gortex-extract-function.md ===
+---
+description: "Extract code into a function or method via LSP refactor."
+---
+
+# Extract a Function with Gortex
+
+1. Inspect the file with `read({operation: "editing_context", target: {file: "<path>"}})`.
+2. Resolve the selected range with `change({operation: "ranges", source: {file: "<path>", range: {...}}})`.
+3. Request extraction actions with `change({operation: "code_actions", source: {file: "<path>", range: {...}}})`.
+4. Apply the selected action through `refactor({operation: "apply_code_action", target: {file: "<path>"}, options: {...}})`.
+5. Run `change` operations `detect`, `tests`, `guards`, and `contract`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/commands/gortex-fix-all.md ===
+---
+description: "Clear LSP diagnostics — one error, a file, or source.fixAll."
+---
+
+# Fix Diagnostics with Gortex
+
+1. Read diagnostics using `change({operation: "diagnostics", source: {file: "<path>"}})`.
+2. Fetch applicable fixes with `change({operation: "code_actions", source: {file: "<path>"}})`.
+3. Apply one reviewed action with `refactor({operation: "apply_code_action", target: {file: "<path>"}, options: {...}})`, or use operation `fix_all` only when the user asked for all safe fixes.
+4. Re-run diagnostics, then run `change` operations `detect` and `tests`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/commands/gortex-guide.md ===
+---
+description: "Gortex reference: available tools, graph schema, and workflow."
+---
+
+# Gortex Guide
+
+Use this sequence for codebase work:
+
+1. `explore({operation: "task", task: "<goal or bug>"})` — localize the task and obtain the working set.
+2. `search({operation: "symbols", query: "<name>"})` or `search({operation: "text", query: "<literal>"})` — resolve a precise anchor.
+3. `read({operation: "source", target: {symbol: "<id>"}})` — read only the source needed.
+4. `relations({operation: "usages", target: {symbol: "<id>"}})` or `trace({operation: "call_chain", target: {symbol: "<id>"}})` — follow verified graph edges.
+5. `change({operation: "impact", source: {symbols: ["<id>"]}})` — assess a planned change.
+6. Apply with `edit` or `refactor`, then run `change` operations `detect`, `guards`, and `tests`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/commands/gortex-impact.md ===
+---
+description: "Assess what breaks if you change X before editing it."
+---
+
+# Assess Change Impact with Gortex
+
+1. Resolve the target with `search({operation: "symbols", query: "<name>"})`.
+2. Query `relations` operations `usages`, `dependents`, and `implementations` for the resolved symbol.
+3. Call `change({operation: "impact", source: {symbols: ["<id>"]}})`; add operation `api_impact` for a public API.
+4. For a signature change, require `change({operation: "verify", source: {changes: [{symbol_id: "<id>", new_signature: "<signature>"}]}})`.
+5. Report direct callers, transitive risk, interfaces, contracts, and the tests returned by `change({operation: "tests", source: {symbols: ["<id>"]}})`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/commands/gortex-incident-investigation.md ===
+---
+description: "Walk a production symptom back to its root cause."
+---
+
+# Investigate an Incident with Gortex
+
+1. Paste the exact symptom into `explore({operation: "task", task: "<alert, error, and time window>"})`.
+2. Search exact error text with `search({operation: "text", query: "<literal>"})`.
+3. Walk `relations` operation `callers` and `trace` operations `call_chain`, `flow`, or `taint` from symptom toward cause.
+4. Correlate repository-wide `analyze({kind: "recent_changes"})` with symbol-scoped `recall({operation: "surface", arguments: {symbol_ids: "<id>", task: "<symptom>"}})`.
+5. Separate evidence, hypothesis, and unknowns. Gate any fix through `change` before and after the mutation.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/commands/gortex-onboarding.md ===
+---
+description: "Structured tour of an unfamiliar repo."
+---
+
+# Onboard to a Repository with Gortex
+
+1. Call `explore({operation: "outline"})`, then `explore({operation: "task", task: "explain the repository's main responsibilities and entry points"})`.
+2. Run `analyze` with kinds `architecture`, `communities`, and `processes`.
+3. Trace one representative request or job with `trace({operation: "call_chain", target: {symbol: "<entry-id>"}})`.
+4. Read only the key returned symbols. Deliver a concise map of entry points, boundaries, data flow, tests, and operational risks.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/commands/gortex-pr-review-agent.md ===
+---
+description: "Coding-agent review verdict via the gortex review verb."
+---
+
+# Review a Change as a Sub-Agent
+
+## MCP-capable harness
+
+Native Gortex MCP is mandatory. Call `review({operation: "run", source: {scope: "<scope>"}})`, then use `change` operations `guards`, `tests`, and `contract`. When the proposed signature is known, run operation `verify` before mutation. If the configured callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or use the Bash path below.
+
+## Bash-only harness
+
+Use this path only when the harness has no MCP transport by design:
+
+```bash
+gortex review --audience agent --format json
+```
+
+In either mode, return `VERDICT: clean` or `VERDICT: findings` followed by actionable findings with severity and `file:line`. Do not replace graph-backed review with ad-hoc `git diff` inspection.
+=== global/home/.config/opencode/commands/gortex-pr-review.md ===
+---
+description: "Graph-grounded review of a pending change or PR."
+---
+
+# Review a Change with Gortex
+
+1. Project the working tree with `change({operation: "detect", source: {scope: "unstaged"}})`; use `staged` or `compare` only when that is the requested review scope.
+2. Build review context with `review({operation: "run", source: {scope: "<scope>"}})` and operation `diff_context` when per-file context is needed.
+3. Require `change` operations `guards`, `tests`, and `contract`. When the proposed signature is known, run operation `verify` before mutation.
+4. Check wire boundaries with `analyze({kind: "contracts", options: {action: "check"}})` when APIs or events changed.
+5. Report only actionable findings with severity, `file:line`, evidence, consequence, and correction. State an explicit clean verdict when none remain.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/commands/gortex-quality-audit.md ===
+---
+description: "Repo-scale quality scan — dead code, hotspots, clones."
+---
+
+# Audit Repository Quality with Gortex
+
+1. Establish scope with `workspace({operation: "info"})` and `explore({operation: "outline"})`.
+2. Run `analyze` for `health`, `dead_code`, `hotspots`, `cycles`, and `clones`.
+3. Validate high-risk findings with `read` and `relations`; do not report an unverified heuristic as a fact.
+4. Rank findings by evidence, impact, and remediation cost. Include exact paths, symbol IDs, and a smallest-first action plan.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/commands/gortex-refactor.md ===
+---
+description: "Rename, extract, split, or restructure code safely."
+---
+
+# Refactor with Gortex
+
+1. Call `explore({operation: "task", task: "<refactor goal>"})` and resolve every target with `search`.
+2. Run `change({operation: "impact", source: {symbols: ["<id>"]}})`. Before altering a signature, also run `change({operation: "verify", source: {changes: [{symbol_id: "<id>", new_signature: "<signature>"}]}})`.
+3. Choose exactly one `refactor` operation: `rename`, `move`, `inline`, `delete`, or `apply_code_action`. For example: `refactor({operation: "rename", target: {symbol: "<id>"}, new_name: "<name>"})`.
+4. Require `change` operations `detect`, `tests`, `guards`, and `contract` after the mutation. Resolve every violation before finishing.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/commands/gortex-rename.md ===
+---
+description: "Rename a symbol and update every reference atomically."
+---
+
+# Rename a Symbol with Gortex
+
+1. Resolve exactly one symbol with `search({operation: "symbols", query: "<old name>"})`.
+2. Enumerate references and implementations with `relations` operations `usages` and `implementations`.
+3. Run `change({operation: "impact", source: {symbols: ["<id>"]}})`. For a public signature rename, also run `change({operation: "verify", source: {changes: [{symbol_id: "<id>", new_signature: "<signature with new name>"}]}})`.
+4. Preview with `refactor({operation: "rename", target: {symbol: "<id>"}, new_name: "<new>", dry_run: true})`, then repeat it with `dry_run: false` to apply.
+5. Require `change` operations `detect`, `guards`, and `tests`; confirm no old usages remain.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/commands/gortex-safe-edit.md ===
+---
+description: "Preview an edit's blast radius on the shadow graph before writing."
+---
+
+# Make a Safe Edit with Gortex
+
+1. Localize with `explore` and inspect `read({operation: "editing_context", target: {file: "<path>"}})`.
+2. Run `change({operation: "impact", source: {symbols: ["<id>"]}})` before editing.
+3. Choose `edit` operation `file`, `symbol`, or `batch`. Preview with `dry_run: true`; after review, repeat the same guarded request with `dry_run: false`. Use `change({operation: "simulate", source: {steps: "<WorkspaceEdit JSON array>"}})` for a multi-step semantic edit.
+4. Run `change` operations `detect`, `tests`, `guards`, and `contract`. Signature verification belongs before mutation with the proposed signature.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/plugin/gortex.js ===
+// Gortex plugin for OpenCode (1.18.18).
+//
+// OpenCode has no lifecycle-hook configuration at all — there is no
+// settings key that runs a command on session start or before a tool
+// call. A JS/TS plugin is its only enforcement surface, so this file is
+// the OpenCode half of the Gortex bridge: on each relevant plugin hook it
+// shells `gortex hook --agent=opencode`, writes a BridgeEvent envelope to
+// stdin, and applies the BridgeDecision it reads back.
+//
+// Every policy decision — the deny / enrich / consult-unlock / nudge
+// postures, indexed-source classification, telemetry — stays in Go
+// (internal/hooks/opencode.go + pi.go). Re-implementing any of it here
+// would give OpenCode a second, drifting copy of rules every other host
+// reads from one place.
+//
+// This file is written verbatim by the `opencode` adapter except for
+// three sentinels, each replaced with a JSON literal at install time:
+//
+//   GORTEX_BIN        -> string:  resolved `gortex` binary path
+//   GORTEX_HOOK_ARGV  -> array:   full hook argv, argv[0] included
+//   GORTEX_ENFORCE    -> boolean: false when installed with --no-hooks
+//
+// Zero package dependencies, deliberately: OpenCode installs plugin
+// dependencies from `.opencode/package.json` with a bun install at
+// startup. Anything beyond a `node:` built-in would need a package.json
+// this installer does not own, and a failed install would take the plugin
+// down with it.
+
+import { execFileSync } from "node:child_process";
+
+const GORTEX_BIN = "gortex";
+const HOOK_ARGV = ["gortex","hook","--agent=opencode"];
+
+// The adapter does not write this file at all under --no-hooks, so a
+// rendered `false` only ever reaches disk via a hand-copied or downgraded
+// install. Honouring it anyway costs one branch and means the documented
+// off switch still works on a file that outlived its installer.
+const ENFORCE = true;
+
+// How long a single bridge call may take before we give up and let the
+// tool through. The Go side answers from a local daemon in single-digit
+// milliseconds; this ceiling exists for the pathological case (daemon
+// mid-restart, machine swapping), where waiting longer would be felt as
+// the agent hanging.
+const HOOK_TIMEOUT_MS = 5000;
+
+// Cap on the per-call decision map. A session is thousands of tool calls
+// long and OpenCode gives no "call finished" signal we can trust for
+// cleanup, so the map is cleared wholesale once it grows past this. The
+// only cost of a clear is that an in-flight call loses its parked tip.
+const DECISION_CACHE_MAX = 256;
+
+// OpenCode's built-in tool vocabulary, mapped onto the Claude names the
+// shared Go enrichment switches on. Deliberately the same seven entries
+// as openCodeToolNames in internal/hooks/opencode.go, in the same order,
+// so the two tables can be diffed by eye. Anything unrecognised is passed
+// through untouched; the Go classifier ignores names it does not know,
+// which is the fail-open default this whole file is built around.
+const TOOL_NAMES = {
+  read: "Read",
+  write: "Write",
+  edit: "Edit",
+  bash: "Bash",
+  grep: "Grep",
+  glob: "Glob",
+  task: "Task",
+};
+
+// A tool call that IS a Gortex graph query. OpenCode exposes MCP tools as
+// `<server>_<tool>`, and our server is registered as `gortex`, so the
+// prefix identifies them; the `mcp__gortex__` spelling is accepted too in
+// case a future OpenCode adopts Claude's naming. The flag matters to the
+// Go side: consult-unlock uses a graph query as the handshake that
+// unlocks fallback reads, and adaptive-nudge resets its streak on one.
+const GORTEX_TOOL_PATTERN = /^(gortex[_.]|mcp__gortex__)/;
+
+function isGortexTool(name) {
+  return GORTEX_TOOL_PATTERN.test(String(name || ""));
+}
+
+function normalizeToolName(name) {
+  const raw = String(name || "").trim();
+  return TOOL_NAMES[raw.toLowerCase()] || raw;
+}
+
+function firstString(obj, keys) {
+  if (!obj || typeof obj !== "object") return undefined;
+  for (const key of keys) {
+    const value = obj[key];
+    if (typeof value === "string" && value !== "") return value;
+  }
+  return undefined;
+}
+
+// normalizeToolInput maps OpenCode's argument keys onto the canonical
+// `file_path` / `pattern` / `command` shape the Go enrichment reads.
+// OpenCode spells the first one `filePath`; without this the classifier
+// would see no path on any read or edit and quietly classify nothing,
+// which looks exactly like a healthy install that enforces nothing.
+// Original keys are kept alongside the canonical ones — the envelope is
+// ours, and dropping them would lose context for future rules.
+function normalizeToolInput(args) {
+  const out = args && typeof args === "object" ? { ...args } : {};
+  const path = firstString(out, ["file_path", "filePath", "path", "file", "filepath"]);
+  if (path !== undefined) out.file_path = path;
+  const pattern = firstString(out, ["pattern", "glob", "query"]);
+  if (pattern !== undefined) out.pattern = pattern;
+  const command = firstString(out, ["command", "cmd", "script"]);
+  if (command !== undefined) out.command = command;
+  return out;
+}
+
+// callHook sends one envelope to `gortex hook --agent=opencode` and
+// parses the decision it writes back.
+//
+// Fail-open and silent by construction: a missing binary, a non-zero
+// exit, a timeout, or unparsable stdout all land in the catch and return
+// an empty decision, which every caller below treats as "do nothing". A
+// broken bridge must never be able to break the user's session. The
+// child's stderr is discarded rather than inherited so a Go-side warning
+// cannot scribble over OpenCode's TUI.
+function callHook(envelope) {
+  try {
+    const out = execFileSync(GORTEX_BIN, HOOK_ARGV.slice(1), {
+      input: JSON.stringify(envelope),
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024,
+      timeout: HOOK_TIMEOUT_MS,
+      stdio: ["pipe", "pipe", "ignore"],
+    });
+    const trimmed = String(out || "").trim();
+    if (!trimmed) return {};
+    const decision = JSON.parse(trimmed);
+    return decision && typeof decision === "object" ? decision : {};
+  } catch {
+    return {};
+  }
+}
+
+// messageText joins the text parts of a chat message, which is what the
+// Go side scores for "indexed symbols relevant to this turn".
+function messageText(parts) {
+  if (!Array.isArray(parts)) return "";
+  return parts
+    .filter((p) => p && p.type === "text" && typeof p.text === "string")
+    .map((p) => p.text)
+    .join("\n");
+}
+
+// appendToLastTextPart injects context by extending the last text part in
+// place rather than pushing a new one. A part carries identity fields
+// (id, sessionID, messageID) whose shape is OpenCode's, not ours;
+// fabricating one risks a malformed message where the worst case is a
+// broken session, while appending to an existing string cannot be
+// structurally wrong.
+function appendToLastTextPart(parts, text) {
+  if (!Array.isArray(parts) || !text) return;
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const part = parts[i];
+    if (part && part.type === "text" && typeof part.text === "string") {
+      part.text = part.text + "\n\n" + text;
+      return;
+    }
+  }
+}
+
+export const GortexPlugin = async ({ directory, worktree }) => {
+  // The repo the Go side resolves indexed-source coverage against.
+  // `worktree` is the git root and `directory` the CWD OpenCode started
+  // in; prefer the former so a session opened in a subdirectory is still
+  // recognised as covered.
+  const cwd = worktree || directory || process.cwd();
+
+  // callID -> soft guidance parked by tool.execute.before for
+  // tool.execute.after to deliver. Presence of a key also records "this
+  // call was already decided", which is what keeps permission.ask from
+  // asking the same question twice for one tool call.
+  const decided = new Map();
+
+  // The session briefing is a once-per-session injection; OpenCode has no
+  // session-start hook in the stable set, so the first chat message is
+  // where it goes.
+  let oriented = false;
+
+  function remember(callID, tip) {
+    if (!callID) return;
+    if (decided.size >= DECISION_CACHE_MAX) decided.clear();
+    decided.set(callID, tip || "");
+  }
+
+  return {
+    // Throwing from tool.execute.before is OpenCode's documented way to
+    // refuse a tool call: the throw becomes the tool's error and the
+    // model reads the message. That makes the thrown reason the deny
+    // text, which is why it is the Go decision's Reason verbatim.
+    "tool.execute.before": async (input, output) => {
+      if (!ENFORCE) return;
+      const tool = String(input?.tool ?? "");
+      const gortexTool = isGortexTool(tool);
+      const callID = String(input?.callID ?? "");
+
+      const decision = callHook({
+        event: "tool.execute.before",
+        tool_name: gortexTool ? tool : normalizeToolName(tool),
+        tool_input: normalizeToolInput(output?.args),
+        cwd,
+        session_id: String(input?.sessionID ?? ""),
+        is_gortex_tool: gortexTool,
+      });
+
+      remember(callID, decision.additional_context);
+      if (decision.block) {
+        throw new Error(
+          decision.reason || "[Gortex] blocked — use the Gortex graph tools instead of raw file reads.",
+        );
+      }
+    },
+
+    // This hook deliberately does NOT shell the bridge. The Go router
+    // maps no "after" phase, so every call would spend a subprocess to
+    // receive a guaranteed-empty decision. What it is for is delivery:
+    // it is the only stable hook that can put text in front of the model
+    // without blocking anything, so it hands over the soft guidance the
+    // before-hook parked (the enrich and nudge postures' whole output).
+    "tool.execute.after": async (input, output) => {
+      const callID = String(input?.callID ?? "");
+      if (!callID || !decided.has(callID)) return;
+      const tip = decided.get(callID);
+      decided.delete(callID);
+      if (!tip) return;
+      try {
+        if (output && typeof output.output === "string") {
+          output.output = output.output + "\n\n" + tip;
+        }
+      } catch {
+        // Never let context delivery break a tool result.
+      }
+    },
+
+    // permission.ask is a second gate, not a duplicate one: OpenCode
+    // raises it from inside a tool that needs approval, after
+    // tool.execute.before has already run for that callID. Deferring to
+    // the earlier decision keeps one tool call from being scored twice —
+    // double-counting would inflate doctor's run tallies and, under
+    // consult-unlock / adaptive-nudge, move per-session state twice for
+    // one action. A permission with no matching before-hook is still
+    // asked about.
+    "permission.ask": async (input, output) => {
+      if (!ENFORCE) return;
+      const callID = String(input?.callID ?? "");
+      if (callID && decided.has(callID)) return;
+      const type = String(input?.type ?? "");
+      if (isGortexTool(type)) return;
+
+      const decision = callHook({
+        event: "permission.ask",
+        tool_name: normalizeToolName(type),
+        tool_input: normalizeToolInput(input?.metadata),
+        cwd,
+        session_id: String(input?.sessionID ?? ""),
+      });
+
+      remember(callID, "");
+      if (decision.block) {
+        output.status = "deny";
+      }
+    },
+
+    // chat.message carries the user's turn with a mutable parts array —
+    // the one place a bridged host can inject context the way Claude's
+    // UserPromptSubmit hook does. Two envelopes go out on the first turn:
+    // the session briefing (once) and the per-turn symbol context.
+    "chat.message": async (input, output) => {
+      const role = output?.message?.role;
+      if (role && role !== "user") return;
+      const sessionID = String(output?.message?.sessionID ?? input?.sessionID ?? "");
+      const injected = [];
+
+      if (!oriented) {
+        oriented = true;
+        const briefing = callHook({ event: "session", cwd, session_id: sessionID });
+        if (briefing.orientation) injected.push(briefing.orientation);
+      }
+
+      const decision = callHook({
+        event: "chat.message",
+        prompt: messageText(output?.parts),
+        cwd,
+        session_id: sessionID,
+      });
+      if (decision.additional_context) injected.push(decision.additional_context);
+
+      if (injected.length > 0) {
+        try {
+          appendToLastTextPart(output?.parts, injected.join("\n\n"));
+        } catch {
+          // Best effort — never break message assembly.
+        }
+      }
+    },
+  };
+};
+=== global/home/.config/opencode/skills/gortex-add-test/SKILL.md ===
+---
+name: gortex-add-test
+description: "Add tests for under-tested code and coverage gaps."
+---
+
+# Add Tests with Gortex
+
+1. Localize the behavior with `explore`.
+2. Confirm the specific gap with `change({operation: "tests", source: {symbols: ["<id>"]}})`. Use repository-wide `analyze({kind: "untested"})` or path-scoped `analyze({kind: "coverage_gaps", options: {path_prefix: "<path>"}})` only for broader coverage discovery.
+3. Inspect callers with `relations({operation: "callers", target: {symbol: "<id>"}})` and request targets with `change({operation: "tests", source: {symbols: ["<id>"]}})`.
+4. Add the narrowest test with `edit({operation: "file", target: {file: "<existing test path>"}, ...})`; use operation `write` for a new test file.
+5. Run the test, then require `change` operations `detect` and `guards`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/skills/gortex-architecture-review/SKILL.md ===
+---
+name: gortex-architecture-review
+description: "Graph-grounded architectural read of a repo."
+---
+
+# Review Architecture with Gortex
+
+1. Build the map with `explore({operation: "outline"})` and `analyze` kinds `architecture` and `communities`.
+2. Measure boundaries with `analyze({kind: "coupling"})` and cycles with `analyze({kind: "cycles"})`.
+3. Trace representative paths with `trace` and inspect public boundaries with `analyze({kind: "contracts", options: {action: "list"}})`.
+4. Deliver observed structure, intended structure, violations, consequences, and prioritized changes. Cite graph evidence for every finding.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/skills/gortex-cli/SKILL.md ===
+---
+name: gortex-cli
+description: "Bash-only mirror of Gortex MCP tools for harnesses without MCP support."
+---
+
+# Gortex from a Bash-Only Harness
+
+Use this skill only in a harness that has no MCP transport by design. If a Gortex MCP server is configured but its callable tools are missing, report an integration failure; do not use this skill as a fallback.
+
+Every public MCP tool has the same name through `gortex call`:
+
+```bash
+gortex call explore --arg task='locate the authentication flow'
+gortex call search --arg operation=symbols --arg query=UserStore
+gortex call read --arg target='{"symbol":"internal/store.go::UserStore"}'
+gortex call relations --arg operation=usages --arg target='{"symbol":"internal/store.go::UserStore"}'
+gortex call change --arg operation=impact --arg target='{"symbol":"internal/store.go::UserStore"}'
+gortex call edit --arg target='{"file":"internal/store.go"}' --arg match='old text' --arg replacement='new text'
+gortex call change --arg operation=detect --arg source='{"scope":"all"}'
+```
+
+For an exact operation schema:
+
+```bash
+gortex call capabilities --arg domain=read --arg operation=source --arg detail=schema
+```
+
+The required order is `explore` → targeted `search/read/relations/trace` → pre-change `change` → `edit/refactor` → post-change `change`. Do not use shell file reads or search as a substitute.
+=== global/home/.config/opencode/skills/gortex-co-change/SKILL.md ===
+---
+name: gortex-co-change
+description: "Find what changes together and hidden coupling."
+---
+
+# Analyze Co-Change with Gortex
+
+1. Resolve the anchor with `search({operation: "symbols", query: "<name>"})`.
+2. Call symbol-scoped `analyze({kind: "co_change", target: {symbol: "<id>"}})` and repository-wide `analyze({kind: "churn"})`.
+3. Compare structural coupling through `relations` operations `cluster` and `dependents`.
+4. Report strong historical pairs, graph-confirmed dependencies, likely hidden coupling, and an actionable boundary or guard.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/skills/gortex-cross-repo-usage/SKILL.md ===
+---
+name: gortex-cross-repo-usage
+description: "Find who uses a symbol across all consumer repos."
+---
+
+# Find Cross-Repository Usage with Gortex
+
+1. Confirm tracked repositories with `workspace({operation: "repos"})`.
+2. Resolve the provider symbol with `search({operation: "symbols", query: "<name>", options: {repo: "<provider>"}})`.
+3. Call `relations({operation: "usages", target: {symbol: "<id>"}})` and group results by repository.
+4. Add `analyze({kind: "cross_repo", options: {repo: "<provider>"}})` for repository boundaries and `analyze({kind: "contracts", options: {action: "bridge", mode: "impact", symbol: "<id>"}})` for wire-level consumers.
+5. Report indexed coverage and name any untracked repositories as an explicit gap.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/skills/gortex-dataflow-trace/SKILL.md ===
+---
+name: gortex-dataflow-trace
+description: "Trace where a value flows through the code."
+---
+
+# Trace Data Flow with Gortex
+
+1. Call `explore({operation: "task", task: "trace <value> from <source> to <sink>"})`.
+2. Resolve endpoints with `search({operation: "symbols", query: "<source or sink>"})`.
+3. Use `trace({operation: "flow", target: {symbol: "<source-id>"}, to: {symbol: "<sink-id>"}})`. Use operation `taint` when source/sink security semantics matter.
+4. Cross-check control flow with operation `call_chain` when the data-flow graph has a gap.
+5. Report each hop with its symbol ID and confidence; distinguish no path from incomplete indexing.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/skills/gortex-debug/SKILL.md ===
+---
+name: gortex-debug
+description: "Debug a bug, trace an error, or find why something fails."
+---
+
+# Debug with Gortex
+
+1. Localize the exact symptom with `explore({operation: "task", task: "<error and observed behavior>"})`.
+2. For a literal error, call `search({operation: "text", query: "<exact text>"})`. For a name, use operation `symbols`.
+3. Walk toward the cause with `relations({operation: "callers", target: {symbol: "<id>"}})` and `trace({operation: "call_chain", target: {symbol: "<id>"}})`. Use `flow` or `taint` only after resolving both `target` and `to` endpoints.
+4. Confirm repository-wide error propagation with `analyze({kind: "error_surface"})`; use `options.repo` to narrow a multi-repository workspace.
+5. Before fixing, run `change({operation: "impact", source: {symbols: ["<id>"]}})`. After fixing, run `change` operations `detect`, `tests`, and `guards`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/skills/gortex-episode-replay/SKILL.md ===
+---
+name: gortex-episode-replay
+description: "Reconstruct what changed in a window (postmortem, release, PR)."
+---
+
+# Replay a Change Episode with Gortex
+
+1. Run `analyze({kind: "replay", options: {from: "<start>", to: "<end>"}})` for the requested window.
+2. Project the relevant diff with `change({operation: "detect", source: {scope: "<scope>"}})`.
+3. Surface decisions with `recall({operation: "surface", arguments: {task: "<episode>"}})`.
+4. Trace important before/after paths using `trace` and identify which change altered behavior.
+5. Produce a timestamped narrative with evidence links, impact, missed signals, and remaining uncertainty.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/skills/gortex-explore/SKILL.md ===
+---
+name: gortex-explore
+description: "Understand how code works or trace an execution flow."
+---
+
+# Explore a Codebase with Gortex
+
+1. Call `explore({operation: "task", task: "<question>"})`.
+2. Read only a returned anchor with `read({target: {symbol: "<id>"}})`.
+3. Choose the needed relationship (`callers`, `usages`, or `dependencies`), for example `relations({operation: "callers", target: {symbol: "<id>"}})`; use `trace({operation: "call_chain", target: {symbol: "<id>"}})` for execution order.
+4. Answer with the execution path, file locations, symbol IDs, and any graph uncertainty.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/skills/gortex-extract-function/SKILL.md ===
+---
+name: gortex-extract-function
+description: "Extract code into a function or method via LSP refactor."
+---
+
+# Extract a Function with Gortex
+
+1. Inspect the file with `read({operation: "editing_context", target: {file: "<path>"}})`.
+2. Resolve the selected range with `change({operation: "ranges", source: {file: "<path>", range: {...}}})`.
+3. Request extraction actions with `change({operation: "code_actions", source: {file: "<path>", range: {...}}})`.
+4. Apply the selected action through `refactor({operation: "apply_code_action", target: {file: "<path>"}, options: {...}})`.
+5. Run `change` operations `detect`, `tests`, `guards`, and `contract`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/skills/gortex-fix-all/SKILL.md ===
+---
+name: gortex-fix-all
+description: "Clear LSP diagnostics — one error, a file, or source.fixAll."
+---
+
+# Fix Diagnostics with Gortex
+
+1. Read diagnostics using `change({operation: "diagnostics", source: {file: "<path>"}})`.
+2. Fetch applicable fixes with `change({operation: "code_actions", source: {file: "<path>"}})`.
+3. Apply one reviewed action with `refactor({operation: "apply_code_action", target: {file: "<path>"}, options: {...}})`, or use operation `fix_all` only when the user asked for all safe fixes.
+4. Re-run diagnostics, then run `change` operations `detect` and `tests`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/skills/gortex-guide/SKILL.md ===
+---
+name: gortex-guide
+description: "Gortex reference: available tools, graph schema, and workflow."
+---
+
+# Gortex Guide
+
+Use this sequence for codebase work:
+
+1. `explore({operation: "task", task: "<goal or bug>"})` — localize the task and obtain the working set.
+2. `search({operation: "symbols", query: "<name>"})` or `search({operation: "text", query: "<literal>"})` — resolve a precise anchor.
+3. `read({operation: "source", target: {symbol: "<id>"}})` — read only the source needed.
+4. `relations({operation: "usages", target: {symbol: "<id>"}})` or `trace({operation: "call_chain", target: {symbol: "<id>"}})` — follow verified graph edges.
+5. `change({operation: "impact", source: {symbols: ["<id>"]}})` — assess a planned change.
+6. Apply with `edit` or `refactor`, then run `change` operations `detect`, `guards`, and `tests`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/skills/gortex-impact/SKILL.md ===
+---
+name: gortex-impact
+description: "Assess what breaks if you change X before editing it."
+---
+
+# Assess Change Impact with Gortex
+
+1. Resolve the target with `search({operation: "symbols", query: "<name>"})`.
+2. Query `relations` operations `usages`, `dependents`, and `implementations` for the resolved symbol.
+3. Call `change({operation: "impact", source: {symbols: ["<id>"]}})`; add operation `api_impact` for a public API.
+4. For a signature change, require `change({operation: "verify", source: {changes: [{symbol_id: "<id>", new_signature: "<signature>"}]}})`.
+5. Report direct callers, transitive risk, interfaces, contracts, and the tests returned by `change({operation: "tests", source: {symbols: ["<id>"]}})`.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/skills/gortex-incident-investigation/SKILL.md ===
+---
+name: gortex-incident-investigation
+description: "Walk a production symptom back to its root cause."
+---
+
+# Investigate an Incident with Gortex
+
+1. Paste the exact symptom into `explore({operation: "task", task: "<alert, error, and time window>"})`.
+2. Search exact error text with `search({operation: "text", query: "<literal>"})`.
+3. Walk `relations` operation `callers` and `trace` operations `call_chain`, `flow`, or `taint` from symptom toward cause.
+4. Correlate repository-wide `analyze({kind: "recent_changes"})` with symbol-scoped `recall({operation: "surface", arguments: {symbol_ids: "<id>", task: "<symptom>"}})`.
+5. Separate evidence, hypothesis, and unknowns. Gate any fix through `change` before and after the mutation.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/skills/gortex-onboarding/SKILL.md ===
+---
+name: gortex-onboarding
+description: "Structured tour of an unfamiliar repo."
+---
+
+# Onboard to a Repository with Gortex
+
+1. Call `explore({operation: "outline"})`, then `explore({operation: "task", task: "explain the repository's main responsibilities and entry points"})`.
+2. Run `analyze` with kinds `architecture`, `communities`, and `processes`.
+3. Trace one representative request or job with `trace({operation: "call_chain", target: {symbol: "<entry-id>"}})`.
+4. Read only the key returned symbols. Deliver a concise map of entry points, boundaries, data flow, tests, and operational risks.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/skills/gortex-pr-review-agent/SKILL.md ===
+---
+name: gortex-pr-review-agent
+description: "Coding-agent review verdict via the gortex review verb."
+---
+
+# Review a Change as a Sub-Agent
+
+## MCP-capable harness
+
+Native Gortex MCP is mandatory. Call `review({operation: "run", source: {scope: "<scope>"}})`, then use `change` operations `guards`, `tests`, and `contract`. When the proposed signature is known, run operation `verify` before mutation. If the configured callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or use the Bash path below.
+
+## Bash-only harness
+
+Use this path only when the harness has no MCP transport by design:
+
+```bash
+gortex review --audience agent --format json
+```
+
+In either mode, return `VERDICT: clean` or `VERDICT: findings` followed by actionable findings with severity and `file:line`. Do not replace graph-backed review with ad-hoc `git diff` inspection.
+=== global/home/.config/opencode/skills/gortex-pr-review/SKILL.md ===
+---
+name: gortex-pr-review
+description: "Graph-grounded review of a pending change or PR."
+---
+
+# Review a Change with Gortex
+
+1. Project the working tree with `change({operation: "detect", source: {scope: "unstaged"}})`; use `staged` or `compare` only when that is the requested review scope.
+2. Build review context with `review({operation: "run", source: {scope: "<scope>"}})` and operation `diff_context` when per-file context is needed.
+3. Require `change` operations `guards`, `tests`, and `contract`. When the proposed signature is known, run operation `verify` before mutation.
+4. Check wire boundaries with `analyze({kind: "contracts", options: {action: "check"}})` when APIs or events changed.
+5. Report only actionable findings with severity, `file:line`, evidence, consequence, and correction. State an explicit clean verdict when none remain.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/skills/gortex-quality-audit/SKILL.md ===
+---
+name: gortex-quality-audit
+description: "Repo-scale quality scan — dead code, hotspots, clones."
+---
+
+# Audit Repository Quality with Gortex
+
+1. Establish scope with `workspace({operation: "info"})` and `explore({operation: "outline"})`.
+2. Run `analyze` for `health`, `dead_code`, `hotspots`, `cycles`, and `clones`.
+3. Validate high-risk findings with `read` and `relations`; do not report an unverified heuristic as a fact.
+4. Rank findings by evidence, impact, and remediation cost. Include exact paths, symbol IDs, and a smallest-first action plan.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/skills/gortex-refactor/SKILL.md ===
+---
+name: gortex-refactor
+description: "Rename, extract, split, or restructure code safely."
+---
+
+# Refactor with Gortex
+
+1. Call `explore({operation: "task", task: "<refactor goal>"})` and resolve every target with `search`.
+2. Run `change({operation: "impact", source: {symbols: ["<id>"]}})`. Before altering a signature, also run `change({operation: "verify", source: {changes: [{symbol_id: "<id>", new_signature: "<signature>"}]}})`.
+3. Choose exactly one `refactor` operation: `rename`, `move`, `inline`, `delete`, or `apply_code_action`. For example: `refactor({operation: "rename", target: {symbol: "<id>"}, new_name: "<name>"})`.
+4. Require `change` operations `detect`, `tests`, `guards`, and `contract` after the mutation. Resolve every violation before finishing.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/skills/gortex-rename/SKILL.md ===
+---
+name: gortex-rename
+description: "Rename a symbol and update every reference atomically."
+---
+
+# Rename a Symbol with Gortex
+
+1. Resolve exactly one symbol with `search({operation: "symbols", query: "<old name>"})`.
+2. Enumerate references and implementations with `relations` operations `usages` and `implementations`.
+3. Run `change({operation: "impact", source: {symbols: ["<id>"]}})`. For a public signature rename, also run `change({operation: "verify", source: {changes: [{symbol_id: "<id>", new_signature: "<signature with new name>"}]}})`.
+4. Preview with `refactor({operation: "rename", target: {symbol: "<id>"}, new_name: "<new>", dry_run: true})`, then repeat it with `dry_run: false` to apply.
+5. Require `change` operations `detect`, `guards`, and `tests`; confirm no old usages remain.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.
+=== global/home/.config/opencode/skills/gortex-safe-edit/SKILL.md ===
+---
+name: gortex-safe-edit
+description: "Preview an edit's blast radius on the shadow graph before writing."
+---
+
+# Make a Safe Edit with Gortex
+
+1. Localize with `explore` and inspect `read({operation: "editing_context", target: {file: "<path>"}})`.
+2. Run `change({operation: "impact", source: {symbols: ["<id>"]}})` before editing.
+3. Choose `edit` operation `file`, `symbol`, or `batch`. Preview with `dry_run: true`; after review, repeat the same guarded request with `dry_run: false`. Use `change({operation: "simulate", source: {steps: "<WorkspaceEdit JSON array>"}})` for a multi-step semantic edit.
+4. Run `change` operations `detect`, `tests`, `guards`, and `contract`. Signature verification belongs before mutation with the proposed signature.
+
+## Required behavior
+
+- Native Gortex MCP is mandatory for this MCP-configured workflow. If its callable tools are missing, report a Gortex MCP integration failure and stop; do not start a daemon or switch to a CLI/shell fallback.
+- Do not substitute shell reads, file search, or Git plumbing.
+- Start task-shaped work with `explore`. For one already-known symbol, start with `search`.
+- Use `change` before a mutation and again after it. Write only through `edit` or `refactor`.
+- Call `capabilities({domain: "<tool>", operation: "<operation>", detail: "schema"})` only when an operation's exact arguments are unclear.
+- Report graph-backed paths and symbol IDs. Never invent a result when an operation returns no match.

--- a/cmd/gortex/testdata/agent-render/pi.txt
+++ b/cmd/gortex/testdata/agent-render/pi.txt
@@ -1,4 +1,4 @@
-=== root/.pi/extensions/gortex/index.ts ===
+=== project/root/.pi/extensions/gortex/index.ts ===
 // Gortex extension for the Pi coding agent (earendil-works/pi).
 //
 // Pi has no MCP support by design — the extension API's registerTool
@@ -22,7 +22,7 @@
 //
 //   "gortex"          -> string: resolved `gortex` binary path
 //   ["gortex","hook","--agent=pi"]    -> array: full hook argv
-//   false      -> boolean: wire read-discipline enforcement
+//   true      -> boolean: wire read-discipline enforcement
 //                              (false when installed with --no-hooks)
 //   "core" -> string: default eager tool preset;
 //                              GORTEX_TOOLS overrides it at runtime
@@ -40,7 +40,7 @@ import { execFileSync, spawn } from "node:child_process";
 
 const GORTEX_BIN: string = "gortex";
 const HOOK_ARGV: string[] = ["gortex","hook","--agent=pi"];
-const ENFORCE: boolean = false;
+const ENFORCE: boolean = true;
 
 // Which eager preset to expose as native Pi tools. The daemon itself
 // defaults to the `core` preset in `defer` mode, so for `core` (and
@@ -712,8 +712,722 @@ export default function (pi: any) {
     return;
   });
 }
-=== root/AGENTS.md ===
+=== project/root/AGENTS.md ===
 <!-- gortex:communities:start -->
 - [example-community](.claude/skills/example/SKILL.md) — example routing block
 
 <!-- gortex:communities:end -->
+=== global/home/.pi/agent/extensions/gortex/index.ts ===
+// Gortex extension for the Pi coding agent (earendil-works/pi).
+//
+// Pi has no MCP support by design — the extension API's registerTool
+// covers it. This extension does two things:
+//
+//   1. Exposes Gortex's graph tools as native Pi tools through a
+//      persistent MCP stdio bridge: one `gortex mcp` child per session,
+//      spoken to over standard JSON-RPC 2.0. The eager tools/list
+//      surface is registered up front; the deferred catalogue is
+//      reached via the server's own `tools_search` tool, whose
+//      promotions are re-synced into Pi's registry on
+//      notifications/tools/list_changed.
+//
+//   2. Re-creates the "prefer graph tools over raw file reads"
+//      enforcement by forwarding lifecycle events to
+//      `gortex hook --agent=pi` and applying its decision — the Go side
+//      owns the postures, identical to every other agent.
+//
+// This file is written verbatim by the `pi` agent adapter, except for
+// four templated sentinels replaced with JSON literals at install time:
+//
+//   "gortex"          -> string: resolved `gortex` binary path
+//   ["gortex","hook","--agent=pi"]    -> array: full hook argv
+//   true      -> boolean: wire read-discipline enforcement
+//                              (false when installed with --no-hooks)
+//   "core" -> string: default eager tool preset;
+//                              GORTEX_TOOLS overrides it at runtime
+//
+// NOTE: Pi is pre-1.0. The event names and built-in tool names mapped in
+// normalizeToolCall() below are pinned to Pi's documented API
+// (packages/coding-agent/docs/extensions.md); if an upgrade renames one,
+// adjust the small maps here — the Go wire contract stays unchanged.
+
+// Zero runtime dependencies, by design: a single-file auto-discovered
+// extension has no node_modules, so any non-built-in import would throw
+// at load and take the whole extension down. Tool `parameters` are the
+// MCP server's JSON-Schema objects, passed verbatim.
+import { execFileSync, spawn } from "node:child_process";
+
+const GORTEX_BIN: string = "gortex";
+const HOOK_ARGV: string[] = ["gortex","hook","--agent=pi"];
+const ENFORCE: boolean = true;
+
+// Which eager preset to expose as native Pi tools. The daemon itself
+// defaults to the `core` preset in `defer` mode, so for `core` (and
+// `full`) the bridge passes nothing and the daemon's own surface applies.
+// A non-default preset (edit|nav|readonly) is forwarded to the `gortex
+// mcp` proxy via GORTEX_TOOLS, always with GORTEX_TOOLS_MODE=defer — in
+// hide mode the proxy would -32601 calls to tools promoted later by
+// tools_search. Anything unrecognised (a typo, a stale baked value) is
+// NOT forwarded: server-side it would parse as a one-tool allow-list and
+// silently filter every promoted tool out of the session — fail open to
+// the daemon's default surface instead. GORTEX_TOOLS in the environment
+// overrides the value baked at install time.
+const TOOLS_PRESET: string = ((process.env && process.env.GORTEX_TOOLS) || "core").trim();
+
+// Identity reported as MCP clientInfo, plus the gortex/wire capability
+// declared in the initialize request: the daemon reads it to learn which
+// compact wire formats this client decodes, so list-shaped tools default
+// to GCX1 for this session without a server-side client-name allowlist
+// entry.
+const CLIENT_NAME = "pi";
+const CLIENT_VERSION = "1.0.0";
+const WIRE_FORMATS: string[] = ["gcx"];
+
+// Names the Gortex tools are registered under in Pi — usually the bare
+// daemon name, except for a few aliased to dodge Pi's built-ins (see
+// piAliasName). Tracks the post-alias name.
+const gortexToolNames = new Set<string>();
+
+// ---------------------------------------------------------------------------
+// Daemon lifecycle
+// ---------------------------------------------------------------------------
+
+// ensureDaemon brings the shared Gortex daemon up before the MCP child
+// dials it. Idempotent, fire-and-forget (we don't block on the launcher's
+// ≤60s readiness poll), and never throws — a missing binary or spawn
+// failure must not take the extension down. The bridge's initialize retry
+// absorbs the warm-up window.
+function ensureDaemon(): void {
+  try {
+    const child = spawn(GORTEX_BIN, ["daemon", "start", "--detach"], {
+      stdio: "ignore",
+      detached: true,
+    });
+    child.on("error", () => { }); // binary missing / spawn failure — swallow
+    // No teardown counterpart, by design: the daemon is shared, long-lived
+    // infrastructure that outlives the session.
+    child.unref();
+  } catch {
+  }
+}
+
+// ---------------------------------------------------------------------------
+// MCP stdio client (newline-delimited JSON-RPC 2.0 over a `gortex mcp` child)
+// ---------------------------------------------------------------------------
+
+const INIT_TIMEOUT_MS = 60_000;
+const RPC_TIMEOUT_MS = 30_000;
+// tools/call cap: generous enough for long analyzers (sast sweeps,
+// reviews, enrich passes), finite so a wedged daemon behind a
+// still-alive child can't hang the agent turn forever.
+const CALL_TIMEOUT_MS = 600_000;
+// A single JSON-RPC frame past this cap kills the child: the stream
+// can't be resynced mid-frame, and the old shell-out path errored at
+// execFileSync's 64 MiB maxBuffer for the same reason.
+const MAX_BUFFER_BYTES = 64 * 1024 * 1024;
+
+interface PendingRequest {
+  resolve: (value: any) => void;
+  reject: (err: Error) => void;
+  timer?: ReturnType<typeof setTimeout>;
+}
+
+class MCPStdioClient {
+  private child: any = null;
+  private buffer = "";
+  private searchStart = 0;
+  private nextId = 1;
+  private pending = new Map<number, PendingRequest>();
+  private exited = true;
+  private respawnPromise: Promise<void> | null = null;
+
+  // Fired on notifications/tools/list_changed (server-side promotion).
+  onToolsListChanged: (() => void) | null = null;
+
+  private childEnv(): Record<string, string | undefined> {
+    const env: Record<string, string | undefined> = { ...process.env };
+    const preset = TOOLS_PRESET.toLowerCase();
+    // The daemon's own default surface already IS core/defer; only a
+    // recognised non-default preset needs the proxy-side narrowing.
+    // Unknown values are dropped (fail open) — forwarded verbatim they
+    // would parse as a one-tool allow-list and leave the session with
+    // no callable graph tools at all.
+    const FORWARDED_PRESETS = new Set(["edit", "nav", "readonly"]);
+    if (!env.GORTEX_TOOLS && FORWARDED_PRESETS.has(preset)) {
+      env.GORTEX_TOOLS = TOOLS_PRESET;
+    }
+    // Never let a preset hide-block tools promoted later by tools_search.
+    if (env.GORTEX_TOOLS && !env.GORTEX_TOOLS_MODE) env.GORTEX_TOOLS_MODE = "defer";
+    return env;
+  }
+
+  private spawnChild(): void {
+    const child = spawn(GORTEX_BIN, ["mcp"], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: this.childEnv(),
+    });
+    this.child = child;
+    this.buffer = "";
+    this.searchStart = 0;
+    this.exited = false;
+    child.stdout.on("data", (chunk: Buffer) => this.onData(chunk));
+    // Consume stderr so the child never blocks on a full pipe; routing it
+    // to the terminal would corrupt Pi's TUI.
+    child.stderr.on("data", () => { });
+    child.stdin.on("error", () => { }); // EPIPE race: child may exit before stdin.write() finishes
+    child.on("error", () => this.markExited(new Error("gortex mcp spawn failed")));
+    child.on("exit", () => this.markExited(new Error("gortex mcp exited")));
+  }
+
+  private markExited(err: Error): void {
+    if (this.exited && this.pending.size === 0) return;
+    this.exited = true;
+    this.child = null;
+    for (const [, p] of this.pending) {
+      if (p.timer) clearTimeout(p.timer);
+      p.reject(err);
+    }
+    this.pending.clear();
+  }
+
+  private onData(chunk: Buffer): void {
+    this.buffer += chunk.toString("utf8");
+    let nl: number;
+    // Resume the newline scan where the previous chunk left off — a
+    // large frame split across many chunks must not re-scan the whole
+    // growing buffer from index 0 on every data event.
+    while ((nl = this.buffer.indexOf("\n", this.searchStart)) >= 0) {
+      const line = this.buffer.slice(0, nl).trim();
+      this.buffer = this.buffer.slice(nl + 1);
+      this.searchStart = 0;
+      if (!line) continue;
+      let msg: any;
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        continue; // non-JSON noise — ignore
+      }
+      this.dispatch(msg);
+    }
+    this.searchStart = this.buffer.length;
+    if (this.buffer.length > MAX_BUFFER_BYTES) {
+      // One frame past the cap is fatal for this child (no way to
+      // resync mid-frame): pending requests reject, the next call
+      // respawns a fresh child.
+      this.buffer = "";
+      this.searchStart = 0;
+      const child = this.child;
+      this.markExited(new Error(`gortex mcp frame exceeded ${MAX_BUFFER_BYTES} bytes`));
+      try {
+        child?.kill();
+      } catch {
+      }
+    }
+  }
+
+  private dispatch(msg: any): void {
+    if (msg && typeof msg.id === "number" && this.pending.has(msg.id)) {
+      const p = this.pending.get(msg.id)!;
+      this.pending.delete(msg.id);
+      if (p.timer) clearTimeout(p.timer);
+      if (msg.error) {
+        p.reject(new Error(msg.error.message || `JSON-RPC error ${msg.error.code}`));
+      } else {
+        p.resolve(msg.result);
+      }
+      return;
+    }
+    if (msg && msg.method === "notifications/tools/list_changed") {
+      try {
+        this.onToolsListChanged?.();
+      } catch {
+        // best effort — never break the read loop.
+      }
+    }
+  }
+
+  private send(obj: Record<string, unknown>): void {
+    if (!this.child || this.exited) throw new Error("gortex mcp is not running");
+    this.child.stdin.write(JSON.stringify(obj) + "\n");
+  }
+
+  // A single shared respawn: concurrent callers of request() against a
+  // dead child all await the same spawn+initialize, so a burst of tool
+  // calls can never fork multiple children.
+  private respawn(): Promise<void> {
+    if (!this.respawnPromise) {
+      this.respawnPromise = (async () => {
+        this.spawnChild();
+        await this.initialize();
+      })().finally(() => {
+        this.respawnPromise = null;
+      });
+    }
+    return this.respawnPromise;
+  }
+
+  async request(method: string, params: unknown, timeoutMs: number = RPC_TIMEOUT_MS): Promise<any> {
+    if (this.exited) await this.respawn();
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      const entry: PendingRequest = { resolve, reject };
+      if (Number.isFinite(timeoutMs)) {
+        entry.timer = setTimeout(() => {
+          this.pending.delete(id);
+          reject(new Error(`${method} timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+      }
+      this.pending.set(id, entry);
+      try {
+        this.send({ jsonrpc: "2.0", id, method, params });
+      } catch (err: any) {
+        this.pending.delete(id);
+        if (entry.timer) clearTimeout(entry.timer);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+  }
+
+  private notify(method: string, params: unknown): void {
+    try {
+      this.send({ jsonrpc: "2.0", method, params });
+    } catch {
+      // notifications are best-effort.
+    }
+  }
+
+  private async initialize(): Promise<void> {
+    await this.request(
+      "initialize",
+      {
+        protocolVersion: "2025-06-18",
+        // gortex/wire self-declares this client's compact-format
+        // decoders; the daemon prefers it over its name allowlist.
+        capabilities: { experimental: { "gortex/wire": WIRE_FORMATS } },
+        clientInfo: { name: CLIENT_NAME, version: CLIENT_VERSION },
+      },
+      INIT_TIMEOUT_MS,
+    );
+    this.notify("notifications/initialized", {});
+  }
+
+  // start spawns the child and runs the MCP handshake, retrying once
+  // after a 1s backoff — the daemon may still be warming up right after
+  // ensureDaemon() kicked it off.
+  async start(): Promise<void> {
+    this.spawnChild();
+    try {
+      await this.initialize();
+    } catch {
+      await new Promise((r) => setTimeout(r, 1_000));
+      if (this.exited) this.spawnChild();
+      await this.initialize();
+    }
+  }
+
+  async listTools(): Promise<any[]> {
+    const res = await this.request("tools/list", {});
+    return Array.isArray(res?.tools) ? res.tools : [];
+  }
+
+  // Tool calls get a generous cap rather than none: long-running
+  // analyzers (sast sweeps, reviews, enrich passes) must be able to
+  // finish, but a wedged daemon behind a still-alive child must not
+  // hang the agent turn forever.
+  async callTool(name: string, args: Record<string, unknown>): Promise<any> {
+    return this.request("tools/call", { name, arguments: args ?? {} }, CALL_TIMEOUT_MS);
+  }
+
+  stop(): void {
+    const child = this.child;
+    this.markExited(new Error("gortex mcp bridge stopped"));
+    try {
+      child?.kill();
+    } catch {
+    }
+  }
+}
+
+// The session's live bridge; claimed synchronously at session_start (so
+// an overlapping restart can stop it) and nulled when the handshake
+// fails or the session is superseded.
+let client: MCPStdioClient | null = null;
+
+// Why the bridge is down this session (empty when it's up). Surfaced
+// once through the orientation injection so the user learns that
+// /reload retries the handshake.
+let bridgeError = "";
+
+// textFromResult joins the text parts of an MCP tools/call result.
+function textFromResult(result: any): string {
+  const parts = Array.isArray(result?.content) ? result.content : [];
+  return parts
+    .filter((c: any) => c && c.type === "text" && typeof c.text === "string")
+    .map((c: any) => c.text)
+    .join("\n");
+}
+
+interface PiDecision {
+  block?: boolean;
+  reason?: string;
+  additional_context?: string;
+  orientation?: string;
+}
+
+// callHook sends a normalized event envelope to `gortex hook --agent=pi`
+// and parses the PiDecision it writes back. Fail-open: any error returns
+// an empty decision so the extension never blocks Pi's flow on a hook
+// hiccup (daemon down, parse error, timeout).
+function callHook(envelope: Record<string, unknown>): PiDecision {
+  try {
+    const out = execFileSync(HOOK_ARGV[0], HOOK_ARGV.slice(1), {
+      input: JSON.stringify(envelope),
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024,
+      timeout: 5_000,
+    }).trim();
+    if (!out) return {};
+    return JSON.parse(out) as PiDecision;
+  } catch {
+    return {};
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tool-call normalization (Pi vocabulary -> canonical Claude-Code vocabulary)
+// ---------------------------------------------------------------------------
+//
+// The Go enrich() classifier switches on Claude-Code tool names
+// ("Read"/"Grep"/"Glob"/"Bash"/"Edit"/"Write") and reads canonical input
+// keys ("file_path"/"pattern"/"command"). Pi uses its own lowercase names
+// and input shapes, so we translate here — keeping all Pi-specific
+// knowledge in this Pi-specific file.
+const toolNameMap: Record<string, string> = {
+  read: "Read",
+  grep: "Grep",
+  find: "Glob",
+  ls: "Glob",
+  bash: "Bash",
+  edit: "Edit",
+  write: "Write",
+};
+
+function firstString(obj: Record<string, unknown>, keys: string[]): string | undefined {
+  for (const k of keys) {
+    const v = obj[k];
+    if (typeof v === "string" && v !== "") return v;
+  }
+  return undefined;
+}
+
+function normalizeToolCall(
+  piName: string,
+  piInput: Record<string, unknown>,
+): { tool_name: string; tool_input: Record<string, unknown> } {
+  const canonical = toolNameMap[piName.toLowerCase()] ?? piName;
+  const out: Record<string, unknown> = { ...piInput };
+
+  const path = firstString(piInput, ["file_path", "path", "file", "filepath", "absolute_path"]);
+  if (path !== undefined) out.file_path = path;
+
+  let pattern = firstString(piInput, ["pattern", "glob", "query", "regex", "name"]);
+  if (pattern === undefined && canonical === "Glob") pattern = path;
+  if (pattern !== undefined) out.pattern = pattern;
+
+  const command = firstString(piInput, ["command", "cmd", "script"]);
+  if (command !== undefined) out.command = command;
+
+  return { tool_name: canonical, tool_input: out };
+}
+
+// ---------------------------------------------------------------------------
+// Dynamic tool registration
+// ---------------------------------------------------------------------------
+
+interface ToolDescriptor {
+  name: string;
+  description?: string;
+  inputSchema?: unknown;
+}
+
+// Pi's reserved built-in names (mirrors toolNameMap's keys). Pi lets an
+// extension silently replace a built-in by reusing its name, but our
+// generic bridge doesn't match the built-in's result shape — breaking
+// Pi's own rendering and any extension hooked to the built-in (e.g. a
+// lint-on-edit plugin). Only "edit"/"read" collide today; checking all
+// seven guards against future facade additions too.
+const PI_RESERVED_TOOL_NAMES = new Set(Object.keys(toolNameMap));
+const PI_ALIAS_PREFIX = "gortex_";
+
+// piAliasName is unchanged unless name collides with a built-in above, in
+// which case it's registered under a `gortex_`-prefixed alias instead.
+function piAliasName(name: string): string {
+  return PI_RESERVED_TOOL_NAMES.has(name) ? PI_ALIAS_PREFIX + name : name;
+}
+
+// piAliasNote tells the model which tools got aliased this session, so it
+// can translate bare names in Gortex's own guidance. Pi-local by design —
+// not a fact any other agent needs.
+function piAliasNote(): string {
+  const aliased = Array.from(gortexToolNames).filter((n) => n.startsWith(PI_ALIAS_PREFIX));
+  if (aliased.length === 0) return "";
+  const pairs = aliased
+    .map((n) => `\`${n.slice(PI_ALIAS_PREFIX.length)}\` -> \`${n}\``)
+    .join(", ");
+  return (
+    `[Gortex] This session renamed these Gortex tools to avoid colliding with Pi's own built-ins ` +
+    `of the same name: ${pairs}. Wherever Gortex's guidance or tool descriptions mention the bare name, call the renamed one instead.`
+  );
+}
+
+// safeRegister registers under the alias name (piAliasName), tolerating a
+// redundant registration — a reload can re-fire session_start without
+// resetting the registry. Returns the name actually registered.
+function safeRegister(pi: any, def: any): string {
+  def.name = piAliasName(def.name);
+  def.label = def.name;
+  try {
+    pi.registerTool(def);
+  } catch {
+    // already live this session — the existing registration stands.
+  }
+  return def.name;
+}
+
+// Lazily resolved TUI Text component, used only to collapse a gortex
+// tool's result to nothing until the user expands it (ctrl+o). Resolved
+// via require (not a static import) so a Pi packaging that can't
+// provide @earendil-works/pi-tui to a dependency-free single-file
+// extension degrades to Pi's default renderer instead of throwing at
+// load and taking tool registration down with it — the same hazard the
+// file's zero-runtime-dependency design already avoids for typebox.
+let TuiText: (new (text: string, x: number, y: number) => any) | undefined;
+try {
+  TuiText = require("@earendil-works/pi-tui").Text;
+} catch {
+  TuiText = undefined;
+}
+
+// registerOneTool registers a single Gortex tool as a native Pi tool
+// under its bare daemon name, whose execute() forwards to the MCP
+// bridge's tools/call. The MCP input schema is passed verbatim as Pi's
+// parameters (Pi validates plain JSON Schema), so the model sees real
+// parameter docs. Idempotent — a name already registered is skipped.
+// Adds the name to gortexToolNames so the read-discipline postures treat
+// a call to it as a graph query, not a raw file read. Used both for the
+// eager tools/list surface and for tools promoted later by a
+// tools_search call (picked up via the list_changed re-sync).
+//
+// renderResult keeps the collapsed view to just the tool name (Pi's
+// fallback renderCall already shows that) — no preview, no summary.
+// ctrl+o (expand) is the only way to see the actual output.
+function registerOneTool(pi: any, desc: ToolDescriptor): void {
+  const name = desc.name;
+  if (!name) return;
+  if (gortexToolNames.has(piAliasName(name))) return;
+  const parameters =
+    desc.inputSchema && typeof desc.inputSchema === "object"
+      ? desc.inputSchema
+      : { type: "object", properties: {} };
+  const def: any = {
+    name,
+    label: name,
+    description: (desc.description || name).trim(),
+    parameters,
+    async execute(_id: string, params: Record<string, unknown>) {
+      if (!client) throw new Error(`gortex ${name}: MCP bridge is not connected`);
+      let result: any;
+      try {
+        result = await client.callTool(name, params ?? {});
+      } catch (err: any) {
+        throw new Error(`gortex ${name} failed: ${err?.message || String(err)}`);
+      }
+      if (name === "tools_search") {
+        // The daemon just promoted the matches and fired list_changed;
+        // register them NOW (bypassing the debounce) so every tool the
+        // reply cites is already callable when the model reads it.
+        await syncTools(pi);
+      }
+      const text = textFromResult(result) ||
+        JSON.stringify(result?.structuredContent ?? result ?? {});
+      if (result?.isError) throw new Error(text || `gortex ${name} failed`);
+      return { content: [{ type: "text", text }], details: {} };
+    },
+  };
+  if (TuiText) {
+    def.renderResult = (result: any, opts: { expanded?: boolean }) => {
+      if (!opts?.expanded) return new TuiText!("", 0, 0);
+      const text = textFromResult(result) ||
+        JSON.stringify(result?.structuredContent ?? result ?? {});
+      return new TuiText!(text, 0, 0);
+    };
+  }
+  gortexToolNames.add(safeRegister(pi, def));
+}
+
+// registerGortexTools fetches the daemon's eager surface (tools/list —
+// the configured preset, full schemas included) and registers each entry,
+// including the server's `tools_search` discovery tool.
+async function registerGortexTools(pi: any): Promise<void> {
+  if (!client) return;
+  for (const desc of await client.listTools()) {
+    if (!desc) continue;
+    registerOneTool(pi, desc);
+  }
+}
+
+// syncTools re-fetches tools/list after a notifications/tools/list_changed
+// and registers anything new. This is how tools promoted by a
+// tools_search call become callable Pi tools.
+async function syncTools(pi: any): Promise<void> {
+  try {
+    await registerGortexTools(pi);
+  } catch {
+    // transient — the next promotion or session retries.
+  }
+}
+
+// The daemon fires one list_changed per promoted tool, so a tools_search
+// sweep arrives as a notification burst; debounce to a single trailing
+// re-fetch instead of one full tools/list round-trip per notification.
+// (The tools_search execute() path awaits syncTools directly, bypassing
+// the debounce, so the reply never waits on this timer.)
+const SYNC_DEBOUNCE_MS = 200;
+let syncTimer: ReturnType<typeof setTimeout> | null = null;
+function scheduleSyncTools(pi: any): void {
+  if (syncTimer) clearTimeout(syncTimer);
+  syncTimer = setTimeout(() => {
+    syncTimer = null;
+    void syncTools(pi);
+  }, SYNC_DEBOUNCE_MS);
+}
+
+// ---------------------------------------------------------------------------
+// Extension entry point
+// ---------------------------------------------------------------------------
+
+export default function (pi: any) {
+  let orientationInjected = false;
+  // Orientation awaiting injection into the next LLM call. The `context`
+  // hook appends it as a tail user message rather than mutating
+  // systemPrompt: a systemPrompt change sits at messages[0] and invalidates
+  // prefix prompt caching. Computed once per session.
+  let pendingOrientation = "";
+
+  // Pi resets the session's tool registry on every session_start, so
+  // (re)register here. Clear the name guard first — it persists across
+  // sessions and would otherwise suppress re-registration. The previous
+  // session's bridge child (if any) is stopped before a fresh handshake.
+  pi.on("session_start", async () => {
+    orientationInjected = false;
+    pendingOrientation = "";
+    bridgeError = "";
+    ensureDaemon();
+    gortexToolNames.clear();
+    if (syncTimer) {
+      clearTimeout(syncTimer);
+      syncTimer = null;
+    }
+    if (client) {
+      client.stop();
+      client = null;
+    }
+    const c = new MCPStdioClient();
+    // Claim the slot before the first await: an overlapping
+    // session_start (rapid /new or /reload) then sees and stops THIS
+    // bridge instead of leaking its child mid-handshake.
+    client = c;
+    try {
+      await c.start();
+      if (client !== c) return; // superseded while handshaking
+      c.onToolsListChanged = () => {
+        scheduleSyncTools(pi);
+      };
+      await registerGortexTools(pi);
+    } catch (err: any) {
+      // daemon unreachable / binary missing / handshake or tools/list
+      // failure — no graph tools this session; /reload (or the next
+      // session_start) retries.
+      c.stop();
+      if (client === c) {
+        client = null;
+        bridgeError = err?.message || String(err);
+      }
+    }
+  });
+
+  // Fires before the agent loop's first LLM call. It can't mutate messages
+  // itself, so it just parks the orientation for the `context` hook.
+  pi.on("before_agent_start", () => {
+    if (orientationInjected) return;
+    const decision = callHook({ event: "session_start", cwd: pi?.cwd ?? process.cwd() });
+    const parts: string[] = [];
+    if (bridgeError) {
+      parts.push(
+        `[Gortex] graph tools are unavailable this session (${bridgeError}). ` +
+        `Tell the user to run /reload to retry the connection.`,
+      );
+      bridgeError = "";
+    }
+    if (decision.orientation) parts.push(decision.orientation);
+    const aliasNote = piAliasNote();
+    if (aliasNote) parts.push(aliasNote);
+    if (parts.length > 0) {
+      pendingOrientation = parts.join("\n\n");
+      orientationInjected = true;
+    }
+    return;
+  });
+
+  // Fires before each LLM call with a mutable message array. Append the
+  // parked orientation once, then clear it so it isn't repeated each call.
+  pi.on("context", (event: any) => {
+    if (!pendingOrientation) return;
+    const text = pendingOrientation;
+    pendingOrientation = "";
+    try {
+      if (event && Array.isArray(event.messages)) {
+        event.messages.push({ role: "user", content: text });
+        return { messages: event.messages };
+      }
+    } catch {
+      // best effort — never break context assembly.
+    }
+    return;
+  });
+
+  if (!ENFORCE) return;
+
+  // Enforcement: every non-Gortex tool call is checked against the Go hook.
+  pi.on("tool_call", async (event: any, ctx: any) => {
+    const piName: string = event?.toolName ?? "";
+    const piInput: Record<string, unknown> = event?.input ?? {};
+    const isGortexTool = gortexToolNames.has(piName);
+
+    const norm = normalizeToolCall(piName, piInput);
+    const decision = callHook({
+      event: "tool_call",
+      tool_name: norm.tool_name,
+      tool_input: norm.tool_input,
+      cwd: ctx?.cwd ?? pi?.cwd ?? process.cwd(),
+      session_id: ctx?.sessionManager?.sessionId ?? "",
+      is_gortex_tool: isGortexTool,
+    });
+
+    if (decision.block) {
+      return { block: true, reason: decision.reason ?? "[Gortex] blocked — prefer graph tools." };
+    }
+    if (decision.additional_context) {
+      // Soft guidance: surface it without blocking the call.
+      try {
+        pi.sendMessage(
+          { customType: "gortex", content: decision.additional_context, display: true },
+          { deliverAs: "steer" },
+        );
+      } catch {
+        // sendMessage shape can vary across Pi versions; never fatal.
+      }
+    }
+    return;
+  });
+}

--- a/cmd/gortex/testdata/agent-render/vscode.txt
+++ b/cmd/gortex/testdata/agent-render/vscode.txt
@@ -1,9 +1,9 @@
-=== root/.github/copilot-instructions.md ===
+=== project/root/.github/copilot-instructions.md ===
 <!-- gortex:communities:start -->
 - [example-community](.claude/skills/example/SKILL.md) — example routing block
 
 <!-- gortex:communities:end -->
-=== root/.vscode/mcp.json ===
+=== project/root/.vscode/mcp.json ===
 {
   "servers": {
     "gortex": {

--- a/cmd/gortex/testdata/agent-render/windsurf.txt
+++ b/cmd/gortex/testdata/agent-render/windsurf.txt
@@ -1,4 +1,4 @@
-=== home/.codeium/mcp_config.json ===
+=== project/home/.codeium/mcp_config.json ===
 {
   "mcpServers": {
     "gortex": {
@@ -12,8 +12,22 @@
     }
   }
 }
-=== root/.windsurfrules ===
+=== project/root/.windsurfrules ===
 <!-- gortex:communities:start -->
 - [example-community](.claude/skills/example/SKILL.md) — example routing block
 
 <!-- gortex:communities:end -->
+=== global/home/.codeium/mcp_config.json ===
+{
+  "mcpServers": {
+    "gortex": {
+      "args": [
+        "mcp"
+      ],
+      "command": "gortex",
+      "env": {
+        "GORTEX_INDEX_WORKERS": "8"
+      }
+    }
+  }
+}

--- a/cmd/gortex/testdata/agent-render/zed.txt
+++ b/cmd/gortex/testdata/agent-render/zed.txt
@@ -1,4 +1,4 @@
-=== home/.config/zed/settings.json ===
+=== project/home/.config/zed/settings.json ===
 {
   "context_servers": {
     "gortex": {
@@ -13,8 +13,23 @@
     }
   }
 }
-=== root/.rules ===
+=== project/root/.rules ===
 <!-- gortex:communities:start -->
 - [example-community](.claude/skills/example/SKILL.md) — example routing block
 
 <!-- gortex:communities:end -->
+=== global/home/.config/zed/settings.json ===
+{
+  "context_servers": {
+    "gortex": {
+      "args": [
+        "mcp"
+      ],
+      "command": "gortex",
+      "env": {
+        "GORTEX_INDEX_WORKERS": "8"
+      },
+      "source": "custom"
+    }
+  }
+}

--- a/cmd/gortex/uninstall.go
+++ b/cmd/gortex/uninstall.go
@@ -95,6 +95,11 @@ var (
 	}
 	uninstallDirs = []string{
 		".claude/commands",
+		// Claude Code's per-community skills, unlike the three shared
+		// trees below, sit under a `generated/` level that exists for
+		// exactly this reason: nothing but Gortex writes there, so the
+		// whole directory can go without inspecting its entries.
+		".claude/skills/generated",
 		".kiro/steering",
 		".kiro/hooks",
 		".kiro/settings",

--- a/cmd/gortex/uninstall.go
+++ b/cmd/gortex/uninstall.go
@@ -5,13 +5,18 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/cobra"
 
 	"github.com/zzet/gortex/internal/agents"
 	"github.com/zzet/gortex/internal/agents/claudecode"
+	"github.com/zzet/gortex/internal/agents/codex"
+	"github.com/zzet/gortex/internal/agents/copilotcli"
+	"github.com/zzet/gortex/internal/agents/opencode"
 	"github.com/zzet/gortex/internal/daemon"
 	"github.com/zzet/gortex/internal/progress"
 	"github.com/zzet/gortex/internal/tui"
@@ -35,15 +40,21 @@ var uninstallCmd = &cobra.Command{
 	Long: `Removes the per-repo Gortex footprint from the current directory:
 
   .mcp.json
+  .opencode/plugin/gortex.js
   .claude/commands/
   .kiro/{steering,hooks,settings}/
+  the gortex-* skills inside .agents/skills/, .opencode/skills/ and
+  .github/skills/ (those trees are shared — your own skills stay)
 
 Counterpart to ` + "`gortex init`" + `. For machine-wide setup (user MCP config,
-~/.claude/CLAUDE.md block, user hooks) installed by ` + "`gortex install`" + `,
-pass --global to also strip the user-level Claude Code footprint (MCP
-config, permission allowlist, hooks, the CLAUDE.md rule block, and the
-gortex skills / commands / sub-agents). --global honors
-$CLAUDE_CONFIG_DIR; target a specific profile with --claude-config-dir.
+rule blocks, user hooks) installed by ` + "`gortex install`" + `, pass --global
+to also strip the user-level footprint of every host Gortex configures —
+Claude Code, Codex, GitHub Copilot CLI and OpenCode: MCP entries,
+permission allowlists, hooks, the rule blocks, and the gortex skills /
+commands / sub-agents / bridge plugin. Merged files keep everything that
+is not ours, and a gortex skill you have edited is kept, not deleted.
+--global honors $CLAUDE_CONFIG_DIR; target a specific Claude Code profile
+with --claude-config-dir.
 
 Pass --purge to additionally tear down the machine-level runtime: stop the
 daemon, remove its OS service unit (launchd / systemd / Task Scheduler),
@@ -64,7 +75,7 @@ docs / scripts / muscle memory still work.`,
 
 func init() {
 	uninstallCmd.Flags().BoolVarP(&uninstallYes, "yes", "y", false, "skip the confirmation prompt (required when stdin is not a TTY)")
-	uninstallCmd.Flags().BoolVar(&uninstallGlobal, "global", false, "also remove the machine-level Claude Code footprint (user MCP config, settings, CLAUDE.md rule block, skills/commands/agents) installed by `gortex install`")
+	uninstallCmd.Flags().BoolVar(&uninstallGlobal, "global", false, "also remove the machine-level footprint of every configured host (Claude Code, Codex, Copilot CLI, OpenCode): user MCP entries, settings, rule blocks, hooks, skills/commands/agents/plugin, as installed by `gortex install`")
 	uninstallCmd.Flags().BoolVar(&uninstallPurge, "purge", false, "also tear down the machine-level runtime: stop the daemon, remove its OS service unit, and delete the ~/.gortex data/cache/config tree (and the binary, for an installer-script install)")
 	uninstallCmd.Flags().StringVar(&uninstallClaudeConfigDir, "claude-config-dir", "", "Claude Code config root to clean (implies --global); overrides $CLAUDE_CONFIG_DIR, defaults to ~/.claude")
 	uninstallCmd.Flags().StringVar(&uninstallClaudeConfigDir, "config-root", "", "alias for --claude-config-dir")
@@ -77,6 +88,10 @@ func init() {
 var (
 	uninstallFiles = []string{
 		".mcp.json",
+		// The OpenCode bridge is user-level today, but an install from
+		// before that split could have left one in the repo tree. The name
+		// is Gortex's alone, so removing it here is safe.
+		".opencode/plugin/gortex.js",
 	}
 	uninstallDirs = []string{
 		".claude/commands",
@@ -85,6 +100,56 @@ var (
 		".kiro/settings",
 	}
 )
+
+// uninstallOwnedDir is a target the slice-of-paths form above cannot
+// express: "only the entries we own inside this directory".
+//
+// The three skill trees below are SHARED. `.agents/skills` is the
+// vendor-neutral root Codex reads, `.opencode/skills` is OpenCode's and
+// `.github/skills` is the Copilot CLI's, and in every one of them a team's
+// own hand-written skills sit directly beside the ones `gortex init`
+// generated. Adding any of these to uninstallDirs would delete the user's
+// work, which is why they get a typed target rather than a bent slice.
+//
+// Ownership is the `gortex-` directory prefix — the same signal `gortex
+// uninstall` already uses for `.kiro/steering` files, and the only one
+// available here: generated community skills track the current graph, so
+// unlike the curated user-level pack there is no stable shipped body to
+// byte-compare against. The generators enforce that prefix on every
+// DirName they emit (see each adapter's skills.go), so a `gortex-` skill
+// directory in one of these trees is one we wrote.
+type uninstallOwnedDir struct {
+	// dir is the shared tree, repo-relative.
+	dir string
+	// prefix marks the entries inside it that are ours.
+	prefix string
+}
+
+var uninstallOwnedDirs = []uninstallOwnedDir{
+	{dir: ".agents/skills", prefix: "gortex-"},   // codex
+	{dir: ".opencode/skills", prefix: "gortex-"}, // opencode
+	{dir: ".github/skills", prefix: "gortex-"},   // copilot-cli
+}
+
+// ownedEntries lists the entries inside t.dir that are Gortex's, as
+// repo-relative paths. Resolving the typed target down to concrete paths
+// is what lets the confirm wizard preview exactly what will be deleted:
+// preview and deletion read the same list rather than two descriptions of
+// it that can drift.
+func (t uninstallOwnedDir) ownedEntries() []string {
+	entries, err := os.ReadDir(t.dir)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, e := range entries {
+		if !e.IsDir() || !strings.HasPrefix(e.Name(), t.prefix) {
+			continue
+		}
+		out = append(out, filepath.Join(t.dir, e.Name()))
+	}
+	return out
+}
 
 // runUninstall is the per-repo removal entry point. Used by both
 // `gortex uninstall` and `gortex clean` (the legacy alias) — same flow,
@@ -109,10 +174,12 @@ func runUninstall(cmd *cobra.Command, _ []string) error {
 	// when nothing exists feels noisy.
 	presentFiles, presentDirs := filterPresentUninstallTargets()
 
-	// --global also strips the user-level Claude Code footprint that
-	// `gortex install` wrote. GlobalArtifacts lists only paths that
-	// actually carry a Gortex footprint, honoring any config-dir
-	// override resolved above.
+	// --global also strips the user-level footprint that `gortex install`
+	// wrote, for every host that has one. Each adapter's GlobalArtifacts
+	// lists only paths that actually carry a Gortex footprint — and applies
+	// the same ownership tests its RemoveGlobal does, so a skill the user
+	// customised never shows up in a preview that would then keep it.
+	// claudecode honors any config-dir override resolved above.
 	var (
 		home        string
 		globalItems []string
@@ -123,7 +190,7 @@ func runUninstall(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("--global needs a home directory: %w", err)
 		}
 		home = h
-		globalItems = claudecode.GlobalArtifacts(home)
+		globalItems = globalUninstallArtifacts(home)
 	}
 
 	// --purge extends the removal to the machine-level runtime that `gortex
@@ -171,9 +238,11 @@ func runUninstall(cmd *cobra.Command, _ []string) error {
 	globalCleaned := false
 	if uninstallGlobal && len(globalItems) > 0 {
 		env := agents.Env{Home: home, Mode: agents.ModeGlobal}
-		gRemoved, gFailures := claudecode.New().RemoveGlobal(env, agents.ApplyOpts{})
-		removed += gRemoved
-		failures = append(failures, gFailures...)
+		for _, host := range globalHosts() {
+			gRemoved, gFailures := host.remove(env, agents.ApplyOpts{})
+			removed += gRemoved
+			failures = append(failures, gFailures...)
+		}
 		globalCleaned = true
 	}
 
@@ -192,9 +261,14 @@ func runUninstall(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-// filterPresentUninstallTargets returns the subset of uninstallFiles /
-// uninstallDirs that actually exist on disk. Lets the wizard preview the
-// real blast radius and skip the "nothing to uninstall" branch in one pass.
+// filterPresentUninstallTargets resolves every target — the flat file and
+// directory lists, plus the owned-entries-inside-a-shared-tree targets —
+// down to the concrete paths that exist on disk right now.
+//
+// Lowering uninstallOwnedDirs here rather than at deletion time is what
+// keeps the wizard honest: it previews the same list executeUninstall
+// deletes, so it can neither promise to remove a user's own skill nor stay
+// silent about a Gortex one it is about to delete.
 func filterPresentUninstallTargets() ([]string, []string) {
 	var pf, pd []string
 	for _, f := range uninstallFiles {
@@ -207,7 +281,45 @@ func filterPresentUninstallTargets() ([]string, []string) {
 			pd = append(pd, d)
 		}
 	}
+	for _, owned := range uninstallOwnedDirs {
+		pd = append(pd, owned.ownedEntries()...)
+	}
 	return pf, pd
+}
+
+// globalHost pairs one host's user-level footprint reporter with its
+// remover.
+//
+// They are one row rather than two lists on purpose: that is the shape
+// that makes the two halves impossible to get out of step. A host present
+// only in the preview promises a deletion nothing performs; a host present
+// only in the remover deletes files the confirm wizard never showed the
+// user. Both are the same bug, and neither is representable here.
+type globalHost struct {
+	artifacts func(home string) []string
+	remove    func(env agents.Env, opts agents.ApplyOpts) (removed int, failures []string)
+}
+
+// globalHosts is every adapter with a user-level footprint `gortex
+// install` writes and `gortex uninstall --global` must take back.
+func globalHosts() []globalHost {
+	return []globalHost{
+		{artifacts: claudecode.GlobalArtifacts, remove: claudecode.New().RemoveGlobal},
+		{artifacts: codex.GlobalArtifacts, remove: codex.New().RemoveGlobal},
+		{artifacts: copilotcli.GlobalArtifacts, remove: copilotcli.New().RemoveGlobal},
+		{artifacts: opencode.GlobalArtifacts, remove: opencode.New().RemoveGlobal},
+	}
+}
+
+// globalUninstallArtifacts is the union of every host's user-level Gortex
+// footprint, sorted so the wizard's list is stable across runs.
+func globalUninstallArtifacts(home string) []string {
+	var out []string
+	for _, host := range globalHosts() {
+		out = append(out, host.artifacts(home)...)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // runUninstallConfirmWizard renders a confirm wizard listing every target
@@ -284,6 +396,21 @@ func executeUninstall(files, dirs []string) (int, []string) {
 		}
 		removed++
 	}
+	// A shared skill tree we emptied is ours to tidy; one that still holds
+	// the user's own skills is not, and os.Remove refusing a non-empty
+	// directory is exactly that distinction. Only trees we actually took an
+	// entry out of are considered: an empty `.github/skills` the user made
+	// and we never wrote to was not in the wizard's preview, so removing it
+	// would be a deletion nobody agreed to.
+	for _, owned := range uninstallOwnedDirs {
+		cleaned := filepath.Clean(owned.dir)
+		for _, d := range dirs {
+			if filepath.Dir(d) == cleaned {
+				_ = os.Remove(owned.dir)
+				break
+			}
+		}
+	}
 	return removed, failures
 }
 
@@ -315,11 +442,12 @@ func emitUninstallSummary(w io.Writer, removed int, failures []string, totalPres
 		}
 		fmt.Fprintf(w, "[gortex uninstall] done (%d/%d items removed)\n", removed, totalPresent)
 		if globalCleaned {
-			fmt.Fprintln(w, "Note: the user-level Claude Code footprint was removed (CLAUDE.md rule block, MCP config, hooks, skills/commands/agents). Other content in those files was preserved.")
+			fmt.Fprintln(w, "Note: the user-level footprint was removed for Claude Code, Codex, Copilot CLI and OpenCode (rule blocks, MCP entries, hooks, skills/commands/agents/plugin). Other content in those files was preserved, and any gortex skill you had edited was kept.")
 		} else {
 			fmt.Fprintln(w, "Note: CLAUDE.md was not modified — remove the Gortex block manually if needed (or re-run with --global).")
 		}
 		fmt.Fprintln(w, "Note: .kiro/steering/ files with 'gortex-' prefix were removed. Other .kiro/ files were preserved.")
+		fmt.Fprintln(w, "Note: only 'gortex-' skills were removed from .agents/skills/, .opencode/skills/ and .github/skills/ — those trees are shared, so your own skills were preserved.")
 		fmt.Fprintln(w, "Note: Antigravity KIs are global and were not removed. Manually delete ~/.gemini/antigravity/knowledge/gortex-workflow if desired.")
 		fmt.Fprintln(w, "Note: Hermes config is global and was not removed. Manually delete the gortex entry in ~/.hermes/config.yaml (+ profiles), the gortex pre_tool_call / pre_llm_call entries under its `hooks:` block, and the gortex / gortex-* skill directories under ~/.hermes/skills/ if desired.")
 		return
@@ -344,11 +472,13 @@ func emitUninstallSummary(w io.Writer, removed int, failures []string, totalPres
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "     "+progress.Heading("preserved"))
 	if globalCleaned {
-		fmt.Fprintln(w, "       "+progress.StyleHint.Render("·")+"  "+progress.StyleVal.Render("non-Gortex content in CLAUDE.md / settings / .claude.json (Gortex entries removed)"))
+		fmt.Fprintln(w, "       "+progress.StyleHint.Render("·")+"  "+progress.StyleVal.Render("non-Gortex content in every merged config (Gortex entries removed)"))
+		fmt.Fprintln(w, "       "+progress.StyleHint.Render("·")+"  "+progress.StyleVal.Render("gortex skills you had edited — a customised copy is never deleted"))
 	} else {
 		fmt.Fprintln(w, "       "+progress.StyleHint.Render("·")+"  "+progress.StyleVal.Render("CLAUDE.md — remove the Gortex block manually if needed (or re-run with --global)"))
 	}
 	fmt.Fprintln(w, "       "+progress.StyleHint.Render("·")+"  "+progress.StyleVal.Render(".kiro/ files without the 'gortex-' prefix"))
+	fmt.Fprintln(w, "       "+progress.StyleHint.Render("·")+"  "+progress.StyleVal.Render("your own skills in .agents/skills/, .opencode/skills/ and .github/skills/"))
 	fmt.Fprintln(w, "       "+progress.StyleHint.Render("·")+"  "+progress.StyleVal.Render("~/.gemini/antigravity/knowledge/gortex-workflow (global)"))
 	fmt.Fprintln(w, "       "+progress.StyleHint.Render("·")+"  "+progress.StyleVal.Render("~/.hermes/config.yaml + skills (global)"))
 	fmt.Fprintln(w)

--- a/cmd/gortex/uninstall_test.go
+++ b/cmd/gortex/uninstall_test.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/opencode"
+	"github.com/zzet/gortex/internal/testenv"
+)
+
+// seedUninstallSandbox builds a repo that looks like `gortex init` ran in
+// it AND like a team has been writing its own skills in the same trees.
+// The user's files are what the test is really about: the three skill
+// roots are shared, so a removal that reasons about directories instead of
+// ownership destroys them.
+func seedUninstallSandbox(t *testing.T) (repo string, userSkills []string) {
+	t.Helper()
+	repo = t.TempDir()
+	t.Chdir(repo)
+
+	write := func(rel, body string) string {
+		path := filepath.Join(repo, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+
+	write(".mcp.json", `{"mcpServers":{"gortex":{"command":"gortex","args":["mcp"]}}}`)
+	write(".opencode/plugin/gortex.js", "// gortex bridge\n")
+	for _, tree := range []string{".agents/skills", ".opencode/skills", ".github/skills"} {
+		write(filepath.Join(tree, "gortex-stub", "SKILL.md"), "---\nname: gortex-stub\n---\n\ngenerated\n")
+	}
+	userSkills = []string{
+		write(filepath.Join(".agents/skills", "team-runbook", "SKILL.md"), "---\nname: team-runbook\n---\n\nours\n"),
+		write(filepath.Join(".opencode/skills", "deploy-notes", "SKILL.md"), "---\nname: deploy-notes\n---\n\nours\n"),
+		write(filepath.Join(".github/skills", "handwritten", "SKILL.md"), "---\nname: handwritten\n---\n\nours\n"),
+	}
+	return repo, userSkills
+}
+
+func pinUninstallFlags(t *testing.T) {
+	t.Helper()
+	yes, global, purge, quiet := uninstallYes, uninstallGlobal, uninstallPurge, noProgress
+	t.Cleanup(func() {
+		uninstallYes, uninstallGlobal, uninstallPurge, noProgress = yes, global, purge, quiet
+	})
+	uninstallYes, uninstallGlobal, uninstallPurge, noProgress = true, false, false, true
+}
+
+// TestUninstallRemovesOnlyGortexEntriesFromSharedSkillTrees is the guard
+// against the tempting one-line version of this feature: adding the three
+// skill roots to uninstallDirs. That would pass every "no gortex-* left"
+// assertion and delete the team's own skills on the way.
+func TestUninstallRemovesOnlyGortexEntriesFromSharedSkillTrees(t *testing.T) {
+	repo, userSkills := seedUninstallSandbox(t)
+	pinUninstallFlags(t)
+
+	before := map[string][]byte{}
+	for _, path := range userSkills {
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		before[path] = body
+	}
+
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	if err := runUninstall(cmd, nil); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+
+	for _, gone := range []string{
+		".mcp.json",
+		".opencode/plugin/gortex.js",
+		".agents/skills/gortex-stub",
+		".opencode/skills/gortex-stub",
+		".github/skills/gortex-stub",
+	} {
+		if _, err := os.Stat(filepath.Join(repo, gone)); err == nil {
+			t.Errorf("%s survived uninstall", gone)
+		}
+	}
+	for path, want := range before {
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("a user skill was deleted: %v", err)
+		}
+		if string(got) != string(want) {
+			t.Errorf("a user skill changed:\n%s", got)
+		}
+	}
+}
+
+// TestUninstallPrunesASharedTreeItEmptied: pruning is conditional on the
+// tree being empty, which is the same predicate that keeps a user's skill
+// alive. os.Remove refusing a non-empty directory is what enforces it.
+func TestUninstallPrunesASharedTreeItEmptied(t *testing.T) {
+	repo := t.TempDir()
+	t.Chdir(repo)
+	pinUninstallFlags(t)
+
+	path := filepath.Join(repo, ".opencode", "skills", "gortex-stub", "SKILL.md")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("generated\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	if err := runUninstall(cmd, nil); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(repo, ".opencode", "skills")); err == nil {
+		t.Error("a skills tree holding nothing but ours should be pruned")
+	}
+}
+
+// TestUninstallPreviewIsExactlyWhatGetsDeleted pins the wizard's promise.
+// The confirm screen is the only thing standing between the user and an
+// irreversible delete, so it may neither name a file removal will keep nor
+// stay silent about one it will take.
+func TestUninstallPreviewIsExactlyWhatGetsDeleted(t *testing.T) {
+	repo, _ := seedUninstallSandbox(t)
+
+	files, dirs := filterPresentUninstallTargets()
+	previewed := append(append([]string{}, files...), dirs...)
+	slices.Sort(previewed)
+
+	// FromSlash because the owned-entry targets are built with
+	// filepath.Join, which separates with a backslash on Windows.
+	var want []string
+	for _, rel := range []string{
+		".agents/skills/gortex-stub",
+		".github/skills/gortex-stub",
+		".mcp.json",
+		".opencode/plugin/gortex.js",
+		".opencode/skills/gortex-stub",
+	} {
+		want = append(want, filepath.FromSlash(rel))
+	}
+	slices.Sort(want)
+	if !slices.Equal(previewed, want) {
+		t.Fatalf("preview = %v, want %v", previewed, want)
+	}
+
+	removed, failures := executeUninstall(files, dirs)
+	if len(failures) != 0 {
+		t.Fatalf("uninstall failures: %v", failures)
+	}
+	if removed != len(want) {
+		t.Errorf("removed %d items, previewed %d", removed, len(want))
+	}
+	for _, rel := range want {
+		if _, err := os.Stat(filepath.Join(repo, rel)); err == nil {
+			t.Errorf("%s was previewed but survived", rel)
+		}
+	}
+}
+
+// TestGlobalUninstallArtifactsCoversEveryHost is the wiring guard for the
+// user-level half: the preview used to be claudecode's alone, so a machine
+// with only OpenCode configured reported "nothing to uninstall" and the
+// removal branch never ran.
+func TestGlobalUninstallArtifactsCoversEveryHost(t *testing.T) {
+	home := t.TempDir()
+	testenv.SandboxAt(t, home)
+
+	env := agents.Env{
+		Root:            t.TempDir(),
+		Home:            home,
+		HookCommand:     "/tmp/test-gortex hook",
+		Mode:            agents.ModeGlobal,
+		InstallHooks:    true,
+		InstructionsDir: filepath.Join(home, ".gortex", "instructions"),
+	}
+	if _, err := opencode.New().Apply(env, agents.ApplyOpts{ForceDetect: true}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	got := globalUninstallArtifacts(home)
+	if !slices.Contains(got, opencode.PluginPath(home)) {
+		t.Errorf("the global preview misses the OpenCode bridge; got %v", got)
+	}
+
+	for _, host := range globalHosts() {
+		removed, failures := host.remove(env, agents.ApplyOpts{})
+		if len(failures) != 0 {
+			t.Errorf("remove failures: %v", failures)
+		}
+		_ = removed
+	}
+	if got := globalUninstallArtifacts(home); len(got) != 0 {
+		t.Errorf("the global footprint should be empty after removal, got %v", got)
+	}
+}

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -26,7 +26,8 @@ commands accept `--agents=<csv>` to constrain setup and
 | `aider`         | `.aiderignore` block, `CONVENTIONS.md` communities block                                        | project    | https://aider.chat/docs/config/aider_conf.html                      |
 | `antigravity`   | `~/.gemini/antigravity/mcp_config.json` + Knowledge Item                                        | user       | https://antigravity.google/docs/mcp                                 |
 | `cline`         | `cline_mcp_settings.json` (per VS Code / Cursor globalStorage), `.clinerules/gortex-communities.md` | both     | https://docs.cline.bot/mcp/mcp-overview                             |
-| `codex`         | `~/.codex/config.toml` (`[mcp_servers.gortex]` + `SessionStart`, `UserPromptSubmit`, Bash/Gortex-read `PreToolUse`, and Bash/`apply_patch` `PostToolUse` hooks), `~/.codex/AGENTS.md` rule block, repo `AGENTS.md` communities block | both       | https://developers.openai.com/codex/mcp                             |
+| `codex`         | `~/.codex/config.toml` (`[mcp_servers.gortex]` + `SessionStart`, `UserPromptSubmit`, Bash/Gortex-read `PreToolUse`, and Bash/`apply_patch` `PostToolUse` hooks), `~/.codex/AGENTS.md` rule block, `~/.agents/skills/gortex-*`, repo `AGENTS.md` communities block, repo `.agents/skills/gortex-*` | both       | https://learn.chatgpt.com/docs/extend/mcp                           |
+| `copilot-cli`   | `~/.copilot/mcp-config.json` (`mcpServers`), `~/.copilot/copilot-instructions.md` rule block, `~/.copilot/skills/gortex-*`, `~/.copilot/agents/gortex-*.agent.md`, `~/.copilot/hooks/gortex.json`, repo `.github/copilot-instructions.md` communities block, repo `.github/skills/gortex-*` | both       | https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers |
 | `continue`      | `.continue/mcpServers/gortex.json`, `.continue/rules/gortex-communities.md`                     | project    | https://docs.continue.dev/customize/deep-dives/mcp                  |
 | `cursor`        | `.cursor/mcp.json` (project) or `~/.cursor/mcp.json`, `.cursor/rules/gortex-communities.mdc`    | both       | https://docs.cursor.com/en/context/mcp                              |
 | `gemini`        | `.gemini/settings.json` or `~/.gemini/settings.json`, `GEMINI.md` communities block             | both       | https://geminicli.com/docs/tools/mcp-server/                        |
@@ -35,7 +36,7 @@ commands accept `--agents=<csv>` to constrain setup and
 | `kimi`          | `.kimi-code/mcp.json` (project) or `~/.kimi-code/mcp.json` + `~/.kimi-code/config.toml` (`UserPromptSubmit` / `PreToolUse` / `Stop` / `SubagentStart` hooks) | both       | https://www.kimi.com/code/docs/en/kimi-code-cli/customization/hooks.html |
 | `kiro`          | `.kiro/settings/mcp.json` + steering/hooks or user-level                                        | both       | https://kiro.dev/docs/mcp/configuration                             |
 | `oh-my-pi`      | `.omp/mcp.json`                                                                                 | project    | https://github.com/can1357/oh-my-pi/blob/main/docs/mcp-config.md   |
-| `opencode`      | `opencode.json` (or existing `opencode.jsonc`), `AGENTS.md` communities block                   | project    | https://opencode.ai/docs/mcp                                        |
+| `opencode`      | `opencode.json` (or existing `opencode.jsonc`), `AGENTS.md` communities block, repo `.opencode/skills/gortex-*`, `~/.config/opencode/skills/gortex-*`, `~/.config/opencode/commands/gortex-*.md`, `~/.config/opencode/plugin/gortex.js` | both       | https://opencode.ai/docs/mcp                                        |
 | `openclaw`      | `~/.openclaw/openclaw.json` (`mcp.servers.gortex`)                                              | user       | https://docs.openclaw.ai/cli/mcp                                    |
 | `pi`            | `.pi/extensions/gortex/index.ts` (project) or `~/.pi/agent/extensions/gortex/index.ts`; `AGENTS.md` communities block only when `--skills` | both | https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/extensions.md |
 | `vscode`        | `.vscode/mcp.json` (`servers` key, 1.102+), `.github/copilot-instructions.md` communities block | project    | https://code.visualstudio.com/docs/copilot/chat/mcp-servers         |
@@ -46,6 +47,57 @@ Mode legend: **project** writes inside the repo (`gortex init` only);
 **user** writes under `$HOME` (`gortex install` only); **both** means
 the adapter splits: `gortex install` writes the user-level pieces and
 `gortex init` writes the repo-level pieces.
+
+Note that `copilot-cli` is the standalone `copilot` binary
+(`npm i -g @github/copilot`). Copilot inside VS Code is the separate
+`vscode` adapter, and the `copilot` LLM provider in `.gortex.yaml` is a
+third, unrelated thing — see [`llm.md`](llm.md).
+
+## Skill and hook surfaces per host
+
+Four hosts receive the same 21 skill bodies, each re-wrapped in that
+host's own frontmatter from one authoring source. The curated pack is
+always user-level, so `gortex init` never adds Gortex markdown to a
+repo that teammates have to review; only per-community skills, which
+describe that specific codebase, are written into the repo.
+
+| Host | Skills | Slash commands | Sub-agents | Enforcement hooks |
+| --- | --- | --- | --- | --- |
+| Claude Code | `~/.claude/skills/` | `~/.claude/commands/` | `~/.claude/agents/` | native, `deny` / `enrich` postures |
+| Codex CLI | `~/.agents/skills/` | **no** — see below | not written | native, 4 events |
+| OpenCode | `~/.config/opencode/skills/` | `~/.config/opencode/commands/` | not written | **no hook system** — JS plugin bridge |
+| GitHub Copilot CLI | `~/.copilot/skills/` | **no** — see below | `~/.copilot/agents/` | native, 4 of 14 events |
+
+The gaps are the hosts', not ours:
+
+- **Codex has no slash-command surface worth targeting.** `$CODEX_HOME/prompts`
+  is deprecated in favour of skills and is user-level only, with no
+  project directory. Skills are the substitute.
+- **Copilot CLI does not read prompt files.** `.github/prompts/*.prompt.md`
+  is a VS Code / Visual Studio surface; the CLI maintainers closed the
+  request as superseded by skills.
+- **OpenCode has no lifecycle-hook configuration at all.** Its only
+  extension point is a JS/TS plugin, so Gortex installs one that speaks
+  the same bridge protocol the Pi extension uses. It goes to the
+  user-level plugin directory rather than the repo: it is the only
+  executable artifact Gortex writes, and the repo-level directory is
+  committed.
+- **Copilot CLI's `agentStop` carries no context channel** (only a
+  decision and a reason), so there is no turn-end briefing on that host.
+- **OpenCode sub-agents are not written.** Their `tools` map is keyed by
+  tool name and the spelling for an MCP-served tool is unverified; a
+  wrong key silently grants nothing.
+
+`~/.agents/skills` is a shared cross-agent root that both Codex and
+OpenCode scan, so one write serves both. Copilot CLI dropped it in
+v1.0.66 and needs `~/.copilot/skills`; it also stopped reading
+home-level `~/.claude/*` in v1.0.36.
+
+Hook postures differ by host and are worth knowing before debugging a
+quiet integration: Codex gates every hook behind per-hook trust
+(`/hooks` inside Codex), Copilot CLI fails **closed** on a `preToolUse`
+non-zero exit but fails **open** on a timeout, and the OpenCode bridge
+fails open on any error so a broken plugin can never break a session.
 
 Tool-usage guidance is agent-neutral. Every named MCP connection receives the
 same mandatory, compact workflow in the server initialization response.
@@ -158,8 +210,19 @@ Every adapter under `internal/agents/<name>/` implements the
 - `Apply(env, opts)` — performs the writes, respecting
   `opts.DryRun` and `opts.Force`
 
-Every write funnels through `agents.WriteIfNotExists`,
-`agents.MergeJSON`, or `agents.MergeTOML`. Those helpers provide:
+Every write funnels through one of the shared helpers, never through
+`os.WriteFile` directly:
+
+| Helper | Use it for |
+| --- | --- |
+| `agents.WriteIfNotExists` | a file the user owns after we create it (never overwritten) |
+| `agents.WriteOwnedFile` | a file Gortex regenerates (skips when byte-identical) |
+| `agents.MergeJSON` / `MergeTOML` / `MergeYAML` | a config file shared with the host and the user |
+| `agents.UpsertMarkedBlock` | a marker-guarded block inside a human-edited markdown file |
+| `agents.UpsertMCPServer` / `RemoveMCPServer` | the `gortex` MCP stanza in any config shape |
+| `agents.UpsertMCPServerApprovalList` | a per-tool approval list, preserving a user-narrowed one |
+
+Those helpers provide:
 
 - Atomic temp-file-plus-rename — a partial failure can't leave a
   half-written config

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -2,7 +2,7 @@
 
 `gortex install` (once per machine) and `gortex init` (once per repo)
 auto-configure Gortex for every AI coding assistant detected on your
-machine. Nineteen adapters ship today.
+machine. 20 adapters ship today.
 
 - `gortex install` writes user-level machinery: `~/.claude.json` MCP,
   `~/.claude/skills/gortex-*`, `~/.claude/commands/gortex-*.md`,

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -26,7 +26,7 @@ commands accept `--agents=<csv>` to constrain setup and
 | `aider`         | `.aiderignore` block, `CONVENTIONS.md` communities block                                        | project    | https://aider.chat/docs/config/aider_conf.html                      |
 | `antigravity`   | `~/.gemini/antigravity/mcp_config.json` + Knowledge Item                                        | user       | https://antigravity.google/docs/mcp                                 |
 | `cline`         | `cline_mcp_settings.json` (per VS Code / Cursor globalStorage), `.clinerules/gortex-communities.md` | both     | https://docs.cline.bot/mcp/mcp-overview                             |
-| `codex`         | `~/.codex/config.toml` (`[mcp_servers.gortex]` + `SessionStart`, `UserPromptSubmit`, Bash/Gortex-read `PreToolUse`, and Bash/`apply_patch` `PostToolUse` hooks), `~/.codex/AGENTS.md` rule block, `~/.agents/skills/gortex-*`, repo `AGENTS.md` communities block, repo `.agents/skills/gortex-*` | both       | https://learn.chatgpt.com/docs/extend/mcp                           |
+| `codex`         | `~/.codex/config.toml` (`[mcp_servers.gortex]` + `SessionStart`, `UserPromptSubmit`, Bash/Gortex-read `PreToolUse`, and Bash/`apply_patch` `PostToolUse` hooks), `~/.codex/AGENTS.md` rule block, `~/.agents/skills/gortex-*`, `~/.codex/agents/gortex-*.toml`, repo `AGENTS.md` communities block, repo `.agents/skills/gortex-*` | both       | https://learn.chatgpt.com/docs/extend/mcp                           |
 | `copilot-cli`   | `~/.copilot/mcp-config.json` (`mcpServers`), `~/.copilot/copilot-instructions.md` rule block, `~/.copilot/skills/gortex-*`, `~/.copilot/agents/gortex-*.agent.md`, `~/.copilot/hooks/gortex.json`, repo `.github/copilot-instructions.md` communities block, repo `.github/skills/gortex-*` | both       | https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers |
 | `continue`      | `.continue/mcpServers/gortex.json`, `.continue/rules/gortex-communities.md`                     | project    | https://docs.continue.dev/customize/deep-dives/mcp                  |
 | `cursor`        | `.cursor/mcp.json` (project) or `~/.cursor/mcp.json`, `.cursor/rules/gortex-communities.mdc`    | both       | https://docs.cursor.com/en/context/mcp                              |
@@ -64,7 +64,7 @@ describe that specific codebase, are written into the repo.
 | Host | Skills | Slash commands | Sub-agents | Enforcement hooks |
 | --- | --- | --- | --- | --- |
 | Claude Code | `~/.claude/skills/` | `~/.claude/commands/` | `~/.claude/agents/` | native, `deny` / `enrich` postures |
-| Codex CLI | `~/.agents/skills/` | **no** — see below | not written | native, 4 events |
+| Codex CLI | `~/.agents/skills/` | **no** — see below | `~/.codex/agents/*.toml` | native, 4 events |
 | OpenCode | `~/.config/opencode/skills/` | `~/.config/opencode/commands/` | not written | **no hook system** — JS plugin bridge |
 | GitHub Copilot CLI | `~/.copilot/skills/` | **no** — see below | `~/.copilot/agents/` | native, 4 of 14 events |
 
@@ -87,6 +87,25 @@ The gaps are the hosts', not ours:
 - **OpenCode sub-agents are not written.** Their `tools` map is keyed by
   tool name and the spelling for an MCP-served tool is unverified; a
   wrong key silently grants nothing.
+- **No sub-agent gets a tool allowlist except Claude Code's.** Codex has
+  no per-agent allowlist at all, and Copilot's `tools` key expects names
+  that Claude's `mcp__gortex__*` spelling does not resolve to. An
+  unrecognised entry grants nothing rather than falling back to the full
+  toolbox, so both inherit the session's tools instead.
+
+Codex sub-agents are worth one extra note, because the file format has
+two ways to fail that leave no error behind. Codex rejects an agent file
+outright on a single unknown key, and its `mcp_servers` field is a table
+of full server definitions rather than a list of server names — the
+intuitive `mcp_servers = ["gortex"]` voids the whole agent. Gortex
+therefore emits four keys and no `mcp_servers`; omitting it inherits the
+session's servers, which is what we want anyway. Project-scoped
+`.codex/agents/` is skipped entirely unless the project is trusted, so
+these install user-level only.
+
+Verify a Codex install with `codex doctor`: a rejected agent file shows
+up there as a startup warning mentioning `agent role`, while the exit
+code stays 0 and everything else loads normally.
 
 `~/.agents/skills` is a shared cross-agent root that both Codex and
 OpenCode scan, so one write serves both. Copilot CLI dropped it in

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -4,11 +4,11 @@
 
 After `gortex install` (once per machine) and `gortex init` (once per repo), Claude Code automatically starts Gortex via `.mcp.json`. The agent gets:
 
-- **Slash commands (19):** installed to `~/.claude/commands/` by `gortex install`. Three groups:
+- **Slash commands (20):** installed to `~/.claude/commands/` by `gortex install`. Three groups:
   - *Discovery & analysis (8)* — `/gortex-guide`, `/gortex-explore`, `/gortex-debug`, `/gortex-impact`, `/gortex-dataflow-trace`, `/gortex-cross-repo-usage`, `/gortex-co-change`, `/gortex-onboarding`
   - *Refactor & edit (enforce tool-call order) (6)* — `/gortex-refactor`, `/gortex-safe-edit`, `/gortex-rename`, `/gortex-extract-function`, `/gortex-fix-all`, `/gortex-add-test`. These wrap the speculative-execution (`preview_edit` / `simulate_chain`) and LSP code-actions (`get_code_actions` / `apply_code_action` / `fix_all_in_file`) paths so the agent does not bypass the safety steps by calling `Edit` / `Write` directly.
-  - *Review & operate (graph-grounded playbooks) (5)* — `/gortex-pr-review`, `/gortex-architecture-review`, `/gortex-quality-audit`, `/gortex-incident-investigation`, `/gortex-episode-replay`. These wrap the discovery + impact + memory surfaces into ordered playbooks so postmortems, audits, and PR reviews are graph-grounded.
-- **Tool-usage skills:** the same 19 are installed as model-invoked skills to `~/.claude/skills/` by `gortex install` — one copy per user, used across every repo
+  - *Review & operate (graph-grounded playbooks) (6)* — `/gortex-pr-review`, `/gortex-pr-review-agent`, `/gortex-architecture-review`, `/gortex-quality-audit`, `/gortex-incident-investigation`, `/gortex-episode-replay`. These wrap the discovery + impact + memory surfaces into ordered playbooks so postmortems, audits, and PR reviews are graph-grounded.
+- **Tool-usage skills (21):** the same 20 plus `gortex-cli` (skill only — it teaches the shell verbs for a harness with no MCP transport), installed as model-invoked skills to `~/.claude/skills/` by `gortex install` — one copy per user, used across every repo
 - **Sub-agents (2):** installed to `~/.claude/agents/` by `gortex install`. Claude Code auto-routes matching prompts to them; each runs in a fresh context window and returns a single summary, keeping the parent's context clean. Tool allowlists are pinned to gortex graph tools only — Bash / Grep / Glob are unavailable to the sub-agent by construction.
   - `gortex-search` — locate code, trace call paths, explore architecture
   - `gortex-impact` — assess blast radius before editing (`verify_change`, `simulate_chain`, `check_guards`, `get_test_targets`)
@@ -30,9 +30,9 @@ The trade-off versus an MCP install — push notifications and per-session overl
 
 ## Usage with other agents
 
-`gortex install` (user-level) and `gortex init` (repo-level) together auto-detect and configure 14 other AI coding assistants — Kiro, Cursor, VS Code / Copilot, Windsurf, Continue.dev, Cline, OpenCode, Antigravity, Codex CLI, Gemini CLI, Zed, Aider, Kilo Code, OpenClaw. Each adapter writes only when its host is present on the machine, and every re-run is idempotent.
+`gortex install` (user-level) and `gortex init` (repo-level) together auto-detect and configure 19 other AI coding assistants — Kiro, Cursor, VS Code / Copilot, GitHub Copilot CLI, Windsurf, Continue.dev, Cline, OpenCode, Antigravity, Codex CLI, Gemini CLI, Zed, Aider, Kilo Code, OpenClaw, Hermes, Kimi, Pi, oh-my-pi. Each adapter writes only when its host is present on the machine, and every re-run is idempotent.
 
-Tool-usage guidance for agents that have a user-level surface (Claude Code, Antigravity) lives once per user; for the rest, MCP tool descriptions carry the teaching and `gortex init` adds only a per-repo community-routing block — no more duplicated instructions blocks in every repo.
+Four hosts read the same skill bodies Claude Code gets, each re-wrapped in its own frontmatter: Claude Code, Codex CLI, OpenCode and GitHub Copilot CLI. Codex and OpenCode share the cross-agent `~/.agents/skills` root, so one write serves both. For the remaining hosts, MCP tool descriptions carry the teaching and `gortex init` adds only a per-repo community-routing block — no duplicated instructions blocks in every repo.
 
 - **Adapter matrix + per-agent schema notes:** [`agents.md`](agents.md)
 - **Audit what's currently configured:** `gortex doctor` (zero-op; `--json` for CI consumers)

--- a/internal/agents/codex/adapter.go
+++ b/internal/agents/codex/adapter.go
@@ -123,6 +123,7 @@ func (a *Adapter) Plan(env agents.Env) (*agents.Plan, error) {
 		return nil, err
 	}
 	p.Files = append(p.Files, skillFiles...)
+	p.Files = append(p.Files, planSubAgents(env)...)
 	return p, nil
 }
 
@@ -244,6 +245,13 @@ func (a *Adapter) Apply(env agents.Env, opts agents.ApplyOpts) (*agents.Result, 
 		return res, fmt.Errorf("codex skills: %w", err)
 	}
 	res.Files = append(res.Files, skillActions...)
+
+	// Sub-agents → ~/.codex/agents/*.toml. ModeGlobal only: the
+	// project-scoped agents directory is only scanned for a TRUSTED
+	// project, so writing there is a gamble on state the installer cannot
+	// see — and it would put Gortex files in the user's working tree.
+	// subagents.go documents the rest of the vendor surface.
+	res.Files = append(res.Files, installSubAgents(env, opts)...)
 
 	res.Configured = true
 	return res, nil

--- a/internal/agents/codex/adapter.go
+++ b/internal/agents/codex/adapter.go
@@ -118,6 +118,11 @@ func (a *Adapter) Plan(env agents.Env) (*agents.Plan, error) {
 			Keys: []string{"communities-block"},
 		})
 	}
+	skillFiles, err := planSkills(env)
+	if err != nil {
+		return nil, err
+	}
+	p.Files = append(p.Files, skillFiles...)
 	return p, nil
 }
 
@@ -229,6 +234,16 @@ func (a *Adapter) Apply(env agents.Env, opts agents.ApplyOpts) (*agents.Result, 
 		}
 		res.Files = append(res.Files, routingAction)
 	}
+
+	// Skills. ModeGlobal installs the curated playbook pack under
+	// $HOME/.agents/skills; ModeProject materialises the generated
+	// community skills under <root>/.agents/skills. skills.go documents
+	// why neither ever goes near ~/.codex.
+	skillActions, err := applySkills(env, opts)
+	if err != nil {
+		return res, fmt.Errorf("codex skills: %w", err)
+	}
+	res.Files = append(res.Files, skillActions...)
 
 	res.Configured = true
 	return res, nil

--- a/internal/agents/codex/adapter_test.go
+++ b/internal/agents/codex/adapter_test.go
@@ -31,8 +31,9 @@ func TestCodexWritesMcpServersTOMLTable(t *testing.T) {
 		t.Fatalf("apply: %v", err)
 	}
 	// Two creates: ~/.codex/config.toml for MCP plus AGENTS.md, the
-	// per-repo instructions file Codex CLI reads on every task.
-	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionCreate: 2})
+	// per-repo instructions file Codex CLI reads on every task. Plus one
+	// SKILL.md per generated community skill under <root>/.agents/skills.
+	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionCreate: 2 + len(env.GeneratedSkills)})
 
 	data, err := os.ReadFile(filepath.Join(env.Home, ".codex", "config.toml"))
 	if err != nil {
@@ -167,7 +168,7 @@ command = "other"
 	if err != nil {
 		t.Fatalf("second apply: %v", err)
 	}
-	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionSkip: 1})
+	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionSkip: 1 + curatedSkillCount(t)})
 }
 
 func TestCodexDirectNamespaceUpgradesBooleanFeatureForm(t *testing.T) {
@@ -315,7 +316,7 @@ func TestCodexInstallsSessionStartHook(t *testing.T) {
 	if err != nil {
 		t.Fatalf("apply: %v", err)
 	}
-	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionCreate: 1})
+	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionCreate: 1 + curatedSkillCount(t)})
 
 	cfg := readCodexConfig(t, env)
 	entries := sessionStartEntries(t, cfg)
@@ -354,7 +355,7 @@ func TestCodexInstallsPreToolUseHook(t *testing.T) {
 	if err != nil {
 		t.Fatalf("apply: %v", err)
 	}
-	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionCreate: 1})
+	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionCreate: 1 + curatedSkillCount(t)})
 
 	cfg := readCodexConfig(t, env)
 	entries := preToolUseEntries(t, cfg)
@@ -389,7 +390,7 @@ func TestCodexInstallsPostToolUseHook(t *testing.T) {
 	if err != nil {
 		t.Fatalf("apply: %v", err)
 	}
-	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionCreate: 1})
+	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionCreate: 1 + curatedSkillCount(t)})
 
 	cfg := readCodexConfig(t, env)
 	entries := postToolUseEntries(t, cfg)
@@ -462,7 +463,7 @@ func TestCodexInstallsUserPromptSubmitHook(t *testing.T) {
 	if err != nil {
 		t.Fatalf("apply: %v", err)
 	}
-	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionCreate: 1})
+	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionCreate: 1 + curatedSkillCount(t)})
 
 	cfg := readCodexConfig(t, env)
 	entries := userPromptSubmitEntries(t, cfg)
@@ -715,7 +716,7 @@ func TestCodexSessionStartHookIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second apply: %v", err)
 	}
-	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionSkip: 1})
+	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionSkip: 1 + curatedSkillCount(t)})
 
 	cfg := readCodexConfig(t, env)
 	if count := gortexSessionStartHookCount(t, cfg); count != 1 {
@@ -814,7 +815,7 @@ statusMessage = "User PostToolUse"
 	if err != nil {
 		t.Fatalf("apply: %v", err)
 	}
-	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionMerge: 1})
+	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionMerge: 1, agents.ActionCreate: curatedSkillCount(t)})
 
 	cfg := readCodexConfig(t, env)
 	if cfg["model"] != "gpt-5-codex" {
@@ -893,7 +894,7 @@ statusMessage = "Old Gortex MCP Read PreToolUse"
 	if err != nil {
 		t.Fatalf("apply: %v", err)
 	}
-	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionMerge: 1})
+	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionMerge: 1, agents.ActionCreate: curatedSkillCount(t)})
 
 	cfg := readCodexConfig(t, env)
 	preEntries := preToolUseEntries(t, cfg)
@@ -932,8 +933,9 @@ func TestCodexNoHooksSkipsSessionStartHook(t *testing.T) {
 	if err != nil {
 		t.Fatalf("plan: %v", err)
 	}
-	if len(plan.Files) != 1 {
-		t.Fatalf("plan files=%d want 1", len(plan.Files))
+	// config.toml plus one planned SKILL.md per curated skill.
+	if want := 1 + curatedSkillCount(t); len(plan.Files) != want {
+		t.Fatalf("plan files=%d want %d", len(plan.Files), want)
 	}
 	for _, key := range plan.Files[0].Keys {
 		if key == "hooks" {

--- a/internal/agents/codex/adapter_test.go
+++ b/internal/agents/codex/adapter_test.go
@@ -168,7 +168,7 @@ command = "other"
 	if err != nil {
 		t.Fatalf("second apply: %v", err)
 	}
-	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionSkip: 1 + curatedSkillCount(t)})
+	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionSkip: 1 + curatedSkillCount(t) + subAgentCount()})
 }
 
 func TestCodexDirectNamespaceUpgradesBooleanFeatureForm(t *testing.T) {
@@ -316,7 +316,7 @@ func TestCodexInstallsSessionStartHook(t *testing.T) {
 	if err != nil {
 		t.Fatalf("apply: %v", err)
 	}
-	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionCreate: 1 + curatedSkillCount(t)})
+	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionCreate: 1 + curatedSkillCount(t) + subAgentCount()})
 
 	cfg := readCodexConfig(t, env)
 	entries := sessionStartEntries(t, cfg)
@@ -355,7 +355,7 @@ func TestCodexInstallsPreToolUseHook(t *testing.T) {
 	if err != nil {
 		t.Fatalf("apply: %v", err)
 	}
-	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionCreate: 1 + curatedSkillCount(t)})
+	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionCreate: 1 + curatedSkillCount(t) + subAgentCount()})
 
 	cfg := readCodexConfig(t, env)
 	entries := preToolUseEntries(t, cfg)
@@ -390,7 +390,7 @@ func TestCodexInstallsPostToolUseHook(t *testing.T) {
 	if err != nil {
 		t.Fatalf("apply: %v", err)
 	}
-	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionCreate: 1 + curatedSkillCount(t)})
+	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionCreate: 1 + curatedSkillCount(t) + subAgentCount()})
 
 	cfg := readCodexConfig(t, env)
 	entries := postToolUseEntries(t, cfg)
@@ -463,7 +463,7 @@ func TestCodexInstallsUserPromptSubmitHook(t *testing.T) {
 	if err != nil {
 		t.Fatalf("apply: %v", err)
 	}
-	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionCreate: 1 + curatedSkillCount(t)})
+	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionCreate: 1 + curatedSkillCount(t) + subAgentCount()})
 
 	cfg := readCodexConfig(t, env)
 	entries := userPromptSubmitEntries(t, cfg)
@@ -716,7 +716,7 @@ func TestCodexSessionStartHookIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second apply: %v", err)
 	}
-	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionSkip: 1 + curatedSkillCount(t)})
+	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionSkip: 1 + curatedSkillCount(t) + subAgentCount()})
 
 	cfg := readCodexConfig(t, env)
 	if count := gortexSessionStartHookCount(t, cfg); count != 1 {
@@ -815,7 +815,7 @@ statusMessage = "User PostToolUse"
 	if err != nil {
 		t.Fatalf("apply: %v", err)
 	}
-	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionMerge: 1, agents.ActionCreate: curatedSkillCount(t)})
+	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionMerge: 1, agents.ActionCreate: curatedSkillCount(t) + subAgentCount()})
 
 	cfg := readCodexConfig(t, env)
 	if cfg["model"] != "gpt-5-codex" {
@@ -894,7 +894,7 @@ statusMessage = "Old Gortex MCP Read PreToolUse"
 	if err != nil {
 		t.Fatalf("apply: %v", err)
 	}
-	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionMerge: 1, agents.ActionCreate: curatedSkillCount(t)})
+	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionMerge: 1, agents.ActionCreate: curatedSkillCount(t) + subAgentCount()})
 
 	cfg := readCodexConfig(t, env)
 	preEntries := preToolUseEntries(t, cfg)
@@ -933,8 +933,9 @@ func TestCodexNoHooksSkipsSessionStartHook(t *testing.T) {
 	if err != nil {
 		t.Fatalf("plan: %v", err)
 	}
-	// config.toml plus one planned SKILL.md per curated skill.
-	if want := 1 + curatedSkillCount(t); len(plan.Files) != want {
+	// config.toml, one planned SKILL.md per curated skill, and one
+	// planned .toml per sub-agent.
+	if want := 1 + curatedSkillCount(t) + subAgentCount(); len(plan.Files) != want {
 		t.Fatalf("plan files=%d want %d", len(plan.Files), want)
 	}
 	for _, key := range plan.Files[0].Keys {

--- a/internal/agents/codex/remove.go
+++ b/internal/agents/codex/remove.go
@@ -19,6 +19,11 @@ package codex
 // even when the active profile says it should not be installed. Losing a
 // user's edits to a cleanup command is not a trade worth making.
 //
+// `~/.codex/agents` is a shared root for the same reason — it holds the
+// user's own custom agents beside our two — so the sub-agent files get
+// the identical byte-compare treatment, and the directory itself is only
+// pruned when our removals are what emptied it.
+//
 // Merged config files are edited, never removed: the Gortex MCP stanza,
 // the direct-namespace opt-in and the Gortex lifecycle hooks come out of
 // ~/.codex/config.toml, and every other server, feature and hook in it
@@ -91,6 +96,11 @@ func (a *Adapter) RemoveGlobal(env agents.Env, opts agents.ApplyOpts) (removed i
 	removed += skillsRemoved
 	failures = append(failures, skillFailures...)
 
+	// 4. ~/.codex/agents/<id>.toml — the sub-agents.
+	subAgentsRemoved, subAgentFailures := removeSubAgents(env, opts)
+	removed += subAgentsRemoved
+	failures = append(failures, subAgentFailures...)
+
 	return removed, failures
 }
 
@@ -123,9 +133,19 @@ func GlobalArtifacts(home string) []string {
 		root := codexSkillsRoot(home)
 		for _, s := range skills {
 			path := filepath.Join(root, s.ID, skillFileName)
-			if isShippedCodexSkill(path, renderSkill(s)) {
+			if isShippedCodexFile(path, renderSkill(s)) {
 				present = append(present, path)
 			}
+		}
+	}
+	subAgents := SubAgents()
+	for _, id := range SubAgentNames() {
+		body, ok := subAgents[id]
+		if !ok {
+			continue
+		}
+		if path := subAgentPath(home, id); path != "" && isShippedCodexFile(path, body) {
+			present = append(present, path)
 		}
 	}
 
@@ -302,9 +322,35 @@ func removeOwnedFile(w io.Writer, path, shipped string, opts agents.ApplyOpts) (
 	return 1, nil
 }
 
-// isShippedCodexSkill is the read-only half of removeOwnedFile, so the
+// removeSubAgents deletes ~/.codex/agents/<id>.toml for each sub-agent
+// whose bytes are still ours, and prunes the agents directory only when
+// our removals are what emptied it. That directory is the user's own
+// agent root — a hand-written agent sitting beside ours keeps it alive,
+// exactly as a user skill keeps the shared skills root alive.
+func removeSubAgents(env agents.Env, opts agents.ApplyOpts) (removed int, failures []string) {
+	defs := SubAgents()
+	for _, id := range SubAgentNames() {
+		body, ok := defs[id]
+		if !ok {
+			continue
+		}
+		path := subAgentPath(env.Home, id)
+		if path == "" {
+			continue
+		}
+		n, f := removeOwnedFile(env.Stderr, path, body, opts)
+		removed += n
+		failures = append(failures, f...)
+	}
+	if removed > 0 && !opts.DryRun {
+		pruneEmptyDir(subAgentsDir(env.Home))
+	}
+	return removed, failures
+}
+
+// isShippedCodexFile is the read-only half of removeOwnedFile, so the
 // preview and the deletion cannot disagree about what is ours.
-func isShippedCodexSkill(path, shipped string) bool {
+func isShippedCodexFile(path, shipped string) bool {
 	data, err := os.ReadFile(path)
 	return err == nil && string(data) == shipped
 }

--- a/internal/agents/codex/remove.go
+++ b/internal/agents/codex/remove.go
@@ -1,0 +1,333 @@
+package codex
+
+// remove.go is the counterpart to Apply for `gortex uninstall --global`.
+//
+// # Ownership, not location
+//
+// Every deletion here is gated on evidence that Gortex authored the thing
+// being deleted, never on the path it sits at. That distinction is the
+// whole point of this file: `$HOME/.agents/skills` is a SHARED root —
+// Codex, OpenCode and anything else honouring the vendor-neutral layout
+// read it, and a user's own hand-written skills live there beside ours.
+// Removing the directory would delete their work.
+//
+// The ownership predicate is the same one skills.go writes with: a
+// `gortex-`-prefixed id from the shipped pack whose SKILL.md is still
+// byte-identical to the body we render. A file that differs is a copy the
+// user edited, and it is KEPT — the same posture as
+// claudecode.SyncGlobalSkills, which refuses to delete a customised skill
+// even when the active profile says it should not be installed. Losing a
+// user's edits to a cleanup command is not a trade worth making.
+//
+// Merged config files are edited, never removed: the Gortex MCP stanza,
+// the direct-namespace opt-in and the Gortex lifecycle hooks come out of
+// ~/.codex/config.toml, and every other server, feature and hook in it
+// survives. The rule block comes out of ~/.codex/AGENTS.md through the
+// documented empty-body UpsertMarkedBlock path, which leaves the
+// surrounding prose exactly where it was.
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/internalutil"
+)
+
+// RemoveGlobal strips the user-level Codex footprint `gortex install`
+// wrote. Returns the number of artifacts removed-or-cleaned and any
+// per-artifact failures — a partial clean still reports rather than
+// aborting, because a cleanup that gives up halfway leaves the user worse
+// off than one that says which two files it could not touch. Signature
+// mirrors claudecode.Adapter.RemoveGlobal so `gortex uninstall` can call
+// every host through the same shape.
+func (a *Adapter) RemoveGlobal(env agents.Env, opts agents.ApplyOpts) (removed int, failures []string) {
+	if env.Home == "" {
+		return 0, []string{"codex: global cleanup requires a resolved home directory"}
+	}
+	w := env.Stderr
+
+	count := func(action agents.FileAction, err error, label string) {
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", label, err))
+			return
+		}
+		if action.Action != agents.ActionSkip {
+			removed++
+		}
+	}
+
+	// 1. ~/.codex/config.toml — the MCP stanza, the direct-namespace
+	// opt-in and the lifecycle hooks, in one merge so the file is
+	// rewritten once rather than three times.
+	configPath := filepath.Join(env.Home, ".codex", "config.toml")
+	configAction, err := agents.MergeTOML(w, configPath, func(root map[string]any, _ bool) (bool, error) {
+		changed := removeCodexMCPServer(root)
+		if removeCodexDirectToolNamespaces(root) {
+			changed = true
+		}
+		if removeCodexHooks(root) {
+			changed = true
+		}
+		return changed, nil
+	}, opts)
+	count(configAction, err, configPath)
+
+	// 2. ~/.codex/AGENTS.md — an empty body makes UpsertMarkedBlock drop
+	// the marker-fenced block in place, which is the documented removal
+	// path and the only one that preserves surrounding user prose.
+	insPath := GlobalInstructionsPath(env.Home)
+	insAction, err := agents.UpsertMarkedBlock(w, insPath, "",
+		agents.GlobalRulesStartMarker, agents.GlobalRulesEndMarker, opts)
+	count(insAction, err, insPath)
+
+	// 3. $HOME/.agents/skills/<id>/SKILL.md — the curated pack.
+	skillsRemoved, skillFailures := removeCuratedSkills(env, opts)
+	removed += skillsRemoved
+	failures = append(failures, skillFailures...)
+
+	return removed, failures
+}
+
+// GlobalArtifacts lists the user-level Codex paths that currently carry a
+// Gortex footprint, sorted. It applies the SAME ownership tests
+// RemoveGlobal does — a customised skill is absent from this list exactly
+// because removal will keep it — so the uninstall wizard's preview can
+// never promise a deletion that will not happen, nor stay silent about one
+// that will.
+func GlobalArtifacts(home string) []string {
+	if home == "" {
+		return nil
+	}
+	var present []string
+
+	// The config file is listed when it carries any of the three things
+	// RemoveGlobal takes out of it. The namespace opt-in is checked as a
+	// string because Inspect does not report it, and `mcp__gortex` appears
+	// in config.toml nowhere else.
+	configPath := filepath.Join(home, ".codex", "config.toml")
+	state := Inspect(home)
+	if state.ConfigPresent &&
+		(state.MCPServer || configuredHookCount(state.Hooks) > 0 || codexFileContains(configPath, codexGortexToolNamespace)) {
+		present = append(present, configPath)
+	}
+	if ins := GlobalInstructionsPath(home); codexFileContains(ins, agents.GlobalRulesStartMarker) {
+		present = append(present, ins)
+	}
+	if skills, err := Skills(); err == nil {
+		root := codexSkillsRoot(home)
+		for _, s := range skills {
+			path := filepath.Join(root, s.ID, skillFileName)
+			if isShippedCodexSkill(path, renderSkill(s)) {
+				present = append(present, path)
+			}
+		}
+	}
+
+	sort.Strings(present)
+	return present
+}
+
+// removeCodexMCPServer drops the gortex entry from Codex's TOML server
+// table, pruning the table when it empties.
+//
+// agents.RemoveMCPServer is the shared helper for this, and it is not
+// usable here: it keys on "mcpServers", the JSON spelling every other host
+// uses, while Codex's TOML table is "mcp_servers". Same policy, different
+// key — the user's other servers are never touched.
+func removeCodexMCPServer(root map[string]any) bool {
+	servers, ok := root["mcp_servers"].(map[string]any)
+	if !ok {
+		return false
+	}
+	if _, exists := servers["gortex"]; !exists {
+		return false
+	}
+	delete(servers, "gortex")
+	if len(servers) == 0 {
+		delete(root, "mcp_servers")
+	} else {
+		root["mcp_servers"] = servers
+	}
+	return true
+}
+
+// removeCodexDirectToolNamespaces takes Gortex's two namespace spellings
+// back out of features.code_mode.direct_only_tool_namespaces, pruning each
+// level only when our removal is what emptied it. A namespace the user
+// added for another server survives, and so does every other code_mode
+// field.
+func removeCodexDirectToolNamespaces(root map[string]any) bool {
+	features, ok := root["features"].(map[string]any)
+	if !ok {
+		return false
+	}
+	codeMode, ok := features["code_mode"].(map[string]any)
+	if !ok {
+		return false
+	}
+	const field = "direct_only_tool_namespaces"
+	namespaces, valid := codexStringList(codeMode[field])
+	if !valid || len(namespaces) == 0 {
+		return false
+	}
+	ours := map[string]bool{
+		codexGortexToolNamespace:            true,
+		codexGortexNonPrefixedToolNamespace: true,
+	}
+	kept := make([]string, 0, len(namespaces))
+	for _, ns := range namespaces {
+		if ours[ns] {
+			continue
+		}
+		kept = append(kept, ns)
+	}
+	if len(kept) == len(namespaces) {
+		return false
+	}
+	if len(kept) == 0 {
+		delete(codeMode, field)
+	} else {
+		codeMode[field] = kept
+	}
+	if len(codeMode) == 0 {
+		delete(features, "code_mode")
+	}
+	if len(features) == 0 {
+		delete(root, "features")
+	}
+	return true
+}
+
+// removeCodexHooks drops every Gortex-authored hook entry, reusing the
+// writer's own recognisers so a hook shape this package installs is always
+// a hook shape it can find again. Entries authored by anyone else stay in
+// their event's list, in order.
+func removeCodexHooks(root map[string]any) bool {
+	hooks, ok := root["hooks"].(map[string]any)
+	if !ok {
+		return false
+	}
+	recognisers := map[string]func(any) bool{
+		"SessionStart":     codexHookEntryIsGortexSessionStart,
+		"UserPromptSubmit": codexHookEntryIsGortexUserPromptSubmit,
+		"PreToolUse":       codexHookEntryIsGortexPreToolUse,
+		"PostToolUse":      codexHookEntryIsGortexPostToolUse,
+	}
+	changed := false
+	for event, isGortex := range recognisers {
+		entries, ok := codexHookList(hooks[event])
+		if !ok {
+			continue
+		}
+		kept := make([]any, 0, len(entries))
+		for _, entry := range entries {
+			if isGortex(entry) {
+				changed = true
+				continue
+			}
+			kept = append(kept, entry)
+		}
+		if len(kept) == len(entries) {
+			continue
+		}
+		if len(kept) == 0 {
+			delete(hooks, event)
+		} else {
+			hooks[event] = kept
+		}
+	}
+	if !changed {
+		return false
+	}
+	if len(hooks) == 0 {
+		delete(root, "hooks")
+	}
+	return true
+}
+
+// removeCuratedSkills deletes the shipped pack from
+// `$HOME/.agents/skills`, one SKILL.md at a time, and prunes each skill's
+// directory only when nothing else is left in it. A user's own skill
+// directory in the same root is never even looked at.
+func removeCuratedSkills(env agents.Env, opts agents.ApplyOpts) (removed int, failures []string) {
+	skills, err := Skills()
+	if err != nil {
+		return 0, []string{fmt.Sprintf("codex skills: %v", err)}
+	}
+	root := codexSkillsRoot(env.Home)
+	for _, s := range skills {
+		dir := filepath.Join(root, s.ID)
+		n, f := removeOwnedFile(env.Stderr, filepath.Join(dir, skillFileName), renderSkill(s), opts)
+		removed += n
+		failures = append(failures, f...)
+		if n > 0 && !opts.DryRun {
+			pruneEmptyDir(dir)
+		}
+	}
+	if removed > 0 && !opts.DryRun {
+		pruneEmptyDir(root)
+		pruneEmptyDir(filepath.Dir(root))
+	}
+	return removed, failures
+}
+
+// removeOwnedFile deletes path only when its bytes are still exactly what
+// Gortex shipped. Anything else is the user's edit and is kept with a
+// warning, mirroring writeSkillFile's never-clobber posture on the way in.
+func removeOwnedFile(w io.Writer, path, shipped string, opts agents.ApplyOpts) (removed int, failures []string) {
+	existing, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, []string{fmt.Sprintf("%s: %v", path, err)}
+	}
+	if string(existing) != shipped {
+		internalutil.Warnf(w, "keeping customised %s", path)
+		return 0, nil
+	}
+	if opts.DryRun {
+		return 1, nil
+	}
+	if err := os.Remove(path); err != nil {
+		return 0, []string{fmt.Sprintf("%s: %v", path, err)}
+	}
+	internalutil.Logf(w, "[gortex uninstall] removed %s", path)
+	return 1, nil
+}
+
+// isShippedCodexSkill is the read-only half of removeOwnedFile, so the
+// preview and the deletion cannot disagree about what is ours.
+func isShippedCodexSkill(path, shipped string) bool {
+	data, err := os.ReadFile(path)
+	return err == nil && string(data) == shipped
+}
+
+// pruneEmptyDir removes dir only when it holds nothing. os.Remove refuses
+// a non-empty directory, which is exactly the guard we want: a user file
+// sitting next to a skill we deleted keeps its directory alive.
+func pruneEmptyDir(dir string) {
+	_ = os.Remove(dir)
+}
+
+func configuredHookCount(hooks map[string]int) int {
+	total := 0
+	for _, n := range hooks {
+		total += n
+	}
+	return total
+}
+
+func codexFileContains(path, needle string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(data), needle)
+}

--- a/internal/agents/codex/remove_test.go
+++ b/internal/agents/codex/remove_test.go
@@ -140,6 +140,18 @@ func TestCodexRemoveGlobalLeavesNoGortexArtifact(t *testing.T) {
 		}
 	}
 
+	// Both sub-agents are gone and the directory they had to themselves
+	// is pruned. subagents_test.go covers the shared-root case, where a
+	// user's own agent keeps the directory alive.
+	for _, id := range SubAgentNames() {
+		if _, err := os.Stat(subAgentPath(env.Home, id)); !os.IsNotExist(err) {
+			t.Errorf("sub-agent %s survived removal (stat err=%v)", id, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(env.Home, ".codex", "agents")); !os.IsNotExist(err) {
+		t.Errorf("the emptied agents directory was not pruned (stat err=%v)", err)
+	}
+
 	// The user's own skill in that same root is byte-identical.
 	after, err := os.ReadFile(userSkill)
 	if err != nil {

--- a/internal/agents/codex/remove_test.go
+++ b/internal/agents/codex/remove_test.go
@@ -1,0 +1,230 @@
+package codex
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/agents"
+)
+
+// userCodexConfig seeds ~/.codex/config.toml with content that is
+// unambiguously the user's: a second MCP server and a hook that has
+// nothing to do with Gortex. Everything RemoveGlobal does has to leave
+// both exactly where they are.
+const userCodexConfig = `[mcp_servers.other]
+command = "node"
+args = ["server.js"]
+
+[[hooks.PreToolUse]]
+matcher = "^Bash$"
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = "my-own-linter"
+`
+
+const userCodexProse = "# My notes\n\nBe terse.\n"
+
+func writeCodexFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// installedCodexGlobal runs a ModeGlobal Apply over a home already
+// carrying the user's own config, prose and skill, and returns the env
+// plus the user skill's path. Every RemoveGlobal test starts from a real
+// install rather than a hand-built fixture, so a change to what Apply
+// writes cannot leave the remover asserting against a shape that no
+// longer ships.
+func installedCodexGlobal(t *testing.T) (agents.Env, string) {
+	t.Helper()
+	env := codexGlobalEnv(t)
+	env.InstallGlobalInstructions = true
+
+	writeCodexFile(t, filepath.Join(env.Home, ".codex", "config.toml"), userCodexConfig)
+	writeCodexFile(t, GlobalInstructionsPath(env.Home), userCodexProse)
+
+	// A hand-written skill in the SHARED `.agents/skills` root — the whole
+	// reason removal cannot just delete the directory.
+	userSkill := filepath.Join(codexSkillsRoot(env.Home), "team-runbook", "SKILL.md")
+	writeCodexFile(t, userSkill, "---\nname: team-runbook\n---\n\nOurs, not Gortex's.\n")
+
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if got := GlobalArtifacts(env.Home); len(got) == 0 {
+		t.Fatal("expected a non-empty footprint after install")
+	}
+	return env, userSkill
+}
+
+// TestCodexRemoveGlobalLeavesNoGortexArtifact is the round-trip contract:
+// after Apply then RemoveGlobal nothing of Gortex's is left, and every
+// user-owned thing that shared a file or a directory with it survives.
+func TestCodexRemoveGlobalLeavesNoGortexArtifact(t *testing.T) {
+	env, userSkill := installedCodexGlobal(t)
+	before, err := os.ReadFile(userSkill)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	removed, failures := New().RemoveGlobal(env, agents.ApplyOpts{})
+	if len(failures) != 0 {
+		t.Fatalf("RemoveGlobal failures: %v", failures)
+	}
+	if removed == 0 {
+		t.Fatal("expected RemoveGlobal to remove at least one artifact")
+	}
+
+	root := readCodexConfig(t, env)
+
+	// The gortex MCP stanza is gone; the user's other server is not.
+	servers, _ := root["mcp_servers"].(map[string]any)
+	if _, exists := servers["gortex"]; exists {
+		t.Error("config.toml still registers the gortex MCP server")
+	}
+	if _, exists := servers["other"]; !exists {
+		t.Error("config.toml lost the user's own MCP server")
+	}
+
+	// The direct-namespace opt-in is gone.
+	if strings.Contains(rawCodexConfig(t, env), codexGortexToolNamespace) {
+		t.Error("config.toml still opts gortex into direct tool namespaces")
+	}
+
+	// Every Gortex hook is gone; the user's PreToolUse hook is intact.
+	if got := rawCodexConfig(t, env); strings.Contains(got, "--agent=codex") {
+		t.Errorf("config.toml still carries a gortex hook:\n%s", got)
+	}
+	hooks, _ := root["hooks"].(map[string]any)
+	entries, ok := codexHookList(hooks["PreToolUse"])
+	if !ok || len(entries) != 1 {
+		t.Fatalf("PreToolUse should hold exactly the user's entry, got %v", hooks["PreToolUse"])
+	}
+	if got := codexHookEntryCommand(entries[0]); got != "my-own-linter" {
+		t.Errorf("the surviving PreToolUse entry is %q, want the user's linter", got)
+	}
+	for _, event := range []string{"SessionStart", "UserPromptSubmit", "PostToolUse"} {
+		if left, _ := codexHookList(hooks[event]); len(left) != 0 {
+			t.Errorf("%s should be empty after removal, got %v", event, left)
+		}
+	}
+
+	// AGENTS.md keeps the user's prose and loses the marker block.
+	md, err := os.ReadFile(GlobalInstructionsPath(env.Home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(md), agents.GlobalRulesStartMarker) {
+		t.Errorf("AGENTS.md still carries the gortex marker:\n%s", md)
+	}
+	if !strings.Contains(string(md), "Be terse.") {
+		t.Errorf("AGENTS.md lost the user's prose:\n%s", md)
+	}
+
+	// Every curated skill is gone from the shared root.
+	skills, err := Skills()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range skills {
+		if _, err := os.Stat(filepath.Join(codexSkillsRoot(env.Home), s.ID)); err == nil {
+			t.Errorf("curated skill %s survived removal", s.ID)
+		}
+	}
+
+	// The user's own skill in that same root is byte-identical.
+	after, err := os.ReadFile(userSkill)
+	if err != nil {
+		t.Fatalf("the user's skill was deleted: %v", err)
+	}
+	if string(after) != string(before) {
+		t.Errorf("the user's skill changed:\n%s", after)
+	}
+
+	if got := GlobalArtifacts(env.Home); len(got) != 0 {
+		t.Errorf("GlobalArtifacts should be empty after RemoveGlobal, got %v", got)
+	}
+}
+
+// TestCodexRemoveGlobalKeepsACustomisedSkill pins the posture
+// SyncGlobalSkills established on the install side: a Gortex skill the
+// user edited is their work now. Deleting it to satisfy a cleanup command
+// is not a trade worth making, and the wizard preview must agree — a path
+// removal will keep may never appear in GlobalArtifacts.
+func TestCodexRemoveGlobalKeepsACustomisedSkill(t *testing.T) {
+	env, _ := installedCodexGlobal(t)
+
+	skills, err := Skills()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skills) == 0 {
+		t.Fatal("curated pack is empty")
+	}
+	customised := filepath.Join(codexSkillsRoot(env.Home), skills[0].ID, skillFileName)
+	body := renderSkill(skills[0]) + "\n<!-- my own note -->\n"
+	writeCodexFile(t, customised, body)
+
+	for _, path := range GlobalArtifacts(env.Home) {
+		if path == customised {
+			t.Errorf("the preview promises to delete a customised skill: %s", path)
+		}
+	}
+
+	if _, failures := New().RemoveGlobal(env, agents.ApplyOpts{}); len(failures) != 0 {
+		t.Fatalf("RemoveGlobal failures: %v", failures)
+	}
+	got, err := os.ReadFile(customised)
+	if err != nil {
+		t.Fatalf("the customised skill was deleted: %v", err)
+	}
+	if string(got) != body {
+		t.Errorf("the customised skill changed:\n%s", got)
+	}
+}
+
+// TestCodexRemoveGlobalDryRunTouchesNothing keeps the preview honest in
+// the other direction: it must count the same artifacts without writing.
+func TestCodexRemoveGlobalDryRunTouchesNothing(t *testing.T) {
+	env, _ := installedCodexGlobal(t)
+	before := rawCodexConfig(t, env)
+
+	removed, failures := New().RemoveGlobal(env, agents.ApplyOpts{DryRun: true})
+	if len(failures) != 0 {
+		t.Fatalf("RemoveGlobal failures: %v", failures)
+	}
+	if removed == 0 {
+		t.Fatal("a dry run should still count what it would remove")
+	}
+	if got := rawCodexConfig(t, env); got != before {
+		t.Error("dry run rewrote config.toml")
+	}
+	if got := GlobalArtifacts(env.Home); len(got) == 0 {
+		t.Error("dry run removed the footprint")
+	}
+}
+
+// TestCodexRemoveGlobalNeedsAHome refuses rather than guessing at a root.
+func TestCodexRemoveGlobalNeedsAHome(t *testing.T) {
+	removed, failures := New().RemoveGlobal(agents.Env{}, agents.ApplyOpts{})
+	if removed != 0 || len(failures) != 1 {
+		t.Fatalf("want (0, one failure), got (%d, %v)", removed, failures)
+	}
+}
+
+func rawCodexConfig(t *testing.T, env agents.Env) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(env.Home, ".codex", "config.toml"))
+	if err != nil {
+		t.Fatalf("read config.toml: %v", err)
+	}
+	return string(data)
+}

--- a/internal/agents/codex/skills.go
+++ b/internal/agents/codex/skills.go
@@ -26,8 +26,6 @@ package codex
 // in as direct children like everything else.
 
 import (
-	"errors"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -106,22 +104,55 @@ func applySkills(env agents.Env, opts agents.ApplyOpts) ([]agents.FileAction, er
 // An existing file that differs from the shipped body is the user's:
 // it is left alone (ActionSkip "customised"), the same never-clobber
 // posture as claudecode's writeAgentArtifact.
+//
+// `allowed` is nil here — install materialises the whole pack, and
+// `gortex instructions switch` narrows it afterwards through SyncSkills.
+// Both go through the same reconciler so an install and a profile switch
+// can never disagree about what belongs on disk.
 func installCuratedSkills(env agents.Env, opts agents.ApplyOpts) ([]agents.FileAction, error) {
+	return syncCuratedSkills(env.Stderr, codexSkillsRoot(env.Home), nil, opts)
+}
+
+// SyncSkills reshapes an ALREADY-INSTALLED `$HOME/.agents/skills` tree
+// to the allowed subset (nil = every shipped skill). This is the entry
+// point `gortex instructions switch` drives.
+//
+// A missing skills root is a silent no-op, not an install: switching a
+// profile must never conjure a Codex surface on a machine that never ran
+// `gortex install`, and most machines carry only one or two of the
+// supported hosts. That is the one behavioural difference from
+// installCuratedSkills, which shares the reconciler below.
+func SyncSkills(w io.Writer, home string, allowed []string, opts agents.ApplyOpts) ([]agents.FileAction, error) {
+	if home == "" {
+		return nil, nil
+	}
+	root := codexSkillsRoot(home)
+	if _, err := os.Stat(root); err != nil {
+		return nil, nil
+	}
+	return syncCuratedSkills(w, root, allowed, opts)
+}
+
+// syncCuratedSkills is the one reconciler both entry points reach. The
+// deletion rule (never remove a customised file) lives in skillpack, not
+// here, so all four skill-aware hosts enforce it identically.
+func syncCuratedSkills(w io.Writer, root string, allowed []string, opts agents.ApplyOpts) ([]agents.FileAction, error) {
 	skills, err := Skills()
 	if err != nil {
 		return nil, err
 	}
-	root := codexSkillsRoot(env.Home)
-	out := make([]agents.FileAction, 0, len(skills))
+	rendered := make(map[string]string, len(skills))
 	for _, s := range skills {
-		path := filepath.Join(root, s.ID, skillFileName)
-		action, err := writeSkillFile(env.Stderr, path, renderSkill(s), opts)
-		if err != nil {
-			return out, fmt.Errorf("skill %s: %w", s.ID, err)
-		}
-		out = append(out, action)
+		rendered[s.ID] = renderSkill(s)
 	}
-	return out, nil
+	// KnownHashes stays unset: this pack has only ever shipped one
+	// rendering, so the byte compare against `rendered` is the complete
+	// definition of "still ours".
+	return skillpack.Sync(w, skillpack.SyncSpec{
+		Dir:      root,
+		FileName: skillFileName,
+		Rendered: rendered,
+	}, allowed, opts)
 }
 
 // installGeneratedSkills materialises the per-community skills the
@@ -203,25 +234,4 @@ func planSkills(env agents.Env) ([]agents.FileAction, error) {
 		})
 	}
 	return out, nil
-}
-
-// writeSkillFile installs content at path only when nothing is there,
-// and never overwrites a file the user has edited.
-//
-// Replicated from claudecode's writeAgentArtifact rather than shared:
-// that helper is unexported and carries claudecode's v0.60.0 migration
-// hashes, which describe artifacts this adapter has never shipped.
-func writeSkillFile(w io.Writer, path, content string, opts agents.ApplyOpts) (agents.FileAction, error) {
-	existing, err := os.ReadFile(path)
-	if errors.Is(err, os.ErrNotExist) {
-		return agents.WriteIfNotExists(w, path, content, opts)
-	}
-	if err != nil {
-		return agents.FileAction{}, fmt.Errorf("read %s: %w", path, err)
-	}
-	if string(existing) == content {
-		return agents.FileAction{Path: path, Action: agents.ActionSkip, Reason: "unchanged"}, nil
-	}
-	internalutil.Warnf(w, "keeping customised skill %s", path)
-	return agents.FileAction{Path: path, Action: agents.ActionSkip, Reason: "customised"}, nil
 }

--- a/internal/agents/codex/skills.go
+++ b/internal/agents/codex/skills.go
@@ -109,7 +109,16 @@ func applySkills(env agents.Env, opts agents.ApplyOpts) ([]agents.FileAction, er
 // `gortex instructions switch` narrows it afterwards through SyncSkills.
 // Both go through the same reconciler so an install and a profile switch
 // can never disagree about what belongs on disk.
+// An empty Home is refused rather than defaulted. codexSkillsRoot joins
+// onto it, so an unresolved home turns "$HOME/.agents/skills" into the
+// relative ".agents/skills" and the curated pack lands in whatever
+// directory the process happens to be in — most often the user's repo,
+// which is exactly where this pack must never go. planSkills already
+// guards for it; this is the same guard on the write side.
 func installCuratedSkills(env agents.Env, opts agents.ApplyOpts) ([]agents.FileAction, error) {
+	if env.Home == "" {
+		return nil, nil
+	}
 	return syncCuratedSkills(env.Stderr, codexSkillsRoot(env.Home), nil, opts)
 }
 

--- a/internal/agents/codex/skills.go
+++ b/internal/agents/codex/skills.go
@@ -1,0 +1,227 @@
+package codex
+
+// skills.go installs the Gortex playbooks as Codex skills.
+//
+// # The discovery root is `.agents/skills`, and only that
+//
+// Codex (0.147.0) looks for skills in exactly three places: the
+// `.agents/skills` directory of the current working directory and of
+// every parent up to the repository root, `$HOME/.agents/skills`, and
+// `/etc/codex/skills`.
+//
+// `~/.codex` is Codex's *configuration* home — config.toml, AGENTS.md,
+// session state — and holds no skills. A SKILL.md written to
+// `~/.codex/skills` or `<repo>/.codex/skills` produces no error and no
+// warning: Codex simply never looks there, so the installer reports a
+// clean success and the user gets nothing. That is the one mistake this
+// file exists to avoid, and why skills_test.go asserts the `.codex`
+// paths stay empty rather than only asserting the `.agents` paths fill.
+//
+// # One directory per skill, never nested
+//
+// Codex documents the layout as one directory per skill directly under
+// `.agents/skills`, each containing a `SKILL.md`. Recursion into deeper
+// subdirectories (`.agents/skills/generated/foo/SKILL.md`) is not
+// documented, so nothing here nests — the generated community skills go
+// in as direct children like everything else.
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/claudecode"
+	"github.com/zzet/gortex/internal/agents/internalutil"
+	"github.com/zzet/gortex/internal/agents/skillpack"
+)
+
+// skillFileName is the file Codex loads inside each skill directory.
+const skillFileName = "SKILL.md"
+
+// codexSkillsRoot is the skills directory Codex scans under base —
+// `$HOME/.agents/skills` for the user-level pack, `<repo>/.agents/skills`
+// for the per-repo one. See the package-level note above for why this is
+// not derived from `.codex`.
+func codexSkillsRoot(base string) string {
+	return filepath.Join(base, ".agents", "skills")
+}
+
+// Skills returns the curated Gortex playbook pack in host-neutral form.
+//
+// The bodies are single-sourced in internal/agents/claudecode and each
+// host re-wraps them in its own frontmatter dialect; skillpack does the
+// stripping. Reading claudecode's map directly from an adapter is the
+// established direction (hermes does the same) — claudecode never
+// imports another adapter, so there is no cycle to trip over.
+func Skills() ([]skillpack.Skill, error) {
+	return skillpack.ParseAll(claudecode.GlobalSkills)
+}
+
+// renderSkill puts Codex's frontmatter envelope in front of a neutral
+// skill body.
+//
+// Codex reads exactly two frontmatter fields — `name` and `description`
+// — and ignores everything else. The envelope is held to those two on
+// purpose: `$HOME/.agents/skills` is a shared root (see
+// installCuratedSkills), so every extra key is one more chance for two
+// adapters to disagree byte-for-byte about a file they both write.
+func renderSkill(s skillpack.Skill) string {
+	return skillpack.RenderFrontmatter([][2]string{
+		{"name", s.Name},
+		{"description", s.Description},
+	}) + "\n" + s.Body
+}
+
+// applySkills installs whichever skill set belongs to this Env's mode.
+// The two sets never overlap: the curated pack is machine-wide and the
+// generated community pack is repo-specific.
+func applySkills(env agents.Env, opts agents.ApplyOpts) ([]agents.FileAction, error) {
+	if env.Mode == agents.ModeGlobal {
+		return installCuratedSkills(env, opts)
+	}
+	return installGeneratedSkills(env, opts), nil
+}
+
+// installCuratedSkills writes the curated pack to
+// `$HOME/.agents/skills/<id>/SKILL.md`.
+//
+// ModeGlobal only, mirroring claudecode — whose SyncGlobalSkills sits
+// inside applyGlobal for the same reason. The playbooks are codebase-
+// and host-agnostic, so a `gortex init` that dropped 21 markdown files
+// into a repo would be handing the user's teammates a pile of unrelated
+// files to review for no benefit.
+//
+// `$HOME/.agents/skills` is also one of OpenCode's global skill roots,
+// so this single write serves both hosts. That convergence is
+// deliberate: the vendors agreed on a root, and duplicating the same
+// bodies under a second host-specific directory would only create two
+// copies to drift apart. The consequence is that one `gortex install`
+// run can reach this path twice, once per adapter, so the write must be
+// byte-stable — whichever adapter runs second sees identical bytes and
+// reports ActionSkip instead of churning the file.
+//
+// An existing file that differs from the shipped body is the user's:
+// it is left alone (ActionSkip "customised"), the same never-clobber
+// posture as claudecode's writeAgentArtifact.
+func installCuratedSkills(env agents.Env, opts agents.ApplyOpts) ([]agents.FileAction, error) {
+	skills, err := Skills()
+	if err != nil {
+		return nil, err
+	}
+	root := codexSkillsRoot(env.Home)
+	out := make([]agents.FileAction, 0, len(skills))
+	for _, s := range skills {
+		path := filepath.Join(root, s.ID, skillFileName)
+		action, err := writeSkillFile(env.Stderr, path, renderSkill(s), opts)
+		if err != nil {
+			return out, fmt.Errorf("skill %s: %w", s.ID, err)
+		}
+		out = append(out, action)
+	}
+	return out, nil
+}
+
+// installGeneratedSkills materialises the per-community skills the
+// skills generator produced, at `<root>/.agents/skills/<DirName>/SKILL.md`.
+//
+// Codex is the first non-Claude adapter to consume Env.GeneratedSkills —
+// until now only claudecode did, under `.claude/skills/generated/`.
+// There is no `generated/` grouping level here: Codex only documents
+// one directory per skill directly under `.agents/skills`, and DirName
+// already carries a `gortex-` prefix, so it cannot collide with the
+// curated pack even without a grouping directory.
+//
+// A DirName that is not kebab-case is skipped rather than written. The
+// same generated fixture flows on to OpenCode and Copilot, which refuse
+// a non-kebab skill name at load time — and refuse it silently, so the
+// skill just never appears in the picker. A loud warning here beats
+// three hosts quietly ignoring the file.
+//
+// WriteOwnedFile (not the never-clobber writer used for the curated
+// pack) because these track the current graph and must be regenerated
+// on every init; it reports ActionSkip "unchanged" when the content is
+// byte-identical, which is what keeps a re-run idempotent.
+func installGeneratedSkills(env agents.Env, opts agents.ApplyOpts) []agents.FileAction {
+	root := codexSkillsRoot(env.Root)
+	out := make([]agents.FileAction, 0, len(env.GeneratedSkills))
+	for _, s := range env.GeneratedSkills {
+		if !skillpack.ValidID(s.DirName) {
+			internalutil.Warnf(env.Stderr, "skipping generated skill %q: Codex skill directories must be kebab-case", s.DirName)
+			continue
+		}
+		path := filepath.Join(root, s.DirName, skillFileName)
+		action, err := agents.WriteOwnedFile(env.Stderr, path, s.Content, opts)
+		if err != nil {
+			internalutil.Warnf(env.Stderr, "could not write generated skill %s: %v", s.DirName, err)
+			continue
+		}
+		out = append(out, action)
+	}
+	return out
+}
+
+// planSkills enumerates every SKILL.md this adapter would write for env.
+//
+// Plan is what `gortex doctor` and `--print-config` read — they never
+// call Apply — so a path that Apply writes but Plan omits is invisible
+// to both, and a user debugging a missing skill has nothing to check
+// against.
+func planSkills(env agents.Env) ([]agents.FileAction, error) {
+	if env.Mode == agents.ModeGlobal {
+		if env.Home == "" {
+			return nil, nil
+		}
+		skills, err := Skills()
+		if err != nil {
+			return nil, err
+		}
+		root := codexSkillsRoot(env.Home)
+		out := make([]agents.FileAction, 0, len(skills))
+		for _, s := range skills {
+			out = append(out, agents.FileAction{
+				Path:   filepath.Join(root, s.ID, skillFileName),
+				Action: agents.ActionWouldCreate,
+			})
+		}
+		return out, nil
+	}
+	if env.Root == "" {
+		return nil, nil
+	}
+	root := codexSkillsRoot(env.Root)
+	out := make([]agents.FileAction, 0, len(env.GeneratedSkills))
+	for _, s := range env.GeneratedSkills {
+		if !skillpack.ValidID(s.DirName) {
+			continue
+		}
+		out = append(out, agents.FileAction{
+			Path:   filepath.Join(root, s.DirName, skillFileName),
+			Action: agents.ActionWouldCreate,
+		})
+	}
+	return out, nil
+}
+
+// writeSkillFile installs content at path only when nothing is there,
+// and never overwrites a file the user has edited.
+//
+// Replicated from claudecode's writeAgentArtifact rather than shared:
+// that helper is unexported and carries claudecode's v0.60.0 migration
+// hashes, which describe artifacts this adapter has never shipped.
+func writeSkillFile(w io.Writer, path, content string, opts agents.ApplyOpts) (agents.FileAction, error) {
+	existing, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return agents.WriteIfNotExists(w, path, content, opts)
+	}
+	if err != nil {
+		return agents.FileAction{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	if string(existing) == content {
+		return agents.FileAction{Path: path, Action: agents.ActionSkip, Reason: "unchanged"}, nil
+	}
+	internalutil.Warnf(w, "keeping customised skill %s", path)
+	return agents.FileAction{Path: path, Action: agents.ActionSkip, Reason: "customised"}, nil
+}

--- a/internal/agents/codex/skills_test.go
+++ b/internal/agents/codex/skills_test.go
@@ -1,0 +1,471 @@
+package codex
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/agentstest"
+)
+
+// TestCodexSkillsNeverLandUnderDotCodex is the test that separates a
+// shipped feature from a green suite over nothing.
+//
+// Codex scans `.agents/skills` (cwd upward), `$HOME/.agents/skills` and
+// `/etc/codex/skills` — and nothing else. `~/.codex` is configuration
+// only. A SKILL.md written under `~/.codex/skills` or
+// `<repo>/.codex/skills` is neither an error nor a warning: Codex never
+// looks, so every positive assertion about "we wrote the skills" would
+// still pass while the user's picker stayed empty. This test fails the
+// moment an install starts writing to the dead drop.
+func TestCodexSkillsNeverLandUnderDotCodex(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		newEnv func(*testing.T) agents.Env
+	}{
+		{"global", codexGlobalEnv},
+		{"project", codexProjectEnv},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			env := tc.newEnv(t)
+			if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+				t.Fatalf("apply: %v", err)
+			}
+			assertNoSkillsDir(t, filepath.Join(env.Home, ".codex", "skills"))
+			assertNoSkillsDir(t, filepath.Join(env.Root, ".codex", "skills"))
+		})
+	}
+}
+
+// TestCodexGlobalModeInstallsCuratedSkillPack pins the curated pack to
+// the shared `$HOME/.agents/skills` root — the one OpenCode reads too,
+// so a single write serves both hosts.
+func TestCodexGlobalModeInstallsCuratedSkillPack(t *testing.T) {
+	env := codexGlobalEnv(t)
+	res, err := New().Apply(env, agents.ApplyOpts{})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	skills, err := Skills()
+	if err != nil {
+		t.Fatalf("skills: %v", err)
+	}
+	if len(skills) == 0 {
+		t.Fatal("curated skill pack is empty")
+	}
+	for _, s := range skills {
+		path := filepath.Join(env.Home, ".agents", "skills", s.ID, "SKILL.md")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if got := string(data); got != renderSkill(s) {
+			t.Fatalf("%s is not the rendered skill:\n%s", path, got)
+		}
+		if !reportsPath(res, path) {
+			t.Fatalf("apply did not report %s in its file actions", path)
+		}
+	}
+
+	// The curated pack is codebase-agnostic; `gortex install` must not
+	// leak it into the repo the user happens to be standing in.
+	assertNoSkillsDir(t, filepath.Join(env.Root, ".agents", "skills"))
+}
+
+// TestCodexProjectModeSkipsCuratedSkillPack keeps `gortex init` from
+// dropping 21 host-agnostic markdown files into a user's working tree
+// for their teammates to review. Same reason claudecode's
+// SyncGlobalSkills lives inside applyGlobal.
+func TestCodexProjectModeSkipsCuratedSkillPack(t *testing.T) {
+	env := codexProjectEnv(t)
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	assertNoSkillsDir(t, filepath.Join(env.Home, ".agents", "skills"))
+	for _, dir := range skillDirNames(t, filepath.Join(env.Root, ".agents", "skills")) {
+		if dir == "gortex-explore" {
+			t.Fatalf("curated skill %q leaked into the repo", dir)
+		}
+	}
+}
+
+// TestCodexProjectModeWritesGeneratedCommunitySkills covers the first
+// non-Claude consumer of Env.GeneratedSkills. The content is passed
+// through verbatim — the generator already renders a complete SKILL.md.
+func TestCodexProjectModeWritesGeneratedCommunitySkills(t *testing.T) {
+	env := codexProjectEnv(t)
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	for _, s := range env.GeneratedSkills {
+		path := filepath.Join(env.Root, ".agents", "skills", s.DirName, "SKILL.md")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if string(data) != s.Content {
+			t.Fatalf("%s content drifted from the generated skill:\n%s", path, data)
+		}
+	}
+}
+
+// TestCodexSkillsAreNeverNested guards the layout Codex documents: one
+// directory per skill, directly under `.agents/skills`. Recursion into a
+// deeper subdirectory is undocumented, so a `generated/` grouping level
+// would be a silent gamble.
+func TestCodexSkillsAreNeverNested(t *testing.T) {
+	t.Run("global", func(t *testing.T) {
+		env := codexGlobalEnv(t)
+		if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+		assertSkillDepth(t, filepath.Join(env.Home, ".agents", "skills"))
+	})
+	t.Run("project", func(t *testing.T) {
+		env := codexProjectEnv(t)
+		if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+		assertSkillDepth(t, filepath.Join(env.Root, ".agents", "skills"))
+	})
+}
+
+// TestCodexSkillFrontmatterIsNameAndDescriptionOnly pins the envelope.
+// Codex uses those two keys and ignores the rest, and the file is shared
+// with OpenCode — every extra key is one more way for two adapters to
+// disagree byte-for-byte about a path they both write.
+func TestCodexSkillFrontmatterIsNameAndDescriptionOnly(t *testing.T) {
+	env := codexGlobalEnv(t)
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	skills, err := Skills()
+	if err != nil {
+		t.Fatalf("skills: %v", err)
+	}
+	for _, s := range skills {
+		path := filepath.Join(env.Home, ".agents", "skills", s.ID, "SKILL.md")
+		keys := frontmatterKeys(t, path)
+		if len(keys) != 2 || keys[0] != "name" || keys[1] != "description" {
+			t.Fatalf("%s frontmatter keys=%v want [name description]", path, keys)
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		// The Claude frontmatter must have been stripped, not stacked:
+		// two blocks in one file makes most hosts drop the skill.
+		if strings.Count(string(body), "\n---\n") > 1 {
+			t.Fatalf("%s carries a second frontmatter fence:\n%s", path, body)
+		}
+	}
+}
+
+// TestCodexKeepsUserEditedCuratedSkill pins the never-clobber posture.
+// `gortex install` runs again after every upgrade; a writer that
+// regenerated these would silently discard the user's edits each time.
+func TestCodexKeepsUserEditedCuratedSkill(t *testing.T) {
+	env := codexGlobalEnv(t)
+	a := New()
+	if _, err := a.Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	path := filepath.Join(env.Home, ".agents", "skills", "gortex-explore", "SKILL.md")
+	const edited = "---\nname: gortex-explore\ndescription: my own wording\n---\n\n# Mine\n"
+	if err := os.WriteFile(path, []byte(edited), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := a.Apply(env, agents.ApplyOpts{})
+	if err != nil {
+		t.Fatalf("second apply: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != edited {
+		t.Fatalf("user-edited skill was overwritten:\n%s", data)
+	}
+	for _, f := range res.Files {
+		if f.Path != path {
+			continue
+		}
+		if f.Action != agents.ActionSkip || f.Reason != "customised" {
+			t.Fatalf("action for %s = %s/%q want skip/customised", path, f.Action, f.Reason)
+		}
+	}
+}
+
+// TestCodexSkipsNonKebabGeneratedSkill: OpenCode and GitHub Copilot
+// refuse a non-kebab skill name at load time, and refuse it silently.
+// The same generated fixture flows to all three hosts, so a bad DirName
+// is dropped loudly here rather than written once and ignored thrice.
+func TestCodexSkipsNonKebabGeneratedSkill(t *testing.T) {
+	env := codexProjectEnv(t)
+	env.GeneratedSkills = []agents.GeneratedSkill{
+		{CommunityID: "bad", Label: "Bad Skill", DirName: "Gortex_Bad Skill", Content: "---\nname: bad\n---\n# Bad\n"},
+		{CommunityID: "good", Label: "good", DirName: "gortex-good", Content: "---\nname: gortex-good\n---\n# Good\n"},
+	}
+	buf := env.Stderr.(*bytes.Buffer)
+
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	got := skillDirNames(t, filepath.Join(env.Root, ".agents", "skills"))
+	if len(got) != 1 || got[0] != "gortex-good" {
+		t.Fatalf("skill dirs=%v want [gortex-good]", got)
+	}
+	if !strings.Contains(buf.String(), "kebab-case") {
+		t.Fatalf("expected a warning naming the kebab-case rule:\n%s", buf.String())
+	}
+
+	plan, err := New().Plan(env)
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	for _, f := range plan.Files {
+		if strings.Contains(f.Path, "Bad Skill") {
+			t.Fatalf("Plan advertised a skill Apply refuses to write: %s", f.Path)
+		}
+	}
+}
+
+// TestCodexPlanEnumeratesEverySkillPath: `gortex doctor` and
+// --print-config read Plan(), never Apply(), so a path missing from the
+// plan is invisible to both — a user chasing a missing skill has nothing
+// to compare against.
+func TestCodexPlanEnumeratesEverySkillPath(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		newEnv func(*testing.T) agents.Env
+	}{
+		{"global", codexGlobalEnv},
+		{"project", codexProjectEnv},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			env := tc.newEnv(t)
+			a := New()
+			plan, err := a.Plan(env)
+			if err != nil {
+				t.Fatalf("plan: %v", err)
+			}
+			planned := make(map[string]bool, len(plan.Files))
+			for _, f := range plan.Files {
+				planned[f.Path] = true
+			}
+
+			res, err := a.Apply(env, agents.ApplyOpts{})
+			if err != nil {
+				t.Fatalf("apply: %v", err)
+			}
+			written := 0
+			for _, f := range res.Files {
+				if filepath.Base(f.Path) != "SKILL.md" {
+					continue
+				}
+				written++
+				if !planned[f.Path] {
+					t.Fatalf("Apply wrote %s but Plan never listed it", f.Path)
+				}
+			}
+			if written == 0 {
+				t.Fatal("expected Apply to write at least one SKILL.md")
+			}
+		})
+	}
+}
+
+// TestCodexSkillsIdempotent: a re-run must skip every skill, in both
+// modes. `gortex install` / `gortex init` are re-run after every upgrade.
+func TestCodexSkillsIdempotent(t *testing.T) {
+	t.Run("global", func(t *testing.T) {
+		env := codexGlobalEnv(t)
+		a := New()
+		res, err := a.Apply(env, agents.ApplyOpts{})
+		if err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+		agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{
+			agents.ActionCreate: 1 + curatedSkillCount(t),
+		})
+		agentstest.AssertIdempotent(t, a, env)
+	})
+	t.Run("project", func(t *testing.T) {
+		env := codexProjectEnv(t)
+		a := New()
+		res, err := a.Apply(env, agents.ApplyOpts{})
+		if err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+		agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{
+			agents.ActionCreate: 2 + len(env.GeneratedSkills),
+		})
+		agentstest.AssertIdempotent(t, a, env)
+	})
+}
+
+// TestCodexSkillsDryRunTouchesNothing: --dry-run must plan the pack
+// without materialising it.
+func TestCodexSkillsDryRunTouchesNothing(t *testing.T) {
+	env := codexGlobalEnv(t)
+	res, err := New().Apply(env, agents.ApplyOpts{DryRun: true})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	assertNoSkillsDir(t, filepath.Join(env.Home, ".agents", "skills"))
+	wouldCreate := 0
+	for _, f := range res.Files {
+		if filepath.Base(f.Path) == "SKILL.md" && f.Action == agents.ActionWouldCreate {
+			wouldCreate++
+		}
+	}
+	if wouldCreate != curatedSkillCount(t) {
+		t.Fatalf("dry-run planned %d skills, want %d", wouldCreate, curatedSkillCount(t))
+	}
+}
+
+// codexProjectEnv is the ModeProject counterpart to codexGlobalEnv:
+// codex detected via ~/.codex, a stubbed version probe, and the
+// generated-skill fixture agentstest seeds.
+func codexProjectEnv(t *testing.T) agents.Env {
+	t.Helper()
+	t.Setenv(codexHookModeEnvVar, "")
+	stubCodexVersion(t, "codex-cli 0.147.0\n")
+	env, _ := agentstest.NewEnv(t)
+	if err := os.MkdirAll(filepath.Join(env.Home, ".codex"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return env
+}
+
+// curatedSkillCount is how many SKILL.md files a ModeGlobal Apply
+// writes. Derived, not hardcoded, so adding a playbook to the shipped
+// pack does not mean editing every count assertion in this package.
+func curatedSkillCount(t *testing.T) int {
+	t.Helper()
+	skills, err := Skills()
+	if err != nil {
+		t.Fatalf("skills: %v", err)
+	}
+	return len(skills)
+}
+
+// assertNoSkillsDir fails when dir exists at all — an empty directory we
+// created is still a directory the user has to wonder about.
+func assertNoSkillsDir(t *testing.T, dir string) {
+	t.Helper()
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return
+	} else if err != nil {
+		t.Fatalf("stat %s: %v", dir, err)
+	}
+	var found []string
+	if err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			found = append(found, path)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk %s: %v", dir, err)
+	}
+	t.Fatalf("nothing should be written to %s; found dir with files %v", dir, found)
+}
+
+// assertSkillDepth requires every file under root to sit exactly one
+// directory deep: <root>/<skill>/SKILL.md.
+func assertSkillDepth(t *testing.T, root string) {
+	t.Helper()
+	seen := 0
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		parts := strings.Split(rel, string(filepath.Separator))
+		if len(parts) != 2 || parts[1] != "SKILL.md" {
+			t.Fatalf("skill file %s is not <skill>/SKILL.md directly under %s", rel, root)
+		}
+		seen++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	if seen == 0 {
+		t.Fatalf("no skill files under %s", root)
+	}
+}
+
+// skillDirNames lists the immediate child directory names of root, or
+// nothing when root does not exist.
+func skillDirNames(t *testing.T, root string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(root)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("read dir %s: %v", root, err)
+	}
+	var out []string
+	for _, e := range entries {
+		if e.IsDir() {
+			out = append(out, e.Name())
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// frontmatterKeys returns the top-level YAML keys of path's leading
+// frontmatter block, in file order.
+func frontmatterKeys(t *testing.T, path string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	lines := strings.Split(string(data), "\n")
+	if len(lines) == 0 || lines[0] != "---" {
+		t.Fatalf("%s does not open with a frontmatter fence:\n%s", path, data)
+	}
+	var keys []string
+	for _, line := range lines[1:] {
+		if line == "---" {
+			return keys
+		}
+		key, _, ok := strings.Cut(line, ":")
+		if !ok {
+			t.Fatalf("%s has a non key/value frontmatter line %q", path, line)
+		}
+		keys = append(keys, key)
+	}
+	t.Fatalf("%s has an unterminated frontmatter block:\n%s", path, data)
+	return nil
+}
+
+// reportsPath reports whether res mentions path in its file actions.
+func reportsPath(res *agents.Result, path string) bool {
+	for _, f := range res.Files {
+		if f.Path == path {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/agents/codex/skills_test.go
+++ b/internal/agents/codex/skills_test.go
@@ -331,6 +331,82 @@ func TestCodexSkillsDryRunTouchesNothing(t *testing.T) {
 	}
 }
 
+// profileSubset is the three-skill shape an instruction profile like
+// `localization` narrows the pack to.
+var profileSubset = []string{"gortex-explore", "gortex-guide", "gortex-debug"}
+
+// TestCodexSyncSkillsNarrowsToProfileSubset is the point of the whole
+// exercise: `gortex instructions switch localization` must leave Codex
+// holding three playbooks, not twenty-one. Before this existed, only
+// Claude Code's picker shrank and every other host kept the full pack.
+func TestCodexSyncSkillsNarrowsToProfileSubset(t *testing.T) {
+	env := codexGlobalEnv(t)
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	root := filepath.Join(env.Home, ".agents", "skills")
+	if got := len(skillDirNames(t, root)); got != curatedSkillCount(t) {
+		t.Fatalf("install left %d skills, want the full pack (%d)", got, curatedSkillCount(t))
+	}
+
+	if _, err := SyncSkills(env.Stderr, env.Home, profileSubset, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("SyncSkills: %v", err)
+	}
+	want := append([]string(nil), profileSubset...)
+	sort.Strings(want)
+	if got := skillDirNames(t, root); strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("after the switch %v remain, want %v", got, want)
+	}
+}
+
+// TestCodexSyncSkillsKeepsCustomisedSkill: a profile is not worth a
+// user's edits. An out-of-profile playbook the user rewrote stays, byte
+// for byte, and the switch says so instead of silently shipping a wider
+// surface than requested.
+func TestCodexSyncSkillsKeepsCustomisedSkill(t *testing.T) {
+	env := codexGlobalEnv(t)
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	root := filepath.Join(env.Home, ".agents", "skills")
+	path := filepath.Join(root, "gortex-rename", "SKILL.md")
+	const mine = "---\nname: gortex-rename\ndescription: mine\n---\n\n# my own steps\n"
+	if err := os.WriteFile(path, []byte(mine), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	log := &bytes.Buffer{}
+	if _, err := SyncSkills(log, env.Home, profileSubset, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("SyncSkills: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("customised skill was deleted to satisfy a profile: %v", err)
+	}
+	if string(data) != mine {
+		t.Fatalf("customised skill was rewritten:\n%s", data)
+	}
+	if !strings.Contains(log.String(), "gortex-rename") {
+		t.Fatalf("expected a warning naming the kept skill, got:\n%s", log.String())
+	}
+}
+
+// TestCodexSyncSkillsWithoutAnInstalledRootIsANoOp: most machines run
+// one or two of the supported hosts. Switching a profile must not
+// conjure a Codex skills tree on a machine that never ran `gortex
+// install`, and must not fail because the tree is absent.
+func TestCodexSyncSkillsWithoutAnInstalledRootIsANoOp(t *testing.T) {
+	env := codexGlobalEnv(t)
+	actions, err := SyncSkills(env.Stderr, env.Home, profileSubset, agents.ApplyOpts{})
+	if err != nil {
+		t.Fatalf("SyncSkills on an uninstalled machine: %v", err)
+	}
+	if len(actions) != 0 {
+		t.Fatalf("actions = %v, want none", actions)
+	}
+	assertNoSkillsDir(t, filepath.Join(env.Home, ".agents", "skills"))
+}
+
 // codexProjectEnv is the ModeProject counterpart to codexGlobalEnv:
 // codex detected via ~/.codex, a stubbed version probe, and the
 // generated-skill fixture agentstest seeds.

--- a/internal/agents/codex/skills_test.go
+++ b/internal/agents/codex/skills_test.go
@@ -293,7 +293,7 @@ func TestCodexSkillsIdempotent(t *testing.T) {
 			t.Fatalf("apply: %v", err)
 		}
 		agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{
-			agents.ActionCreate: 1 + curatedSkillCount(t),
+			agents.ActionCreate: 1 + curatedSkillCount(t) + subAgentCount(),
 		})
 		agentstest.AssertIdempotent(t, a, env)
 	})

--- a/internal/agents/codex/subagents.go
+++ b/internal/agents/codex/subagents.go
@@ -1,0 +1,264 @@
+package codex
+
+// subagents.go installs Gortex's two sub-agents as Codex custom agents —
+// the CLI's delegation surface, its analogue of Claude Code's sub-agents.
+// Same bodies, same role: a fresh context that answers one delegated
+// question with the graph tools instead of burning the main session's
+// window.
+//
+// The envelope is deliberately four keys wide. Codex 0.147.0 parses an
+// agent file into a `#[serde(deny_unknown_fields)]` struct, so ONE
+// unrecognised key — a typo, a hopeful future field — rejects the whole
+// file, silently. There is no partial load and no warning: the agent
+// simply never appears. Everything written below is a key we can name
+// from the vendor docs, and nothing else is written at all.
+//
+// # `mcp_servers` is omitted on purpose
+//
+// The intuitive `mcp_servers = ["gortex"]` is not a thing. The key is a
+// TABLE of full server definitions (the same shape as a top-level
+// `[mcp_servers.<id>]` stanza), so the array form fails deserialization
+// with `invalid type: sequence, expected a map` — and, per the rule
+// above, takes the entire agent file down with it. Omitting the key
+// inherits the parent session's MCP servers, which is exactly what these
+// two agents need. Codex also has no allowlist semantics, so there is
+// nothing to gain by naming servers even in the correct shape: an agent
+// cannot be restricted to a subset. Same reasoning retires Claude's
+// `tools:` frontmatter, which is spelled in the `mcp__gortex__*`
+// vocabulary and has no Codex equivalent.
+//
+// # User-level only
+//
+// Personal agents live in `$CODEX_HOME/agents/`. A project-scoped
+// `<repo>/.codex/agents/` exists too, but it is gated on the project
+// being TRUSTED — an untrusted project's entire config layer is skipped,
+// so the directory is never even scanned. Writing there would be a
+// coin-flip on a state we cannot see from the installer, and it would put
+// Gortex files in the user's working tree, which `gortex init` never
+// does. ModeGlobal only, matching every other curated artifact here.
+//
+// # Discovery details worth not re-deriving
+//
+// The `.toml` extension is required and matched case-sensitively
+// lowercase — a `.TOML` file is ignored. The scan recurses into
+// subdirectories, but these are written flat. The agent's NAME comes from
+// the `name` key, not the filename; the file is still named after the
+// agent because that is the documented convention and it keeps
+// inspection and removal obvious.
+//
+// No feature flag is needed: `features.multi_agent` and `agents.enabled`
+// are both stable and default to true. (`multi_agent_v2` is a separate,
+// off-by-default surface and is not touched.)
+//
+// Docs: https://learn.chatgpt.com/codex (custom agents)
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/claudecode"
+	"github.com/zzet/gortex/internal/agents/internalutil"
+	"github.com/zzet/gortex/internal/agents/skillpack"
+)
+
+const (
+	// subAgentsDirName is the leaf under ~/.codex that Codex scans.
+	subAgentsDirName = "agents"
+	// subAgentFileExt is discovery-critical: required, and matched
+	// case-sensitively lowercase.
+	subAgentFileExt = ".toml"
+	// subAgentSandboxMode turns a written instruction into a guarantee.
+	// Both agents are read-only by contract — gortex-search only
+	// navigates, and gortex-impact's body says "Do not mutate files" —
+	// so the sandbox should not be able to grant more than the prompt
+	// asks for. `model` and `model_reasoning_effort` are equally legal
+	// here and are deliberately NOT written: those are the user's
+	// preference, not ours to pin.
+	subAgentSandboxMode = "read-only"
+)
+
+// SubAgentNames returns the sub-agent IDs, sorted, so Plan, Apply and the
+// uninstall preview stay byte-stable across runs.
+func SubAgentNames() []string {
+	names := make([]string, 0, len(claudecode.SubAgents))
+	for file := range claudecode.SubAgents {
+		names = append(names, subAgentID(file))
+	}
+	sort.Strings(names)
+	return names
+}
+
+// SubAgents renders claudecode.SubAgents into Codex agent TOML, keyed by
+// agent ID (the filename without any extension).
+func SubAgents() map[string]string {
+	out := make(map[string]string, len(claudecode.SubAgents))
+	for file, claudeBody := range claudecode.SubAgents {
+		id := subAgentID(file)
+		skill, err := skillpack.Parse(id, claudeBody)
+		if err != nil {
+			// Compile-time constants: only reachable if claudecode is
+			// edited into a shape skillpack rejects. Skip rather than
+			// install an agent whose frontmatter we could not rewrite.
+			continue
+		}
+		out[id] = renderSubAgent(skill)
+	}
+	return out
+}
+
+// renderSubAgent emits the four-key agent file.
+//
+// `developer_instructions` is a multi-line LITERAL string — the form
+// delimited by three apostrophes, which processes no escape sequences at
+// all. The bodies are Go raw-string constants full of backticks and
+// double quotes, and a future edit could easily introduce a backslash;
+// inside the basic multi-line form (three double quotes) that backslash
+// would be read as an escape and either mangle the text or reject the
+// file. A literal string has no such failure mode.
+//
+// The two things a literal string cannot hold are a run of three
+// apostrophes and a trailing apostrophe adjacent to the closing
+// delimiter. The renderer puts its own newline before the delimiter so
+// the second case cannot arise here, and subagents_test.go fails loudly
+// on either — a mangled file is worth a build break, not a silent skip.
+func renderSubAgent(skill skillpack.Skill) string {
+	var b strings.Builder
+	b.WriteString("name = " + quoteTOMLBasicString(skill.ID) + "\n")
+	b.WriteString("description = " + quoteTOMLBasicString(skill.Description) + "\n")
+	b.WriteString("sandbox_mode = " + quoteTOMLBasicString(subAgentSandboxMode) + "\n")
+	b.WriteString("developer_instructions = '''\n")
+	b.WriteString(subAgentInstructions(skill))
+	b.WriteString("\n'''\n")
+	return b.String()
+}
+
+// subAgentInstructions is the exact text that lands between the
+// delimiters. Split out so the safety test can check the embedded string
+// itself rather than re-deriving it from the rendered file.
+func subAgentInstructions(skill skillpack.Skill) string {
+	return strings.Trim(skill.Body, "\n")
+}
+
+// quoteTOMLBasicString renders s as a TOML basic string.
+//
+// skillpack.QuoteYAMLValue is the wrong tool despite the superficial
+// resemblance: it returns identifier-ish values UNQUOTED (`gortex-search`
+// comes back bare), which is a YAML convenience and a TOML syntax error —
+// TOML has no bare values. Its escape set is YAML's, too. So this is a
+// small TOML-correct quoter rather than a reuse.
+func quoteTOMLBasicString(s string) string {
+	var b strings.Builder
+	b.Grow(len(s) + 2)
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		case '\b':
+			b.WriteString(`\b`)
+		case '\t':
+			b.WriteString(`\t`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\f':
+			b.WriteString(`\f`)
+		case '\r':
+			b.WriteString(`\r`)
+		default:
+			// Every other control character needs the \uXXXX form; TOML
+			// forbids raw control characters inside a basic string.
+			if r < 0x20 || r == 0x7f {
+				fmt.Fprintf(&b, `\u%04X`, r)
+				continue
+			}
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+// subAgentID strips the ".md" claudecode uses as its map key, leaving the
+// bare name the Codex filename and the `name` key both carry.
+func subAgentID(file string) string {
+	return strings.TrimSuffix(file, ".md")
+}
+
+// subAgentsDir is ~/.codex/agents. An empty home yields "" rather than a
+// relative path — see installSubAgents.
+func subAgentsDir(home string) string {
+	if home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".codex", subAgentsDirName)
+}
+
+// subAgentPath is ~/.codex/agents/<id>.toml, flat.
+func subAgentPath(home, id string) string {
+	dir := subAgentsDir(home)
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, id+subAgentFileExt)
+}
+
+// installSubAgents writes the agent files, ModeGlobal only.
+//
+// An empty Home is refused rather than defaulted, the same guard
+// installCuratedSkills carries: filepath.Join onto an empty home yields a
+// RELATIVE ".codex/agents/…", so the artifacts would land in whatever
+// directory the process happens to be in — most often the user's repo.
+//
+// WriteIfNotExists, not WriteOwnedFile: a user who tuned a description or
+// pinned a `model` keeps their copy across re-installs.
+func installSubAgents(env agents.Env, opts agents.ApplyOpts) []agents.FileAction {
+	if env.Mode != agents.ModeGlobal || env.Home == "" {
+		return nil
+	}
+	defs := SubAgents()
+	out := make([]agents.FileAction, 0, len(defs))
+	for _, id := range SubAgentNames() {
+		body, ok := defs[id]
+		if !ok {
+			continue
+		}
+		path := subAgentPath(env.Home, id)
+		if path == "" {
+			continue
+		}
+		action, err := agents.WriteIfNotExists(env.Stderr, path, body, opts)
+		if err != nil {
+			internalutil.Warnf(env.Stderr, "codex sub-agent %s: %v", id, err)
+			continue
+		}
+		out = append(out, action)
+	}
+	return out
+}
+
+// planSubAgents enumerates what installSubAgents would write. `gortex
+// doctor` and `--print-config` read Plan(), never Apply(), so a path Apply
+// writes but Plan omits is invisible to both.
+func planSubAgents(env agents.Env) []agents.FileAction {
+	if env.Mode != agents.ModeGlobal || env.Home == "" {
+		return nil
+	}
+	out := make([]agents.FileAction, 0, len(claudecode.SubAgents))
+	for _, id := range SubAgentNames() {
+		path := subAgentPath(env.Home, id)
+		if path == "" {
+			continue
+		}
+		out = append(out, agents.FileAction{
+			Path:   path,
+			Action: agents.ActionWouldCreate,
+			Keys:   []string{"sub-agent"},
+		})
+	}
+	return out
+}

--- a/internal/agents/codex/subagents_test.go
+++ b/internal/agents/codex/subagents_test.go
@@ -1,0 +1,415 @@
+package codex
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	toml "github.com/pelletier/go-toml/v2"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/claudecode"
+	"github.com/zzet/gortex/internal/agents/skillpack"
+)
+
+// subAgentKeys is the complete key set a Codex agent file may carry from
+// us. Codex parses the file into a `#[serde(deny_unknown_fields)]`
+// struct, so a fifth key of any spelling voids the WHOLE file — silently,
+// with no warning and no partial load. Pinning the set exactly is the
+// only cheap defence against that.
+var subAgentKeys = []string{"description", "developer_instructions", "name", "sandbox_mode"}
+
+// TestCodexGlobalModeInstallsSubAgents pins the discovery-critical
+// filename: lowercase `.toml`, flat under ~/.codex/agents.
+func TestCodexGlobalModeInstallsSubAgents(t *testing.T) {
+	env := codexGlobalEnv(t)
+	res, err := New().Apply(env, agents.ApplyOpts{})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	names := SubAgentNames()
+	if len(names) != len(claudecode.SubAgents) {
+		t.Fatalf("rendered %d sub-agents, want %d", len(names), len(claudecode.SubAgents))
+	}
+	if len(names) == 0 {
+		t.Fatal("sub-agent set is empty")
+	}
+	for _, id := range names {
+		path := filepath.Join(env.Home, ".codex", "agents", id+".toml")
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("sub-agent not installed at %s: %v", path, err)
+		}
+		if !reportsPath(res, path) {
+			t.Fatalf("apply did not report %s in its file actions", path)
+		}
+	}
+
+	// The extension is matched case-sensitively lowercase, and the write
+	// must stay flat even though the scan recurses.
+	assertFlatLowercaseTOML(t, filepath.Join(env.Home, ".codex", "agents"))
+}
+
+// TestCodexSubAgentsAreUserLevelOnly: a project-scoped
+// `<repo>/.codex/agents/` is only scanned when the project is TRUSTED —
+// an untrusted project's whole config layer is skipped — so writing there
+// is a gamble on state the installer cannot see. It would also put Gortex
+// files in the user's working tree, which `gortex init` never does.
+func TestCodexSubAgentsAreUserLevelOnly(t *testing.T) {
+	env := codexProjectEnv(t)
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	for _, dir := range []string{
+		filepath.Join(env.Home, ".codex", "agents"),
+		filepath.Join(env.Root, ".codex", "agents"),
+	} {
+		if _, err := os.Stat(dir); !os.IsNotExist(err) {
+			t.Errorf("project mode wrote %s (stat err=%v)", dir, err)
+		}
+	}
+}
+
+// TestCodexSubAgentOmitsMcpServersBecauseTheArrayFormVoidsTheFile is the
+// negative test this whole file exists for.
+//
+// `mcp_servers = ["gortex"]` — the intuitive shape — is not an array of
+// server names. The key is a TABLE of full server definitions, so the
+// array form fails deserialization with `invalid type: sequence, expected
+// a map`, and under deny_unknown_fields that rejects the ENTIRE agent
+// file: no agent, no warning. Omitting the key inherits the parent
+// session's MCP servers, which is what we want, and Codex has no
+// allowlist semantics — an agent cannot be restricted to a subset of
+// servers — so there is nothing to gain by writing it even correctly.
+func TestCodexSubAgentOmitsMcpServersBecauseTheArrayFormVoidsTheFile(t *testing.T) {
+	for id, body := range SubAgents() {
+		if strings.Contains(body, "mcp_servers") {
+			t.Errorf("sub-agent %s names mcp_servers; the array form voids the whole file and there is no allowlist to gain:\n%s", id, body)
+		}
+		var decoded map[string]any
+		if err := toml.Unmarshal([]byte(body), &decoded); err != nil {
+			t.Fatalf("sub-agent %s does not parse: %v\n%s", id, err, body)
+		}
+		if _, exists := decoded["mcp_servers"]; exists {
+			t.Errorf("sub-agent %s decoded an mcp_servers key: %#v", id, decoded)
+		}
+	}
+}
+
+// TestCodexSubAgentTOMLRoundTrips parses every rendered agent with the
+// same library Codex's config path uses here and asserts the three
+// required keys are present and non-blank (whitespace-only counts as
+// missing and is rejected), plus that the key set is EXACTLY the four we
+// can name — the deny_unknown_fields guard.
+func TestCodexSubAgentTOMLRoundTrips(t *testing.T) {
+	for id, body := range SubAgents() {
+		var decoded map[string]any
+		if err := toml.Unmarshal([]byte(body), &decoded); err != nil {
+			t.Fatalf("sub-agent %s does not parse as TOML: %v\n%s", id, err, body)
+		}
+
+		got := make([]string, 0, len(decoded))
+		for key := range decoded {
+			got = append(got, key)
+		}
+		sort.Strings(got)
+		if strings.Join(got, ",") != strings.Join(subAgentKeys, ",") {
+			t.Fatalf("sub-agent %s keys=%v want exactly %v", id, got, subAgentKeys)
+		}
+
+		for _, key := range []string{"name", "description", "developer_instructions"} {
+			value, _ := decoded[key].(string)
+			if strings.TrimSpace(value) == "" {
+				t.Errorf("sub-agent %s: %s is blank; Codex rejects the file", id, key)
+			}
+		}
+		if decoded["name"] != id {
+			t.Errorf("sub-agent %s: name=%v — the agent's name comes from this key, not the filename", id, decoded["name"])
+		}
+		// Read-only by contract, so read-only by sandbox: gortex-search
+		// only navigates and gortex-impact's body says "Do not mutate
+		// files".
+		if decoded["sandbox_mode"] != "read-only" {
+			t.Errorf("sub-agent %s: sandbox_mode=%v want read-only", id, decoded["sandbox_mode"])
+		}
+		// The user's model preference is not ours to pin.
+		for _, key := range []string{"model", "model_reasoning_effort"} {
+			if _, exists := decoded[key]; exists {
+				t.Errorf("sub-agent %s pins %s, which belongs to the user", id, key)
+			}
+		}
+	}
+}
+
+// TestCodexSubAgentInstructionsFitALiteralString guards the other way an
+// agent file breaks silently.
+//
+// `developer_instructions` is a multi-line LITERAL string — the form
+// delimited by three apostrophes — chosen because it processes no escape
+// sequences. The bodies are Go raw-string constants full of backticks and
+// quotes, and a future backslash would be an escape inside the basic
+// (three double quotes) form. What a literal string cannot hold is a run
+// of three apostrophes, or a trailing apostrophe adjacent to the closing
+// delimiter (that would make four in a row, which TOML forbids). The
+// renderer's own newline currently
+// separates the body from the delimiter, so the second half of this check
+// is conservative on purpose: it stays correct if that newline is ever
+// removed, and a loud build failure beats a silently mangled agent.
+func TestCodexSubAgentInstructionsFitALiteralString(t *testing.T) {
+	skills := subAgentSkills(t)
+	if len(skills) == 0 {
+		t.Fatal("sub-agent set is empty")
+	}
+	for _, skill := range skills {
+		body := subAgentInstructions(skill)
+		if strings.Contains(body, "'''") {
+			t.Errorf("sub-agent %s body contains ''' and cannot be embedded in a TOML literal string", skill.ID)
+		}
+		if strings.HasSuffix(body, "'") {
+			t.Errorf("sub-agent %s body ends with an apostrophe; adjacent to ''' that is four in a row, which TOML forbids", skill.ID)
+		}
+		// The apostrophes that DO appear ("an operation's arguments") are
+		// exactly why the guard above is not vacuous.
+		rendered := renderSubAgent(skill)
+		if !strings.Contains(rendered, "developer_instructions = '''\n") {
+			t.Errorf("sub-agent %s does not use a multi-line literal string:\n%s", skill.ID, rendered)
+		}
+	}
+}
+
+// TestCodexSubAgentQuotingIsTOMLNotYAML pins why skillpack.QuoteYAMLValue
+// is not reused: it returns identifier-ish values UNQUOTED, and TOML has
+// no bare values, so `name = gortex-search` would be a syntax error.
+func TestCodexSubAgentQuotingIsTOMLNotYAML(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"gortex-search", `"gortex-search"`},
+		{`say "hi"`, `"say \"hi\""`},
+		{`back\slash`, `"back\\slash"`},
+		{"line\nbreak", `"line\nbreak"`},
+		{"bell\x07", `"bell\u0007"`},
+	} {
+		if got := quoteTOMLBasicString(tc.in); got != tc.want {
+			t.Errorf("quoteTOMLBasicString(%q)=%s want %s", tc.in, got, tc.want)
+		}
+	}
+	var decoded map[string]any
+	if err := toml.Unmarshal([]byte("name = "+quoteTOMLBasicString(`a "quoted" \ value`)+"\n"), &decoded); err != nil {
+		t.Fatalf("quoted value does not parse: %v", err)
+	}
+	if decoded["name"] != `a "quoted" \ value` {
+		t.Errorf("round trip lost the value: %#v", decoded["name"])
+	}
+}
+
+// TestCodexSubAgentIsNeverOverwritten covers the full ownership contract
+// for a tuned copy: a second Apply leaves it alone, RemoveGlobal keeps
+// it, and the uninstall preview never promises to delete it.
+func TestCodexSubAgentIsNeverOverwritten(t *testing.T) {
+	env := codexGlobalEnv(t)
+	a := New()
+	if _, err := a.Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+
+	path := subAgentPath(env.Home, "gortex-search")
+	const custom = "name = \"gortex-search\"\ndescription = \"mine\"\ndeveloper_instructions = '''\nmy own instructions\n'''\n"
+	if err := os.WriteFile(path, []byte(custom), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := a.Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("second apply: %v", err)
+	}
+	if got := readCodexFile(t, path); got != custom {
+		t.Fatalf("customised sub-agent was overwritten:\n%s", got)
+	}
+
+	for _, listed := range GlobalArtifacts(env.Home) {
+		if listed == path {
+			t.Errorf("the preview promises to delete a customised sub-agent: %s", listed)
+		}
+	}
+	if _, failures := a.RemoveGlobal(env, agents.ApplyOpts{}); len(failures) != 0 {
+		t.Fatalf("RemoveGlobal failures: %v", failures)
+	}
+	if got := readCodexFile(t, path); got != custom {
+		t.Fatalf("the customised sub-agent was changed or deleted:\n%s", got)
+	}
+}
+
+// TestCodexRemoveGlobalRemovesSubAgentsAndPrunesTheDirectory is the
+// round-trip: install then uninstall leaves no Gortex agent file and no
+// empty directory to wonder about.
+func TestCodexRemoveGlobalRemovesSubAgentsAndPrunesTheDirectory(t *testing.T) {
+	env := codexGlobalEnv(t)
+	a := New()
+	if _, err := a.Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	dir := filepath.Join(env.Home, ".codex", "agents")
+
+	listed := make(map[string]bool)
+	for _, path := range GlobalArtifacts(env.Home) {
+		listed[path] = true
+	}
+	for _, id := range SubAgentNames() {
+		if !listed[subAgentPath(env.Home, id)] {
+			t.Fatalf("GlobalArtifacts omits sub-agent %s: %v", id, GlobalArtifacts(env.Home))
+		}
+	}
+
+	if _, failures := a.RemoveGlobal(env, agents.ApplyOpts{}); len(failures) != 0 {
+		t.Fatalf("RemoveGlobal failures: %v", failures)
+	}
+	for _, id := range SubAgentNames() {
+		if _, err := os.Stat(subAgentPath(env.Home, id)); !os.IsNotExist(err) {
+			t.Errorf("sub-agent %s survived removal (stat err=%v)", id, err)
+		}
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("the emptied agents directory was not pruned (stat err=%v)", err)
+	}
+	for _, path := range GlobalArtifacts(env.Home) {
+		if strings.Contains(path, string(filepath.Separator)+"agents"+string(filepath.Separator)) {
+			t.Errorf("GlobalArtifacts still lists %s after removal", path)
+		}
+	}
+}
+
+// TestCodexRemoveGlobalKeepsAUsersOwnAgent: ~/.codex/agents is the user's
+// own agent root. A hand-written agent beside ours survives byte-identical
+// and keeps the directory alive — the same posture the shared skills root
+// gets.
+func TestCodexRemoveGlobalKeepsAUsersOwnAgent(t *testing.T) {
+	env := codexGlobalEnv(t)
+	a := New()
+	if _, err := a.Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	dir := filepath.Join(env.Home, ".codex", "agents")
+	mine := filepath.Join(dir, "mine.toml")
+	const body = "name = \"mine\"\ndescription = \"my own agent\"\ndeveloper_instructions = '''\ndo my thing\n'''\n"
+	if err := os.WriteFile(mine, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, failures := a.RemoveGlobal(env, agents.ApplyOpts{}); len(failures) != 0 {
+		t.Fatalf("RemoveGlobal failures: %v", failures)
+	}
+	if got := readCodexFile(t, mine); got != body {
+		t.Fatalf("the user's own agent changed:\n%s", got)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("the agents directory was pruned out from under the user's agent: %v", err)
+	}
+}
+
+// TestCodexPlanEnumeratesEverySubAgentPath: `gortex doctor` and
+// --print-config read Plan(), never Apply(), so a path Apply writes but
+// Plan omits is invisible to both.
+func TestCodexPlanEnumeratesEverySubAgentPath(t *testing.T) {
+	env := codexGlobalEnv(t)
+	a := New()
+	plan, err := a.Plan(env)
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	planned := make(map[string]bool, len(plan.Files))
+	for _, f := range plan.Files {
+		planned[f.Path] = true
+	}
+	for _, id := range SubAgentNames() {
+		path := subAgentPath(env.Home, id)
+		if !planned[path] {
+			t.Fatalf("Plan omitted %s: %#v", path, plan.Files)
+		}
+	}
+
+	// Project mode plans nothing, matching Apply.
+	projectPlan, err := a.Plan(codexProjectEnv(t))
+	if err != nil {
+		t.Fatalf("project plan: %v", err)
+	}
+	for _, f := range projectPlan.Files {
+		if strings.HasSuffix(f.Path, ".toml") && strings.Contains(f.Path, "agents") {
+			t.Errorf("project mode planned a sub-agent: %s", f.Path)
+		}
+	}
+}
+
+// TestCodexSubAgentsRefuseAnEmptyHome: filepath.Join onto an empty home
+// yields a RELATIVE path, so the agents would land in whatever directory
+// the process is standing in — most often the user's repo.
+func TestCodexSubAgentsRefuseAnEmptyHome(t *testing.T) {
+	env := agents.Env{Mode: agents.ModeGlobal}
+	if got := installSubAgents(env, agents.ApplyOpts{}); len(got) != 0 {
+		t.Fatalf("installSubAgents with no home returned %#v", got)
+	}
+	if got := planSubAgents(env); len(got) != 0 {
+		t.Fatalf("planSubAgents with no home returned %#v", got)
+	}
+	if got := subAgentPath("", "gortex-search"); got != "" {
+		t.Fatalf("subAgentPath with no home = %q, want empty", got)
+	}
+}
+
+// subAgentSkills re-parses the shared bodies the way SubAgents does, so a
+// test can inspect the neutral Skill rather than the rendered file.
+func subAgentSkills(t *testing.T) []skillpack.Skill {
+	t.Helper()
+	out := make([]skillpack.Skill, 0, len(claudecode.SubAgents))
+	for file, body := range claudecode.SubAgents {
+		skill, err := skillpack.Parse(subAgentID(file), body)
+		if err != nil {
+			t.Fatalf("parse %s: %v", file, err)
+		}
+		out = append(out, skill)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+// assertFlatLowercaseTOML fails when the agents directory holds a
+// subdirectory or a file whose extension is not lowercase `.toml`. The
+// scan recurses, but the extension match is case-sensitive: a `.TOML`
+// file is ignored with no error at all.
+func assertFlatLowercaseTOML(t *testing.T, dir string) {
+	t.Helper()
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if path == dir {
+			return nil
+		}
+		if d.IsDir() {
+			t.Errorf("sub-agents must be written flat, found directory %s", path)
+			return fs.SkipDir
+		}
+		if filepath.Ext(d.Name()) != ".toml" {
+			t.Errorf("%s is not a lowercase .toml file; Codex ignores it silently", path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", dir, err)
+	}
+}
+
+// subAgentCount is how many agent files a ModeGlobal Apply writes.
+// Derived, not hardcoded — the same reason curatedSkillCount is — so
+// shipping a third sub-agent does not mean editing every count assertion
+// in this package.
+func subAgentCount() int { return len(SubAgentNames()) }
+
+func readCodexFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}

--- a/internal/agents/copilotcli/adapter.go
+++ b/internal/agents/copilotcli/adapter.go
@@ -1,0 +1,443 @@
+// Package copilotcli implements the Gortex init integration for the
+// standalone GitHub Copilot CLI — the `copilot` binary shipped as the
+// npm package @github/copilot. It is a different host from the `vscode`
+// adapter in this tree: that one wires GitHub Copilot *inside* VS Code
+// (.vscode/mcp.json), while this one wires the terminal CLI, whose
+// configuration lives under ~/.copilot/ (or $COPILOT_HOME).
+//
+// Two schema quirks are worth recording, because the two Copilot hosts
+// disagree on both and a maintainer reading only the VS Code adapter
+// will get them backwards:
+//
+//  1. The MCP file's top-level key is "mcpServers" — NOT VS Code's
+//     "servers". A config written under "servers" parses fine and
+//     yields zero registered servers, so the failure is silent.
+//  2. Every server entry needs an explicit transport discriminator,
+//     "type": "local", next to command/args/env. VS Code infers stdio
+//     from the presence of a command, which is why
+//     agents.DefaultGortexMCPEntry() emits no "type" — reusing it
+//     verbatim here produces an entry the CLI will not launch.
+//
+// A third quirk lives in discovery rather than schema: the CLI walks
+// cwd upward looking for a repo-level .mcp.json / .github/mcp.json, and
+// what it finds there takes precedence over ~/.copilot/mcp-config.json.
+// Gortex's claudecode adapter owns a repo .mcp.json whose gortex entry
+// predates both rules above, so in project mode this adapter reconciles
+// that entry in place (reconcileRepoMCPJSON) instead of letting a stale
+// file shadow the user-level config we just wrote.
+//
+// Two surfaces this adapter deliberately does NOT write:
+//   - ~/.claude/* — the CLI stopped loading Claude's directories in
+//     v1.0.36, so anything written there is dead weight.
+//   - .github/prompts/*.prompt.md — prompt files are a VS Code chat
+//     feature the CLI has never supported.
+//
+// Docs: https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers
+package copilotcli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/internalutil"
+)
+
+const (
+	Name    = "copilot-cli"
+	DocsURL = "https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers"
+)
+
+const (
+	// copilotHomeEnvVar relocates the CLI's whole config directory.
+	copilotHomeEnvVar = "COPILOT_HOME"
+	// copilotConfigDirName is the default config home under $HOME.
+	copilotConfigDirName = ".copilot"
+	// mcpConfigFileName is the CLI's MCP registry. Note the name differs
+	// from every other host's mcp.json.
+	mcpConfigFileName = "mcp-config.json"
+	// instructionsFileName is used at both levels: ~/.copilot/ for the
+	// user-wide rules and .github/ for the repo's own.
+	instructionsFileName = "copilot-instructions.md"
+	// localTransport is the "type" discriminator a stdio server needs.
+	localTransport = "local"
+	// serverName is the key our entry lives under in mcpServers.
+	serverName = "gortex"
+)
+
+type Adapter struct{}
+
+func New() *Adapter                { return &Adapter{} }
+func (a *Adapter) Name() string    { return Name }
+func (a *Adapter) DocsURL() string { return DocsURL }
+
+// lookCopilotBinary is a seam so the "no Copilot installed" detection
+// test stays hermetic on a developer machine that happens to have the
+// CLI on PATH.
+var lookCopilotBinary = func() (string, error) { return exec.LookPath("copilot") }
+
+// Detect looks for the `copilot` binary or an existing config home.
+// Deliberately never keys off .vscode — Copilot-in-VS-Code is the
+// `vscode` adapter's host, and detecting on it here would configure the
+// CLI for users who have never installed it.
+func (a *Adapter) Detect(env agents.Env) (bool, error) {
+	if p, err := lookCopilotBinary(); err == nil && p != "" {
+		return true, nil
+	}
+	home := copilotConfigHome(env)
+	if home == "" {
+		return false, nil
+	}
+	if _, err := os.Stat(home); err == nil {
+		return true, nil
+	}
+	return false, nil
+}
+
+// copilotConfigHome resolves the directory the CLI reads its config
+// from. $COPILOT_HOME wins — but only when Env.Home is the machine's
+// real home. A sandbox Env (adapter tests, the `gortex agents render`
+// drift fence) has to stay inside its temp root; an exported
+// COPILOT_HOME in the developer's shell would otherwise redirect those
+// writes onto the real config and make the render golden
+// machine-dependent.
+func copilotConfigHome(env agents.Env) string {
+	if override := strings.TrimSpace(os.Getenv(copilotHomeEnvVar)); override != "" && isRealUserHome(env.Home) {
+		return override
+	}
+	if env.Home == "" {
+		return ""
+	}
+	return filepath.Join(env.Home, copilotConfigDirName)
+}
+
+func isRealUserHome(home string) bool {
+	if home == "" {
+		return false
+	}
+	real, err := os.UserHomeDir()
+	if err != nil || real == "" {
+		return false
+	}
+	return filepath.Clean(real) == filepath.Clean(home)
+}
+
+// MCPConfigPath is where the CLI's MCP registry lives for this Env.
+func MCPConfigPath(env agents.Env) string {
+	home := copilotConfigHome(env)
+	if home == "" {
+		return ""
+	}
+	return filepath.Join(home, mcpConfigFileName)
+}
+
+// GlobalInstructionsPath is the CLI's user-level instructions file. The
+// CLI merges it into every session ahead of the repo's own
+// .github/copilot-instructions.md, which makes it the Copilot analogue
+// of ~/.claude/CLAUDE.md and ~/.codex/AGENTS.md.
+func GlobalInstructionsPath(env agents.Env) string {
+	home := copilotConfigHome(env)
+	if home == "" {
+		return ""
+	}
+	return filepath.Join(home, instructionsFileName)
+}
+
+// repoInstructionsPath is the per-repo instructions file. Shared with
+// the `vscode` adapter on purpose: both hosts read the same file, so
+// both adapters upsert the same marker-fenced block into it and a repo
+// running both converges on one block rather than two.
+func repoInstructionsPath(root string) string {
+	return filepath.Join(root, ".github", instructionsFileName)
+}
+
+// repoMCPJSONPath is claudecode's file, not ours. We only ever
+// reconcile a Gortex-authored entry already inside it — see
+// reconcileRepoMCPJSON.
+func repoMCPJSONPath(root string) string {
+	return filepath.Join(root, ".mcp.json")
+}
+
+func (a *Adapter) Plan(env agents.Env) (*agents.Plan, error) {
+	p := &agents.Plan{}
+	if path := MCPConfigPath(env); path != "" {
+		p.Files = append(p.Files, agents.FileAction{
+			Path: path, Action: agents.ActionWouldMerge, Keys: []string{"mcpServers"},
+		})
+	}
+	if env.Mode == agents.ModeGlobal && env.InstallGlobalInstructions {
+		if path := GlobalInstructionsPath(env); path != "" {
+			p.Files = append(p.Files, agents.FileAction{
+				Path: path, Action: agents.ActionWouldMerge, Keys: []string{"gortex-rules-block"},
+			})
+		}
+	}
+	if env.Mode != agents.ModeGlobal {
+		if env.SkillsRouting != "" {
+			p.Files = append(p.Files, agents.FileAction{
+				Path: repoInstructionsPath(env.Root), Action: agents.ActionWouldMerge,
+				Keys: []string{"communities-block"},
+			})
+		}
+		// Only planned when the file is already there with an entry we
+		// authored: this adapter never creates .mcp.json.
+		if repoMCPJSONHasGortexEntry(repoMCPJSONPath(env.Root)) {
+			p.Files = append(p.Files, agents.FileAction{
+				Path: repoMCPJSONPath(env.Root), Action: agents.ActionWouldMerge,
+				Keys: []string{"mcpServers"},
+			})
+		}
+	}
+	return p, nil
+}
+
+func (a *Adapter) Apply(env agents.Env, opts agents.ApplyOpts) (*agents.Result, error) {
+	res := &agents.Result{Name: Name, DocsURL: DocsURL}
+	detected, _ := a.Detect(env)
+	res.Detected = detected
+	if !detected && !opts.ForceDetect {
+		internalutil.Logf(env.Stderr, "[gortex init] skip GitHub Copilot CLI setup (copilot not detected)")
+		return res, nil
+	}
+	mcpPath := MCPConfigPath(env)
+	if mcpPath == "" {
+		return res, fmt.Errorf("copilot-cli: requires a resolved home directory")
+	}
+	internalutil.Logf(env.Stderr, "[gortex init] setting up GitHub Copilot CLI integration...")
+
+	action, err := agents.MergeJSON(env.Stderr, mcpPath, func(root map[string]any, _ bool) (bool, error) {
+		return upsertCopilotMCPServer(root, env.Stderr, mcpPath, opts), nil
+	}, opts)
+	if err != nil {
+		return res, err
+	}
+	res.Files = append(res.Files, action)
+
+	// User-level instructions → ~/.copilot/copilot-instructions.md. The
+	// CLI reads plain markdown and has no @-include mechanism, so the
+	// active profile body is inlined (Claude Code gets a pointer block
+	// instead) and refreshed in place on every install.
+	if env.Mode == agents.ModeGlobal && env.InstallGlobalInstructions {
+		insAction, err := upsertGlobalInstructions(env, opts)
+		if err != nil {
+			return res, fmt.Errorf("copilot-cli global instructions: %w", err)
+		}
+		res.Files = append(res.Files, insAction)
+	}
+
+	if env.Mode != agents.ModeGlobal {
+		if env.SkillsRouting != "" {
+			routingAction, err := agents.UpsertMarkedBlock(env.Stderr, repoInstructionsPath(env.Root), env.SkillsRouting,
+				agents.CommunitiesStartMarker, agents.CommunitiesEndMarker, opts)
+			if err != nil {
+				return res, err
+			}
+			res.Files = append(res.Files, routingAction)
+		}
+		repoAction, wrote, err := reconcileRepoMCPJSON(env, opts)
+		if err != nil {
+			return res, err
+		}
+		if wrote {
+			res.Files = append(res.Files, repoAction)
+		}
+	}
+
+	res.Configured = true
+	return res, nil
+}
+
+// upsertGlobalInstructions writes the machine-wide Gortex rule block
+// into the CLI's user-level instructions file. Without it a Copilot CLI
+// session carries no standing rule: the MCP server's `instructions`
+// field is not guaranteed to reach the model, so most turns arrive with
+// nothing and the model falls back to shell reads and greps.
+func upsertGlobalInstructions(env agents.Env, opts agents.ApplyOpts) (agents.FileAction, error) {
+	path := GlobalInstructionsPath(env)
+	action, err := agents.UpsertMarkedBlock(nil, path, agents.GlobalInlineBody(agents.InstructionsDir(env)),
+		agents.GlobalRulesStartMarker, agents.GlobalRulesEndMarker, opts)
+	if err != nil {
+		return agents.FileAction{}, err
+	}
+	// UpsertMarkedBlock is shared with the per-repo communities block, so
+	// it labels every action with "communities-block". Relabel here so the
+	// install report distinguishes the two.
+	if action.Keys != nil {
+		action.Keys = []string{"gortex-rules-block"}
+	}
+	if !opts.DryRun && action.Action != agents.ActionSkip {
+		internalutil.Logf(env.Stderr, "[gortex install] wrote rule block to %s", path)
+	}
+	return action, nil
+}
+
+// gortexMCPEntry is the shared {command, args, env} stanza plus the
+// transport discriminator the CLI requires. Built from
+// agents.DefaultGortexMCPEntry so the launch command and args stay in
+// lockstep with every other adapter — only "type" is Copilot-specific.
+func gortexMCPEntry() map[string]any {
+	entry := agents.DefaultGortexMCPEntry()
+	entry["type"] = localTransport
+	return entry
+}
+
+// upsertCopilotMCPServer registers Gortex under "mcpServers" in the
+// CLI's own config. An entry we did not author is left exactly as it is
+// (the user owns it); one we did author is upgraded in place, which is
+// how a config written before the "type" discriminator was known heals
+// itself on the next run.
+func upsertCopilotMCPServer(root map[string]any, w io.Writer, path string, opts agents.ApplyOpts) bool {
+	servers, ok := root["mcpServers"].(map[string]any)
+	if !ok {
+		if _, exists := root["mcpServers"]; exists {
+			// Present but not an object: a shape we don't understand and
+			// must not overwrite.
+			return false
+		}
+		servers = make(map[string]any)
+	}
+	existing, exists := servers[serverName]
+	if !exists || opts.Force {
+		servers[serverName] = gortexMCPEntry()
+		root["mcpServers"] = servers
+		return true
+	}
+	if !agents.IsGortexAuthoredMCPEntry(existing) {
+		return false
+	}
+	entry, ok := existing.(map[string]any)
+	if !ok {
+		return false
+	}
+	if !reconcileCopilotEntry(entry, w, path) {
+		return false
+	}
+	servers[serverName] = entry
+	root["mcpServers"] = servers
+	return true
+}
+
+// reconcileRepoMCPJSON repairs a Gortex-authored entry in the repo's
+// .mcp.json so the file the CLI finds first does not shadow the config
+// we just wrote with one it cannot use. The claudecode adapter owns
+// that file and writes an entry with no "type" and a shell-style
+// "${GORTEX_WORKERS:-8}" default the CLI never expands.
+//
+// The file is only ever edited, never created: an absent .mcp.json is
+// claudecode's to author, and every non-Gortex server entry in it is
+// somebody else's.
+func reconcileRepoMCPJSON(env agents.Env, opts agents.ApplyOpts) (agents.FileAction, bool, error) {
+	path := repoMCPJSONPath(env.Root)
+	if !repoMCPJSONHasGortexEntry(path) {
+		return agents.FileAction{}, false, nil
+	}
+	action, err := agents.MergeJSON(env.Stderr, path, func(root map[string]any, _ bool) (bool, error) {
+		entry, ok := gortexEntryOf(root)
+		if !ok {
+			return false, nil
+		}
+		return reconcileCopilotEntry(entry, env.Stderr, path), nil
+	}, opts)
+	if err != nil {
+		return agents.FileAction{}, false, err
+	}
+	return action, true, nil
+}
+
+// repoMCPJSONHasGortexEntry reports whether path exists and carries a
+// Gortex-authored server entry. Pure (read-only), so Plan can call it.
+func repoMCPJSONHasGortexEntry(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	var root map[string]any
+	if err := json.Unmarshal(data, &root); err != nil {
+		return false
+	}
+	_, ok := gortexEntryOf(root)
+	return ok
+}
+
+func gortexEntryOf(root map[string]any) (map[string]any, bool) {
+	servers, ok := root["mcpServers"].(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	existing, exists := servers[serverName]
+	if !exists || !agents.IsGortexAuthoredMCPEntry(existing) {
+		return nil, false
+	}
+	entry, ok := existing.(map[string]any)
+	return entry, ok
+}
+
+// reconcileCopilotEntry brings one Gortex-authored server entry up to
+// what the CLI actually requires: an explicit "local" transport, and
+// environment values it can use verbatim. Reports whether it changed
+// anything, so callers can stay idempotent.
+func reconcileCopilotEntry(entry map[string]any, w io.Writer, path string) bool {
+	changed := false
+	if t, _ := entry["type"].(string); t != localTransport {
+		entry["type"] = localTransport
+		changed = true
+		internalutil.Logf(w, "[gortex init] %s: set the gortex server type to %q (Copilot CLI has no inferred transport)", path, localTransport)
+	}
+	envMap, ok := entry["env"].(map[string]any)
+	if !ok {
+		return changed
+	}
+	for _, key := range sortedKeys(envMap) {
+		value, ok := envMap[key].(string)
+		if !ok || !strings.Contains(value, "${") {
+			continue
+		}
+		literal, ok := shellDefault(value)
+		if !ok {
+			internalutil.Warnf(w, "%s: gortex env %s=%q uses shell syntax Copilot CLI does not expand; replace it with a literal value", path, key, value)
+			continue
+		}
+		envMap[key] = literal
+		changed = true
+		internalutil.Logf(w, "[gortex init] %s: rewrote gortex env %s to the literal %q (Copilot CLI does not expand shell defaults)", path, key, literal)
+	}
+	return changed
+}
+
+// shellDefault extracts D from a "${NAME:-D}" parameter expansion — the
+// only shell form Gortex itself writes. Anything else returns false so
+// the caller warns instead of guessing at a value.
+func shellDefault(value string) (string, bool) {
+	if !strings.HasPrefix(value, "${") || !strings.HasSuffix(value, "}") {
+		return "", false
+	}
+	inner := value[2 : len(value)-1]
+	sep := strings.Index(inner, ":-")
+	if sep < 0 {
+		return "", false
+	}
+	name, fallback := inner[:sep], inner[sep+2:]
+	if name == "" || fallback == "" {
+		return "", false
+	}
+	if strings.ContainsAny(name, "${}") || strings.ContainsAny(fallback, "${}") {
+		return "", false
+	}
+	return fallback, true
+}
+
+// sortedKeys keeps log lines deterministic across runs.
+func sortedKeys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/agents/copilotcli/adapter.go
+++ b/internal/agents/copilotcli/adapter.go
@@ -26,11 +26,17 @@
 // that entry in place (reconcileRepoMCPJSON) instead of letting a stale
 // file shadow the user-level config we just wrote.
 //
-// Two surfaces this adapter deliberately does NOT write:
-//   - ~/.claude/* — the CLI stopped loading Claude's directories in
+// Three surfaces this adapter deliberately does NOT write:
+//   - ~/.claude/* — the CLI stopped loading Claude's home directories in
 //     v1.0.36, so anything written there is dead weight.
+//   - ~/.agents/skills/ — same story, retired in v1.0.66.
 //   - .github/prompts/*.prompt.md — prompt files are a VS Code chat
 //     feature the CLI has never supported.
+//
+// The surfaces it does write beyond MCP + instructions live in sibling
+// files, each with its own vendor notes: skills.go (Agent Skills),
+// subagents.go (custom agents), hooks.go (lifecycle hooks) and
+// inspect.go (the read-only view `gortex doctor` consumes).
 //
 // Docs: https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers
 package copilotcli
@@ -47,6 +53,7 @@ import (
 
 	"github.com/zzet/gortex/internal/agents"
 	"github.com/zzet/gortex/internal/agents/internalutil"
+	"github.com/zzet/gortex/internal/agents/skillpack"
 )
 
 const (
@@ -178,11 +185,46 @@ func (a *Adapter) Plan(env agents.Env) (*agents.Plan, error) {
 			})
 		}
 	}
+	if env.Mode == agents.ModeGlobal {
+		// Curated skills + sub-agents are codebase-agnostic, so they are
+		// user-level only; the hook config is machine-local posture.
+		for _, id := range CuratedSkillNames() {
+			if path := curatedSkillPath(env, id); path != "" {
+				p.Files = append(p.Files, agents.FileAction{
+					Path: path, Action: agents.ActionWouldCreate, Keys: []string{"skill"},
+				})
+			}
+		}
+		for _, id := range SubAgentNames() {
+			if path := subAgentPath(env, id); path != "" {
+				p.Files = append(p.Files, agents.FileAction{
+					Path: path, Action: agents.ActionWouldCreate, Keys: []string{"sub-agent"},
+				})
+			}
+		}
+		if env.InstallHooks {
+			if path := HookConfigPath(env); path != "" {
+				p.Files = append(p.Files, agents.FileAction{
+					Path: path, Action: agents.ActionWouldMerge, Keys: []string{"hooks"},
+				})
+			}
+		}
+	}
 	if env.Mode != agents.ModeGlobal {
 		if env.SkillsRouting != "" {
 			p.Files = append(p.Files, agents.FileAction{
 				Path: repoInstructionsPath(env.Root), Action: agents.ActionWouldMerge,
 				Keys: []string{"communities-block"},
+			})
+		}
+		// Generated community skills are per-repo by construction.
+		for _, s := range env.GeneratedSkills {
+			if !skillpack.ValidID(s.DirName) {
+				continue
+			}
+			p.Files = append(p.Files, agents.FileAction{
+				Path: generatedSkillPath(env.Root, s.DirName), Action: agents.ActionWouldCreate,
+				Keys: []string{"skill"},
 			})
 		}
 		// Only planned when the file is already there with an entry we
@@ -231,6 +273,28 @@ func (a *Adapter) Apply(env agents.Env, opts agents.ApplyOpts) (*agents.Result, 
 		res.Files = append(res.Files, insAction)
 	}
 
+	if env.Mode == agents.ModeGlobal {
+		// Curated Agent Skills → ~/.copilot/skills/. User-level because
+		// the pack is codebase-agnostic; see skills.go for why every
+		// other discovery root the CLI once honoured is now dead.
+		res.Files = append(res.Files, installCuratedSkills(env, opts)...)
+
+		// Custom agents → ~/.copilot/agents/. A home agent shadows a repo
+		// agent of the same name, so this is the only level worth writing.
+		res.Files = append(res.Files, installSubAgents(env, opts)...)
+
+		// Lifecycle hooks → ~/.copilot/hooks/gortex.json. Never
+		// .github/hooks/: that file is committed and would fire on every
+		// teammate's clone.
+		if env.InstallHooks {
+			hookAction, err := installHooks(env, opts)
+			if err != nil {
+				return res, fmt.Errorf("copilot-cli hooks: %w", err)
+			}
+			res.Files = append(res.Files, hookAction)
+		}
+	}
+
 	if env.Mode != agents.ModeGlobal {
 		if env.SkillsRouting != "" {
 			routingAction, err := agents.UpsertMarkedBlock(env.Stderr, repoInstructionsPath(env.Root), env.SkillsRouting,
@@ -240,6 +304,8 @@ func (a *Adapter) Apply(env agents.Env, opts agents.ApplyOpts) (*agents.Result, 
 			}
 			res.Files = append(res.Files, routingAction)
 		}
+		// Generated community skills → <root>/.github/skills/, flat.
+		res.Files = append(res.Files, installGeneratedSkills(env, opts)...)
 		repoAction, wrote, err := reconcileRepoMCPJSON(env, opts)
 		if err != nil {
 			return res, err

--- a/internal/agents/copilotcli/adapter_test.go
+++ b/internal/agents/copilotcli/adapter_test.go
@@ -1,0 +1,437 @@
+package copilotcli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/agentstest"
+	"github.com/zzet/gortex/internal/agents/vscode"
+)
+
+// newCopilotEnv returns a sandbox Env the adapter detects: a temp home
+// with a ~/.copilot directory. COPILOT_HOME is cleared so a developer
+// who exports it cannot redirect these writes onto their real config.
+func newCopilotEnv(t *testing.T) (agents.Env, *bytes.Buffer) {
+	t.Helper()
+	t.Setenv(copilotHomeEnvVar, "")
+	env, buf := agentstest.NewEnv(t)
+	if err := os.MkdirAll(filepath.Join(env.Home, copilotConfigDirName), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return env, buf
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func gortexServer(t *testing.T, cfg map[string]any) map[string]any {
+	t.Helper()
+	servers, ok := cfg["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing mcpServers object: %v", cfg)
+	}
+	entry, ok := servers[serverName].(map[string]any)
+	if !ok {
+		t.Fatalf("missing gortex entry: %v", servers)
+	}
+	return entry
+}
+
+// TestApplyWritesMcpServersWithLocalTransport pins the two schema facts
+// the VS Code adapter would mislead a maintainer about: the top-level
+// key is "mcpServers" (not "servers"), and the entry carries an explicit
+// "type": "local" the CLI needs to launch it.
+func TestApplyWritesMcpServersWithLocalTransport(t *testing.T) {
+	env, _ := newCopilotEnv(t)
+
+	res, err := New().Apply(env, agents.ApplyOpts{})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !res.Detected || !res.Configured {
+		t.Fatalf("expected detected+configured, got %+v", res)
+	}
+	if res.DocsURL != DocsURL {
+		t.Fatalf("DocsURL = %q, want %q", res.DocsURL, DocsURL)
+	}
+
+	cfg := agentstest.ReadJSON(t, MCPConfigPath(env))
+	if _, wrong := cfg["servers"]; wrong {
+		t.Fatalf("wrote VS Code's \"servers\" key; Copilot CLI reads \"mcpServers\": %v", cfg)
+	}
+	entry := gortexServer(t, cfg)
+	if entry["type"] != localTransport {
+		t.Fatalf("entry type = %v, want %q — the CLI does not infer stdio", entry["type"], localTransport)
+	}
+	if entry["command"] != "gortex" {
+		t.Fatalf("command = %v, want gortex", entry["command"])
+	}
+	args, _ := entry["args"].([]any)
+	if len(args) != 1 || args[0] != "mcp" {
+		t.Fatalf("args = %v, want [mcp]", entry["args"])
+	}
+	envMap, _ := entry["env"].(map[string]any)
+	if envMap["GORTEX_INDEX_WORKERS"] != "8" {
+		t.Fatalf("env GORTEX_INDEX_WORKERS = %v, want the literal \"8\"", envMap["GORTEX_INDEX_WORKERS"])
+	}
+}
+
+// TestDetectFalseInEmptySandbox: no copilot binary, no config home.
+func TestDetectFalseInEmptySandbox(t *testing.T) {
+	t.Setenv(copilotHomeEnvVar, "")
+	original := lookCopilotBinary
+	lookCopilotBinary = func() (string, error) { return "", errors.New("not found") }
+	t.Cleanup(func() { lookCopilotBinary = original })
+
+	env, _ := agentstest.NewEnv(t)
+	detected, err := New().Detect(env)
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if detected {
+		t.Fatal("Detect must be false with no copilot binary and no ~/.copilot")
+	}
+
+	// And a .vscode directory must not flip it — that is the vscode
+	// adapter's host, not ours.
+	if err := os.MkdirAll(filepath.Join(env.Root, ".vscode"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if detected, _ := New().Detect(env); detected {
+		t.Fatal("Detect must not key off .vscode")
+	}
+}
+
+func TestApplyIsIdempotent(t *testing.T) {
+	env, _ := newCopilotEnv(t)
+	a := New()
+
+	if _, err := a.Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	mcpBefore := readFile(t, MCPConfigPath(env))
+	insBefore := readFile(t, filepath.Join(env.Root, ".github", instructionsFileName))
+
+	agentstest.AssertIdempotent(t, a, env)
+
+	if got := readFile(t, MCPConfigPath(env)); got != mcpBefore {
+		t.Fatalf("mcp-config.json changed on re-run:\n%s\n---\n%s", mcpBefore, got)
+	}
+	if got := readFile(t, filepath.Join(env.Root, ".github", instructionsFileName)); got != insBefore {
+		t.Fatal("copilot-instructions.md changed on re-run")
+	}
+}
+
+// TestUserAuthoredEntriesSurvive: a server we did not author is the
+// user's, whatever it is named.
+func TestUserAuthoredEntriesSurvive(t *testing.T) {
+	env, _ := newCopilotEnv(t)
+	seed := map[string]any{
+		"mcpServers": map[string]any{
+			// Named "gortex" but launched by something else — a user who
+			// wired their own wrapper. Never rewrite it.
+			serverName: map[string]any{
+				"type":    "local",
+				"command": "node",
+				"args":    []any{"./my-gortex-wrapper.js"},
+			},
+			"acme": map[string]any{"command": "acme-server", "args": []any{"--stdio"}},
+		},
+	}
+	agentstest.WriteJSON(t, MCPConfigPath(env), seed)
+	before := readFile(t, MCPConfigPath(env))
+
+	res, err := New().Apply(env, agents.ApplyOpts{})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if got := readFile(t, MCPConfigPath(env)); got != before {
+		t.Fatalf("user-authored entries were rewritten:\n%s\n---\n%s", before, got)
+	}
+	for _, f := range res.Files {
+		if f.Path == MCPConfigPath(env) && f.Action != agents.ActionSkip {
+			t.Fatalf("expected a skip for a user-owned config, got %s", f.Action)
+		}
+	}
+}
+
+// TestInstructionsConvergeWithVSCodeAdapter is the co-existence fence.
+// The vscode adapter writes the same community-routing block into the
+// same .github/copilot-instructions.md, so a repo running both must end
+// up with exactly one marker-fenced block regardless of apply order.
+// The agent-render golden cannot catch this: it renders each adapter
+// into its own sandbox, so the two never meet there.
+func TestInstructionsConvergeWithVSCodeAdapter(t *testing.T) {
+	cases := []struct {
+		name  string
+		order []agents.Adapter
+	}{
+		{"vscode-first", []agents.Adapter{vscode.New(), New()}},
+		{"copilot-cli-first", []agents.Adapter{New(), vscode.New()}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env, _ := newCopilotEnv(t)
+			// ForceDetect so the assertion does not depend on whether VS
+			// Code happens to be installed on the machine running the test.
+			opts := agents.ApplyOpts{ForceDetect: true}
+			apply := func() {
+				for _, a := range tc.order {
+					if _, err := a.Apply(env, opts); err != nil {
+						t.Fatalf("%s apply: %v", a.Name(), err)
+					}
+				}
+			}
+
+			apply()
+			path := filepath.Join(env.Root, ".github", instructionsFileName)
+			first := readFile(t, path)
+			if n := strings.Count(first, agents.CommunitiesStartMarker); n != 1 {
+				t.Fatalf("expected exactly 1 communities block, got %d:\n%s", n, first)
+			}
+			if n := strings.Count(first, agents.CommunitiesEndMarker); n != 1 {
+				t.Fatalf("expected exactly 1 communities end marker, got %d:\n%s", n, first)
+			}
+
+			apply()
+			if second := readFile(t, path); second != first {
+				t.Fatalf("re-running both adapters was not byte-stable:\n%s\n---\n%s", first, second)
+			}
+		})
+	}
+}
+
+// claudecodeMCPJSON is the repo .mcp.json the claudecode adapter writes,
+// plus an unrelated sibling server. Its gortex entry has no "type" and
+// an env value in shell-parameter form — neither of which the CLI
+// understands, and the CLI prefers this file over ~/.copilot's.
+const claudecodeMCPJSON = `{
+  "mcpServers": {
+    "acme": {
+      "command": "acme-server",
+      "args": [
+        "--stdio"
+      ]
+    },
+    "gortex": {
+      "command": "gortex",
+      "args": [
+        "mcp"
+      ],
+      "env": {
+        "GORTEX_INDEX_WORKERS": "${GORTEX_WORKERS:-8}"
+      }
+    }
+  }
+}
+`
+
+func TestReconcilesRepoMCPJSONThatShadowsUserConfig(t *testing.T) {
+	env, _ := newCopilotEnv(t)
+	path := filepath.Join(env.Root, ".mcp.json")
+	if err := os.WriteFile(path, []byte(claudecodeMCPJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var seeded map[string]any
+	if err := json.Unmarshal([]byte(claudecodeMCPJSON), &seeded); err != nil {
+		t.Fatal(err)
+	}
+	wantSibling, _ := json.Marshal(seeded["mcpServers"].(map[string]any)["acme"])
+
+	res, err := New().Apply(env, agents.ApplyOpts{})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	var touched bool
+	for _, f := range res.Files {
+		if f.Path == path {
+			touched = true
+			if f.Action != agents.ActionMerge {
+				t.Fatalf(".mcp.json action = %s, want merge", f.Action)
+			}
+		}
+	}
+	if !touched {
+		t.Fatal("Apply did not report the .mcp.json reconciliation")
+	}
+
+	cfg := agentstest.ReadJSON(t, path)
+	entry := gortexServer(t, cfg)
+	if entry["type"] != localTransport {
+		t.Fatalf("type = %v, want %q added to the shadowing entry", entry["type"], localTransport)
+	}
+	envMap, _ := entry["env"].(map[string]any)
+	if envMap["GORTEX_INDEX_WORKERS"] != "8" {
+		t.Fatalf("env GORTEX_INDEX_WORKERS = %v, want the literal \"8\"", envMap["GORTEX_INDEX_WORKERS"])
+	}
+
+	gotSibling, _ := json.Marshal(cfg["mcpServers"].(map[string]any)["acme"])
+	if string(gotSibling) != string(wantSibling) {
+		t.Fatalf("non-gortex server changed:\n%s\n---\n%s", wantSibling, gotSibling)
+	}
+
+	// Second run must be a no-op on the file we repaired.
+	before := readFile(t, path)
+	agentstest.AssertIdempotent(t, New(), env)
+	if after := readFile(t, path); after != before {
+		t.Fatalf(".mcp.json rewritten on re-run:\n%s\n---\n%s", before, after)
+	}
+}
+
+// TestNeverCreatesRepoMCPJSON: an absent .mcp.json belongs to the
+// claudecode adapter; we must not conjure one.
+func TestNeverCreatesRepoMCPJSON(t *testing.T) {
+	env, _ := newCopilotEnv(t)
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(env.Root, ".mcp.json")); !os.IsNotExist(err) {
+		t.Fatalf(".mcp.json must not be created by this adapter (stat err = %v)", err)
+	}
+}
+
+// TestLeavesForeignRepoMCPJSONAlone: a .mcp.json with no Gortex-authored
+// entry is entirely somebody else's file.
+func TestLeavesForeignRepoMCPJSONAlone(t *testing.T) {
+	env, _ := newCopilotEnv(t)
+	path := filepath.Join(env.Root, ".mcp.json")
+	agentstest.WriteJSON(t, path, map[string]any{
+		"mcpServers": map[string]any{"acme": map[string]any{"command": "acme-server", "args": []any{"--stdio"}}},
+	})
+	before := readFile(t, path)
+
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if after := readFile(t, path); after != before {
+		t.Fatalf("foreign .mcp.json was rewritten:\n%s\n---\n%s", before, after)
+	}
+}
+
+// TestWritesNothingUnderClaudeOrPrompts pins two surfaces that look
+// plausible and are dead: the CLI stopped reading ~/.claude/* in
+// v1.0.36, and it has never supported .github/prompts prompt files.
+func TestWritesNothingUnderClaudeOrPrompts(t *testing.T) {
+	env, _ := newCopilotEnv(t)
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	for _, dir := range []string{
+		filepath.Join(env.Home, ".claude"),
+		filepath.Join(env.Root, ".claude"),
+		filepath.Join(env.Root, ".github", "prompts"),
+	} {
+		if _, err := os.Stat(dir); !os.IsNotExist(err) {
+			t.Errorf("%s must not be written by the Copilot CLI adapter (stat err = %v)", dir, err)
+		}
+	}
+}
+
+func TestGlobalModeWritesUserInstructions(t *testing.T) {
+	env, _ := newCopilotEnv(t)
+	env.Mode = agents.ModeGlobal
+	env.InstallGlobalInstructions = true
+
+	a := New()
+	if _, err := a.Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	body := readFile(t, GlobalInstructionsPath(env))
+	if !strings.Contains(body, agents.GlobalRulesStartMarker) || !strings.Contains(body, agents.GlobalRulesEndMarker) {
+		t.Fatalf("rule block missing from %s:\n%s", GlobalInstructionsPath(env), body)
+	}
+	if strings.Contains(body, agents.CommunitiesStartMarker) {
+		t.Fatal("global instructions must carry the rules block, not the communities block")
+	}
+	// The CLI reads plain markdown; a Claude-style @-include would be
+	// prose to it, so the profile body has to be inlined.
+	if strings.Contains(body, "@"+agents.InstructionsDir(env)) {
+		t.Fatal("global instructions must inline the profile body, not @-include it")
+	}
+	agentstest.AssertIdempotent(t, a, env)
+}
+
+// TestPlanEnumeratesEveryAppliedFile keeps `gortex doctor` /
+// --print-config honest: they read Plan, not Apply.
+func TestPlanEnumeratesEveryAppliedFile(t *testing.T) {
+	env, _ := newCopilotEnv(t)
+	if err := os.WriteFile(filepath.Join(env.Root, ".mcp.json"), []byte(claudecodeMCPJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	plan, err := New().Plan(env)
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	planned := make(map[string]agents.ActionKind, len(plan.Files))
+	for _, f := range plan.Files {
+		planned[f.Path] = f.Action
+	}
+
+	res, err := New().Apply(env, agents.ApplyOpts{})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	for _, f := range res.Files {
+		if _, ok := planned[f.Path]; !ok {
+			t.Errorf("Apply touched %s but Plan did not list it", f.Path)
+		}
+	}
+	if _, ok := planned[filepath.Join(env.Root, ".mcp.json")]; !ok {
+		t.Error("Plan must list the repo .mcp.json it reconciles")
+	}
+}
+
+func TestCopilotConfigHomeHonoursOverrideOnlyForRealHome(t *testing.T) {
+	override := t.TempDir()
+	t.Setenv(copilotHomeEnvVar, override)
+
+	real, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no resolvable user home on this machine")
+	}
+	if got := copilotConfigHome(agents.Env{Home: real}); got != override {
+		t.Fatalf("COPILOT_HOME ignored for the real home: got %q, want %q", got, override)
+	}
+
+	sandbox := t.TempDir()
+	want := filepath.Join(sandbox, copilotConfigDirName)
+	if got := copilotConfigHome(agents.Env{Home: sandbox}); got != want {
+		t.Fatalf("sandbox Env escaped its root: got %q, want %q", got, want)
+	}
+	if got := copilotConfigHome(agents.Env{}); got != "" {
+		t.Fatalf("empty Home must yield no path, got %q", got)
+	}
+}
+
+func TestShellDefault(t *testing.T) {
+	cases := []struct {
+		in    string
+		want  string
+		valid bool
+	}{
+		{"${GORTEX_WORKERS:-8}", "8", true},
+		{"8", "", false},
+		{"${GORTEX_WORKERS}", "", false},
+		{"${GORTEX_WORKERS:-${NESTED}}", "", false},
+		{"prefix${A:-1}", "", false},
+	}
+	for _, tc := range cases {
+		got, ok := shellDefault(tc.in)
+		if ok != tc.valid || got != tc.want {
+			t.Errorf("shellDefault(%q) = (%q, %v), want (%q, %v)", tc.in, got, ok, tc.want, tc.valid)
+		}
+	}
+}

--- a/internal/agents/copilotcli/hooks.go
+++ b/internal/agents/copilotcli/hooks.go
@@ -1,0 +1,412 @@
+package copilotcli
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/zzet/gortex/internal/agents"
+)
+
+// hooks.go writes ~/.copilot/hooks/gortex.json — the Copilot CLI's
+// lifecycle hook config.
+//
+// # Why user-level only
+//
+// The CLI reads hooks from ~/.copilot/hooks/*.json AND .github/hooks/*.json.
+// Only the first is written. A repo-level hook file is committed, so it
+// would fire `gortex hook` on every teammate's machine the moment they
+// clone — including the ones with no gortex installed, who would get a
+// failed subprocess on every tool call. Hooks are a machine-local
+// posture; they are installed by `gortex install`, never by `gortex init`.
+//
+// # Why four events and not fourteen
+//
+// The CLI defines fourteen lifecycle events. Gortex produces a payload
+// for four of them; the other ten (userPromptTransformed, preCompact,
+// agentStop, subagentStart, subagentStop, errorOccurred,
+// permissionRequest, notification, postToolUseFailure, sessionEnd) would
+// map to nothing. Registering an event is not free — it spawns a
+// subprocess per occurrence — so an event that returns nothing is a pure
+// per-turn tax.
+//
+// # Why every entry carries two command fields
+//
+// A hook entry has SEPARATE `bash` and `powershell` fields; the CLI picks
+// by platform rather than shelling one string through whatever shell is
+// present. A POSIX-only entry therefore leaves Windows users with a hook
+// that silently never runs, which reads exactly like "Gortex configured,
+// Gortex ignored". Both fields are always emitted.
+//
+// # Matchers
+//
+// Matchers apply to preToolUse / postToolUse / permissionRequest, are
+// matched against the tool name, and the CLI anchors them as
+// `^(?:PATTERN)$`. The built-in tool names are LOWERCASE — `view`, not
+// `View` — and `powershell` is a first-class sibling of `bash`, so a
+// matcher that lists only `bash` leaves the entire Windows shell surface
+// unguarded.
+//
+// Docs: https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/create-hooks
+
+const (
+	// hooksDirName holds one JSON file per hook source.
+	hooksDirName = "hooks"
+	// hookFileName is ours; a user's own hook files sit beside it.
+	hookFileName = "gortex.json"
+	// hookConfigVersion is the schema version the CLI expects.
+	hookConfigVersion = 1
+	// hookTimeoutSeconds bounds each spawn. Timeouts fail OPEN, so this
+	// is a latency ceiling rather than a safety control: the graph probe
+	// the handler runs is local and sub-second, and a hung daemon must
+	// not stall every tool call for longer than a user would tolerate.
+	hookTimeoutSeconds = 10
+	// hookAgentFlag routes the payload to the Copilot decoder. It must
+	// match the --agent value cmd/gortex dispatches on.
+	hookAgentFlag = "copilot-cli"
+)
+
+// copilotHookEventNames translates Gortex's PascalCase event vocabulary
+// into the camelCase names the CLI reads on disk.
+//
+// The split is deliberate and load-bearing in one direction only:
+// everything Gortex measures — internal/hooks telemetry, `gortex doctor`
+// — keys on the PascalCase spellings, so those are what Inspect reports
+// and what HookEvents lists. The camelCase spellings exist nowhere but
+// this map, the writer, and the recogniser. Leaking them outward makes
+// every event score zero runs in doctor's tally and turns a healthy
+// install into a permanent "configured but none has run" blocker.
+//
+// Note userPromptSubmitted: the CLI's name is past tense, Claude's
+// (UserPromptSubmit) is not.
+var copilotHookEventNames = map[string]string{
+	"SessionStart":     "sessionStart",
+	"UserPromptSubmit": "userPromptSubmitted",
+	"PreToolUse":       "preToolUse",
+	"PostToolUse":      "postToolUse",
+}
+
+// copilotToolMatcherNames are the CLI's built-in tools whose use Gortex
+// has something to say about: reads (view), searches (grep, rg, glob),
+// shells (bash, powershell) and writes (create, edit). Sorted so the
+// rendered alternation is byte-stable.
+//
+// The CLI's remaining built-ins — ask_user, task, web_fetch, web_search,
+// update_todo — never touch indexed source, so matching them would spawn
+// a subprocess for nothing.
+var copilotToolMatcherNames = []string{
+	"bash", "create", "edit", "glob", "grep", "powershell", "rg", "view",
+}
+
+// copilotToolMatcher renders the anchored alternation. Anchoring is
+// written explicitly rather than relying on the CLI to wrap it, so the
+// pattern means the same thing if it is ever read by anything else.
+func copilotToolMatcher() string {
+	return "^(?:" + strings.Join(copilotToolMatcherNames, "|") + ")$"
+}
+
+// HookConfigPath is ~/.copilot/hooks/gortex.json for this Env.
+func HookConfigPath(env agents.Env) string {
+	home := copilotConfigHome(env)
+	if home == "" {
+		return ""
+	}
+	return filepath.Join(home, hooksDirName, hookFileName)
+}
+
+// hookBinary resolves the gortex binary the entries invoke.
+//
+// Env.HookCommand is "<binary> hook" — the caller resolves the binary
+// once (through agents.ResolveGortexHookBinary, which refuses a `go run`
+// temp build) and appends the subcommand. That subcommand is stripped
+// back off here because the PowerShell field has to quote the path on its
+// own, which is impossible once binary and arguments are one string.
+func hookBinary(env agents.Env) string {
+	if base := strings.TrimSpace(env.HookCommand); base != "" {
+		if bin, ok := strings.CutSuffix(base, " hook"); ok {
+			return strings.TrimSpace(bin)
+		}
+		return base
+	}
+	return agents.ResolveGortexHookBinary()
+}
+
+// hookArgs is the tail both shells append to the binary.
+const hookArgs = " hook --agent=" + hookAgentFlag
+
+// bashHookCommand renders the POSIX form. Backslashes are normalised to
+// forward slashes for the same reason the Claude adapter does it: a
+// native Windows path inside an unquoted shell word is mangled by Git
+// Bash, and no real POSIX binary path uses a backslash as a separator.
+func bashHookCommand(env agents.Env) string {
+	return posixQuote(strings.ReplaceAll(hookBinary(env), `\`, "/")) + hookArgs
+}
+
+// powershellHookCommand renders the Windows form.
+//
+// A bare path runs as a command; a quoted one is just a string
+// expression PowerShell echoes, so quoting forces the call operator `&`
+// in front of it. Quoting is therefore applied only when the path needs
+// it — which also keeps `&` out of the JSON in the common case, where
+// encoding/json would escape it to the unreadable "&".
+func powershellHookCommand(env agents.Env) string {
+	bin := hookBinary(env)
+	if powershellBareSafe(bin) {
+		return bin + hookArgs
+	}
+	return "& " + powershellQuote(bin) + hookArgs
+}
+
+// powershellBareSafe reports whether a path can be typed as a bare
+// PowerShell command. Backslashes are fine — PowerShell's escape
+// character is the backtick — so a native Windows path usually qualifies.
+func powershellBareSafe(s string) bool {
+	return s != "" && !strings.ContainsAny(s, " \t\n\"'`$;|&(){}[]<>@#,")
+}
+
+// posixQuote single-quotes s when it carries anything a POSIX shell would
+// interpret. A plain path is left bare so the written config stays
+// readable.
+func posixQuote(s string) string {
+	if s != "" && !strings.ContainsAny(s, " \t\n\"'\\$`&;|<>()*?[]{}#~!") {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// powershellQuote always single-quotes: a Windows path routinely contains
+// spaces ("C:\Program Files\..."), and inside PowerShell single quotes
+// the only escape needed is a doubled quote.
+func powershellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}
+
+// desiredHookEntry builds the entry for one PascalCase event.
+//
+// A matcher is emitted only for the tool-scoped events. sessionStart and
+// userPromptSubmitted have no tool name to match against, and a matcher
+// on them is at best ignored.
+func desiredHookEntry(event string, env agents.Env) map[string]any {
+	entry := map[string]any{
+		"type":       "command",
+		"bash":       bashHookCommand(env),
+		"powershell": powershellHookCommand(env),
+		// Relative cwd: the hook must run inside the session's repository
+		// so the handler resolves the same workspace the tools serve.
+		"cwd":        ".",
+		"timeoutSec": hookTimeoutSeconds,
+	}
+	if event == "PreToolUse" || event == "PostToolUse" {
+		entry["matcher"] = copilotToolMatcher()
+	}
+	return entry
+}
+
+// upsertCopilotHooks merges our four events into a parsed hooks config.
+// Returns whether anything changed.
+func upsertCopilotHooks(root map[string]any, env agents.Env, opts agents.ApplyOpts) bool {
+	changed := false
+
+	// Only ever seeded, never corrected: `version` is the CLI's to bump
+	// and `disableAllHooks: true` is a user kill-switch we must not flip
+	// back on their behalf.
+	if _, exists := root["version"]; !exists {
+		root["version"] = hookConfigVersion
+		changed = true
+	}
+	if _, exists := root["disableAllHooks"]; !exists {
+		root["disableAllHooks"] = false
+		changed = true
+	}
+
+	hooks, ok := root["hooks"].(map[string]any)
+	if !ok {
+		if _, exists := root["hooks"]; exists {
+			// Present but not an object: a shape we don't understand and
+			// must not overwrite.
+			return changed
+		}
+		hooks = make(map[string]any)
+	}
+
+	for _, event := range HookEvents {
+		if upsertCopilotHookEvent(hooks, copilotHookEventNames[event], desiredHookEntry(event, env), opts) {
+			changed = true
+		}
+	}
+	if changed {
+		root["hooks"] = hooks
+	}
+	return changed
+}
+
+// upsertCopilotHookEvent reconciles one event's entry list against the
+// single entry we want there. The policy, modelled on the Codex adapter:
+//
+//   - entries we did not author are kept byte-identical, always;
+//   - our entry is replaced in place, so N re-runs leave exactly one;
+//   - a Gortex entry whose matcher the user NARROWED is left alone —
+//     they deliberately scoped our hook, and silently re-widening it on
+//     the next `gortex install` is the kind of surprise that gets hooks
+//     turned off wholesale. opts.Force is the way back to our matcher.
+func upsertCopilotHookEvent(hooks map[string]any, event string, want map[string]any, opts agents.ApplyOpts) bool {
+	entries, ok := copilotHookList(hooks[event])
+	if !ok {
+		// Present but not a list: not ours to reshape.
+		return false
+	}
+
+	found := false
+	changed := false
+	kept := make([]any, 0, len(entries)+1)
+	for _, entry := range entries {
+		if !isGortexCopilotHookEntry(entry) {
+			kept = append(kept, entry)
+			continue
+		}
+		if opts.Force {
+			changed = true
+			continue
+		}
+		if !found && (copilotHookMatcherIsNarrowed(entry, want) || agents.MCPEntriesEqual(entry, want)) {
+			found = true
+			kept = append(kept, entry)
+			continue
+		}
+		// A Gortex entry that is neither current nor a deliberate
+		// narrowing: a stale command, timeout, or a duplicate from an
+		// older run. Drop it instead of accumulating.
+		changed = true
+	}
+	if !found {
+		kept = append(kept, want)
+		changed = true
+	}
+	if !changed {
+		return false
+	}
+	hooks[event] = kept
+	return true
+}
+
+// copilotHookList normalises an event's value to a slice. A missing key
+// is an empty list (ok); a non-list is a shape we refuse to touch.
+func copilotHookList(v any) ([]any, bool) {
+	if v == nil {
+		return nil, true
+	}
+	switch list := v.(type) {
+	case []any:
+		return append([]any(nil), list...), true
+	case []map[string]any:
+		out := make([]any, 0, len(list))
+		for _, entry := range list {
+			out = append(out, entry)
+		}
+		return out, true
+	default:
+		return nil, false
+	}
+}
+
+// isGortexCopilotHookEntry reports whether an entry invokes our hook,
+// in either shell field. Recognition is by command content rather than a
+// marker key, so an entry written by an older gortex — or by a user who
+// copied ours and edited the matcher — is still recognised as ours.
+func isGortexCopilotHookEntry(entry any) bool {
+	fields, ok := entry.(map[string]any)
+	if !ok {
+		return false
+	}
+	for _, key := range []string{"bash", "powershell", "command"} {
+		if cmd, _ := fields[key].(string); commandInvokesCopilotHook(cmd) {
+			return true
+		}
+	}
+	return false
+}
+
+func commandInvokesCopilotHook(cmd string) bool {
+	cmd = strings.TrimSpace(cmd)
+	if cmd == "" {
+		return false
+	}
+	lower := strings.ToLower(cmd)
+	if !strings.Contains(lower, "gortex") || !strings.Contains(lower, "hook") {
+		return false
+	}
+	return strings.Contains(cmd, "--agent="+hookAgentFlag) || strings.Contains(cmd, "--agent "+hookAgentFlag)
+}
+
+// copilotHookMatcherIsNarrowed reports whether entry's matcher is a
+// strict subset of the one we want — the fingerprint of a user who
+// trimmed our alternation down to the tools they care about.
+//
+// Only the anchored alternation form is understood. A matcher rewritten
+// into any other shape is not recognised as a narrowing, so it falls
+// through to the stale-entry path and is refreshed; guessing at an
+// arbitrary regex's coverage would be worse than being wrong loudly.
+func copilotHookMatcherIsNarrowed(entry any, want map[string]any) bool {
+	fields, ok := entry.(map[string]any)
+	if !ok {
+		return false
+	}
+	got, gotOK := matcherAlternation(fields["matcher"])
+	full, wantOK := matcherAlternation(want["matcher"])
+	if !gotOK || !wantOK || len(got) == 0 || len(got) >= len(full) {
+		return false
+	}
+	allowed := make(map[string]bool, len(full))
+	for _, name := range full {
+		allowed[name] = true
+	}
+	for _, name := range got {
+		if !allowed[name] {
+			return false
+		}
+	}
+	return true
+}
+
+// matcherAlternation splits `^(?:a|b|c)$` into its alternatives.
+func matcherAlternation(v any) ([]string, bool) {
+	s, ok := v.(string)
+	if !ok {
+		return nil, false
+	}
+	inner, ok := strings.CutPrefix(s, "^(?:")
+	if !ok {
+		return nil, false
+	}
+	inner, ok = strings.CutSuffix(inner, ")$")
+	if !ok {
+		return nil, false
+	}
+	parts := strings.Split(inner, "|")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			return nil, false
+		}
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out, true
+}
+
+// installHooks writes ~/.copilot/hooks/gortex.json. Callers gate this on
+// env.InstallHooks and ModeGlobal.
+func installHooks(env agents.Env, opts agents.ApplyOpts) (agents.FileAction, error) {
+	path := HookConfigPath(env)
+	action, err := agents.MergeJSON(env.Stderr, path, func(root map[string]any, _ bool) (bool, error) {
+		return upsertCopilotHooks(root, env, opts), nil
+	}, opts)
+	if err != nil {
+		return agents.FileAction{}, err
+	}
+	if action.Action != agents.ActionSkip {
+		action.Keys = []string{"hooks"}
+	}
+	return action, nil
+}

--- a/internal/agents/copilotcli/hooks_test.go
+++ b/internal/agents/copilotcli/hooks_test.go
@@ -1,0 +1,416 @@
+package copilotcli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/agentstest"
+)
+
+// hookEvents reads the hooks object out of the written config.
+func hookEvents(t *testing.T, env agents.Env) map[string][]map[string]any {
+	t.Helper()
+	cfg := agentstest.ReadJSON(t, HookConfigPath(env))
+	raw, ok := cfg["hooks"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing top-level hooks object: %v", cfg)
+	}
+	out := make(map[string][]map[string]any, len(raw))
+	for event, v := range raw {
+		list, ok := v.([]any)
+		if !ok {
+			t.Fatalf("event %s is not a list: %v", event, v)
+		}
+		for _, e := range list {
+			entry, ok := e.(map[string]any)
+			if !ok {
+				t.Fatalf("event %s carries a non-object entry: %v", event, e)
+			}
+			out[event] = append(out[event], entry)
+		}
+	}
+	return out
+}
+
+func sortedEventNames(events map[string][]map[string]any) []string {
+	names := make([]string, 0, len(events))
+	for name := range events {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// TestHookConfigShape pins every vendor fact the writer encodes: the
+// camelCase event names, the four-event budget, the anchored lowercase
+// matchers, and the two per-entry command fields.
+func TestHookConfigShape(t *testing.T) {
+	env, _ := globalEnv(t)
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	cfg := agentstest.ReadJSON(t, HookConfigPath(env))
+	if cfg["version"] != float64(hookConfigVersion) {
+		t.Fatalf("version = %v, want %d", cfg["version"], hookConfigVersion)
+	}
+	if cfg["disableAllHooks"] != false {
+		t.Fatalf("disableAllHooks = %v, want false", cfg["disableAllHooks"])
+	}
+
+	events := hookEvents(t, env)
+	want := []string{"postToolUse", "preToolUse", "sessionStart", "userPromptSubmitted"}
+	if got := sortedEventNames(events); strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("registered events = %v, want exactly %v — each extra event costs a subprocess per occurrence", got, want)
+	}
+
+	for event, entries := range events {
+		if len(entries) != 1 {
+			t.Fatalf("event %s has %d entries, want 1", event, len(entries))
+		}
+		entry := entries[0]
+		if entry["type"] != "command" {
+			t.Errorf("%s type = %v, want command", event, entry["type"])
+		}
+		// Both shells, always: the CLI picks by platform, so a POSIX-only
+		// entry leaves Windows users with a hook that never runs.
+		for _, key := range []string{"bash", "powershell"} {
+			cmd, _ := entry[key].(string)
+			if cmd == "" {
+				t.Errorf("%s is missing a %s command", event, key)
+				continue
+			}
+			if !strings.Contains(cmd, "--agent="+hookAgentFlag) {
+				t.Errorf("%s %s command does not route to the copilot decoder: %q", event, key, cmd)
+			}
+			if strings.Contains(cmd, filepath.Clean(os.TempDir())+string(os.PathSeparator)+"go-build") {
+				t.Errorf("%s %s baked an ephemeral build path: %q", event, key, cmd)
+			}
+		}
+		if entry["cwd"] != "." {
+			t.Errorf("%s cwd = %v, want \".\"", event, entry["cwd"])
+		}
+		if entry["timeoutSec"] != float64(hookTimeoutSeconds) {
+			t.Errorf("%s timeoutSec = %v, want %d", event, entry["timeoutSec"], hookTimeoutSeconds)
+		}
+
+		matcher, hasMatcher := entry["matcher"].(string)
+		switch event {
+		case "preToolUse", "postToolUse":
+			if !hasMatcher {
+				t.Fatalf("%s must carry a tool matcher", event)
+			}
+			if !strings.HasPrefix(matcher, "^(?:") || !strings.HasSuffix(matcher, ")$") {
+				t.Errorf("%s matcher is not anchored: %q", event, matcher)
+			}
+			if _, err := regexp.Compile(matcher); err != nil {
+				t.Errorf("%s matcher does not compile: %v", event, err)
+			}
+			names := strings.Split(strings.TrimSuffix(strings.TrimPrefix(matcher, "^(?:"), ")$"), "|")
+			present := make(map[string]bool, len(names))
+			for _, n := range names {
+				if n != strings.ToLower(n) {
+					t.Errorf("%s matcher lists %q; the CLI's built-in tool names are lowercase", event, n)
+				}
+				present[n] = true
+			}
+			// powershell is a first-class sibling of bash. Omitting it
+			// leaves the whole Windows shell surface unenforced.
+			for _, required := range []string{"view", "grep", "rg", "glob", "bash", "powershell", "create", "edit"} {
+				if !present[required] {
+					t.Errorf("%s matcher does not cover %q: %q", event, required, matcher)
+				}
+			}
+		default:
+			if hasMatcher {
+				t.Errorf("%s carries a matcher (%q) but has no tool name to match against", event, matcher)
+			}
+		}
+	}
+}
+
+// TestHooksNotWrittenWhenDisabled: --no-hooks must leave the file absent,
+// not present-and-empty.
+func TestHooksNotWrittenWhenDisabled(t *testing.T) {
+	env, _ := globalEnv(t)
+	env.InstallHooks = false
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if _, err := os.Stat(HookConfigPath(env)); !os.IsNotExist(err) {
+		t.Fatalf("hook config written despite InstallHooks=false (stat err = %v)", err)
+	}
+}
+
+// TestNeverWritesRepoHooks: .github/hooks/*.json is committed, so it would
+// fire gortex on every teammate's clone — including the ones with no
+// gortex installed.
+func TestNeverWritesRepoHooks(t *testing.T) {
+	for _, mode := range []agents.Mode{agents.ModeProject, agents.ModeGlobal} {
+		env, _ := newCopilotEnv(t)
+		env.Mode = mode
+		if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(env.Root, ".github", "hooks")); !os.IsNotExist(err) {
+			t.Errorf("mode %v: .github/hooks must not be written (stat err = %v)", mode, err)
+		}
+	}
+}
+
+// TestHookUpsertNeverDuplicates: N installs leave one entry per event.
+func TestHookUpsertNeverDuplicates(t *testing.T) {
+	env, _ := globalEnv(t)
+	a := New()
+	for range 3 {
+		if _, err := a.Apply(env, agents.ApplyOpts{}); err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+	}
+	for event, entries := range hookEvents(t, env) {
+		if len(entries) != 1 {
+			t.Fatalf("event %s accumulated %d entries across re-runs", event, len(entries))
+		}
+	}
+}
+
+// seedHooks writes a hook config verbatim so a test can plant user state.
+func seedHooks(t *testing.T, env agents.Env, root map[string]any) {
+	t.Helper()
+	agentstest.WriteJSON(t, HookConfigPath(env), root)
+}
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+// TestUserHookEntriesSurvive: entries we did not author are the user's,
+// on our events and on events we never register.
+func TestUserHookEntriesSurvive(t *testing.T) {
+	env, _ := globalEnv(t)
+	userSessionEnd := map[string]any{
+		"type": "command", "bash": "echo bye", "powershell": "Write-Output bye",
+	}
+	userPreTool := map[string]any{
+		"type": "command", "matcher": "^(?:web_fetch)$",
+		"bash": "echo fetch", "powershell": "Write-Output fetch",
+	}
+	seedHooks(t, env, map[string]any{
+		"version":         1,
+		"disableAllHooks": false,
+		"hooks": map[string]any{
+			"sessionEnd": []any{userSessionEnd},
+			"preToolUse": []any{userPreTool},
+		},
+		// An unrelated top-level key a future CLI version might add.
+		"description": "team hooks",
+	})
+
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	cfg := agentstest.ReadJSON(t, HookConfigPath(env))
+	if cfg["description"] != "team hooks" {
+		t.Errorf("unrelated top-level key was dropped: %v", cfg)
+	}
+	events := hookEvents(t, env)
+	if got := events["sessionEnd"]; len(got) != 1 || mustJSON(t, got[0]) != mustJSON(t, userSessionEnd) {
+		t.Errorf("user entry on an unregistered event changed:\n%v", got)
+	}
+	pre := events["preToolUse"]
+	if len(pre) != 2 {
+		t.Fatalf("preToolUse = %d entries, want the user's + ours", len(pre))
+	}
+	if mustJSON(t, pre[0]) != mustJSON(t, userPreTool) {
+		t.Errorf("user preToolUse entry changed:\n%s\n---\n%s", mustJSON(t, userPreTool), mustJSON(t, pre[0]))
+	}
+	if !isGortexCopilotHookEntry(pre[1]) {
+		t.Errorf("our preToolUse entry was not appended: %v", pre[1])
+	}
+}
+
+// TestUserNarrowedMatcherIsPreserved: a user who trimmed our alternation
+// deliberately scoped the hook. Silently re-widening it on the next
+// install is how hooks get turned off wholesale — so only --force does.
+func TestUserNarrowedMatcherIsPreserved(t *testing.T) {
+	env, _ := globalEnv(t)
+	narrowed := map[string]any{
+		"type":       "command",
+		"matcher":    "^(?:bash|powershell)$",
+		"bash":       bashHookCommand(env),
+		"powershell": powershellHookCommand(env),
+		"cwd":        ".",
+		"timeoutSec": hookTimeoutSeconds,
+	}
+	seed := func() {
+		seedHooks(t, env, map[string]any{
+			"version":         1,
+			"disableAllHooks": false,
+			"hooks":           map[string]any{"preToolUse": []any{narrowed}},
+		})
+	}
+
+	seed()
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	pre := hookEvents(t, env)["preToolUse"]
+	if len(pre) != 1 {
+		t.Fatalf("preToolUse = %d entries, want the narrowed one alone", len(pre))
+	}
+	if pre[0]["matcher"] != "^(?:bash|powershell)$" {
+		t.Fatalf("narrowed matcher was re-widened without --force: %v", pre[0]["matcher"])
+	}
+
+	seed()
+	if _, err := New().Apply(env, agents.ApplyOpts{Force: true}); err != nil {
+		t.Fatalf("forced apply: %v", err)
+	}
+	pre = hookEvents(t, env)["preToolUse"]
+	if len(pre) != 1 {
+		t.Fatalf("forced preToolUse = %d entries, want 1", len(pre))
+	}
+	if pre[0]["matcher"] != copilotToolMatcher() {
+		t.Fatalf("--force did not restore our matcher: %v", pre[0]["matcher"])
+	}
+}
+
+// TestStaleGortexHookEntryIsReplaced: an entry from an older gortex — a
+// dead binary path, a retired flag — is upgraded in place rather than
+// left beside a fresh duplicate.
+func TestStaleGortexHookEntryIsReplaced(t *testing.T) {
+	env, _ := globalEnv(t)
+	seedHooks(t, env, map[string]any{
+		"version":         1,
+		"disableAllHooks": false,
+		"hooks": map[string]any{
+			"sessionStart": []any{map[string]any{
+				"type":       "command",
+				"bash":       "/opt/old/gortex hook --agent=copilot-cli --mode=deny",
+				"powershell": "& '/opt/old/gortex' hook --agent=copilot-cli --mode=deny",
+				"timeoutSec": 99,
+			}},
+		},
+	})
+
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	start := hookEvents(t, env)["sessionStart"]
+	if len(start) != 1 {
+		t.Fatalf("sessionStart = %d entries, want the stale one replaced not duplicated", len(start))
+	}
+	if got, _ := start[0]["bash"].(string); got != bashHookCommand(env) {
+		t.Fatalf("stale command survived: %q", got)
+	}
+}
+
+// TestForeignHookShapeIsLeftAlone: an event whose value is not a list is
+// a shape we do not understand and must not reshape.
+func TestForeignHookShapeIsLeftAlone(t *testing.T) {
+	env, _ := globalEnv(t)
+	seedHooks(t, env, map[string]any{
+		"version":         1,
+		"disableAllHooks": false,
+		"hooks":           map[string]any{"preToolUse": "not-a-list"},
+	})
+
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	cfg := agentstest.ReadJSON(t, HookConfigPath(env))
+	hooks, _ := cfg["hooks"].(map[string]any)
+	if hooks["preToolUse"] != "not-a-list" {
+		t.Fatalf("foreign preToolUse value was rewritten: %v", hooks["preToolUse"])
+	}
+	// The events we do understand are still installed.
+	if _, ok := hooks["sessionStart"]; !ok {
+		t.Error("the remaining events must still be written")
+	}
+}
+
+// TestDisableAllHooksIsNotFlippedBack: it is a user kill-switch, not a
+// field to correct.
+func TestDisableAllHooksIsNotFlippedBack(t *testing.T) {
+	env, _ := globalEnv(t)
+	seedHooks(t, env, map[string]any{"version": 1, "disableAllHooks": true})
+
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	cfg := agentstest.ReadJSON(t, HookConfigPath(env))
+	if cfg["disableAllHooks"] != true {
+		t.Fatalf("disableAllHooks = %v, want the user's true preserved", cfg["disableAllHooks"])
+	}
+}
+
+// TestHookBinaryDropsTheSubcommand: Env.HookCommand is "<binary> hook";
+// the PowerShell field has to quote the path on its own, which is
+// impossible once binary and arguments are one string.
+func TestHookBinaryDropsTheSubcommand(t *testing.T) {
+	// The ordinary case: no quoting, and so no "&" for encoding/json to
+	// escape into an unreadable & in the written file.
+	plain := agents.Env{HookCommand: "/usr/local/bin/gortex hook"}
+	if got := bashHookCommand(plain); got != "/usr/local/bin/gortex hook --agent=copilot-cli" {
+		t.Fatalf("bash command = %q", got)
+	}
+	if got := powershellHookCommand(plain); got != "/usr/local/bin/gortex hook --agent=copilot-cli" {
+		t.Fatalf("powershell command = %q; a bare path needs no call operator", got)
+	}
+
+	env := agents.Env{HookCommand: "/opt/gortex bin/gortex hook"}
+	if got := hookBinary(env); got != "/opt/gortex bin/gortex" {
+		t.Fatalf("hookBinary = %q, want the binary without the subcommand", got)
+	}
+	if got := bashHookCommand(env); got != `'/opt/gortex bin/gortex' hook --agent=copilot-cli` {
+		t.Fatalf("bash command = %q; a path with a space must be quoted", got)
+	}
+	if got := powershellHookCommand(env); got != `& '/opt/gortex bin/gortex' hook --agent=copilot-cli` {
+		t.Fatalf("powershell command = %q; needs the & call operator and quoting", got)
+	}
+}
+
+// TestWindowsHookBinaryIsUsable: a native Windows path must survive into
+// both fields — forward-slashed for Git Bash, verbatim for PowerShell.
+func TestWindowsHookBinaryIsUsable(t *testing.T) {
+	env := agents.Env{HookCommand: `C:\Program Files\gortex\gortex.exe hook`}
+	if got := bashHookCommand(env); got != `'C:/Program Files/gortex/gortex.exe' hook --agent=copilot-cli` {
+		t.Fatalf("bash command = %q", got)
+	}
+	if got := powershellHookCommand(env); got != `& 'C:\Program Files\gortex\gortex.exe' hook --agent=copilot-cli` {
+		t.Fatalf("powershell command = %q", got)
+	}
+}
+
+func TestMatcherNarrowingDetection(t *testing.T) {
+	want := map[string]any{"matcher": copilotToolMatcher()}
+	cases := []struct {
+		matcher  string
+		narrowed bool
+	}{
+		{"^(?:bash)$", true},
+		{"^(?:bash|powershell)$", true},
+		{copilotToolMatcher(), false},   // identical, not narrowed
+		{"^(?:bash|web_fetch)$", false}, // widened with a tool we never listed
+		{"bash", false},                 // unanchored: not a shape we read
+		{"^(?:bash|create|edit|glob|grep|powershell|rg|view|task)$", false},
+	}
+	for _, tc := range cases {
+		got := copilotHookMatcherIsNarrowed(map[string]any{"matcher": tc.matcher}, want)
+		if got != tc.narrowed {
+			t.Errorf("narrowed(%q) = %v, want %v", tc.matcher, got, tc.narrowed)
+		}
+	}
+}

--- a/internal/agents/copilotcli/inspect.go
+++ b/internal/agents/copilotcli/inspect.go
@@ -1,0 +1,120 @@
+package copilotcli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/zzet/gortex/internal/agents"
+)
+
+// inspect.go is the read-only counterpart to Apply: it reports what is
+// actually on disk so `gortex doctor` can compare intent against reality.
+// It reuses the writer's own recogniser, so a hook this package installs
+// and a hook it can find again never drift apart.
+
+// InstallState is the observed state of the Copilot CLI integration.
+//
+// # Stop-line: no adoption / session scan
+//
+// Every other agent doctor covers pairs this with a transcript scan
+// ("what did the model actually call?"). Copilot CLI gets none. Its
+// session history lives in ~/.copilot/session-store.db — SQLite with an
+// undocumented, unversioned schema, no export path, and no compatibility
+// promise. Reading it would mean reverse-engineering private tables that
+// can change in any patch release, and a scanner that silently starts
+// reporting zeros after an upgrade is worse than one that never existed.
+// Doctor reports install state and hook activity for this agent and stops
+// there; the Adoption slice stays at its zero value on purpose.
+type InstallState struct {
+	ConfigPath        string         `json:"config_path"`
+	ConfigPresent     bool           `json:"config_present"`
+	MCPServer         bool           `json:"mcp_server"`
+	Hooks             map[string]int `json:"hooks"`
+	InstructionsPath  string         `json:"instructions_path,omitempty"`
+	InstructionsWired bool           `json:"instructions_wired"`
+}
+
+// HookEvents are the lifecycle events this adapter installs, in the order
+// they matter for adoption: SessionStart is what states the Gortex rule
+// for the session, so its absence explains a silent integration on its
+// own.
+//
+// These are Claude's PascalCase spellings, NOT the camelCase names that
+// go on disk (see copilotHookEventNames). internal/hooks' effectiveness
+// log and doctor's tally are keyed on the PascalCase vocabulary and
+// ignore anything else, so keying this list — or the Hooks map below —
+// with Copilot's own spellings would score every event ran==0 and make
+// doctor print a permanent "configured but none has run" blocker over a
+// perfectly working install.
+var HookEvents = []string{"SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse"}
+
+// Inspect reads the Copilot CLI config under home. Every failure degrades
+// to "not configured" rather than an error: doctor's job is to describe a
+// broken machine, not to fail on one.
+func Inspect(home string) InstallState {
+	state := InstallState{Hooks: map[string]int{}}
+	if home == "" {
+		return state
+	}
+	for _, event := range HookEvents {
+		state.Hooks[event] = 0
+	}
+
+	env := agents.Env{Home: home}
+	configHome := copilotConfigHome(env)
+	if configHome == "" {
+		return state
+	}
+
+	// The hooks file is reported as the config path: it is the one whose
+	// contents doctor's runtime section is about. The MCP registry is a
+	// separate file and is only probed for the server's presence.
+	state.ConfigPath = filepath.Join(configHome, hooksDirName, hookFileName)
+	if data, err := os.ReadFile(state.ConfigPath); err == nil {
+		state.ConfigPresent = true
+		var root map[string]any
+		if json.Unmarshal(data, &root) == nil {
+			countGortexCopilotHooks(root, state.Hooks)
+		}
+	}
+
+	if data, err := os.ReadFile(filepath.Join(configHome, mcpConfigFileName)); err == nil {
+		var root struct {
+			MCPServers map[string]any `json:"mcpServers"`
+		}
+		if json.Unmarshal(data, &root) == nil {
+			_, state.MCPServer = root.MCPServers[serverName]
+		}
+	}
+
+	state.InstructionsPath = filepath.Join(configHome, instructionsFileName)
+	if body, err := os.ReadFile(state.InstructionsPath); err == nil {
+		text := string(body)
+		state.InstructionsWired = strings.Contains(text, agents.GlobalRulesStartMarker) ||
+			strings.Contains(text, agents.InstructionsSentinel)
+	}
+	return state
+}
+
+// countGortexCopilotHooks tallies Gortex-authored entries per event. The
+// on-disk keys are camelCase; the output map is PascalCase, so the
+// translation happens here and nowhere downstream.
+func countGortexCopilotHooks(root map[string]any, out map[string]int) {
+	hooks, ok := root["hooks"].(map[string]any)
+	if !ok {
+		return
+	}
+	for _, event := range HookEvents {
+		entries, ok := copilotHookList(hooks[copilotHookEventNames[event]])
+		if !ok {
+			continue
+		}
+		for _, entry := range entries {
+			if isGortexCopilotHookEntry(entry) {
+				out[event]++
+			}
+		}
+	}
+}

--- a/internal/agents/copilotcli/inspect_test.go
+++ b/internal/agents/copilotcli/inspect_test.go
@@ -1,0 +1,140 @@
+package copilotcli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/agents"
+)
+
+// TestInspectRoundTripsWhatApplyWrote is the fence that keeps the writer
+// and the reporter from drifting: doctor must find the entries this
+// package just installed.
+func TestInspectRoundTripsWhatApplyWrote(t *testing.T) {
+	env, _ := globalEnv(t)
+	env.InstallGlobalInstructions = true
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	state := Inspect(env.Home)
+	if state.ConfigPath != HookConfigPath(env) {
+		t.Fatalf("ConfigPath = %q, want %q", state.ConfigPath, HookConfigPath(env))
+	}
+	if !state.ConfigPresent {
+		t.Fatal("ConfigPresent = false after Apply wrote the hook config")
+	}
+	if !state.MCPServer {
+		t.Fatal("MCPServer = false after Apply registered the gortex server")
+	}
+	if state.InstructionsPath != GlobalInstructionsPath(env) {
+		t.Fatalf("InstructionsPath = %q, want %q", state.InstructionsPath, GlobalInstructionsPath(env))
+	}
+	if !state.InstructionsWired {
+		t.Fatal("InstructionsWired = false after Apply wrote the rule block")
+	}
+	for _, event := range HookEvents {
+		if state.Hooks[event] != 1 {
+			t.Errorf("Hooks[%s] = %d, want 1", event, state.Hooks[event])
+		}
+	}
+	if len(state.Hooks) != len(HookEvents) {
+		t.Errorf("Hooks has %d keys, want %d: %v", len(state.Hooks), len(HookEvents), state.Hooks)
+	}
+}
+
+// TestInspectKeysAreClaudePascalCase is the whole reason inspect.go
+// translates at all. `gortex doctor` tallies hook runs against
+// internal/hooks' PascalCase-only allowlist, so a Hooks map keyed with
+// Copilot's own camelCase spellings scores every event ran==0 — and
+// doctor then prints a permanent "configured but none has run" blocker
+// over a perfectly working install.
+func TestInspectKeysAreClaudePascalCase(t *testing.T) {
+	env, _ := globalEnv(t)
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	want := map[string]bool{
+		"SessionStart": true, "UserPromptSubmit": true,
+		"PreToolUse": true, "PostToolUse": true,
+	}
+	state := Inspect(env.Home)
+	for key := range state.Hooks {
+		if !want[key] {
+			t.Errorf("Hooks key %q is not Claude's PascalCase vocabulary", key)
+		}
+	}
+	// The on-disk spellings must never leak out of the writer.
+	for _, onDisk := range copilotHookEventNames {
+		if _, leaked := state.Hooks[onDisk]; leaked {
+			t.Errorf("Hooks leaked the on-disk spelling %q", onDisk)
+		}
+	}
+	// And they must actually differ, or the test proves nothing.
+	if copilotHookEventNames["UserPromptSubmit"] != "userPromptSubmitted" {
+		t.Fatalf("the CLI's event name is past tense: got %q", copilotHookEventNames["UserPromptSubmit"])
+	}
+}
+
+// TestInspectDegradesOnAnEmptyMachine: doctor's job is to describe a
+// broken machine, not to fail on one.
+func TestInspectDegradesOnAnEmptyMachine(t *testing.T) {
+	t.Setenv(copilotHomeEnvVar, "")
+	if state := Inspect(""); state.ConfigPresent || len(state.Hooks) != 0 {
+		t.Fatalf("empty home must yield a zero state, got %+v", state)
+	}
+	state := Inspect(t.TempDir())
+	if state.ConfigPresent || state.MCPServer || state.InstructionsWired {
+		t.Fatalf("unconfigured home must report nothing installed, got %+v", state)
+	}
+	for _, event := range HookEvents {
+		if state.Hooks[event] != 0 {
+			t.Errorf("Hooks[%s] = %d on an unconfigured machine", event, state.Hooks[event])
+		}
+	}
+}
+
+// TestInspectFindsAHandWrittenGortexHook: recognition is by command
+// content, so an entry written by an older gortex (or copied by a user)
+// still counts.
+func TestInspectFindsAHandWrittenGortexHook(t *testing.T) {
+	env, _ := globalEnv(t)
+	seedHooks(t, env, map[string]any{
+		"version":         1,
+		"disableAllHooks": false,
+		"hooks": map[string]any{
+			"postToolUse": []any{map[string]any{
+				"type": "command", "matcher": "^(?:bash)$",
+				"bash": "gortex hook --agent copilot-cli",
+			}},
+			// A user hook that is not ours must not be counted.
+			"sessionStart": []any{map[string]any{"type": "command", "bash": "echo hi"}},
+		},
+	})
+
+	state := Inspect(env.Home)
+	if state.Hooks["PostToolUse"] != 1 {
+		t.Errorf("PostToolUse = %d, want the space-separated --agent form recognised", state.Hooks["PostToolUse"])
+	}
+	if state.Hooks["SessionStart"] != 0 {
+		t.Errorf("SessionStart = %d, want a user hook not counted as ours", state.Hooks["SessionStart"])
+	}
+}
+
+// TestInspectHonoursTheSandboxHomeGuard mirrors the adapter's own
+// COPILOT_HOME rule: an exported override must not redirect Inspect onto
+// the developer's real config while doctor is probing a sandbox home.
+func TestInspectHonoursTheSandboxHomeGuard(t *testing.T) {
+	t.Setenv(copilotHomeEnvVar, t.TempDir())
+	home := t.TempDir()
+	state := Inspect(home)
+	want := filepath.Join(home, copilotConfigDirName, hooksDirName, hookFileName)
+	if state.ConfigPath != want {
+		t.Fatalf("ConfigPath = %q, want %q", state.ConfigPath, want)
+	}
+	if strings.Contains(state.InstructionsPath, "hooks") {
+		t.Fatalf("InstructionsPath = %q", state.InstructionsPath)
+	}
+}

--- a/internal/agents/copilotcli/remove.go
+++ b/internal/agents/copilotcli/remove.go
@@ -1,0 +1,389 @@
+package copilotcli
+
+// remove.go is the counterpart to Apply for `gortex uninstall --global`.
+//
+// # Ownership, not location
+//
+// Every deletion is gated on evidence Gortex authored the thing being
+// deleted, never on the path it sits at. ~/.copilot/skills and
+// ~/.copilot/agents hold the user's own skills and custom agents beside
+// ours; deleting either directory would destroy their work. The predicate
+// is the one skills.go / subagents.go write with — a shipped id whose file
+// is still byte-identical to the body we render — and a file that differs
+// is KEPT with a warning, the same never-clobber posture Apply takes on
+// the way in.
+//
+// ~/.copilot/hooks/gortex.json is ours by name, but it is still edited
+// rather than blindly deleted: the CLI merges every *.json in that
+// directory, so a user who appended their own entry to our file would lose
+// it. Our entries come out through the writer's own recogniser, and the
+// file is deleted only once nothing but our scaffolding is left.
+//
+// The MCP stanza and the rule block go through the shared removal paths —
+// agents.RemoveMCPServer and an empty-body agents.UpsertMarkedBlock — so
+// other servers and the user's surrounding instructions prose survive.
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/internalutil"
+)
+
+// RemoveGlobal strips the user-level Copilot CLI footprint `gortex
+// install` wrote. Returns the number of artifacts removed-or-cleaned and
+// any per-artifact failures — a partial clean still reports rather than
+// aborting. Signature mirrors claudecode.Adapter.RemoveGlobal so `gortex
+// uninstall` can call every host through the same shape.
+func (a *Adapter) RemoveGlobal(env agents.Env, opts agents.ApplyOpts) (removed int, failures []string) {
+	if copilotConfigHome(env) == "" {
+		return 0, []string{"copilot-cli: global cleanup requires a resolved home directory"}
+	}
+	w := env.Stderr
+
+	count := func(action agents.FileAction, err error, label string) {
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", label, err))
+			return
+		}
+		if action.Action != agents.ActionSkip {
+			removed++
+		}
+	}
+
+	// 1. ~/.copilot/mcp-config.json — drop only the "gortex" server.
+	mcpPath := MCPConfigPath(env)
+	mcpAction, err := agents.MergeJSON(w, mcpPath, func(root map[string]any, _ bool) (bool, error) {
+		return agents.RemoveMCPServer(root, serverName), nil
+	}, opts)
+	count(mcpAction, err, mcpPath)
+
+	// 2. ~/.copilot/copilot-instructions.md — an empty body makes
+	// UpsertMarkedBlock drop the marker-fenced block in place, which is
+	// the documented removal path and the only one that preserves the
+	// user's surrounding prose.
+	insPath := GlobalInstructionsPath(env)
+	insAction, err := agents.UpsertMarkedBlock(w, insPath, "",
+		agents.GlobalRulesStartMarker, agents.GlobalRulesEndMarker, opts)
+	count(insAction, err, insPath)
+
+	// 3. ~/.copilot/hooks/gortex.json — our entries out, the user's kept.
+	hookAction, err := removeCopilotHooks(env, opts)
+	count(hookAction, err, HookConfigPath(env))
+
+	// 4. ~/.copilot/skills/<id>/SKILL.md and ~/.copilot/agents/<id>.agent.md.
+	ownedRemoved, ownedFailures := removeCopilotOwnedFiles(env, opts)
+	removed += ownedRemoved
+	failures = append(failures, ownedFailures...)
+
+	return removed, failures
+}
+
+// GlobalArtifacts lists the user-level Copilot CLI paths that currently
+// carry a Gortex footprint, sorted. It applies the SAME ownership tests
+// RemoveGlobal does — a customised skill is absent from this list exactly
+// because removal will keep it — so the uninstall wizard's preview can
+// never promise a deletion that will not happen, nor stay silent about one
+// that will.
+func GlobalArtifacts(home string) []string {
+	env := agents.Env{Home: home}
+	if copilotConfigHome(env) == "" {
+		return nil
+	}
+	var present []string
+
+	// Parsed rather than grepped: a preview that fires on the word "gortex"
+	// anywhere in the file would promise to edit a config removal will not
+	// touch.
+	if mcpConfigHasGortexServer(MCPConfigPath(env)) {
+		present = append(present, MCPConfigPath(env))
+	}
+	if copilotFileContains(GlobalInstructionsPath(env), agents.GlobalRulesStartMarker) {
+		present = append(present, GlobalInstructionsPath(env))
+	}
+	if hookConfigHasGortexEntry(HookConfigPath(env)) {
+		present = append(present, HookConfigPath(env))
+	}
+	for path, shipped := range copilotOwnedFiles(env) {
+		if isShippedCopilotFile(path, shipped) {
+			present = append(present, path)
+		}
+	}
+
+	sort.Strings(present)
+	return present
+}
+
+// removeCopilotHooks takes our entries out of the hook config and deletes
+// the file only when nothing else was in it.
+//
+// The file carries our name, which is tempting to read as "ours to
+// delete". It is not sufficient: the CLI merges every hooks/*.json, so a
+// user who added an entry to the file we created still owns that entry.
+// Stripping first and deleting only on an empty remainder is what keeps
+// both facts true.
+func removeCopilotHooks(env agents.Env, opts agents.ApplyOpts) (agents.FileAction, error) {
+	path := HookConfigPath(env)
+	action := agents.FileAction{Path: path, Action: agents.ActionSkip}
+
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		action.Reason = "absent"
+		return action, nil
+	}
+	if err != nil {
+		return agents.FileAction{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	var root map[string]any
+	if json.Unmarshal(data, &root) != nil {
+		// A shape we cannot parse is a shape we must not delete.
+		action.Reason = "unparsable"
+		return action, nil
+	}
+	if !stripGortexCopilotHooks(root) {
+		action.Reason = "no-gortex-hooks"
+		return action, nil
+	}
+
+	hooks, _ := root["hooks"].(map[string]any)
+	if len(hooks) == 0 && onlyGortexScaffolding(root) {
+		// Nothing but the version / disableAllHooks pair upsertCopilotHooks
+		// seeds is left, so the whole file is ours.
+		if opts.DryRun {
+			return agents.FileAction{Path: path, Action: agents.ActionWouldDelete}, nil
+		}
+		if err := os.Remove(path); err != nil {
+			return agents.FileAction{}, fmt.Errorf("remove %s: %w", path, err)
+		}
+		internalutil.Logf(env.Stderr, "[gortex uninstall] removed %s", path)
+		pruneEmptyDir(filepath.Dir(path))
+		return agents.FileAction{Path: path, Action: agents.ActionDelete}, nil
+	}
+
+	if opts.DryRun {
+		return agents.FileAction{Path: path, Action: agents.ActionWouldMerge, Keys: []string{"hooks"}}, nil
+	}
+	out, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return agents.FileAction{}, fmt.Errorf("marshal %s: %w", path, err)
+	}
+	if err := agents.AtomicWriteFile(path, out, 0o644); err != nil {
+		return agents.FileAction{}, err
+	}
+	internalutil.Logf(env.Stderr, "[gortex uninstall] removed the gortex hook entries from %s", path)
+	return agents.FileAction{Path: path, Action: agents.ActionMerge, Keys: []string{"hooks"}}, nil
+}
+
+// onlyGortexScaffolding reports whether nothing is left in the parsed
+// config beyond the keys upsertCopilotHooks seeds. A top-level key we did
+// not write is the user's, and its presence is what turns "delete the
+// file" back into "rewrite it" — the file name alone is never enough
+// evidence to destroy content.
+func onlyGortexScaffolding(root map[string]any) bool {
+	ours := map[string]bool{"version": true, "disableAllHooks": true, "hooks": true}
+	for key := range root {
+		if !ours[key] {
+			return false
+		}
+	}
+	return true
+}
+
+// stripGortexCopilotHooks removes every Gortex-authored entry from a
+// parsed hook config, reusing the writer's own recogniser so an entry this
+// package installs is always an entry it can find again. Reports whether
+// anything came out.
+func stripGortexCopilotHooks(root map[string]any) bool {
+	hooks, ok := root["hooks"].(map[string]any)
+	if !ok {
+		return false
+	}
+	changed := false
+	for _, event := range copilotHookEventNames {
+		entries, ok := copilotHookList(hooks[event])
+		if !ok {
+			continue
+		}
+		kept := make([]any, 0, len(entries))
+		for _, entry := range entries {
+			if isGortexCopilotHookEntry(entry) {
+				changed = true
+				continue
+			}
+			kept = append(kept, entry)
+		}
+		if len(kept) == len(entries) {
+			continue
+		}
+		if len(kept) == 0 {
+			delete(hooks, event)
+		} else {
+			hooks[event] = kept
+		}
+	}
+	if !changed {
+		return false
+	}
+	if len(hooks) == 0 {
+		delete(root, "hooks")
+	}
+	return true
+}
+
+// mcpConfigHasGortexServer is the read-only half of
+// agents.RemoveMCPServer's precondition, so the wizard preview and the
+// deletion cannot disagree about whether the registry carries our entry.
+func mcpConfigHasGortexServer(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	var root struct {
+		MCPServers map[string]json.RawMessage `json:"mcpServers"`
+	}
+	if json.Unmarshal(data, &root) != nil {
+		return false
+	}
+	_, ok := root.MCPServers[serverName]
+	return ok
+}
+
+// hookConfigHasGortexEntry is the read-only half of
+// stripGortexCopilotHooks, so the wizard preview and the deletion cannot
+// disagree about whether the hook file carries anything of ours.
+func hookConfigHasGortexEntry(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	var root map[string]any
+	if json.Unmarshal(data, &root) != nil {
+		return false
+	}
+	hooks, ok := root["hooks"].(map[string]any)
+	if !ok {
+		return false
+	}
+	for _, event := range copilotHookEventNames {
+		entries, ok := copilotHookList(hooks[event])
+		if !ok {
+			continue
+		}
+		for _, entry := range entries {
+			if isGortexCopilotHookEntry(entry) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// copilotOwnedFiles maps every curated skill / sub-agent path to the body
+// Gortex ships there. One map so the remover and the preview enumerate
+// exactly the same set.
+func copilotOwnedFiles(env agents.Env) map[string]string {
+	out := make(map[string]string)
+	skills := CuratedSkills()
+	for _, id := range CuratedSkillNames() {
+		body, ok := skills[id]
+		if !ok {
+			continue
+		}
+		if path := curatedSkillPath(env, id); path != "" {
+			out[path] = body
+		}
+	}
+	defs := SubAgents()
+	for _, id := range SubAgentNames() {
+		body, ok := defs[id]
+		if !ok {
+			continue
+		}
+		if path := subAgentPath(env, id); path != "" {
+			out[path] = body
+		}
+	}
+	return out
+}
+
+// removeCopilotOwnedFiles deletes the curated skills and sub-agents whose
+// bytes are still ours, prunes each skill's own directory when it empties,
+// and then the two roots. A user's skill directory in the same root is
+// never looked at, and the roots survive as long as it does.
+func removeCopilotOwnedFiles(env agents.Env, opts agents.ApplyOpts) (removed int, failures []string) {
+	owned := copilotOwnedFiles(env)
+	paths := make([]string, 0, len(owned))
+	for path := range owned {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	for _, path := range paths {
+		n, f := removeOwnedFile(env.Stderr, path, owned[path], opts)
+		removed += n
+		failures = append(failures, f...)
+		if n > 0 && !opts.DryRun && filepath.Base(path) == skillFileName {
+			// Skills are <id>/SKILL.md; sub-agents are flat files.
+			pruneEmptyDir(filepath.Dir(path))
+		}
+	}
+	if removed > 0 && !opts.DryRun {
+		home := copilotConfigHome(env)
+		pruneEmptyDir(filepath.Join(home, skillsDirName))
+		pruneEmptyDir(filepath.Join(home, subAgentsDirName))
+	}
+	return removed, failures
+}
+
+// removeOwnedFile deletes path only when its bytes are still exactly what
+// Gortex shipped. Anything else is the user's edit and is kept with a
+// warning, mirroring the never-clobber WriteIfNotExists posture on the way
+// in.
+func removeOwnedFile(w io.Writer, path, shipped string, opts agents.ApplyOpts) (removed int, failures []string) {
+	existing, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, []string{fmt.Sprintf("%s: %v", path, err)}
+	}
+	if string(existing) != shipped {
+		internalutil.Warnf(w, "keeping customised %s", path)
+		return 0, nil
+	}
+	if opts.DryRun {
+		return 1, nil
+	}
+	if err := os.Remove(path); err != nil {
+		return 0, []string{fmt.Sprintf("%s: %v", path, err)}
+	}
+	internalutil.Logf(w, "[gortex uninstall] removed %s", path)
+	return 1, nil
+}
+
+func isShippedCopilotFile(path, shipped string) bool {
+	data, err := os.ReadFile(path)
+	return err == nil && string(data) == shipped
+}
+
+// pruneEmptyDir removes dir only when it holds nothing. os.Remove refuses
+// a non-empty directory, which is exactly the guard we want: a user file
+// sitting next to one we deleted keeps its directory alive.
+func pruneEmptyDir(dir string) {
+	_ = os.Remove(dir)
+}
+
+func copilotFileContains(path, needle string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(data), needle)
+}

--- a/internal/agents/copilotcli/remove_test.go
+++ b/internal/agents/copilotcli/remove_test.go
@@ -1,0 +1,276 @@
+package copilotcli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/agents"
+)
+
+const userCopilotProse = "# House rules\n\nBe terse.\n"
+
+func writeCopilotFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// userHookEntry is a hook a user added to OUR file. The CLI merges every
+// hooks/*.json, so somebody who appended to gortex.json owns that entry —
+// which is why removal strips rather than deletes.
+func userHookEntry() map[string]any {
+	return map[string]any{
+		"type":       "command",
+		"bash":       "my-own-linter",
+		"powershell": "my-own-linter",
+		"cwd":        ".",
+	}
+}
+
+// installedCopilotGlobal runs a ModeGlobal Apply over a home that already
+// holds the user's own MCP server, instructions prose, hook entry and
+// skill, and returns the env plus the user skill's path. Starting from a
+// real install rather than a hand-built fixture is what keeps the remover
+// from asserting against a shape the writer no longer produces.
+func installedCopilotGlobal(t *testing.T) (agents.Env, string) {
+	t.Helper()
+	env, _ := globalEnv(t)
+	env.InstallGlobalInstructions = true
+
+	writeCopilotFile(t, MCPConfigPath(env), `{"mcpServers":{"other":{"command":"node","args":["server.js"],"type":"local"}}}`)
+	writeCopilotFile(t, GlobalInstructionsPath(env), userCopilotProse)
+
+	// A hand-written skill in the SHARED ~/.copilot/skills root — the whole
+	// reason removal cannot just delete the directory.
+	userSkill := filepath.Join(copilotConfigHome(env), skillsDirName, "team-runbook", skillFileName)
+	writeCopilotFile(t, userSkill, "---\nname: team-runbook\n---\n\nOurs, not Gortex's.\n")
+
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	// Appended after Apply so it survives into RemoveGlobal's input as a
+	// genuine "the user edited our file" case.
+	addUserHookEntry(t, env)
+
+	if got := GlobalArtifacts(env.Home); len(got) == 0 {
+		t.Fatal("expected a non-empty footprint after install")
+	}
+	return env, userSkill
+}
+
+func addUserHookEntry(t *testing.T, env agents.Env) {
+	t.Helper()
+	root := readJSON(t, HookConfigPath(env))
+	hooks, ok := root["hooks"].(map[string]any)
+	if !ok {
+		t.Fatalf("no hooks object in %s", HookConfigPath(env))
+	}
+	event := copilotHookEventNames["PreToolUse"]
+	entries, _ := copilotHookList(hooks[event])
+	hooks[event] = append(entries, userHookEntry())
+	writeJSON(t, HookConfigPath(env), root)
+}
+
+// TestCopilotRemoveGlobalLeavesNoGortexArtifact is the round-trip
+// contract: after Apply then RemoveGlobal nothing of Gortex's is left,
+// and every user-owned thing that shared a file or a directory with it
+// survives.
+func TestCopilotRemoveGlobalLeavesNoGortexArtifact(t *testing.T) {
+	env, userSkill := installedCopilotGlobal(t)
+	skillBefore, err := os.ReadFile(userSkill)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	removed, failures := New().RemoveGlobal(env, agents.ApplyOpts{})
+	if len(failures) != 0 {
+		t.Fatalf("RemoveGlobal failures: %v", failures)
+	}
+	if removed == 0 {
+		t.Fatal("expected RemoveGlobal to remove at least one artifact")
+	}
+
+	// mcp-config.json: gortex gone, the user's server byte-for-byte intact.
+	mcp := readJSON(t, MCPConfigPath(env))
+	servers, _ := mcp["mcpServers"].(map[string]any)
+	if _, exists := servers[serverName]; exists {
+		t.Error("mcp-config.json still registers the gortex server")
+	}
+	wantOther := map[string]any{"command": "node", "args": []any{"server.js"}, "type": "local"}
+	if got := servers["other"]; !reflect.DeepEqual(got, wantOther) {
+		t.Errorf("the user's MCP server changed: %v", got)
+	}
+
+	// copilot-instructions.md: prose kept, marker block gone.
+	md := readString(t, GlobalInstructionsPath(env))
+	if strings.Contains(md, agents.GlobalRulesStartMarker) {
+		t.Errorf("instructions still carry the gortex marker:\n%s", md)
+	}
+	if !strings.Contains(md, "Be terse.") {
+		t.Errorf("instructions lost the user's prose:\n%s", md)
+	}
+
+	// gortex.json survives because the user's entry is still in it, and
+	// that entry is unchanged.
+	hookRoot := readJSON(t, HookConfigPath(env))
+	if strings.Contains(readString(t, HookConfigPath(env)), "--agent="+hookAgentFlag) {
+		t.Error("the hook config still invokes the gortex hook")
+	}
+	hooks, _ := hookRoot["hooks"].(map[string]any)
+	entries, ok := copilotHookList(hooks[copilotHookEventNames["PreToolUse"]])
+	if !ok || len(entries) != 1 {
+		t.Fatalf("preToolUse should hold exactly the user's entry, got %v", hooks)
+	}
+	if !reflect.DeepEqual(entries[0], any(userHookEntry())) {
+		t.Errorf("the user's hook entry changed: %v", entries[0])
+	}
+	for _, event := range []string{"SessionStart", "UserPromptSubmit", "PostToolUse"} {
+		if left, _ := copilotHookList(hooks[copilotHookEventNames[event]]); len(left) != 0 {
+			t.Errorf("%s should be empty after removal, got %v", event, left)
+		}
+	}
+
+	// Curated skills and sub-agents are gone.
+	for _, id := range CuratedSkillNames() {
+		if _, err := os.Stat(curatedSkillPath(env, id)); err == nil {
+			t.Errorf("curated skill %s survived removal", id)
+		}
+	}
+	for _, id := range SubAgentNames() {
+		if _, err := os.Stat(subAgentPath(env, id)); err == nil {
+			t.Errorf("sub-agent %s survived removal", id)
+		}
+	}
+
+	// The user's own skill in that same root is byte-identical.
+	skillAfter, err := os.ReadFile(userSkill)
+	if err != nil {
+		t.Fatalf("the user's skill was deleted: %v", err)
+	}
+	if string(skillAfter) != string(skillBefore) {
+		t.Errorf("the user's skill changed:\n%s", skillAfter)
+	}
+
+	if got := GlobalArtifacts(env.Home); len(got) != 0 {
+		t.Errorf("GlobalArtifacts should be empty after RemoveGlobal, got %v", got)
+	}
+}
+
+// TestCopilotRemoveGlobalDeletesAPureGortexHookFile is the other half of
+// the hook policy: with nothing of the user's left in it, gortex.json is
+// scaffolding we wrote and wholly ours to delete.
+func TestCopilotRemoveGlobalDeletesAPureGortexHookFile(t *testing.T) {
+	env, _ := globalEnv(t)
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if _, err := os.Stat(HookConfigPath(env)); err != nil {
+		t.Fatalf("apply wrote no hook config: %v", err)
+	}
+
+	if _, failures := New().RemoveGlobal(env, agents.ApplyOpts{}); len(failures) != 0 {
+		t.Fatalf("RemoveGlobal failures: %v", failures)
+	}
+	if _, err := os.Stat(HookConfigPath(env)); err == nil {
+		t.Error("a hook file holding only gortex entries should be deleted")
+	}
+}
+
+// TestCopilotRemoveGlobalKeepsACustomisedSkill pins the never-clobber
+// posture Apply takes on the way in: a Gortex skill the user edited is
+// their work now. The wizard preview must agree — a path removal will
+// keep may never appear in GlobalArtifacts.
+func TestCopilotRemoveGlobalKeepsACustomisedSkill(t *testing.T) {
+	env, _ := installedCopilotGlobal(t)
+
+	names := CuratedSkillNames()
+	if len(names) == 0 {
+		t.Fatal("curated pack is empty")
+	}
+	customised := curatedSkillPath(env, names[0])
+	body := CuratedSkills()[names[0]] + "\n<!-- my own note -->\n"
+	writeCopilotFile(t, customised, body)
+
+	for _, path := range GlobalArtifacts(env.Home) {
+		if path == customised {
+			t.Errorf("the preview promises to delete a customised skill: %s", path)
+		}
+	}
+
+	if _, failures := New().RemoveGlobal(env, agents.ApplyOpts{}); len(failures) != 0 {
+		t.Fatalf("RemoveGlobal failures: %v", failures)
+	}
+	got, err := os.ReadFile(customised)
+	if err != nil {
+		t.Fatalf("the customised skill was deleted: %v", err)
+	}
+	if string(got) != body {
+		t.Errorf("the customised skill changed:\n%s", got)
+	}
+}
+
+// TestCopilotRemoveGlobalDryRunTouchesNothing keeps the preview honest in
+// the other direction: it must count the same artifacts without writing.
+func TestCopilotRemoveGlobalDryRunTouchesNothing(t *testing.T) {
+	env, _ := installedCopilotGlobal(t)
+	before := readString(t, HookConfigPath(env))
+
+	removed, failures := New().RemoveGlobal(env, agents.ApplyOpts{DryRun: true})
+	if len(failures) != 0 {
+		t.Fatalf("RemoveGlobal failures: %v", failures)
+	}
+	if removed == 0 {
+		t.Fatal("a dry run should still count what it would remove")
+	}
+	if got := readString(t, HookConfigPath(env)); got != before {
+		t.Error("dry run rewrote the hook config")
+	}
+	if got := GlobalArtifacts(env.Home); len(got) == 0 {
+		t.Error("dry run removed the footprint")
+	}
+}
+
+// TestCopilotRemoveGlobalNeedsAHome refuses rather than guessing at a root.
+func TestCopilotRemoveGlobalNeedsAHome(t *testing.T) {
+	t.Setenv(copilotHomeEnvVar, "")
+	removed, failures := New().RemoveGlobal(agents.Env{}, agents.ApplyOpts{})
+	if removed != 0 || len(failures) != 1 {
+		t.Fatalf("want (0, one failure), got (%d, %v)", removed, failures)
+	}
+}
+
+func readString(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func readJSON(t *testing.T, path string) map[string]any {
+	t.Helper()
+	var root map[string]any
+	if err := json.Unmarshal([]byte(readString(t, path)), &root); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return root
+}
+
+func writeJSON(t *testing.T, path string, root map[string]any) {
+	t.Helper()
+	body, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeCopilotFile(t, path, string(body))
+}

--- a/internal/agents/copilotcli/skills.go
+++ b/internal/agents/copilotcli/skills.go
@@ -1,6 +1,8 @@
 package copilotcli
 
 import (
+	"io"
+	"os"
 	"path/filepath"
 	"sort"
 
@@ -89,13 +91,24 @@ func copilotSkillFromClaude(skill skillpack.Skill) string {
 	}) + skill.Body
 }
 
-// curatedSkillPath is ~/.copilot/skills/<id>/SKILL.md.
-func curatedSkillPath(env agents.Env, id string) string {
+// curatedSkillsRoot is ~/.copilot/skills — the only user-level skills
+// root the CLI still honours (see the file header for the two it
+// dropped). Empty when the Env has no resolvable config home.
+func curatedSkillsRoot(env agents.Env) string {
 	home := copilotConfigHome(env)
 	if home == "" {
 		return ""
 	}
-	return filepath.Join(home, skillsDirName, id, skillFileName)
+	return filepath.Join(home, skillsDirName)
+}
+
+// curatedSkillPath is ~/.copilot/skills/<id>/SKILL.md.
+func curatedSkillPath(env agents.Env, id string) string {
+	root := curatedSkillsRoot(env)
+	if root == "" {
+		return ""
+	}
+	return filepath.Join(root, id, skillFileName)
 }
 
 // generatedSkillPath is <root>/.github/skills/<DirName>/SKILL.md — flat,
@@ -116,26 +129,63 @@ func generatedSkillPath(root, dirName string) string {
 //
 // An existing file is never overwritten — a user who tuned a playbook's
 // description or trimmed its steps keeps that work across re-installs.
+//
+// `allowed` is nil here: install materialises the whole pack, and
+// `gortex instructions switch` narrows it afterwards through SyncSkills.
+// Both go through the same reconciler so an install and a profile switch
+// can never disagree about what belongs on disk.
 func installCuratedSkills(env agents.Env, opts agents.ApplyOpts) []agents.FileAction {
-	skills := CuratedSkills()
-	out := make([]agents.FileAction, 0, len(skills))
-	for _, id := range CuratedSkillNames() {
-		body, ok := skills[id]
-		if !ok {
-			continue
-		}
-		path := curatedSkillPath(env, id)
-		if path == "" {
-			continue
-		}
-		action, err := agents.WriteIfNotExists(env.Stderr, path, body, opts)
-		if err != nil {
-			internalutil.Warnf(env.Stderr, "copilot-cli skill %s: %v", id, err)
-			continue
-		}
-		out = append(out, action)
+	out, err := syncCuratedSkills(env.Stderr, curatedSkillsRoot(env), nil, opts)
+	if err != nil {
+		// Partial progress is still reported: a single unreadable skill
+		// must not hide the ones that did land.
+		internalutil.Warnf(env.Stderr, "copilot-cli skills: %v", err)
 	}
 	return out
+}
+
+// SyncSkills reshapes an ALREADY-INSTALLED ~/.copilot/skills tree to the
+// allowed subset (nil = every shipped skill). This is the entry point
+// `gortex instructions switch` drives.
+//
+// A missing skills root is a silent no-op, not an install: switching a
+// profile must never conjure a Copilot CLI surface on a machine that
+// never ran `gortex install`, and most machines carry only one or two of
+// the supported hosts.
+//
+// home is taken rather than an agents.Env so every host's switch entry
+// point has the same shape; it is wrapped back into an Env because
+// $COPILOT_HOME may relocate the whole config directory, and that
+// override is only honoured for the machine's real home.
+func SyncSkills(w io.Writer, home string, allowed []string, opts agents.ApplyOpts) ([]agents.FileAction, error) {
+	if home == "" {
+		return nil, nil
+	}
+	root := curatedSkillsRoot(agents.Env{Home: home, Stderr: w})
+	if root == "" {
+		return nil, nil
+	}
+	if _, err := os.Stat(root); err != nil {
+		return nil, nil
+	}
+	return syncCuratedSkills(w, root, allowed, opts)
+}
+
+// syncCuratedSkills is the one reconciler both entry points reach. The
+// deletion rule (never remove a customised file) lives in skillpack, not
+// here, so all four skill-aware hosts enforce it identically.
+func syncCuratedSkills(w io.Writer, root string, allowed []string, opts agents.ApplyOpts) ([]agents.FileAction, error) {
+	if root == "" {
+		return nil, nil
+	}
+	// KnownHashes stays unset: this pack has only ever shipped one
+	// rendering, so the byte compare against CuratedSkills() is the
+	// complete definition of "still ours".
+	return skillpack.Sync(w, skillpack.SyncSpec{
+		Dir:      root,
+		FileName: skillFileName,
+		Rendered: CuratedSkills(),
+	}, allowed, opts)
 }
 
 // installGeneratedSkills writes the per-community skills the caller

--- a/internal/agents/copilotcli/skills.go
+++ b/internal/agents/copilotcli/skills.go
@@ -1,0 +1,166 @@
+package copilotcli
+
+import (
+	"path/filepath"
+	"sort"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/claudecode"
+	"github.com/zzet/gortex/internal/agents/internalutil"
+	"github.com/zzet/gortex/internal/agents/skillpack"
+)
+
+// skills.go installs Agent Skills for the Copilot CLI. The CLI adopted
+// Anthropic's Agent Skills spec verbatim — a `<name>/SKILL.md` with
+// `name` + `description` frontmatter — so the bodies are Claude Code's,
+// reused through skillpack with a minimal envelope back on.
+//
+// Where those files may live is the part a maintainer will get wrong,
+// because the CLI has *removed* discovery roots over its life:
+//
+//   - `~/.copilot/skills/` — the only user-level root that still works.
+//   - `~/.claude/skills/` — loaded until v1.0.36, ignored since.
+//   - `~/.agents/skills/` — loaded until v1.0.66, ignored since.
+//
+// Repo-relative `.claude/skills/`, `.github/skills/` and `.agents/skills/`
+// all still load, but this adapter writes only `.github/skills/`: the
+// repo-local Claude directories belong to the claudecode adapter, and two
+// adapters materialising the same generated skill under different roots
+// would double every community skill in the picker.
+//
+// Docs: https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/use-skills
+
+const (
+	// skillsDirName is the leaf directory at both levels.
+	skillsDirName = "skills"
+	// skillFileName is fixed by the Agent Skills spec.
+	skillFileName = "SKILL.md"
+	// githubDirName holds every repo-level Copilot surface.
+	githubDirName = ".github"
+)
+
+// CuratedSkillNames returns the curated pack's skill IDs, sorted, so a
+// Plan, an install report and a golden test all see the same order —
+// Go randomises map iteration, and claudecode.GlobalSkills is a map.
+func CuratedSkillNames() []string {
+	names := make([]string, 0, len(claudecode.GlobalSkills))
+	for name := range claudecode.GlobalSkills {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// CuratedSkills renders claudecode.GlobalSkills into the Copilot
+// envelope, keyed by skill ID.
+//
+// The envelope is `name` + `description` and nothing else. The CLI also
+// accepts `license`, `allowed-tools`, `argument-hint` and
+// `disable-model-invocation`, but every one of them either narrows what
+// the skill may do or hides it from model invocation — emitting a guess
+// for any of them would silently disable a playbook, so the two required
+// keys are all that is written.
+func CuratedSkills() map[string]string {
+	out := make(map[string]string, len(claudecode.GlobalSkills))
+	for id, claudeBody := range claudecode.GlobalSkills {
+		skill, err := skillpack.Parse(id, claudeBody)
+		if err != nil {
+			// The Claude bodies are compile-time constants, so this can
+			// only fire if that package is edited into a shape skillpack
+			// rejects. Skipping beats installing a skill whose frontmatter
+			// we could not rewrite; skillpack's own test over
+			// claudecode.GlobalSkills turns the mistake into a red build.
+			continue
+		}
+		out[id] = copilotSkillFromClaude(skill)
+	}
+	return out
+}
+
+// copilotSkillFromClaude keeps the body byte-for-byte and puts the
+// Copilot frontmatter in front of it. `name` is the skill ID rather than
+// the parsed frontmatter name: the CLI requires a lowercase, hyphenated
+// name and matches it against the containing directory, and the ID is
+// the value that is guaranteed (by skillpack.ValidID) to be both.
+func copilotSkillFromClaude(skill skillpack.Skill) string {
+	return skillpack.RenderFrontmatter([][2]string{
+		{"name", skill.ID},
+		{"description", skill.Description},
+	}) + skill.Body
+}
+
+// curatedSkillPath is ~/.copilot/skills/<id>/SKILL.md.
+func curatedSkillPath(env agents.Env, id string) string {
+	home := copilotConfigHome(env)
+	if home == "" {
+		return ""
+	}
+	return filepath.Join(home, skillsDirName, id, skillFileName)
+}
+
+// generatedSkillPath is <root>/.github/skills/<DirName>/SKILL.md — flat,
+// with no `generated/` level. Claude Code needs that level because its
+// curated pack shares .claude/skills/ with the generated one; here the
+// curated pack is user-level, so the repo root holds generated skills
+// only and DirName already carries the `gortex-` prefix that keeps them
+// distinguishable from a team's own skills.
+func generatedSkillPath(root, dirName string) string {
+	return filepath.Join(root, githubDirName, skillsDirName, dirName, skillFileName)
+}
+
+// installCuratedSkills writes the curated pack to ~/.copilot/skills/.
+//
+// ModeGlobal only, matching claudecode: the pack is codebase-agnostic, so
+// installing it per-repo would commit 21 identical SKILL.md files into
+// every repository `gortex init` touches.
+//
+// An existing file is never overwritten — a user who tuned a playbook's
+// description or trimmed its steps keeps that work across re-installs.
+func installCuratedSkills(env agents.Env, opts agents.ApplyOpts) []agents.FileAction {
+	skills := CuratedSkills()
+	out := make([]agents.FileAction, 0, len(skills))
+	for _, id := range CuratedSkillNames() {
+		body, ok := skills[id]
+		if !ok {
+			continue
+		}
+		path := curatedSkillPath(env, id)
+		if path == "" {
+			continue
+		}
+		action, err := agents.WriteIfNotExists(env.Stderr, path, body, opts)
+		if err != nil {
+			internalutil.Warnf(env.Stderr, "copilot-cli skill %s: %v", id, err)
+			continue
+		}
+		out = append(out, action)
+	}
+	return out
+}
+
+// installGeneratedSkills writes the per-community skills the caller
+// generated from the graph to <root>/.github/skills/.
+//
+// ModeProject only, and owned end-to-end (regenerated every run) because
+// their content tracks the current graph — unlike the curated pack,
+// there is no stable body for a user to have customised.
+func installGeneratedSkills(env agents.Env, opts agents.ApplyOpts) []agents.FileAction {
+	out := make([]agents.FileAction, 0, len(env.GeneratedSkills))
+	for _, s := range env.GeneratedSkills {
+		if !skillpack.ValidID(s.DirName) {
+			// The CLI rejects a non-kebab-case skill name at load time and
+			// says nothing — the skill simply never appears. Warn here so
+			// the generator's mistake is visible at install time instead.
+			internalutil.Warnf(env.Stderr, "skipping generated skill %q: Copilot CLI requires a lowercase, hyphenated name", s.DirName)
+			continue
+		}
+		path := generatedSkillPath(env.Root, s.DirName)
+		action, err := agents.WriteOwnedFile(env.Stderr, path, s.Content, opts)
+		if err != nil {
+			internalutil.Warnf(env.Stderr, "could not write generated skill %s: %v", s.DirName, err)
+			continue
+		}
+		out = append(out, action)
+	}
+	return out
+}

--- a/internal/agents/copilotcli/skills_test.go
+++ b/internal/agents/copilotcli/skills_test.go
@@ -3,6 +3,7 @@ package copilotcli
 import (
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -165,6 +166,103 @@ func TestCuratedSkillIsNeverOverwritten(t *testing.T) {
 	}
 	if got := readFile(t, path); got != custom {
 		t.Fatalf("customised skill was overwritten:\n%s", got)
+	}
+}
+
+// profileSubset is the three-skill shape an instruction profile like
+// `localization` narrows the pack to.
+var profileSubset = []string{"gortex-explore", "gortex-guide", "gortex-debug"}
+
+// installedSkillIDs lists the skill directories that still hold a
+// SKILL.md. Directory presence alone is not the question a profile
+// switch asks — what the CLI loads is.
+func installedSkillIDs(t *testing.T, root string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(root)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("read dir %s: %v", root, err)
+	}
+	var out []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(root, e.Name(), skillFileName)); err == nil {
+			out = append(out, e.Name())
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestSyncSkillsNarrowsToProfileSubset is the point of the whole
+// exercise: `gortex instructions switch localization` must leave the
+// Copilot CLI holding three playbooks, not twenty-one. Before this
+// existed, only Claude Code's picker shrank.
+func TestSyncSkillsNarrowsToProfileSubset(t *testing.T) {
+	env, _ := globalEnv(t)
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	root := filepath.Join(env.Home, copilotConfigDirName, skillsDirName)
+	if got := len(installedSkillIDs(t, root)); got != len(CuratedSkillNames()) {
+		t.Fatalf("install left %d skills, want the full pack (%d)", got, len(CuratedSkillNames()))
+	}
+
+	if _, err := SyncSkills(env.Stderr, env.Home, profileSubset, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("SyncSkills: %v", err)
+	}
+	want := append([]string(nil), profileSubset...)
+	sort.Strings(want)
+	if got := installedSkillIDs(t, root); strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("after the switch %v remain, want %v", got, want)
+	}
+}
+
+// TestSyncSkillsKeepsCustomisedSkill: a profile is not worth a user's
+// edits. An out-of-profile playbook the user rewrote stays byte for
+// byte, and the switch warns instead of silently widening the surface.
+func TestSyncSkillsKeepsCustomisedSkill(t *testing.T) {
+	env, _ := globalEnv(t)
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	path := filepath.Join(env.Home, copilotConfigDirName, skillsDirName, "gortex-rename", skillFileName)
+	const mine = "---\nname: gortex-rename\ndescription: mine\n---\nmy own steps\n"
+	if err := os.WriteFile(path, []byte(mine), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	log := &strings.Builder{}
+	if _, err := SyncSkills(log, env.Home, profileSubset, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("SyncSkills: %v", err)
+	}
+	if got := readFile(t, path); got != mine {
+		t.Fatalf("customised skill was deleted or rewritten:\n%s", got)
+	}
+	if !strings.Contains(log.String(), "gortex-rename") {
+		t.Fatalf("expected a warning naming the kept skill, got:\n%s", log.String())
+	}
+}
+
+// TestSyncSkillsWithoutAnInstalledRootIsANoOp: most machines run one or
+// two of the supported hosts. Switching a profile must not conjure a
+// Copilot skills tree on a machine that never ran `gortex install`, and
+// must not fail because the tree is absent.
+func TestSyncSkillsWithoutAnInstalledRootIsANoOp(t *testing.T) {
+	env, _ := globalEnv(t)
+	actions, err := SyncSkills(env.Stderr, env.Home, profileSubset, agents.ApplyOpts{})
+	if err != nil {
+		t.Fatalf("SyncSkills on an uninstalled machine: %v", err)
+	}
+	if len(actions) != 0 {
+		t.Fatalf("actions = %v, want none", actions)
+	}
+	if _, err := os.Stat(filepath.Join(env.Home, copilotConfigDirName, skillsDirName)); !os.IsNotExist(err) {
+		t.Fatalf("a switch created the skills root (stat err = %v)", err)
 	}
 }
 

--- a/internal/agents/copilotcli/skills_test.go
+++ b/internal/agents/copilotcli/skills_test.go
@@ -1,0 +1,212 @@
+package copilotcli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/agentstest"
+	"github.com/zzet/gortex/internal/agents/claudecode"
+)
+
+// globalEnv is newCopilotEnv switched to the user-level mode `gortex
+// install` runs in — the only mode that writes skills, sub-agents and
+// hooks.
+func globalEnv(t *testing.T) (agents.Env, *strings.Builder) {
+	t.Helper()
+	env, _ := newCopilotEnv(t)
+	env.Mode = agents.ModeGlobal
+	log := &strings.Builder{}
+	env.Stderr = log
+	return env, log
+}
+
+// frontmatterKeys returns the top-level keys of a document's leading
+// YAML block, in order.
+func frontmatterKeys(t *testing.T, body string) []string {
+	t.Helper()
+	if !strings.HasPrefix(body, "---\n") {
+		t.Fatalf("document has no frontmatter fence:\n%s", body)
+	}
+	rest := body[len("---\n"):]
+	end := strings.Index(rest, "\n---\n")
+	if end < 0 {
+		t.Fatalf("unterminated frontmatter:\n%s", body)
+	}
+	var keys []string
+	for _, line := range strings.Split(rest[:end], "\n") {
+		if line == "" {
+			continue
+		}
+		key, _, ok := strings.Cut(line, ":")
+		if !ok {
+			t.Fatalf("frontmatter line is not a key: %q", line)
+		}
+		keys = append(keys, strings.TrimSpace(key))
+	}
+	return keys
+}
+
+// TestGlobalModeInstallsCuratedSkills pins the one user-level skills root
+// the CLI still honours, and the Anthropic-spec envelope it expects.
+func TestGlobalModeInstallsCuratedSkills(t *testing.T) {
+	env, _ := globalEnv(t)
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	names := CuratedSkillNames()
+	if len(names) != len(claudecode.GlobalSkills) {
+		t.Fatalf("curated pack has %d skills, want %d", len(names), len(claudecode.GlobalSkills))
+	}
+	for _, id := range names {
+		path := filepath.Join(env.Home, copilotConfigDirName, "skills", id, "SKILL.md")
+		body := readFile(t, path)
+
+		keys := frontmatterKeys(t, body)
+		want := []string{"name", "description"}
+		if strings.Join(keys, ",") != strings.Join(want, ",") {
+			t.Fatalf("%s frontmatter keys = %v, want %v", path, keys, want)
+		}
+		if !strings.Contains(body, "name: "+id+"\n") {
+			t.Fatalf("%s: frontmatter name must equal the directory name", path)
+		}
+		// A body that still carries Claude's own fence would stack two
+		// frontmatter blocks and the CLI would drop the skill.
+		if n := strings.Count(body, "\n---\n"); n != 1 {
+			t.Fatalf("%s: expected exactly one closing fence, got %d", path, n)
+		}
+	}
+}
+
+// TestProjectModeWritesNoCuratedSkills: the curated pack is
+// codebase-agnostic, so `gortex init` must leave the repo (and the user's
+// config home) untouched by it.
+func TestProjectModeWritesNoCuratedSkills(t *testing.T) {
+	env, _ := newCopilotEnv(t)
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	for _, dir := range []string{
+		filepath.Join(env.Home, copilotConfigDirName, "skills"),
+		filepath.Join(env.Home, copilotConfigDirName, "agents"),
+		filepath.Join(env.Home, copilotConfigDirName, "hooks"),
+	} {
+		if _, err := os.Stat(dir); !os.IsNotExist(err) {
+			t.Errorf("%s must not be written in project mode (stat err = %v)", dir, err)
+		}
+	}
+}
+
+// TestGeneratedSkillsLandFlatUnderGithub pins the repo-level layout:
+// .github/skills/<DirName>/SKILL.md with no `generated/` level. DirName
+// already carries the gortex- prefix, and the curated pack lives
+// elsewhere, so there is nothing here to disambiguate against.
+func TestGeneratedSkillsLandFlatUnderGithub(t *testing.T) {
+	env, _ := newCopilotEnv(t)
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	path := filepath.Join(env.Root, ".github", "skills", "gortex-stub", "SKILL.md")
+	if got := readFile(t, path); got != env.GeneratedSkills[0].Content {
+		t.Fatalf("%s content = %q, want the generated body verbatim", path, got)
+	}
+	if _, err := os.Stat(filepath.Join(env.Root, ".github", "skills", "generated")); !os.IsNotExist(err) {
+		t.Errorf("generated skills must be flat, no generated/ level (stat err = %v)", err)
+	}
+}
+
+// TestGeneratedSkillWithInvalidNameIsSkipped: the CLI rejects a
+// non-kebab-case skill name silently, so a bad DirName must be refused
+// loudly here rather than installed and never seen.
+func TestGeneratedSkillWithInvalidNameIsSkipped(t *testing.T) {
+	env, _ := newCopilotEnv(t)
+	log := &strings.Builder{}
+	env.Stderr = log
+	env.GeneratedSkills = append(env.GeneratedSkills, agents.GeneratedSkill{
+		CommunityID: "bad", Label: "Bad_Name", DirName: "Gortex_Bad_Name",
+		Content: "---\nname: bad\n---\n",
+	})
+
+	res, err := New().Apply(env, agents.ApplyOpts{})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(env.Root, ".github", "skills", "Gortex_Bad_Name")); !os.IsNotExist(err) {
+		t.Fatalf("invalid skill name was installed (stat err = %v)", err)
+	}
+	if !strings.Contains(log.String(), "Gortex_Bad_Name") {
+		t.Fatalf("expected a warning naming the skipped skill, got:\n%s", log)
+	}
+	for _, f := range res.Files {
+		if strings.Contains(f.Path, "Gortex_Bad_Name") {
+			t.Fatalf("Apply reported a write for a skipped skill: %+v", f)
+		}
+	}
+}
+
+// TestCuratedSkillIsNeverOverwritten: a user who tuned a playbook keeps
+// that work across re-installs.
+func TestCuratedSkillIsNeverOverwritten(t *testing.T) {
+	env, _ := globalEnv(t)
+	path := filepath.Join(env.Home, copilotConfigDirName, "skills", "gortex-explore", "SKILL.md")
+	const custom = "---\nname: gortex-explore\ndescription: mine\n---\nmy own steps\n"
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(custom), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if got := readFile(t, path); got != custom {
+		t.Fatalf("customised skill was overwritten:\n%s", got)
+	}
+}
+
+// TestGlobalApplyIsIdempotent covers every user-level surface at once:
+// skills, sub-agents and the hook config must all report skips on a
+// re-run.
+func TestGlobalApplyIsIdempotent(t *testing.T) {
+	env, _ := globalEnv(t)
+	env.InstallGlobalInstructions = true
+	a := New()
+	if _, err := a.Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("first apply: %v", err)
+	}
+	agentstest.AssertIdempotent(t, a, env)
+}
+
+// TestGlobalPlanEnumeratesEveryAppliedFile keeps `gortex doctor` and
+// --print-config honest in the mode that writes the most files: they read
+// Plan, not Apply.
+func TestGlobalPlanEnumeratesEveryAppliedFile(t *testing.T) {
+	env, _ := globalEnv(t)
+	env.InstallGlobalInstructions = true
+
+	plan, err := New().Plan(env)
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	planned := make(map[string]bool, len(plan.Files))
+	for _, f := range plan.Files {
+		planned[f.Path] = true
+	}
+
+	res, err := New().Apply(env, agents.ApplyOpts{})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	for _, f := range res.Files {
+		if !planned[f.Path] {
+			t.Errorf("Apply touched %s but Plan did not list it", f.Path)
+		}
+	}
+	if !planned[HookConfigPath(env)] {
+		t.Error("Plan must list the hook config")
+	}
+}

--- a/internal/agents/copilotcli/subagents.go
+++ b/internal/agents/copilotcli/subagents.go
@@ -1,0 +1,117 @@
+package copilotcli
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/claudecode"
+	"github.com/zzet/gortex/internal/agents/internalutil"
+	"github.com/zzet/gortex/internal/agents/skillpack"
+)
+
+// subagents.go installs Copilot CLI custom agents — the CLI's delegation
+// surface, its analogue of Claude Code's sub-agents. Same bodies, same
+// role: a fresh context that answers one delegated question with the
+// graph tools instead of burning the main session's window.
+//
+// Two vendor facts shape what is written:
+//
+//   - The file is `NAME.agent.md`, not `NAME.md`. A plain `.md` in the
+//     agents directory is not picked up.
+//   - A home-level agent SHADOWS a repo agent of the same name. That is
+//     why these are user-level only: writing `gortex-search` into both
+//     ~/.copilot/agents/ and .github/agents/ would make the repo copy
+//     permanently dead, and committing it would push it at every
+//     teammate who clones.
+//
+// Docs: https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/create-custom-agents
+
+const (
+	// subAgentsDirName is the leaf under the CLI config home.
+	subAgentsDirName = "agents"
+	// subAgentFileSuffix is the discovery-critical double extension.
+	subAgentFileSuffix = ".agent.md"
+)
+
+// SubAgentNames returns the sub-agent IDs, sorted, so Plan and the
+// install report stay byte-stable across runs.
+func SubAgentNames() []string {
+	names := make([]string, 0, len(claudecode.SubAgents))
+	for file := range claudecode.SubAgents {
+		names = append(names, subAgentID(file))
+	}
+	sort.Strings(names)
+	return names
+}
+
+// SubAgents renders claudecode.SubAgents into the Copilot envelope,
+// keyed by agent ID (the filename without any extension).
+//
+// The envelope carries `name` + `description` only. The CLI also accepts
+// `tools`, and the Claude source declares one — but in Claude's own
+// `mcp__gortex__*` vocabulary, which is a Claude Code naming convention
+// rather than anything the Copilot CLI resolves. An unrecognised entry in
+// a `tools` allowlist does not fall back to "allow everything"; it grants
+// nothing, so a faithless mapping would hand the agent an empty toolbox
+// and no error message. Omitting the key inherits the session's tools,
+// which is the safe half of that trade.
+func SubAgents() map[string]string {
+	out := make(map[string]string, len(claudecode.SubAgents))
+	for file, claudeBody := range claudecode.SubAgents {
+		id := subAgentID(file)
+		skill, err := skillpack.Parse(id, claudeBody)
+		if err != nil {
+			// Compile-time constants: only reachable if claudecode is
+			// edited into a shape skillpack rejects. Skip rather than
+			// install an agent whose frontmatter we could not rewrite.
+			continue
+		}
+		out[id] = skillpack.RenderFrontmatter([][2]string{
+			{"name", skill.ID},
+			{"description", skill.Description},
+		}) + skill.Body
+	}
+	return out
+}
+
+// subAgentID strips the ".md" claudecode uses as its map key, leaving the
+// bare name the Copilot filename and frontmatter both need.
+func subAgentID(file string) string {
+	return strings.TrimSuffix(file, ".md")
+}
+
+// subAgentPath is ~/.copilot/agents/<name>.agent.md.
+func subAgentPath(env agents.Env, id string) string {
+	home := copilotConfigHome(env)
+	if home == "" {
+		return ""
+	}
+	return filepath.Join(home, subAgentsDirName, id+subAgentFileSuffix)
+}
+
+// installSubAgents writes the sub-agent definitions, ModeGlobal only.
+// Existing files are left alone so a user's tuned description or added
+// `tools` allowlist survives re-installs.
+func installSubAgents(env agents.Env, opts agents.ApplyOpts) []agents.FileAction {
+	defs := SubAgents()
+	out := make([]agents.FileAction, 0, len(defs))
+	for _, id := range SubAgentNames() {
+		body, ok := defs[id]
+		if !ok {
+			continue
+		}
+		path := subAgentPath(env, id)
+		if path == "" {
+			continue
+		}
+		action, err := agents.WriteIfNotExists(env.Stderr, path, body, opts)
+		if err != nil {
+			internalutil.Warnf(env.Stderr, "copilot-cli sub-agent %s: %v", id, err)
+			continue
+		}
+		out = append(out, action)
+	}
+	return out
+}

--- a/internal/agents/copilotcli/subagents_test.go
+++ b/internal/agents/copilotcli/subagents_test.go
@@ -1,0 +1,83 @@
+package copilotcli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/claudecode"
+)
+
+// TestGlobalModeInstallsSubAgents pins the discovery-critical filename
+// (NAME.agent.md, not NAME.md) and the envelope.
+func TestGlobalModeInstallsSubAgents(t *testing.T) {
+	env, _ := globalEnv(t)
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	names := SubAgentNames()
+	if len(names) != len(claudecode.SubAgents) {
+		t.Fatalf("rendered %d sub-agents, want %d", len(names), len(claudecode.SubAgents))
+	}
+	for _, id := range names {
+		path := filepath.Join(env.Home, copilotConfigDirName, "agents", id+".agent.md")
+		body := readFile(t, path)
+
+		keys := frontmatterKeys(t, body)
+		want := []string{"name", "description"}
+		if strings.Join(keys, ",") != strings.Join(want, ",") {
+			t.Fatalf("%s frontmatter keys = %v, want %v", path, keys, want)
+		}
+		// Claude's allowlist is spelled in mcp__gortex__* — a vocabulary
+		// the CLI does not resolve. An unrecognised tools entry grants
+		// nothing, so the key must be absent rather than mistranslated.
+		if strings.Contains(body, "mcp__gortex__") {
+			t.Fatalf("%s leaked Claude's mcp__gortex__ tool names:\n%s", path, body)
+		}
+		if !strings.Contains(body, "name: "+id+"\n") {
+			t.Fatalf("%s: frontmatter name must equal the file's base name", path)
+		}
+	}
+
+	// A plain .md in the agents directory is invisible to the CLI.
+	if _, err := os.Stat(filepath.Join(env.Home, copilotConfigDirName, "agents", "gortex-search.md")); !os.IsNotExist(err) {
+		t.Errorf("wrote a bare .md sub-agent; the CLI only loads *.agent.md (stat err = %v)", err)
+	}
+}
+
+// TestProjectModeWritesNoRepoSubAgents: a home agent shadows a repo agent
+// of the same name, so a committed .github/agents copy would be
+// permanently dead and pushed at every teammate.
+func TestProjectModeWritesNoRepoSubAgents(t *testing.T) {
+	env, _ := newCopilotEnv(t)
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(env.Root, ".github", "agents")); !os.IsNotExist(err) {
+		t.Errorf(".github/agents must not be written (stat err = %v)", err)
+	}
+}
+
+// TestSubAgentIsNeverOverwritten: a tuned description or a hand-added
+// tools allowlist survives re-installs.
+func TestSubAgentIsNeverOverwritten(t *testing.T) {
+	env, _ := globalEnv(t)
+	path := filepath.Join(env.Home, copilotConfigDirName, "agents", "gortex-search.agent.md")
+	const custom = "---\nname: gortex-search\ndescription: mine\n---\nmy own instructions\n"
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(custom), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if got := readFile(t, path); got != custom {
+		t.Fatalf("customised sub-agent was overwritten:\n%s", got)
+	}
+}

--- a/internal/agents/copilotcli/surfaces_test.go
+++ b/internal/agents/copilotcli/surfaces_test.go
@@ -1,0 +1,85 @@
+package copilotcli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/agents"
+)
+
+// surfaces_test.go is the retired-discovery-root fence. Every directory
+// below is somewhere a maintainer could plausibly install a skill, an
+// agent or a command — and every one of them is dead for the Copilot CLI.
+// A write there costs nothing at install time and produces exactly
+// nothing at runtime, with no error to explain it, so the only way to
+// keep it from creeping back in is to assert its absence.
+
+// deadSurfaces returns the paths this adapter must never create, with the
+// vendor reason attached so a failure explains itself.
+func deadSurfaces(env agents.Env) map[string]string {
+	return map[string]string{
+		filepath.Join(env.Home, ".claude", "skills"):   "the CLI stopped loading ~/.claude/skills in v1.0.36",
+		filepath.Join(env.Home, ".claude", "agents"):   "the CLI stopped loading ~/.claude/agents in v1.0.36",
+		filepath.Join(env.Home, ".claude", "commands"): "the CLI stopped loading ~/.claude/commands in v1.0.36",
+		filepath.Join(env.Home, ".claude"):             "no home-level Claude directory is read since v1.0.36",
+		filepath.Join(env.Home, ".agents", "skills"):   "the CLI stopped loading ~/.agents/skills in v1.0.66",
+		filepath.Join(env.Root, ".claude"):             "the repo-local Claude tree belongs to the claudecode adapter",
+		filepath.Join(env.Root, ".agents"):             "the repo-local .agents tree is not this adapter's to own",
+		filepath.Join(env.Root, ".github", "prompts"):  "prompt files are a VS Code chat feature the CLI has never supported",
+		filepath.Join(env.Root, ".github", "agents"):   "a home agent shadows a repo agent, and a repo copy is committed",
+		filepath.Join(env.Root, ".github", "hooks"):    "a repo hook file is committed and fires on every teammate's clone",
+	}
+}
+
+func TestWritesNothingToRetiredSurfaces(t *testing.T) {
+	modes := map[string]agents.Mode{"project": agents.ModeProject, "global": agents.ModeGlobal}
+	for name, mode := range modes {
+		t.Run(name, func(t *testing.T) {
+			env, _ := newCopilotEnv(t)
+			env.Mode = mode
+			env.InstallGlobalInstructions = true
+			if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+				t.Fatalf("apply: %v", err)
+			}
+			for dir, why := range deadSurfaces(env) {
+				if _, err := os.Stat(dir); !os.IsNotExist(err) {
+					t.Errorf("%s must not be written — %s (stat err = %v)", dir, why, err)
+				}
+			}
+		})
+	}
+}
+
+// TestPlanNeverNamesARetiredSurface: doctor and --print-config read Plan,
+// so a dead path promised there is a dead path a user goes looking for.
+func TestPlanNeverNamesARetiredSurface(t *testing.T) {
+	modes := []agents.Mode{agents.ModeProject, agents.ModeGlobal}
+	for _, mode := range modes {
+		env, _ := newCopilotEnv(t)
+		env.Mode = mode
+		env.InstallGlobalInstructions = true
+		plan, err := New().Plan(env)
+		if err != nil {
+			t.Fatalf("plan: %v", err)
+		}
+		dead := deadSurfaces(env)
+		for _, f := range plan.Files {
+			for dir, why := range dead {
+				if f.Path == dir || isUnder(f.Path, dir) {
+					t.Errorf("Plan names %s under a retired surface — %s", f.Path, why)
+				}
+			}
+		}
+	}
+}
+
+// isUnder reports whether path lives inside ancestor.
+func isUnder(path, ancestor string) bool {
+	rel, err := filepath.Rel(ancestor, path)
+	if err != nil || rel == "." || rel == ".." {
+		return false
+	}
+	return !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}

--- a/internal/agents/hermes/content.go
+++ b/internal/agents/hermes/content.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/zzet/gortex/internal/agents"
 	"github.com/zzet/gortex/internal/agents/claudecode"
+	"github.com/zzet/gortex/internal/agents/skillpack"
 	yaml "gopkg.in/yaml.v3"
 )
 
@@ -143,7 +144,8 @@ func masterSkillCommands() string {
 //
 // The bodies are the single source of truth in
 // internal/agents/claudecode (reused verbatim so the two agents never
-// drift) re-wrapped with Hermes frontmatter. Hermes also turns every
+// drift); internal/agents/skillpack strips the Claude frontmatter off
+// them and Hermes' own envelope goes back on. Hermes also turns every
 // installed skill into a `/skill-name` slash command, so the
 // `/gortex-explore`-style cross-references in the bodies resolve to the
 // sibling skills installed here.
@@ -157,7 +159,17 @@ func RoutingSkills() map[string]string {
 		if name == "gortex-guide" {
 			continue
 		}
-		out[name] = hermesSkillFromClaude(name, claudeBody)
+		skill, err := skillpack.Parse(name, claudeBody)
+		if err != nil {
+			// The Claude bodies are compile-time constants, so this can
+			// only fire if that package is edited into a shape skillpack
+			// rejects (a non-kebab id, an unclosed frontmatter fence).
+			// Skip rather than install a skill whose frontmatter we could
+			// not rewrite — skillpack's test over claudecode.GlobalSkills
+			// is what turns the mistake into a red build.
+			continue
+		}
+		out[name] = hermesSkillFromClaude(skill)
 	}
 	return out
 }
@@ -174,20 +186,24 @@ func RoutingSkillNames() []string {
 	return names
 }
 
-// hermesSkillFromClaude re-frames one Claude Code skill as a Hermes
-// skill: it keeps the body verbatim and swaps the Claude frontmatter
-// (name + description) for Hermes frontmatter (name + description +
-// version + metadata.hermes.{tags,category}).
-func hermesSkillFromClaude(name, claudeContent string) string {
-	desc := claudeFrontmatterField(claudeContent, "description")
-	body := stripClaudeFrontmatter(claudeContent)
-	tags, category := routingSkillTaxonomy(name)
+// hermesSkillFromClaude re-frames one parsed skill as a Hermes skill:
+// it keeps the body verbatim and puts Hermes frontmatter (name +
+// description + version + metadata.hermes.{tags,category}) in front of
+// it.
+//
+// The frontmatter is built here rather than with
+// skillpack.RenderFrontmatter because Hermes' block is a nested mapping
+// with flow sequences, which the flat ordered-pair renderer cannot
+// express. Only the description scalar goes through skillpack, so the
+// prose quoting rule stays shared with every other host.
+func hermesSkillFromClaude(skill skillpack.Skill) string {
+	tags, category := routingSkillTaxonomy(skill.ID)
 
 	var b strings.Builder
 	b.WriteString("---\n")
-	b.WriteString("name: " + name + "\n")
-	if desc != "" {
-		b.WriteString("description: " + desc + "\n")
+	b.WriteString("name: " + skill.ID + "\n")
+	if skill.Description != "" {
+		b.WriteString("description: " + skillpack.QuoteYAMLValue(skill.Description) + "\n")
 	}
 	b.WriteString("version: 1.0.0\n")
 	b.WriteString("metadata:\n")
@@ -197,46 +213,8 @@ func hermesSkillFromClaude(name, claudeContent string) string {
 	b.WriteString("    platforms: [linux, macos, windows]\n")
 	b.WriteString("    related_skills: [" + SkillName + "]\n")
 	b.WriteString("---\n")
-	b.WriteString(body)
+	b.WriteString(skill.Body)
 	return b.String()
-}
-
-// stripClaudeFrontmatter drops the leading `---`-fenced YAML block from
-// a Claude skill body, returning just the markdown. The skill bodies
-// always start with `---\n`; the first `\n---\n` after it closes the
-// frontmatter.
-func stripClaudeFrontmatter(s string) string {
-	const open = "---\n"
-	if !strings.HasPrefix(s, open) {
-		return s
-	}
-	rest := s[len(open):]
-	if _, after, found := strings.Cut(rest, "\n---\n"); found {
-		return after
-	}
-	return s
-}
-
-// claudeFrontmatterField extracts a single-line scalar field from the
-// leading frontmatter block, value verbatim (quotes and inner escapes
-// preserved — the Claude descriptions are already valid YAML double-
-// quoted scalars). Returns "" when the field is absent.
-func claudeFrontmatterField(s, field string) string {
-	const open = "---\n"
-	if !strings.HasPrefix(s, open) {
-		return ""
-	}
-	block := s[len(open):]
-	if before, _, found := strings.Cut(block, "\n---\n"); found {
-		block = before
-	}
-	prefix := field + ":"
-	for line := range strings.SplitSeq(block, "\n") {
-		if rest, ok := strings.CutPrefix(line, prefix); ok {
-			return strings.TrimSpace(rest)
-		}
-	}
-	return ""
 }
 
 // routingSkillTaxonomy assigns Hermes discovery tags + a category to a

--- a/internal/agents/hermes/content_test.go
+++ b/internal/agents/hermes/content_test.go
@@ -1,0 +1,126 @@
+package hermes
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/agents/claudecode"
+)
+
+// TestRoutingSkillsMatchLegacyRendering is the zero-diff guard for the
+// move onto internal/agents/skillpack. legacyHermesSkill below is the
+// frontmatter-swapping code Hermes carried before the extraction,
+// verbatim; every installed routing skill must still come out
+// byte-identical to what it produced. A shared parser is only worth
+// having if it cannot shift a single byte of an installed file.
+func TestRoutingSkillsMatchLegacyRendering(t *testing.T) {
+	routing := RoutingSkills()
+	if len(routing) == 0 {
+		t.Fatal("no routing skills derived")
+	}
+	for name, got := range routing {
+		want := legacyHermesSkill(name, claudecode.GlobalSkills[name])
+		if got != want {
+			t.Errorf("%s: rendering changed\n--- got ---\n%s\n--- want ---\n%s", name, got, want)
+		}
+	}
+}
+
+// TestRoutingSkillFrontmatterIsFrozen pins one full frontmatter block
+// as a literal, so a future change to the shared renderer (quoting
+// rules, key order) fails here rather than silently reshaping every
+// SKILL.md Hermes has on disk.
+func TestRoutingSkillFrontmatterIsFrozen(t *testing.T) {
+	const want = `---
+name: gortex-explore
+description: "Understand how code works or trace an execution flow."
+version: 1.0.0
+metadata:
+  hermes:
+    tags: [code-intelligence, mcp, explore]
+    category: navigation
+    platforms: [linux, macos, windows]
+    related_skills: [gortex]
+---
+`
+	got, ok := RoutingSkills()["gortex-explore"]
+	if !ok {
+		t.Fatal("gortex-explore routing skill missing")
+	}
+	if !strings.HasPrefix(got, want) {
+		t.Errorf("frontmatter drifted\n--- got ---\n%s\n--- want ---\n%s", firstN(got, len(want)), want)
+	}
+	// The Claude body must follow the Hermes frontmatter untouched —
+	// with no second `---` block stacked on top of it.
+	body := strings.TrimPrefix(got, want)
+	if strings.HasPrefix(body, "---") {
+		t.Errorf("body still carries Claude frontmatter:\n%s", firstN(body, 120))
+	}
+	if !strings.HasSuffix(claudecode.GlobalSkills["gortex-explore"], body) {
+		t.Errorf("body is not the Claude body verbatim:\n%s", firstN(body, 200))
+	}
+}
+
+// legacyHermesSkill is the pre-skillpack implementation, kept here as
+// the reference oracle for the test above. Do not "simplify" it to call
+// the production code — a guard that shares the code under test proves
+// nothing.
+func legacyHermesSkill(name, claudeContent string) string {
+	desc := legacyFrontmatterField(claudeContent, "description")
+	body := legacyStripFrontmatter(claudeContent)
+	tags, category := routingSkillTaxonomy(name)
+
+	var b strings.Builder
+	b.WriteString("---\n")
+	b.WriteString("name: " + name + "\n")
+	if desc != "" {
+		b.WriteString("description: " + desc + "\n")
+	}
+	b.WriteString("version: 1.0.0\n")
+	b.WriteString("metadata:\n")
+	b.WriteString("  hermes:\n")
+	b.WriteString("    tags: [" + strings.Join(tags, ", ") + "]\n")
+	b.WriteString("    category: " + category + "\n")
+	b.WriteString("    platforms: [linux, macos, windows]\n")
+	b.WriteString("    related_skills: [" + SkillName + "]\n")
+	b.WriteString("---\n")
+	b.WriteString(body)
+	return b.String()
+}
+
+func legacyStripFrontmatter(s string) string {
+	const open = "---\n"
+	if !strings.HasPrefix(s, open) {
+		return s
+	}
+	rest := s[len(open):]
+	if _, after, found := strings.Cut(rest, "\n---\n"); found {
+		return after
+	}
+	return s
+}
+
+func legacyFrontmatterField(s, field string) string {
+	const open = "---\n"
+	if !strings.HasPrefix(s, open) {
+		return ""
+	}
+	block := s[len(open):]
+	if before, _, found := strings.Cut(block, "\n---\n"); found {
+		block = before
+	}
+	prefix := field + ":"
+	for line := range strings.SplitSeq(block, "\n") {
+		if rest, ok := strings.CutPrefix(line, prefix); ok {
+			return strings.TrimSpace(rest)
+		}
+	}
+	return ""
+}
+
+func firstN(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}

--- a/internal/agents/hermes/sync.go
+++ b/internal/agents/hermes/sync.go
@@ -1,0 +1,46 @@
+package hermes
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/skillpack"
+)
+
+// SyncSkills reconciles the installed routing skills with the active
+// instruction profile's subset, the same way every other host does.
+//
+// Hermes was the first adapter to reuse the Claude skill bodies and the
+// last to learn about profiles, so `gortex instructions switch
+// localization` used to leave all twenty routing skills in place while
+// shrinking Claude Code's to three — the profile was honoured on one
+// host and silently ignored on another.
+//
+// Two Hermes shapes the shared reconciler has to be told about:
+//
+//   - skills live at skills/<category>/<name>/SKILL.md, not directly
+//     under the root, so the directory is resolved through DirFor;
+//   - the native master skill (SkillName) is not a routing skill and is
+//     absent from RoutingSkills, which is what keeps it out of the
+//     subset comparison. It must survive every profile, because it is
+//     the skill that teaches Hermes what Gortex is at all.
+//
+// A machine with no Hermes skills root is a no-op rather than an
+// install: a profile switch must not conjure a surface the user never
+// asked `gortex install` to create.
+func SyncSkills(w io.Writer, home string, allowed []string, opts agents.ApplyOpts) ([]agents.FileAction, error) {
+	if home == "" {
+		return nil, nil
+	}
+	root := filepath.Join(hermesDir(home), "skills")
+	if _, err := os.Stat(root); err != nil {
+		return nil, nil
+	}
+	return skillpack.Sync(w, skillpack.SyncSpec{
+		Dir:      root,
+		Rendered: RoutingSkills(),
+		DirFor:   func(id string) string { return filepath.Dir(skillPath(home, id)) },
+	}, allowed, opts)
+}

--- a/internal/agents/hermes/sync_test.go
+++ b/internal/agents/hermes/sync_test.go
@@ -1,0 +1,96 @@
+package hermes
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/agents"
+)
+
+// installRoutingSkills seeds a Hermes skills tree the way Apply would,
+// so the sync tests start from a real install rather than a fixture
+// that could drift from what the adapter writes.
+func installRoutingSkills(t *testing.T, home string) {
+	t.Helper()
+	routing := RoutingSkills()
+	for _, name := range RoutingSkillNames() {
+		path := skillPath(home, name)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(routing[name]), 0o644))
+	}
+}
+
+// TestSyncSkillsNarrowsToProfileSubset is the behaviour that was missing:
+// a profile switch shrank Claude Code's skill set and left Hermes at full
+// size, so the same machine enforced two different profiles depending on
+// which agent the user happened to open.
+func TestSyncSkillsNarrowsToProfileSubset(t *testing.T) {
+	home := t.TempDir()
+	installRoutingSkills(t, home)
+
+	allowed := []string{"gortex-explore", "gortex-debug"}
+	_, err := SyncSkills(nil, home, allowed, agents.ApplyOpts{})
+	require.NoError(t, err)
+
+	for _, name := range RoutingSkillNames() {
+		_, statErr := os.Stat(skillPath(home, name))
+		if name == "gortex-explore" || name == "gortex-debug" {
+			require.NoError(t, statErr, "%s is in the profile and must survive", name)
+			continue
+		}
+		require.True(t, os.IsNotExist(statErr), "%s is outside the profile and should be pruned", name)
+	}
+}
+
+// TestSyncSkillsKeepsTheMasterSkill pins the one skill that must outlive
+// every profile: the native `gortex` master is not a routing skill, and
+// pruning it would leave Hermes with no statement of what Gortex is.
+func TestSyncSkillsKeepsTheMasterSkill(t *testing.T) {
+	home := t.TempDir()
+	installRoutingSkills(t, home)
+
+	master := skillPath(home, SkillName)
+	require.NoError(t, os.MkdirAll(filepath.Dir(master), 0o755))
+	require.NoError(t, os.WriteFile(master, []byte("---\nname: gortex\n---\nmaster\n"), 0o644))
+
+	_, err := SyncSkills(nil, home, []string{"gortex-explore"}, agents.ApplyOpts{})
+	require.NoError(t, err)
+
+	body, readErr := os.ReadFile(master)
+	require.NoError(t, readErr)
+	require.Equal(t, "---\nname: gortex\n---\nmaster\n", string(body))
+}
+
+// TestSyncSkillsKeepsACustomisedSkill holds the rule that decides whether
+// a user loses work on an upgrade: a skill the user edited is kept even
+// when the profile excludes it.
+func TestSyncSkillsKeepsACustomisedSkill(t *testing.T) {
+	home := t.TempDir()
+	installRoutingSkills(t, home)
+
+	edited := skillPath(home, "gortex-rename")
+	require.NoError(t, os.WriteFile(edited, []byte("---\nname: gortex-rename\n---\nmine\n"), 0o644))
+
+	_, err := SyncSkills(nil, home, []string{"gortex-explore"}, agents.ApplyOpts{})
+	require.NoError(t, err)
+
+	body, readErr := os.ReadFile(edited)
+	require.NoError(t, readErr)
+	require.Equal(t, "---\nname: gortex-rename\n---\nmine\n", string(body))
+}
+
+// TestSyncSkillsWithoutAnInstalledRootIsANoOp keeps a profile switch from
+// conjuring a Hermes surface on a machine that never ran `gortex install`.
+func TestSyncSkillsWithoutAnInstalledRootIsANoOp(t *testing.T) {
+	home := t.TempDir()
+
+	actions, err := SyncSkills(nil, home, []string{"gortex-explore"}, agents.ApplyOpts{})
+	require.NoError(t, err)
+	require.Empty(t, actions)
+
+	_, statErr := os.Stat(filepath.Join(hermesDir(home), "skills"))
+	require.True(t, os.IsNotExist(statErr))
+}

--- a/internal/agents/instructions.go
+++ b/internal/agents/instructions.go
@@ -150,64 +150,12 @@ This harness has no native MCP transport. Invoke public Gortex tools only as ` +
 4. Use ` + "`" + `gortex call capabilities` + "`" + ` only when exact operation fields are unknown.
 `
 
-// AppendInstructions appends body to path, creating the file if
-// missing. Idempotent: when `sentinel` is already present anywhere in
-// the file we skip with ActionSkip and log the reason. Callers pass
-// the adapter's ApplyOpts through so --dry-run / --global / --force
-// all flow to the right FileAction status.
-//
-// Not atomic. Rules files are plaintext a human edits, matching the
-// historical CLAUDE.md append behaviour — a concurrent external writer
-// during init is extraordinarily unlikely and atomic rename of a file
-// a human is editing would fight their editor.
-func AppendInstructions(w io.Writer, path, body, sentinel string, opts ApplyOpts) (FileAction, error) {
-	existing, readErr := os.ReadFile(path)
-	if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
-		return FileAction{}, fmt.Errorf("read %s: %w", path, readErr)
-	}
-	existed := readErr == nil
-	if existed && strings.Contains(string(existing), sentinel) {
-		if w != nil {
-			fmt.Fprintf(w, "[gortex init] skip %s (Gortex block already present)\n", path)
-		}
-		return FileAction{Path: path, Action: ActionSkip, Reason: "block-present"}, nil
-	}
-
-	if opts.DryRun {
-		action := ActionWouldMerge
-		if !existed {
-			action = ActionWouldCreate
-		}
-		return FileAction{Path: path, Action: action, Keys: []string{"gortex-block"}}, nil
-	}
-
-	// Two blank lines between existing content and the block so the
-	// appended section reads as a separate document and doesn't glue
-	// onto the last paragraph the user wrote.
-	prefix := ""
-	if existed && len(existing) > 0 {
-		prefix = "\n\n"
-	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return FileAction{}, err
-	}
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
-	if err != nil {
-		return FileAction{}, err
-	}
-	defer f.Close()
-	if _, err := f.WriteString(prefix + body); err != nil {
-		return FileAction{}, err
-	}
-	if w != nil {
-		fmt.Fprintf(w, "[gortex init] appended Gortex block to %s\n", path)
-	}
-	action := ActionMerge
-	if !existed {
-		action = ActionCreate
-	}
-	return FileAction{Path: path, Action: action, Keys: []string{"gortex-block"}}, nil
-}
+// UpsertMarkedBlock is the only supported way to put a Gortex block into
+// a human-edited instructions file. The older sentinel-guarded append it
+// replaced could not update a block in place — it detected the sentinel
+// and skipped, so a changed body never reached a file that already had
+// one — and it wrote non-atomically. Adapters must not reintroduce that
+// pattern; see UpsertMarkedBlock below.
 
 // CursorMDCFrontmatter wraps the instructions body in the YAML
 // frontmatter Cursor expects for MDC rules files. Cursor reads

--- a/internal/agents/instructions_test.go
+++ b/internal/agents/instructions_test.go
@@ -1,115 +1,12 @@
 package agents
 
 import (
-	"bytes"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
-
-// TestAppendInstructions_CreateThenSkip pins the behaviour every
-// doc-aware adapter depends on: first call creates the file, second
-// call with the same body is a no-op ActionSkip. If this regresses,
-// running `gortex init` twice would append the block twice to every
-// agent's rules file — the user-visible pain we extracted this helper
-// to eliminate.
-func TestAppendInstructions_CreateThenSkip(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "nested", "rules.md")
-
-	var buf bytes.Buffer
-	action, err := AppendInstructions(&buf, path, InstructionsBody, InstructionsSentinel, ApplyOpts{})
-	require.NoError(t, err)
-	assert.Equal(t, ActionCreate, action.Action)
-
-	contents, err := os.ReadFile(path)
-	require.NoError(t, err)
-	assert.Contains(t, string(contents), InstructionsSentinel,
-		"first write must land the full sentinel-bearing block")
-
-	// Second call is idempotent — no duplicate append.
-	action, err = AppendInstructions(&buf, path, InstructionsBody, InstructionsSentinel, ApplyOpts{})
-	require.NoError(t, err)
-	assert.Equal(t, ActionSkip, action.Action)
-	assert.Equal(t, "block-present", action.Reason)
-
-	after, err := os.ReadFile(path)
-	require.NoError(t, err)
-	assert.Equal(t, len(contents), len(after),
-		"second call must not grow the file")
-}
-
-// TestAppendInstructions_PreservesExistingContent guards the merge
-// path — the helper must not clobber a hand-written file, it must
-// append the block after the user's content with a blank-line gap.
-func TestAppendInstructions_PreservesExistingContent(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "AGENTS.md")
-	existing := "# Team conventions\n\nUse tabs, not spaces.\n"
-	require.NoError(t, os.WriteFile(path, []byte(existing), 0o644))
-
-	action, err := AppendInstructions(nil, path, InstructionsBody, InstructionsSentinel, ApplyOpts{})
-	require.NoError(t, err)
-	assert.Equal(t, ActionMerge, action.Action)
-
-	data, err := os.ReadFile(path)
-	require.NoError(t, err)
-	text := string(data)
-
-	assert.True(t, strings.HasPrefix(text, existing),
-		"user content must remain at the top of the file")
-	assert.Contains(t, text, InstructionsSentinel,
-		"block must be appended below the user's content")
-}
-
-// TestAppendInstructions_SharedSentinelAcrossAdapters is the scenario
-// that matters when two adapters target the same file (Codex and
-// Opencode both write AGENTS.md). The second adapter must detect the
-// first adapter's write via the shared InstructionsSentinel and skip,
-// rather than duplicating the block. This is why the sentinel lives
-// in the shared package, not each adapter.
-func TestAppendInstructions_SharedSentinelAcrossAdapters(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "AGENTS.md")
-
-	// Simulate Codex writing first.
-	_, err := AppendInstructions(nil, path, InstructionsBody, InstructionsSentinel, ApplyOpts{})
-	require.NoError(t, err)
-
-	// Simulate Opencode running afterwards against the same repo.
-	action, err := AppendInstructions(nil, path, InstructionsBody, InstructionsSentinel, ApplyOpts{})
-	require.NoError(t, err)
-	assert.Equal(t, ActionSkip, action.Action,
-		"second adapter targeting the same file must skip, not append again")
-}
-
-// TestAppendInstructions_DryRunReportsAction verifies --dry-run never
-// touches the filesystem and reports ActionWouldCreate / ActionWouldMerge
-// correctly. Users rely on the planning output to preview what init
-// will do; a silent write during dry-run would be a real footgun.
-func TestAppendInstructions_DryRunReportsAction(t *testing.T) {
-	dir := t.TempDir()
-	newPath := filepath.Join(dir, "NEW.md")
-	existingPath := filepath.Join(dir, "EXISTING.md")
-	require.NoError(t, os.WriteFile(existingPath, []byte("preexisting\n"), 0o644))
-
-	action, err := AppendInstructions(nil, newPath, InstructionsBody, InstructionsSentinel, ApplyOpts{DryRun: true})
-	require.NoError(t, err)
-	assert.Equal(t, ActionWouldCreate, action.Action)
-	_, err = os.Stat(newPath)
-	assert.True(t, os.IsNotExist(err), "dry-run must not create the file")
-
-	action, err = AppendInstructions(nil, existingPath, InstructionsBody, InstructionsSentinel, ApplyOpts{DryRun: true})
-	require.NoError(t, err)
-	assert.Equal(t, ActionWouldMerge, action.Action)
-	data, _ := os.ReadFile(existingPath)
-	assert.Equal(t, "preexisting\n", string(data),
-		"dry-run must not mutate an existing file")
-}
 
 // TestCursorMDCFrontmatter proves the MDC wrapper emits the two keys
 // Cursor needs — `description` so users can see the rule in the UI

--- a/internal/agents/opencode/adapter.go
+++ b/internal/agents/opencode/adapter.go
@@ -23,9 +23,24 @@
 //	}
 //
 // We preserve any existing $schema reference and add one if absent.
+//
+// # What lands where
+//
+//	ModeProject: <root>/opencode.json               (mcp stanza)
+//	             <root>/AGENTS.md                   (community routing, --skills)
+//	             <root>/.opencode/skills/<dir>/SKILL.md  (generated community skills)
+//
+//	ModeGlobal:  <home>/.config/opencode/skills/<id>/SKILL.md   (curated pack)
+//	             <home>/.config/opencode/commands/<id>.md       (slash commands)
+//	             <home>/.config/opencode/plugin/gortex.js       (enforcement bridge)
+//
+// skills.go explains the split (codebase-agnostic playbooks are a
+// user-level concern, repo-derived skills are not) and plugin.go explains
+// why the one executable artifact is user-level only.
 package opencode
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -75,28 +90,37 @@ func projectConfigPath(root string) string {
 }
 
 func (a *Adapter) Plan(env agents.Env) (*agents.Plan, error) {
-	p := &agents.Plan{Files: []agents.FileAction{
-		{Path: projectConfigPath(env.Root), Action: agents.ActionWouldMerge, Keys: []string{"mcp"}},
-	}}
-	if env.Mode != agents.ModeGlobal && env.SkillsRouting != "" {
+	p := &agents.Plan{}
+	if env.Mode != agents.ModeGlobal {
 		p.Files = append(p.Files, agents.FileAction{
-			Path: filepath.Join(env.Root, "AGENTS.md"), Action: agents.ActionWouldMerge,
-			Keys: []string{"communities-block"},
+			Path: projectConfigPath(env.Root), Action: agents.ActionWouldMerge, Keys: []string{"mcp"},
 		})
+		if env.SkillsRouting != "" {
+			p.Files = append(p.Files, agents.FileAction{
+				Path: filepath.Join(env.Root, "AGENTS.md"), Action: agents.ActionWouldMerge,
+				Keys: []string{"communities-block"},
+			})
+		}
 	}
+	p.Files = append(p.Files, planPlugin(env)...)
+	skillFiles, err := planSkills(env)
+	if err != nil {
+		return nil, err
+	}
+	p.Files = append(p.Files, skillFiles...)
 	return p, nil
 }
 
 func (a *Adapter) Apply(env agents.Env, opts agents.ApplyOpts) (*agents.Result, error) {
 	res := &agents.Result{Name: Name, DocsURL: DocsURL}
-	if env.Mode == agents.ModeGlobal {
-		return res, nil
-	}
 	detected, _ := a.Detect(env)
 	res.Detected = detected
 	if !detected && !opts.ForceDetect {
 		internalutil.Logf(env.Stderr, "[gortex init] skip OpenCode setup (OpenCode not detected)")
 		return res, nil
+	}
+	if env.Mode == agents.ModeGlobal {
+		return res, a.applyGlobal(env, opts, res)
 	}
 	internalutil.Logf(env.Stderr, "[gortex init] setting up OpenCode integration...")
 
@@ -150,6 +174,44 @@ func (a *Adapter) Apply(env agents.Env, opts agents.ApplyOpts) (*agents.Result, 
 		res.Files = append(res.Files, routingAction)
 	}
 
+	// Generated community skills describe this repo, so they are the one
+	// skill set that belongs in the repo tree. skills.go documents the
+	// flat layout and the kebab-case gate.
+	skillActions, err := applySkills(env, opts)
+	if err != nil {
+		return res, fmt.Errorf("opencode skills: %w", err)
+	}
+	res.Files = append(res.Files, skillActions...)
+
 	res.Configured = true
 	return res, nil
+}
+
+// applyGlobal handles `gortex install`: the codebase-agnostic artifacts
+// that belong to the user, not to any one repo — the curated playbook and
+// slash-command packs, plus the enforcement bridge.
+//
+// There is no user-level MCP stanza to write here: `gortex init` puts the
+// server in the repo's own opencode.json, which is where a per-project
+// daemon scope belongs.
+func (a *Adapter) applyGlobal(env agents.Env, opts agents.ApplyOpts, res *agents.Result) error {
+	if env.Home == "" {
+		return fmt.Errorf("opencode: global mode requires a resolved home directory")
+	}
+	internalutil.Logf(env.Stderr, "[gortex install] setting up OpenCode integration...")
+
+	pluginActions, err := applyPlugin(env, opts)
+	if err != nil {
+		return fmt.Errorf("opencode plugin: %w", err)
+	}
+	res.Files = append(res.Files, pluginActions...)
+
+	skillActions, err := applySkills(env, opts)
+	if err != nil {
+		return fmt.Errorf("opencode skills: %w", err)
+	}
+	res.Files = append(res.Files, skillActions...)
+
+	res.Configured = true
+	return nil
 }

--- a/internal/agents/opencode/adapter_test.go
+++ b/internal/agents/opencode/adapter_test.go
@@ -27,9 +27,10 @@ func TestOpenCodeUsesMCPSectionKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("apply: %v", err)
 	}
-	// Two creates: opencode.json for MCP plus AGENTS.md for the
-	// instructions block OpenCode reads on every task.
-	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionCreate: 2})
+	// Three creates: opencode.json for MCP, AGENTS.md for the
+	// instructions block OpenCode reads on every task, and the one
+	// generated community skill NewEnv seeds.
+	agentstest.AssertCountsByAction(t, res, map[agents.ActionKind]int{agents.ActionCreate: 3})
 
 	// The MCP config must be the root opencode.json, not the ignored
 	// .opencode/config.json.

--- a/internal/agents/opencode/inspect.go
+++ b/internal/agents/opencode/inspect.go
@@ -1,0 +1,161 @@
+package opencode
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/zzet/gortex/internal/agents/skillpack"
+)
+
+// inspect.go is the read-only counterpart to Apply: it reports what is
+// actually on disk so `gortex doctor` can compare intent against reality.
+// It resolves paths through the same helpers the writers use, so a file
+// this package installs and a file it recognises can never drift apart.
+
+// InstallState is the observed state of the OpenCode integration.
+//
+// It answers "what did we write", not "is it working". For OpenCode that
+// distinction is sharper than for a hook-config host: there is no hook
+// configuration to read back, so "hooks configured" here means exactly
+// "the bridge plugin is present and is ours" (PluginPresent). Whether it
+// ever ran is a question only the hook invocation log can answer, and the
+// two are only meaningful together.
+type InstallState struct {
+	ConfigPath    string         `json:"config_path"`
+	ConfigPresent bool           `json:"config_present"`
+	MCPServer     bool           `json:"mcp_server"`
+	Hooks         map[string]int `json:"hooks"`
+
+	// PluginPath is the bridge's install location; PluginPresent is true
+	// only when the file is there AND carries PluginMarker, so a
+	// same-named plugin somebody else wrote is not counted as ours.
+	PluginPath    string `json:"plugin_path"`
+	PluginPresent bool   `json:"plugin_present"`
+
+	// Skills / Commands count the curated pack members actually on disk.
+	// A partial pack is the tell-tale of an install interrupted midway or
+	// a user pruning files, which nothing else in the report would show.
+	SkillsDir   string `json:"skills_dir"`
+	Skills      int    `json:"skills"`
+	CommandsDir string `json:"commands_dir"`
+	Commands    int    `json:"commands"`
+}
+
+// HookEvents are the telemetry events this integration can actually
+// produce, which is not the same list as the plugin's hook names.
+//
+// Doctor divides recorded runs by this list and calls out any declared
+// event with zero runs as a blocker, so an event we cannot substantiate
+// becomes a permanent false alarm. The bridge core (internal/hooks/pi.go)
+// records under Claude's event vocabulary, and the plugin drives exactly
+// three of those:
+//
+//   - SessionStart      — the once-per-session briefing, sent from the
+//     first chat.message (OpenCode exposes no session hook).
+//   - UserPromptSubmit  — every chat.message.
+//   - PreToolUse        — every tool.execute.before, plus a permission.ask
+//     with no matching before-hook.
+//
+// PostToolUse is deliberately absent even though the plugin subscribes to
+// tool.execute.after: that hook delivers guidance the before-hook already
+// parked and never shells the bridge, so it can never log a run. Naming
+// it here would put a permanent "configured but never ran" line in every
+// doctor report.
+var HookEvents = []string{"SessionStart", "UserPromptSubmit", "PreToolUse"}
+
+// Inspect reads the OpenCode user-level install under home. Every failure
+// degrades to "not configured" rather than an error: doctor's job is to
+// describe a broken machine, not to fail on one.
+func Inspect(home string) InstallState {
+	state := InstallState{Hooks: map[string]int{}}
+	for _, event := range HookEvents {
+		state.Hooks[event] = 0
+	}
+	if home == "" {
+		return state
+	}
+
+	state.ConfigPath = filepath.Join(globalConfigDir(home), "opencode.json")
+	if data, err := os.ReadFile(state.ConfigPath); err == nil {
+		state.ConfigPresent = true
+		root := map[string]any{}
+		if json.Unmarshal(data, &root) == nil {
+			if servers, ok := root["mcp"].(map[string]any); ok {
+				_, state.MCPServer = servers["gortex"]
+			}
+		}
+	}
+
+	state.PluginPath = PluginPath(home)
+	if data, err := os.ReadFile(state.PluginPath); err == nil {
+		state.PluginPresent = strings.Contains(string(data), PluginMarker)
+	}
+	// The plugin is the whole hook surface: present means every event it
+	// drives is wired, absent means none are. There is no per-event
+	// configuration to count, which is why this is a fan-out of one bool
+	// rather than a tally like the codex adapter's.
+	if state.PluginPresent {
+		for _, event := range HookEvents {
+			state.Hooks[event] = 1
+		}
+	}
+
+	state.SkillsDir = globalSkillsDir(home)
+	state.Skills = countInstalled(state.SkillsDir, func(dir string) string {
+		return filepath.Join(dir, skillFileName)
+	}, curatedSkillIDs())
+
+	state.CommandsDir = globalCommandsDir(home)
+	state.Commands = countInstalled(state.CommandsDir, func(dir string) string {
+		return dir + commandFileExt
+	}, curatedCommandIDs())
+
+	return state
+}
+
+// countInstalled counts how many of ids exist on disk under root, where
+// pathFor maps an id's directory (or basename stem) to the file that must
+// exist. Counting the shipped ids rather than listing the directory keeps
+// an unrelated file a user dropped in there out of the tally.
+func countInstalled(root string, pathFor func(string) string, ids []string) int {
+	if root == "" {
+		return 0
+	}
+	n := 0
+	for _, id := range ids {
+		if _, err := os.Stat(pathFor(filepath.Join(root, id))); err == nil {
+			n++
+		}
+	}
+	return n
+}
+
+// curatedSkillIDs / curatedCommandIDs return the shipped ids, or nil when
+// the corpus fails to parse — a parse failure is a build-time bug the
+// package's own tests catch, and doctor reporting zero is a better
+// outcome than doctor failing.
+func curatedSkillIDs() []string {
+	skills, err := Skills()
+	if err != nil {
+		return nil
+	}
+	return skillIDs(skills)
+}
+
+func curatedCommandIDs() []string {
+	commands, err := Commands()
+	if err != nil {
+		return nil
+	}
+	return skillIDs(commands)
+}
+
+func skillIDs(in []skillpack.Skill) []string {
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		out = append(out, s.ID)
+	}
+	return out
+}

--- a/internal/agents/opencode/inspect_test.go
+++ b/internal/agents/opencode/inspect_test.go
@@ -1,0 +1,140 @@
+package opencode
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/agentstest"
+	"github.com/zzet/gortex/internal/agents/claudecode"
+)
+
+// TestInspectEmptyHome: doctor describes a broken machine, it does not
+// fail on one, so an absent install reports zeroes rather than an error.
+func TestInspectEmptyHome(t *testing.T) {
+	state := Inspect("")
+	if state.ConfigPresent || state.MCPServer || state.PluginPresent {
+		t.Fatalf("empty home reported an install: %+v", state)
+	}
+	for _, event := range HookEvents {
+		if _, ok := state.Hooks[event]; !ok {
+			t.Fatalf("Hooks is missing the declared event %q; doctor would print nothing for it", event)
+		}
+	}
+
+	state = Inspect(t.TempDir())
+	if state.ConfigPresent || state.PluginPresent || state.Skills != 0 || state.Commands != 0 {
+		t.Fatalf("empty home dir reported an install: %+v", state)
+	}
+}
+
+// TestInspectAfterGlobalInstall is the round trip: what Apply wrote is
+// what Inspect finds.
+func TestInspectAfterGlobalInstall(t *testing.T) {
+	env, _ := agentstest.NewEnv(t)
+	env.Mode = agents.ModeGlobal
+	if _, err := New().Apply(env, agents.ApplyOpts{ForceDetect: true}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	state := Inspect(env.Home)
+	if !state.PluginPresent {
+		t.Fatalf("installed bridge not detected at %s", state.PluginPath)
+	}
+	if state.PluginPath != PluginPath(env.Home) {
+		t.Fatalf("PluginPath disagrees with the writer: %s", state.PluginPath)
+	}
+	if state.Skills != len(claudecode.GlobalSkills) {
+		t.Fatalf("found %d skills, want %d", state.Skills, len(claudecode.GlobalSkills))
+	}
+	if state.Commands != len(claudecode.SlashCommands) {
+		t.Fatalf("found %d commands, want %d", state.Commands, len(claudecode.SlashCommands))
+	}
+	// The bridge is the whole hook surface: present means every declared
+	// event is wired.
+	for _, event := range HookEvents {
+		if state.Hooks[event] != 1 {
+			t.Fatalf("event %q not reported as configured: %v", event, state.Hooks)
+		}
+	}
+}
+
+// TestInspectIgnoresForeignPlugin: a plugin somebody else called
+// gortex.js is not ours, and counting it would tell doctor enforcement is
+// wired when nothing is.
+func TestInspectIgnoresForeignPlugin(t *testing.T) {
+	home := t.TempDir()
+	path := PluginPath(home)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("export const NotGortex = async () => ({});\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	state := Inspect(home)
+	if state.PluginPresent {
+		t.Fatalf("a foreign gortex.js was counted as the Gortex bridge")
+	}
+	for _, event := range HookEvents {
+		if state.Hooks[event] != 0 {
+			t.Fatalf("event %q reported configured off a foreign plugin", event)
+		}
+	}
+}
+
+// TestInspectReadsGlobalMCPStanza covers the user-level opencode.json.
+// The adapter does not write it (the MCP server goes in the repo's own
+// config), but a user may have added one by hand and doctor should say
+// so.
+func TestInspectReadsGlobalMCPStanza(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(globalConfigDir(home), "opencode.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"mcp":{"gortex":{"type":"local"}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	state := Inspect(home)
+	if !state.ConfigPresent || !state.MCPServer {
+		t.Fatalf("global MCP stanza not detected: %+v", state)
+	}
+}
+
+// TestHookEventsAreSubstantiatedByThePlugin is the fence the doctor
+// wiring depends on. Doctor divides recorded runs by HookEvents and
+// reports any declared event with zero runs as a blocker, so declaring an
+// event nothing can emit is a permanent false alarm.
+//
+// The mapping is: a bridge phase the plugin sends -> the Claude event
+// name internal/hooks/pi.go logs for it.
+func TestHookEventsAreSubstantiatedByThePlugin(t *testing.T) {
+	emitters := map[string][]string{
+		"SessionStart":     {`event: "session"`},
+		"UserPromptSubmit": {`event: "chat.message"`},
+		"PreToolUse":       {`event: "tool.execute.before"`, `event: "permission.ask"`},
+	}
+	if len(emitters) != len(HookEvents) {
+		t.Fatalf("HookEvents has %d entries but this test knows about %d", len(HookEvents), len(emitters))
+	}
+	for _, event := range HookEvents {
+		phases, ok := emitters[event]
+		if !ok {
+			t.Fatalf("HookEvents declares %q with no plugin phase behind it", event)
+		}
+		for _, phase := range phases {
+			if !strings.Contains(pluginSource, phase) {
+				t.Fatalf("HookEvents declares %q but the plugin no longer sends %s", event, phase)
+			}
+		}
+	}
+	// PostToolUse must stay out: tool.execute.after never shells the
+	// bridge, so it can never log a run.
+	for _, event := range HookEvents {
+		if event == "PostToolUse" {
+			t.Fatalf("PostToolUse cannot be substantiated — the after-hook does not call the bridge")
+		}
+	}
+}

--- a/internal/agents/opencode/plugin.go
+++ b/internal/agents/opencode/plugin.go
@@ -1,0 +1,180 @@
+package opencode
+
+// plugin.go renders and installs the OpenCode enforcement bridge.
+//
+// # Why a plugin at all
+//
+// OpenCode (1.18.18) has no lifecycle-hook configuration: no settings key
+// runs a command on session start, before a tool call, or on a prompt.
+// Its JS/TS plugin API is the only place enforcement can live, so Gortex
+// ships one — a thin shim that shells `gortex hook --agent=opencode` and
+// applies the decision. The policy stays in Go; see plugin/gortex.js.
+//
+// # Why the user-level plugin dir, never the repo's
+//
+// This is the only executable artifact Gortex writes anywhere. The
+// repo-level `<root>/.opencode/` is committed, so dropping a file that
+// shells out on every tool call into the user's git tree would push it
+// onto every teammate who clones — an executable they never asked for,
+// arriving through a code review that reads like a config change. The
+// global dir (`~/.config/opencode/plugin/`) covers every project the user
+// opens without that, so it is where the bridge goes and the repo tree
+// keeps only inert markdown.
+//
+// # Why `plugin/`, singular, when everything else is plural
+//
+// OpenCode accepts `plugin/` and `plugins/` alike, and this file picks
+// the singular for the one reason the choice is not arbitrary: unlike
+// skills, commands and agents, the plugin glob is single-level
+// (`{plugin,plugins}/*.{ts,js}`) and does not recurse. Using the
+// odd-one-out spelling keeps that odd-one-out rule attached to a name a
+// reader will notice, so a later "tidy this up to match the others" edit
+// has to stop and read this comment before nesting the file into a
+// subdirectory where it would silently never load again.
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	_ "embed"
+
+	"github.com/zzet/gortex/internal/agents"
+)
+
+//go:embed plugin/gortex.js
+var pluginSource string
+
+// Templated sentinels in plugin/gortex.js. Each is replaced with a JSON
+// literal so a value containing spaces, quotes or backslashes survives
+// into valid JavaScript.
+const (
+	sentinelBin     = "{{GORTEX_BIN}}"
+	sentinelArgv    = "{{GORTEX_HOOK_ARGV}}"
+	sentinelEnforce = "{{GORTEX_ENFORCE}}"
+)
+
+// PluginFileName is the bridge's file name inside the plugin directory.
+// Stable across releases so a re-install overwrites in place rather than
+// leaving two plugins racing each other on every tool call.
+const PluginFileName = "gortex.js"
+
+// PluginMarker is a string every rendered bridge contains. inspect.go
+// matches on it to tell "a Gortex bridge is installed" from "some other
+// plugin happens to be called gortex.js" — it cannot simply re-render and
+// compare, because the rendered bytes carry the install-time binary path.
+//
+// It is deliberately the argv element rather than a phrase from the doc
+// comment: the argv is what makes the file a Gortex bridge, so a rewrite
+// that drops it has stopped being one, while a comment could be reflowed
+// away by a formatter without changing a thing.
+const PluginMarker = `"--agent=` + Name + `"`
+
+// PluginPath is where the bridge is installed for a given home. Exported
+// so inspect.go and the doctor wiring name the same file the writer does.
+func PluginPath(home string) string {
+	return filepath.Join(globalConfigDir(home), "plugin", PluginFileName)
+}
+
+// hookArgv is the command the plugin shells for every bridged event.
+func hookArgv(env agents.Env) []string {
+	argv := []string{resolveGortexBin(env), "hook", "--agent=" + Name}
+	if mode := normalizeHookMode(env.HookMode); mode != "" && mode != "deny" {
+		argv = append(argv, "--mode="+mode)
+	}
+	return argv
+}
+
+// renderPlugin fills the embedded JavaScript template with the resolved
+// gortex binary, the hook argv, and the enforcement flag.
+func renderPlugin(env agents.Env) string {
+	argv := hookArgv(env)
+	src := pluginSource
+	src = substituteSentinel(src, sentinelBin, jsonValue(argv[0]))
+	src = substituteSentinel(src, sentinelArgv, jsonValue(argv))
+	src = substituteSentinel(src, sentinelEnforce, jsonValue(env.InstallHooks))
+	return src
+}
+
+// applyPlugin writes the bridge, or reports that it deliberately did not.
+//
+// Gated on Env.InstallHooks so `--no-hooks` is the one documented off
+// switch across every hook-capable adapter — a user who turned
+// enforcement off machine-wide should not find an executable that
+// enforces it in their OpenCode config.
+//
+// WriteOwnedFile because Gortex owns this file end-to-end: it must track
+// the current binary path and hook posture on every install, and a
+// user-edited copy of a shim whose wire contract we control is not
+// something to preserve. It reports ActionSkip "unchanged" for
+// byte-identical content, which keeps a re-run idempotent.
+func applyPlugin(env agents.Env, opts agents.ApplyOpts) ([]agents.FileAction, error) {
+	if !env.InstallHooks || env.Home == "" {
+		return nil, nil
+	}
+	action, err := agents.WriteOwnedFile(env.Stderr, PluginPath(env.Home), renderPlugin(env), opts)
+	if err != nil {
+		return nil, err
+	}
+	return []agents.FileAction{action}, nil
+}
+
+// planPlugin mirrors applyPlugin's gating so `--dry-run` and `doctor`
+// never promise a file Apply would skip.
+func planPlugin(env agents.Env) []agents.FileAction {
+	if env.Mode != agents.ModeGlobal || !env.InstallHooks || env.Home == "" {
+		return nil
+	}
+	return []agents.FileAction{{Path: PluginPath(env.Home), Action: agents.ActionWouldCreate}}
+}
+
+// resolveGortexBin prefers the binary the caller already resolved into
+// Env.HookCommand, so every adapter in one `gortex install` run bakes the
+// same path, and falls back to agents.ResolveGortexHookBinary — which
+// pins the running binary unless it is an ephemeral `go run` build under
+// the OS temp dir, where it prefers PATH instead.
+func resolveGortexBin(env agents.Env) string {
+	if fields := strings.Fields(env.HookCommand); len(fields) > 0 {
+		return fields[0]
+	}
+	return agents.ResolveGortexHookBinary()
+}
+
+// normalizeHookMode mirrors the hook postures the daemon accepts; any
+// unknown value (including empty) collapses to the deny default.
+func normalizeHookMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case "enrich":
+		return "enrich"
+	case "consult-unlock":
+		return "consult-unlock"
+	case "nudge", "adaptive-nudge":
+		return "nudge"
+	default:
+		return "deny"
+	}
+}
+
+// substituteSentinel replaces a {{NAME}} placeholder with value, tolerant
+// of inner whitespace. The embedded plugin is plain JavaScript and may be
+// run through a formatter (Prettier reflows `{{NAME}}` to `{{ NAME }}`),
+// so an exact-string match would silently miss a formatted sentinel and
+// ship an un-substituted template. The replacement is literal so a value
+// containing `$` is not treated as a regexp expansion.
+func substituteSentinel(src, sentinel, value string) string {
+	name := strings.TrimSuffix(strings.TrimPrefix(sentinel, "{{"), "}}")
+	re := regexp.MustCompile(`\{\{\s*` + regexp.QuoteMeta(name) + `\s*\}\}`)
+	return re.ReplaceAllLiteralString(src, value)
+}
+
+// jsonValue emits a JSON literal for templating into the JavaScript
+// source. A marshal failure renders `null`, which the plugin's own
+// fail-open paths tolerate.
+func jsonValue(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "null"
+	}
+	return string(b)
+}

--- a/internal/agents/opencode/plugin/gortex.js
+++ b/internal/agents/opencode/plugin/gortex.js
@@ -1,0 +1,302 @@
+// Gortex plugin for OpenCode (1.18.18).
+//
+// OpenCode has no lifecycle-hook configuration at all — there is no
+// settings key that runs a command on session start or before a tool
+// call. A JS/TS plugin is its only enforcement surface, so this file is
+// the OpenCode half of the Gortex bridge: on each relevant plugin hook it
+// shells `gortex hook --agent=opencode`, writes a BridgeEvent envelope to
+// stdin, and applies the BridgeDecision it reads back.
+//
+// Every policy decision — the deny / enrich / consult-unlock / nudge
+// postures, indexed-source classification, telemetry — stays in Go
+// (internal/hooks/opencode.go + pi.go). Re-implementing any of it here
+// would give OpenCode a second, drifting copy of rules every other host
+// reads from one place.
+//
+// This file is written verbatim by the `opencode` adapter except for
+// three sentinels, each replaced with a JSON literal at install time:
+//
+//   GORTEX_BIN        -> string:  resolved `gortex` binary path
+//   GORTEX_HOOK_ARGV  -> array:   full hook argv, argv[0] included
+//   GORTEX_ENFORCE    -> boolean: false when installed with --no-hooks
+//
+// Zero package dependencies, deliberately: OpenCode installs plugin
+// dependencies from `.opencode/package.json` with a bun install at
+// startup. Anything beyond a `node:` built-in would need a package.json
+// this installer does not own, and a failed install would take the plugin
+// down with it.
+
+import { execFileSync } from "node:child_process";
+
+const GORTEX_BIN = {{GORTEX_BIN}};
+const HOOK_ARGV = {{GORTEX_HOOK_ARGV}};
+
+// The adapter does not write this file at all under --no-hooks, so a
+// rendered `false` only ever reaches disk via a hand-copied or downgraded
+// install. Honouring it anyway costs one branch and means the documented
+// off switch still works on a file that outlived its installer.
+const ENFORCE = {{GORTEX_ENFORCE}};
+
+// How long a single bridge call may take before we give up and let the
+// tool through. The Go side answers from a local daemon in single-digit
+// milliseconds; this ceiling exists for the pathological case (daemon
+// mid-restart, machine swapping), where waiting longer would be felt as
+// the agent hanging.
+const HOOK_TIMEOUT_MS = 5000;
+
+// Cap on the per-call decision map. A session is thousands of tool calls
+// long and OpenCode gives no "call finished" signal we can trust for
+// cleanup, so the map is cleared wholesale once it grows past this. The
+// only cost of a clear is that an in-flight call loses its parked tip.
+const DECISION_CACHE_MAX = 256;
+
+// OpenCode's built-in tool vocabulary, mapped onto the Claude names the
+// shared Go enrichment switches on. Deliberately the same seven entries
+// as openCodeToolNames in internal/hooks/opencode.go, in the same order,
+// so the two tables can be diffed by eye. Anything unrecognised is passed
+// through untouched; the Go classifier ignores names it does not know,
+// which is the fail-open default this whole file is built around.
+const TOOL_NAMES = {
+  read: "Read",
+  write: "Write",
+  edit: "Edit",
+  bash: "Bash",
+  grep: "Grep",
+  glob: "Glob",
+  task: "Task",
+};
+
+// A tool call that IS a Gortex graph query. OpenCode exposes MCP tools as
+// `<server>_<tool>`, and our server is registered as `gortex`, so the
+// prefix identifies them; the `mcp__gortex__` spelling is accepted too in
+// case a future OpenCode adopts Claude's naming. The flag matters to the
+// Go side: consult-unlock uses a graph query as the handshake that
+// unlocks fallback reads, and adaptive-nudge resets its streak on one.
+const GORTEX_TOOL_PATTERN = /^(gortex[_.]|mcp__gortex__)/;
+
+function isGortexTool(name) {
+  return GORTEX_TOOL_PATTERN.test(String(name || ""));
+}
+
+function normalizeToolName(name) {
+  const raw = String(name || "").trim();
+  return TOOL_NAMES[raw.toLowerCase()] || raw;
+}
+
+function firstString(obj, keys) {
+  if (!obj || typeof obj !== "object") return undefined;
+  for (const key of keys) {
+    const value = obj[key];
+    if (typeof value === "string" && value !== "") return value;
+  }
+  return undefined;
+}
+
+// normalizeToolInput maps OpenCode's argument keys onto the canonical
+// `file_path` / `pattern` / `command` shape the Go enrichment reads.
+// OpenCode spells the first one `filePath`; without this the classifier
+// would see no path on any read or edit and quietly classify nothing,
+// which looks exactly like a healthy install that enforces nothing.
+// Original keys are kept alongside the canonical ones — the envelope is
+// ours, and dropping them would lose context for future rules.
+function normalizeToolInput(args) {
+  const out = args && typeof args === "object" ? { ...args } : {};
+  const path = firstString(out, ["file_path", "filePath", "path", "file", "filepath"]);
+  if (path !== undefined) out.file_path = path;
+  const pattern = firstString(out, ["pattern", "glob", "query"]);
+  if (pattern !== undefined) out.pattern = pattern;
+  const command = firstString(out, ["command", "cmd", "script"]);
+  if (command !== undefined) out.command = command;
+  return out;
+}
+
+// callHook sends one envelope to `gortex hook --agent=opencode` and
+// parses the decision it writes back.
+//
+// Fail-open and silent by construction: a missing binary, a non-zero
+// exit, a timeout, or unparsable stdout all land in the catch and return
+// an empty decision, which every caller below treats as "do nothing". A
+// broken bridge must never be able to break the user's session. The
+// child's stderr is discarded rather than inherited so a Go-side warning
+// cannot scribble over OpenCode's TUI.
+function callHook(envelope) {
+  try {
+    const out = execFileSync(GORTEX_BIN, HOOK_ARGV.slice(1), {
+      input: JSON.stringify(envelope),
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024,
+      timeout: HOOK_TIMEOUT_MS,
+      stdio: ["pipe", "pipe", "ignore"],
+    });
+    const trimmed = String(out || "").trim();
+    if (!trimmed) return {};
+    const decision = JSON.parse(trimmed);
+    return decision && typeof decision === "object" ? decision : {};
+  } catch {
+    return {};
+  }
+}
+
+// messageText joins the text parts of a chat message, which is what the
+// Go side scores for "indexed symbols relevant to this turn".
+function messageText(parts) {
+  if (!Array.isArray(parts)) return "";
+  return parts
+    .filter((p) => p && p.type === "text" && typeof p.text === "string")
+    .map((p) => p.text)
+    .join("\n");
+}
+
+// appendToLastTextPart injects context by extending the last text part in
+// place rather than pushing a new one. A part carries identity fields
+// (id, sessionID, messageID) whose shape is OpenCode's, not ours;
+// fabricating one risks a malformed message where the worst case is a
+// broken session, while appending to an existing string cannot be
+// structurally wrong.
+function appendToLastTextPart(parts, text) {
+  if (!Array.isArray(parts) || !text) return;
+  for (let i = parts.length - 1; i >= 0; i--) {
+    const part = parts[i];
+    if (part && part.type === "text" && typeof part.text === "string") {
+      part.text = part.text + "\n\n" + text;
+      return;
+    }
+  }
+}
+
+export const GortexPlugin = async ({ directory, worktree }) => {
+  // The repo the Go side resolves indexed-source coverage against.
+  // `worktree` is the git root and `directory` the CWD OpenCode started
+  // in; prefer the former so a session opened in a subdirectory is still
+  // recognised as covered.
+  const cwd = worktree || directory || process.cwd();
+
+  // callID -> soft guidance parked by tool.execute.before for
+  // tool.execute.after to deliver. Presence of a key also records "this
+  // call was already decided", which is what keeps permission.ask from
+  // asking the same question twice for one tool call.
+  const decided = new Map();
+
+  // The session briefing is a once-per-session injection; OpenCode has no
+  // session-start hook in the stable set, so the first chat message is
+  // where it goes.
+  let oriented = false;
+
+  function remember(callID, tip) {
+    if (!callID) return;
+    if (decided.size >= DECISION_CACHE_MAX) decided.clear();
+    decided.set(callID, tip || "");
+  }
+
+  return {
+    // Throwing from tool.execute.before is OpenCode's documented way to
+    // refuse a tool call: the throw becomes the tool's error and the
+    // model reads the message. That makes the thrown reason the deny
+    // text, which is why it is the Go decision's Reason verbatim.
+    "tool.execute.before": async (input, output) => {
+      if (!ENFORCE) return;
+      const tool = String(input?.tool ?? "");
+      const gortexTool = isGortexTool(tool);
+      const callID = String(input?.callID ?? "");
+
+      const decision = callHook({
+        event: "tool.execute.before",
+        tool_name: gortexTool ? tool : normalizeToolName(tool),
+        tool_input: normalizeToolInput(output?.args),
+        cwd,
+        session_id: String(input?.sessionID ?? ""),
+        is_gortex_tool: gortexTool,
+      });
+
+      remember(callID, decision.additional_context);
+      if (decision.block) {
+        throw new Error(
+          decision.reason || "[Gortex] blocked — use the Gortex graph tools instead of raw file reads.",
+        );
+      }
+    },
+
+    // This hook deliberately does NOT shell the bridge. The Go router
+    // maps no "after" phase, so every call would spend a subprocess to
+    // receive a guaranteed-empty decision. What it is for is delivery:
+    // it is the only stable hook that can put text in front of the model
+    // without blocking anything, so it hands over the soft guidance the
+    // before-hook parked (the enrich and nudge postures' whole output).
+    "tool.execute.after": async (input, output) => {
+      const callID = String(input?.callID ?? "");
+      if (!callID || !decided.has(callID)) return;
+      const tip = decided.get(callID);
+      decided.delete(callID);
+      if (!tip) return;
+      try {
+        if (output && typeof output.output === "string") {
+          output.output = output.output + "\n\n" + tip;
+        }
+      } catch {
+        // Never let context delivery break a tool result.
+      }
+    },
+
+    // permission.ask is a second gate, not a duplicate one: OpenCode
+    // raises it from inside a tool that needs approval, after
+    // tool.execute.before has already run for that callID. Deferring to
+    // the earlier decision keeps one tool call from being scored twice —
+    // double-counting would inflate doctor's run tallies and, under
+    // consult-unlock / adaptive-nudge, move per-session state twice for
+    // one action. A permission with no matching before-hook is still
+    // asked about.
+    "permission.ask": async (input, output) => {
+      if (!ENFORCE) return;
+      const callID = String(input?.callID ?? "");
+      if (callID && decided.has(callID)) return;
+      const type = String(input?.type ?? "");
+      if (isGortexTool(type)) return;
+
+      const decision = callHook({
+        event: "permission.ask",
+        tool_name: normalizeToolName(type),
+        tool_input: normalizeToolInput(input?.metadata),
+        cwd,
+        session_id: String(input?.sessionID ?? ""),
+      });
+
+      remember(callID, "");
+      if (decision.block) {
+        output.status = "deny";
+      }
+    },
+
+    // chat.message carries the user's turn with a mutable parts array —
+    // the one place a bridged host can inject context the way Claude's
+    // UserPromptSubmit hook does. Two envelopes go out on the first turn:
+    // the session briefing (once) and the per-turn symbol context.
+    "chat.message": async (input, output) => {
+      const role = output?.message?.role;
+      if (role && role !== "user") return;
+      const sessionID = String(output?.message?.sessionID ?? input?.sessionID ?? "");
+      const injected = [];
+
+      if (!oriented) {
+        oriented = true;
+        const briefing = callHook({ event: "session", cwd, session_id: sessionID });
+        if (briefing.orientation) injected.push(briefing.orientation);
+      }
+
+      const decision = callHook({
+        event: "chat.message",
+        prompt: messageText(output?.parts),
+        cwd,
+        session_id: sessionID,
+      });
+      if (decision.additional_context) injected.push(decision.additional_context);
+
+      if (injected.length > 0) {
+        try {
+          appendToLastTextPart(output?.parts, injected.join("\n\n"));
+        } catch {
+          // Best effort — never break message assembly.
+        }
+      }
+    },
+  };
+};

--- a/internal/agents/opencode/plugin_node_test.go
+++ b/internal/agents/opencode/plugin_node_test.go
@@ -1,0 +1,290 @@
+package opencode
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/agentstest"
+)
+
+// plugin_node_test.go drives the rendered bridge inside a real JavaScript
+// runtime against a stub `gortex hook`.
+//
+// The string assertions in plugin_test.go can only prove the file *says*
+// it fails open. This proves it: a stub that exits non-zero, prints
+// garbage, or prints nothing has to leave the tool call untouched, and
+// only running the code shows that. The alternative — shipping a bridge
+// whose failure mode is "the user's session breaks" — is the one outcome
+// that must never reach a machine.
+//
+// The stub is a POSIX shell script, so this is Unix-only; the rendered
+// JavaScript is platform-independent and plugin_test.go's `node --check`
+// covers syntax everywhere.
+
+// stubHook is the fake `gortex hook`: it records the envelope it was
+// given and answers according to $GORTEX_STUB_MODE.
+const stubHook = `#!/bin/sh
+cat >> "$GORTEX_STUB_CAPTURE"
+printf '\n' >> "$GORTEX_STUB_CAPTURE"
+case "$GORTEX_STUB_MODE" in
+  block)   printf '%s' '{"block":true,"reason":"[Gortex] call search_symbols instead"}' ;;
+  tip)     printf '%s' '{"additional_context":"GRAPH TIP"}' ;;
+  orient)  printf '%s' '{"orientation":"BRIEFING","additional_context":"PROMPT CONTEXT"}' ;;
+  garbage) printf '%s' 'this is not json' ;;
+  crash)   exit 3 ;;
+  *)       : ;;
+esac
+`
+
+// driver exercises every hook the plugin exposes and reports what
+// happened, so one node run covers the whole surface.
+const driver = `import { GortexPlugin } from "./gortex.mjs";
+
+const hooks = await GortexPlugin({ directory: process.cwd(), worktree: process.cwd() });
+const result = { threw: null, toolOutput: null, promptText: null, permission: null };
+
+try {
+  await hooks["tool.execute.before"](
+    { tool: "read", sessionID: "s1", callID: "c1" },
+    { args: { filePath: "/repo/main.go" } },
+  );
+} catch (err) {
+  result.threw = err.message;
+}
+
+const toolResult = { title: "read", output: "FILE CONTENTS", metadata: {} };
+await hooks["tool.execute.after"]({ tool: "read", sessionID: "s1", callID: "c1", args: {} }, toolResult);
+result.toolOutput = toolResult.output;
+
+const parts = [{ type: "text", text: "why is login failing" }];
+await hooks["chat.message"]({}, { message: { role: "user", sessionID: "s1" }, parts });
+result.promptText = parts[0].text;
+
+const permission = { status: "ask" };
+await hooks["permission.ask"](
+  { type: "bash", sessionID: "s1", callID: "c2", metadata: { command: "rm -rf /" } },
+  permission,
+);
+result.permission = permission.status;
+
+console.log(JSON.stringify(result));
+`
+
+type driverResult struct {
+	Threw      *string `json:"threw"`
+	ToolOutput string  `json:"toolOutput"`
+	PromptText string  `json:"promptText"`
+	Permission string  `json:"permission"`
+}
+
+func TestPluginBehaviourUnderNode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the hook stub is a POSIX shell script")
+	}
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node not on PATH")
+	}
+
+	cases := []struct {
+		mode  string
+		check func(t *testing.T, got driverResult)
+	}{
+		{
+			mode: "block",
+			check: func(t *testing.T, got driverResult) {
+				if got.Threw == nil || !strings.Contains(*got.Threw, "call search_symbols instead") {
+					t.Fatalf("a block decision must throw the Go reason verbatim, got %v", got.Threw)
+				}
+				if got.Permission != "deny" {
+					t.Fatalf("permission.ask should have denied, got %q", got.Permission)
+				}
+			},
+		},
+		{
+			mode: "tip",
+			check: func(t *testing.T, got driverResult) {
+				if got.Threw != nil {
+					t.Fatalf("soft guidance must not block: %v", *got.Threw)
+				}
+				if !strings.Contains(got.ToolOutput, "FILE CONTENTS") || !strings.Contains(got.ToolOutput, "GRAPH TIP") {
+					t.Fatalf("the after-hook must append the parked tip to the result, got %q", got.ToolOutput)
+				}
+				if got.Permission != "ask" {
+					t.Fatalf("a non-blocking decision must leave the permission status alone, got %q", got.Permission)
+				}
+			},
+		},
+		{
+			mode: "orient",
+			check: func(t *testing.T, got driverResult) {
+				if !strings.HasPrefix(got.PromptText, "why is login failing") {
+					t.Fatalf("injection must extend the user's text, not replace it: %q", got.PromptText)
+				}
+				if !strings.Contains(got.PromptText, "BRIEFING") || !strings.Contains(got.PromptText, "PROMPT CONTEXT") {
+					t.Fatalf("chat.message must carry both the briefing and the turn context: %q", got.PromptText)
+				}
+			},
+		},
+		// The three fail-open modes: a broken bridge is indistinguishable
+		// from no bridge at all.
+		{mode: "crash", check: assertNoInterference},
+		{mode: "garbage", check: assertNoInterference},
+		{mode: "empty", check: assertNoInterference},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.mode, func(t *testing.T) {
+			dir := t.TempDir()
+			capture := filepath.Join(dir, "capture.jsonl")
+
+			stub := filepath.Join(dir, "gortex")
+			if err := os.WriteFile(stub, []byte(stubHook), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			env, _ := agentstest.NewEnv(t)
+			env.Mode = agents.ModeGlobal
+			env.HookCommand = stub + " hook"
+			if err := os.WriteFile(filepath.Join(dir, "gortex.mjs"), []byte(renderPlugin(env)), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "driver.mjs"), []byte(driver), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			cmd := exec.Command(node, "driver.mjs")
+			cmd.Dir = dir
+			cmd.Env = append(os.Environ(),
+				"GORTEX_STUB_MODE="+tc.mode,
+				"GORTEX_STUB_CAPTURE="+capture,
+			)
+			out, err := cmd.Output()
+			if err != nil {
+				t.Fatalf("driver failed: %v\n%s", err, out)
+			}
+			var got driverResult
+			if err := json.Unmarshal(out, &got); err != nil {
+				t.Fatalf("driver output %q: %v", out, err)
+			}
+			tc.check(t, got)
+		})
+	}
+}
+
+func assertNoInterference(t *testing.T, got driverResult) {
+	t.Helper()
+	if got.Threw != nil {
+		t.Fatalf("a broken bridge must not block a tool call, but it threw %q", *got.Threw)
+	}
+	if got.ToolOutput != "FILE CONTENTS" {
+		t.Fatalf("a broken bridge must not touch the tool result, got %q", got.ToolOutput)
+	}
+	if got.PromptText != "why is login failing" {
+		t.Fatalf("a broken bridge must not touch the user's message, got %q", got.PromptText)
+	}
+	if got.Permission != "ask" {
+		t.Fatalf("a broken bridge must not change a permission decision, got %q", got.Permission)
+	}
+}
+
+// TestPluginEnvelopeMatchesTheBridgeContract reads back what the plugin
+// actually put on the hook's stdin and checks it against the BridgeEvent
+// fields in internal/hooks/pi.go — including the `filePath` -> `file_path`
+// mapping, without which the Go classifier sees no path on any read and
+// enforces nothing while looking perfectly healthy.
+func TestPluginEnvelopeMatchesTheBridgeContract(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the hook stub is a POSIX shell script")
+	}
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node not on PATH")
+	}
+
+	dir := t.TempDir()
+	capture := filepath.Join(dir, "capture.jsonl")
+	stub := filepath.Join(dir, "gortex")
+	if err := os.WriteFile(stub, []byte(stubHook), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	env, _ := agentstest.NewEnv(t)
+	env.Mode = agents.ModeGlobal
+	env.HookCommand = stub + " hook"
+	if err := os.WriteFile(filepath.Join(dir, "gortex.mjs"), []byte(renderPlugin(env)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "driver.mjs"), []byte(driver), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(node, "driver.mjs")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GORTEX_STUB_MODE=empty", "GORTEX_STUB_CAPTURE="+capture)
+	if out, err := cmd.Output(); err != nil {
+		t.Fatalf("driver failed: %v\n%s", err, out)
+	}
+
+	data, err := os.ReadFile(capture)
+	if err != nil {
+		t.Fatalf("no envelope was ever written: %v", err)
+	}
+	envelopes := map[string]map[string]any{}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var ev map[string]any
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			t.Fatalf("envelope %q is not JSON: %v", line, err)
+		}
+		event, _ := ev["event"].(string)
+		envelopes[event] = ev
+	}
+
+	for _, event := range []string{"tool.execute.before", "session", "chat.message", "permission.ask"} {
+		if _, ok := envelopes[event]; !ok {
+			t.Fatalf("no %q envelope was sent; got %v", event, keysOf(envelopes))
+		}
+	}
+
+	before := envelopes["tool.execute.before"]
+	if before["tool_name"] != "Read" {
+		t.Fatalf("tool name must arrive in the Claude vocabulary, got %v", before["tool_name"])
+	}
+	input, _ := before["tool_input"].(map[string]any)
+	if input["file_path"] != "/repo/main.go" {
+		t.Fatalf("OpenCode's filePath was not mapped onto file_path: %v", input)
+	}
+	if before["session_id"] != "s1" {
+		t.Fatalf("session_id missing: %v", before)
+	}
+	if before["cwd"] == "" || before["cwd"] == nil {
+		t.Fatalf("cwd missing: %v", before)
+	}
+
+	perm := envelopes["permission.ask"]
+	if perm["tool_name"] != "Bash" {
+		t.Fatalf("permission type must map onto the Claude vocabulary, got %v", perm["tool_name"])
+	}
+	permInput, _ := perm["tool_input"].(map[string]any)
+	if permInput["command"] != "rm -rf /" {
+		t.Fatalf("permission metadata did not become tool_input: %v", permInput)
+	}
+
+	if prompt, _ := envelopes["chat.message"]["prompt"].(string); prompt != "why is login failing" {
+		t.Fatalf("chat.message must carry the turn text, got %q", prompt)
+	}
+}
+
+func keysOf(m map[string]map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/agents/opencode/plugin_test.go
+++ b/internal/agents/opencode/plugin_test.go
@@ -1,0 +1,264 @@
+package opencode
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/agentstest"
+)
+
+// globalEnv returns an Env in ModeGlobal — the only mode that installs
+// the bridge.
+func globalEnv(t *testing.T) (agents.Env, string) {
+	t.Helper()
+	env, _ := agentstest.NewEnv(t)
+	env.Mode = agents.ModeGlobal
+	return env, PluginPath(env.Home)
+}
+
+// TestPluginLandsInTheGlobalPluginDir pins the install location. The
+// repo-level `.opencode/` is committed, so an executable dropped there
+// would reach every teammate who clones; plugin.go documents the call.
+func TestPluginLandsInTheGlobalPluginDir(t *testing.T) {
+	env, want := globalEnv(t)
+	if _, err := New().Apply(env, agents.ApplyOpts{ForceDetect: true}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	if got := filepath.Join(env.Home, ".config", "opencode", "plugin", "gortex.js"); got != want {
+		t.Fatalf("PluginPath drifted: %s != %s", want, got)
+	}
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("plugin not installed at %s: %v", want, err)
+	}
+	if _, err := os.Stat(filepath.Join(env.Root, ".opencode")); err == nil {
+		t.Fatalf("the bridge must never be written into the repo tree")
+	}
+}
+
+// TestPluginIsTopLevelInPluginDir: the plugin glob is single-level
+// (`{plugin,plugins}/*.{ts,js}`) — unlike skills, commands and agents it
+// does NOT recurse, so a nested file is never loaded and the install
+// would look healthy while enforcing nothing.
+func TestPluginIsTopLevelInPluginDir(t *testing.T) {
+	env, path := globalEnv(t)
+	if _, err := New().Apply(env, agents.ApplyOpts{ForceDetect: true}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	dir := filepath.Dir(path)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			t.Fatalf("%s contains a subdirectory %q; the plugin glob does not recurse", dir, entry.Name())
+		}
+	}
+}
+
+// TestNoHooksWritesNoPlugin: --no-hooks is the documented off switch on
+// every hook-capable adapter, and this is the only one whose artifact is
+// executable.
+func TestNoHooksWritesNoPlugin(t *testing.T) {
+	env, path := globalEnv(t)
+	env.InstallHooks = false
+
+	plan, err := New().Plan(env)
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	for _, f := range plan.Files {
+		if f.Path == path {
+			t.Fatalf("Plan promised the bridge under --no-hooks")
+		}
+	}
+	if _, err := New().Apply(env, agents.ApplyOpts{ForceDetect: true}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if _, err := os.Stat(path); err == nil {
+		t.Fatalf("--no-hooks still installed %s", path)
+	}
+}
+
+// TestEverySentinelIsSubstituted: an un-substituted `{{…}}` is a syntax
+// error at load time, which OpenCode reports by silently not loading the
+// plugin.
+func TestEverySentinelIsSubstituted(t *testing.T) {
+	env, _ := globalEnv(t)
+	rendered := renderPlugin(env)
+	if strings.Contains(rendered, "{{") || strings.Contains(rendered, "}}") {
+		for _, line := range strings.Split(rendered, "\n") {
+			if strings.Contains(line, "{{") || strings.Contains(line, "}}") {
+				t.Errorf("un-substituted sentinel: %s", line)
+			}
+		}
+		t.FailNow()
+	}
+	// The template must still carry every sentinel, or a rename would
+	// pass the check above by leaving the value hard-coded.
+	for _, sentinel := range []string{sentinelBin, sentinelArgv, sentinelEnforce} {
+		if !strings.Contains(pluginSource, sentinel) {
+			t.Fatalf("plugin/gortex.js no longer carries %s", sentinel)
+		}
+	}
+}
+
+// TestRenderedArgvAndEnforce checks the two values the bridge cannot work
+// without: the argv it shells, and the enforcement flag.
+func TestRenderedArgvAndEnforce(t *testing.T) {
+	env, _ := globalEnv(t)
+	env.HookCommand = "/opt/gortex/bin/gortex hook"
+	env.HookMode = "enrich"
+	rendered := renderPlugin(env)
+
+	const wantArgv = `["/opt/gortex/bin/gortex","hook","--agent=opencode","--mode=enrich"]`
+	if !strings.Contains(rendered, wantArgv) {
+		t.Fatalf("rendered argv missing %s", wantArgv)
+	}
+	if !strings.Contains(rendered, `const GORTEX_BIN = "/opt/gortex/bin/gortex";`) {
+		t.Fatalf("rendered binary path is not the one from HookCommand")
+	}
+	if !strings.Contains(rendered, "const ENFORCE = true;") {
+		t.Fatalf("ENFORCE should be true when InstallHooks is set")
+	}
+
+	env.InstallHooks = false
+	if !strings.Contains(renderPlugin(env), "const ENFORCE = false;") {
+		t.Fatalf("ENFORCE should render false under --no-hooks")
+	}
+}
+
+// TestDefaultHookModeOmitsTheFlag: "deny" is the daemon's default, so
+// spelling it out would only make the argv (and every install's rendered
+// bytes) differ for no behavioural reason.
+func TestDefaultHookModeOmitsTheFlag(t *testing.T) {
+	env, _ := globalEnv(t)
+	for _, mode := range []string{"", "deny", "nonsense"} {
+		env.HookMode = mode
+		if strings.Contains(renderPlugin(env), "--mode=") {
+			t.Fatalf("hook mode %q rendered a --mode flag", mode)
+		}
+	}
+}
+
+// TestPluginSubscribesToTheStableHooksOnly. `experimental.*` hooks are
+// explicitly out of bounds — they are renamed without notice, and a
+// renamed hook fails by never firing.
+func TestPluginSubscribesToTheStableHooksOnly(t *testing.T) {
+	for _, hook := range []string{
+		`"tool.execute.before"`, `"tool.execute.after"`, `"permission.ask"`, `"chat.message"`,
+	} {
+		if !strings.Contains(pluginSource, hook) {
+			t.Fatalf("plugin no longer subscribes to %s", hook)
+		}
+	}
+	if strings.Contains(pluginSource, "experimental") {
+		t.Fatalf("plugin references an experimental hook")
+	}
+}
+
+// TestPluginSpeaksTheBridgeWireContract pins the envelope and decision
+// field names against internal/hooks/pi.go. They are two halves of one
+// protocol in two languages, so nothing but a test holds them together.
+func TestPluginSpeaksTheBridgeWireContract(t *testing.T) {
+	// BridgeEvent fields the plugin sends.
+	for _, field := range []string{
+		"event:", "tool_name:", "tool_input:", "cwd,", "session_id:", "is_gortex_tool:", "prompt:",
+	} {
+		if !strings.Contains(pluginSource, field) {
+			t.Fatalf("plugin no longer sends the BridgeEvent field %q", field)
+		}
+	}
+	// BridgeDecision fields the plugin reads.
+	for _, field := range []string{
+		"decision.block", "decision.reason", "decision.additional_context", "briefing.orientation",
+	} {
+		if !strings.Contains(pluginSource, field) {
+			t.Fatalf("plugin no longer reads %s", field)
+		}
+	}
+	// Event phase strings the Go router recognises (bridgeEventSlot).
+	for _, phase := range []string{
+		`event: "tool.execute.before"`, `event: "permission.ask"`,
+		`event: "chat.message"`, `event: "session"`,
+	} {
+		if !strings.Contains(pluginSource, phase) {
+			t.Fatalf("plugin no longer emits %s", phase)
+		}
+	}
+}
+
+// TestPluginFailsOpen: every bridge call has to be inside a try/catch
+// that returns an empty decision, because a spawn error, a non-zero exit,
+// a timeout or garbled stdout must all let the tool call through.
+func TestPluginFailsOpen(t *testing.T) {
+	if !strings.Contains(pluginSource, "timeout: HOOK_TIMEOUT_MS") {
+		t.Fatalf("the bridge call has no timeout — a wedged hook would hang the session")
+	}
+	_, after, ok := strings.Cut(pluginSource, "function callHook(envelope) {")
+	if !ok {
+		t.Fatalf("callHook is gone")
+	}
+	body, _, ok := strings.Cut(after, "\n}\n")
+	if !ok {
+		t.Fatalf("callHook has no closing brace this test can find")
+	}
+	if !strings.Contains(body, "try {") {
+		t.Fatalf("callHook does not guard the spawn:\n%s", body)
+	}
+	if !strings.Contains(body, "catch") || !strings.Contains(body, "return {};") {
+		t.Fatalf("callHook no longer swallows every failure into an empty decision:\n%s", body)
+	}
+	// One spawn call site, so "fails open" is a property of a single
+	// guarded function rather than something each caller has to repeat.
+	if n := strings.Count(pluginSource, "execFileSync("); n != 1 {
+		t.Fatalf("expected exactly one execFileSync call site, found %d", n)
+	}
+}
+
+// TestRenderedPluginParses runs `node --check` on the rendered bridge,
+// which is the only cheap way to catch a template edit that produces
+// invalid JavaScript — OpenCode's own failure mode is to skip the plugin
+// without a word.
+//
+// The copy to `.mjs` is required, not cosmetic: `node --check` parses a
+// `.js` file as CommonJS unless a package.json says otherwise, and this
+// plugin is an ES module (OpenCode's documented plugin shape). We
+// deliberately do not ship a package.json, so the extension is the only
+// signal available.
+func TestRenderedPluginParses(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node not on PATH")
+	}
+	env, _ := globalEnv(t)
+	path := filepath.Join(t.TempDir(), "gortex.mjs")
+	if err := os.WriteFile(path, []byte(renderPlugin(env)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command(node, "--check", path).CombinedOutput(); err != nil {
+		t.Fatalf("rendered plugin is not valid JavaScript: %v\n%s", err, out)
+	}
+}
+
+// TestPluginHasNoPackageDependencies: OpenCode installs plugin deps from
+// `.opencode/package.json` with a bun install at startup. We write no
+// package.json, so any import beyond a node: built-in would fail at load
+// and take the bridge down with it.
+func TestPluginHasNoPackageDependencies(t *testing.T) {
+	for _, line := range strings.Split(pluginSource, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "import ") && !strings.Contains(trimmed, "require(") {
+			continue
+		}
+		if strings.Contains(trimmed, `"node:`) {
+			continue
+		}
+		t.Fatalf("plugin has a non-builtin dependency: %s", trimmed)
+	}
+}

--- a/internal/agents/opencode/remove.go
+++ b/internal/agents/opencode/remove.go
@@ -1,0 +1,214 @@
+package opencode
+
+// remove.go is the counterpart to applyGlobal for `gortex uninstall
+// --global`.
+//
+// # Ownership, not location
+//
+// Every deletion is gated on evidence Gortex authored the thing being
+// deleted, never on the path it sits at. `~/.config/opencode/skills` and
+// `.../commands` are SHARED trees — a user's own skills and slash commands
+// live there beside ours — so removing either directory would delete their
+// work. The predicate is the one skills.go writes with: a shipped id whose
+// file is still byte-identical to the body we render. A file that differs
+// is KEPT with a warning, the same never-clobber posture writeCuratedFile
+// takes on the way in.
+//
+// The bridge plugin is the one file Gortex owns end-to-end, and even it is
+// checked: `plugin/gortex.js` is deleted only when it carries PluginMarker,
+// so a same-named plugin somebody else wrote is left alone.
+//
+// # Stop-line: no MCP stanza and no instructions block at user scope
+//
+// applyGlobal writes neither, so RemoveGlobal removes neither. OpenCode's
+// gortex MCP entry lives in the repo's own opencode.json (written by
+// `gortex init`, removed by the repo-level half of `gortex uninstall`) and
+// the community routing block lives in the repo's AGENTS.md. A `mcp.gortex`
+// entry in `~/.config/opencode/opencode.json` was put there by the user,
+// and a cleanup command that deletes config it never wrote is a cleanup
+// command nobody runs twice.
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/internalutil"
+)
+
+// RemoveGlobal strips the user-level OpenCode footprint `gortex install`
+// wrote. Returns the number of artifacts removed-or-cleaned and any
+// per-artifact failures — a partial clean still reports rather than
+// aborting. Signature mirrors claudecode.Adapter.RemoveGlobal so `gortex
+// uninstall` can call every host through the same shape.
+func (a *Adapter) RemoveGlobal(env agents.Env, opts agents.ApplyOpts) (removed int, failures []string) {
+	if env.Home == "" {
+		return 0, []string{"opencode: global cleanup requires a resolved home directory"}
+	}
+
+	// 1. ~/.config/opencode/plugin/gortex.js — the enforcement bridge.
+	pluginRemoved, pluginFailures := removePlugin(env, opts)
+	removed += pluginRemoved
+	failures = append(failures, pluginFailures...)
+
+	// 2. ~/.config/opencode/{skills,commands}/ — the curated packs.
+	packRemoved, packFailures := removeCuratedPack(env, opts)
+	removed += packRemoved
+	failures = append(failures, packFailures...)
+
+	return removed, failures
+}
+
+// GlobalArtifacts lists the user-level OpenCode paths that currently carry
+// a Gortex footprint, sorted. It applies the SAME ownership tests
+// RemoveGlobal does — a customised skill is absent from this list exactly
+// because removal will keep it — so the uninstall wizard's preview can
+// never promise a deletion that will not happen, nor stay silent about one
+// that will.
+func GlobalArtifacts(home string) []string {
+	if home == "" {
+		return nil
+	}
+	var present []string
+
+	if path := PluginPath(home); opencodeFileContains(path, PluginMarker) {
+		present = append(present, path)
+	}
+	for path, shipped := range ownedPackFiles(home) {
+		if isShippedOpenCodeFile(path, shipped) {
+			present = append(present, path)
+		}
+	}
+
+	sort.Strings(present)
+	return present
+}
+
+// removePlugin deletes the bridge, but only when the file on disk is
+// actually ours. PluginMarker is the argv element that makes the file a
+// Gortex bridge; matching on it rather than on the file name is what keeps
+// a same-named plugin somebody else wrote out of the blast radius.
+func removePlugin(env agents.Env, opts agents.ApplyOpts) (removed int, failures []string) {
+	path := PluginPath(env.Home)
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, []string{fmt.Sprintf("%s: %v", path, err)}
+	}
+	if !strings.Contains(string(data), PluginMarker) {
+		internalutil.Warnf(env.Stderr, "keeping %s: it is not a Gortex bridge", path)
+		return 0, nil
+	}
+	if opts.DryRun {
+		return 1, nil
+	}
+	if err := os.Remove(path); err != nil {
+		return 0, []string{fmt.Sprintf("%s: %v", path, err)}
+	}
+	internalutil.Logf(env.Stderr, "[gortex uninstall] removed %s", path)
+	pruneEmptyDir(filepath.Dir(path))
+	return 1, nil
+}
+
+// ownedPackFiles maps every curated skill / command path to the body
+// Gortex ships there. One map so the remover and the preview enumerate
+// exactly the same set. A corpus that fails to parse yields nothing —
+// the package's own tests turn that into a red build, and reporting an
+// empty footprint beats guessing at one.
+func ownedPackFiles(home string) map[string]string {
+	out := make(map[string]string)
+	if skills, err := Skills(); err == nil {
+		root := globalSkillsDir(home)
+		for _, s := range skills {
+			out[filepath.Join(root, s.ID, skillFileName)] = renderSkill(s)
+		}
+	}
+	if commands, err := Commands(); err == nil {
+		root := globalCommandsDir(home)
+		for _, c := range commands {
+			out[filepath.Join(root, c.ID+commandFileExt)] = renderCommand(c)
+		}
+	}
+	return out
+}
+
+// removeCuratedPack deletes the shipped skills and commands whose bytes
+// are still ours, prunes each skill's own directory when it empties, and
+// then the two roots. A user's skill directory in the same root is never
+// looked at, and the roots survive as long as it does.
+func removeCuratedPack(env agents.Env, opts agents.ApplyOpts) (removed int, failures []string) {
+	owned := ownedPackFiles(env.Home)
+	paths := make([]string, 0, len(owned))
+	for path := range owned {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	for _, path := range paths {
+		n, f := removeOwnedFile(env.Stderr, path, owned[path], opts)
+		removed += n
+		failures = append(failures, f...)
+		if n > 0 && !opts.DryRun && filepath.Base(path) == skillFileName {
+			// Skills are <id>/SKILL.md; commands are flat <id>.md files.
+			pruneEmptyDir(filepath.Dir(path))
+		}
+	}
+	if removed > 0 && !opts.DryRun {
+		pruneEmptyDir(globalSkillsDir(env.Home))
+		pruneEmptyDir(globalCommandsDir(env.Home))
+	}
+	return removed, failures
+}
+
+// removeOwnedFile deletes path only when its bytes are still exactly what
+// Gortex shipped. Anything else is the user's edit and is kept with a
+// warning, mirroring writeCuratedFile's never-clobber posture on the way
+// in.
+func removeOwnedFile(w io.Writer, path, shipped string, opts agents.ApplyOpts) (removed int, failures []string) {
+	existing, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, []string{fmt.Sprintf("%s: %v", path, err)}
+	}
+	if string(existing) != shipped {
+		internalutil.Warnf(w, "keeping customised %s", path)
+		return 0, nil
+	}
+	if opts.DryRun {
+		return 1, nil
+	}
+	if err := os.Remove(path); err != nil {
+		return 0, []string{fmt.Sprintf("%s: %v", path, err)}
+	}
+	internalutil.Logf(w, "[gortex uninstall] removed %s", path)
+	return 1, nil
+}
+
+func isShippedOpenCodeFile(path, shipped string) bool {
+	data, err := os.ReadFile(path)
+	return err == nil && string(data) == shipped
+}
+
+// pruneEmptyDir removes dir only when it holds nothing. os.Remove refuses
+// a non-empty directory, which is exactly the guard we want: a user file
+// sitting next to one we deleted keeps its directory alive.
+func pruneEmptyDir(dir string) {
+	_ = os.Remove(dir)
+}
+
+func opencodeFileContains(path, needle string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(data), needle)
+}

--- a/internal/agents/opencode/remove_test.go
+++ b/internal/agents/opencode/remove_test.go
@@ -1,0 +1,211 @@
+package opencode
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/zzet/gortex/internal/agents"
+)
+
+// userGlobalOpenCodeConfig is the user's own ~/.config/opencode/opencode.json.
+// Gortex never writes at this scope (its MCP stanza goes in the repo's
+// opencode.json), so RemoveGlobal must leave the file byte-identical —
+// including a gortex-looking entry, which could only have been put there
+// by hand.
+const userGlobalOpenCodeConfig = `{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "other": { "type": "local", "command": ["node", "server.js"], "enabled": true }
+  }
+}
+`
+
+func writeOpenCodeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// installedOpenCodeGlobal runs a ModeGlobal Apply over a home that already
+// holds the user's own global config and skill, and returns the env plus
+// the user skill's path. Starting from a real install rather than a
+// hand-built fixture is what keeps the remover from asserting against a
+// shape the writer no longer produces.
+func installedOpenCodeGlobal(t *testing.T) (agents.Env, string) {
+	t.Helper()
+	env, _ := globalEnv(t)
+
+	writeOpenCodeFile(t, filepath.Join(globalConfigDir(env.Home), "opencode.json"), userGlobalOpenCodeConfig)
+
+	// A hand-written skill in the SHARED skills root — the whole reason
+	// removal cannot just delete the directory.
+	userSkill := filepath.Join(globalSkillsDir(env.Home), "team-runbook", skillFileName)
+	writeOpenCodeFile(t, userSkill, "---\nname: team-runbook\n---\n\nOurs, not Gortex's.\n")
+
+	if _, err := New().Apply(env, agents.ApplyOpts{ForceDetect: true}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if got := GlobalArtifacts(env.Home); len(got) == 0 {
+		t.Fatal("expected a non-empty footprint after install")
+	}
+	return env, userSkill
+}
+
+// TestOpenCodeRemoveGlobalLeavesNoGortexArtifact is the round-trip
+// contract: after Apply then RemoveGlobal nothing of Gortex's is left,
+// and every user-owned thing that shared a tree with it survives
+// byte-identical.
+func TestOpenCodeRemoveGlobalLeavesNoGortexArtifact(t *testing.T) {
+	env, userSkill := installedOpenCodeGlobal(t)
+	skillBefore, err := os.ReadFile(userSkill)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	removed, failures := New().RemoveGlobal(env, agents.ApplyOpts{})
+	if len(failures) != 0 {
+		t.Fatalf("RemoveGlobal failures: %v", failures)
+	}
+	if removed == 0 {
+		t.Fatal("expected RemoveGlobal to remove at least one artifact")
+	}
+
+	if _, err := os.Stat(PluginPath(env.Home)); err == nil {
+		t.Error("the bridge plugin survived removal")
+	}
+	skills, err := Skills()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range skills {
+		if _, err := os.Stat(filepath.Join(globalSkillsDir(env.Home), s.ID)); err == nil {
+			t.Errorf("curated skill %s survived removal", s.ID)
+		}
+	}
+	commands, err := Commands()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range commands {
+		if _, err := os.Stat(filepath.Join(globalCommandsDir(env.Home), c.ID+commandFileExt)); err == nil {
+			t.Errorf("curated command %s survived removal", c.ID)
+		}
+	}
+
+	// The user's own skill in the shared root is byte-identical.
+	skillAfter, err := os.ReadFile(userSkill)
+	if err != nil {
+		t.Fatalf("the user's skill was deleted: %v", err)
+	}
+	if string(skillAfter) != string(skillBefore) {
+		t.Errorf("the user's skill changed:\n%s", skillAfter)
+	}
+
+	// The user's global config is untouched — Gortex never wrote it, so a
+	// cleanup that edited it would be deleting config it did not install.
+	got, err := os.ReadFile(filepath.Join(globalConfigDir(env.Home), "opencode.json"))
+	if err != nil {
+		t.Fatalf("the user's global config was deleted: %v", err)
+	}
+	if string(got) != userGlobalOpenCodeConfig {
+		t.Errorf("the user's global config changed:\n%s", got)
+	}
+
+	if got := GlobalArtifacts(env.Home); len(got) != 0 {
+		t.Errorf("GlobalArtifacts should be empty after RemoveGlobal, got %v", got)
+	}
+}
+
+// TestOpenCodeRemoveGlobalKeepsAForeignPlugin: the file name is not the
+// evidence. A plugin somebody else wrote to plugin/gortex.js carries no
+// PluginMarker and is not ours to delete.
+func TestOpenCodeRemoveGlobalKeepsAForeignPlugin(t *testing.T) {
+	env, _ := globalEnv(t)
+	const foreign = "export const Plugin = async () => ({});\n"
+	writeOpenCodeFile(t, PluginPath(env.Home), foreign)
+
+	for _, path := range GlobalArtifacts(env.Home) {
+		if path == PluginPath(env.Home) {
+			t.Error("the preview promises to delete a plugin that is not ours")
+		}
+	}
+	if _, failures := New().RemoveGlobal(env, agents.ApplyOpts{}); len(failures) != 0 {
+		t.Fatalf("RemoveGlobal failures: %v", failures)
+	}
+	got, err := os.ReadFile(PluginPath(env.Home))
+	if err != nil {
+		t.Fatalf("a foreign plugin was deleted: %v", err)
+	}
+	if string(got) != foreign {
+		t.Errorf("a foreign plugin changed:\n%s", got)
+	}
+}
+
+// TestOpenCodeRemoveGlobalKeepsACustomisedSkill pins the never-clobber
+// posture writeCuratedFile takes on the way in: a Gortex skill the user
+// edited is their work now. The wizard preview must agree — a path
+// removal will keep may never appear in GlobalArtifacts.
+func TestOpenCodeRemoveGlobalKeepsACustomisedSkill(t *testing.T) {
+	env, _ := installedOpenCodeGlobal(t)
+
+	skills, err := Skills()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(skills) == 0 {
+		t.Fatal("curated pack is empty")
+	}
+	customised := filepath.Join(globalSkillsDir(env.Home), skills[0].ID, skillFileName)
+	body := renderSkill(skills[0]) + "\n<!-- my own note -->\n"
+	writeOpenCodeFile(t, customised, body)
+
+	for _, path := range GlobalArtifacts(env.Home) {
+		if path == customised {
+			t.Errorf("the preview promises to delete a customised skill: %s", path)
+		}
+	}
+
+	if _, failures := New().RemoveGlobal(env, agents.ApplyOpts{}); len(failures) != 0 {
+		t.Fatalf("RemoveGlobal failures: %v", failures)
+	}
+	got, err := os.ReadFile(customised)
+	if err != nil {
+		t.Fatalf("the customised skill was deleted: %v", err)
+	}
+	if string(got) != body {
+		t.Errorf("the customised skill changed:\n%s", got)
+	}
+}
+
+// TestOpenCodeRemoveGlobalDryRunTouchesNothing keeps the preview honest in
+// the other direction: it must count the same artifacts without writing.
+func TestOpenCodeRemoveGlobalDryRunTouchesNothing(t *testing.T) {
+	env, _ := installedOpenCodeGlobal(t)
+
+	removed, failures := New().RemoveGlobal(env, agents.ApplyOpts{DryRun: true})
+	if len(failures) != 0 {
+		t.Fatalf("RemoveGlobal failures: %v", failures)
+	}
+	if removed == 0 {
+		t.Fatal("a dry run should still count what it would remove")
+	}
+	if _, err := os.Stat(PluginPath(env.Home)); err != nil {
+		t.Error("dry run deleted the bridge plugin")
+	}
+	if got := GlobalArtifacts(env.Home); len(got) == 0 {
+		t.Error("dry run removed the footprint")
+	}
+}
+
+// TestOpenCodeRemoveGlobalNeedsAHome refuses rather than guessing at a root.
+func TestOpenCodeRemoveGlobalNeedsAHome(t *testing.T) {
+	removed, failures := New().RemoveGlobal(agents.Env{}, agents.ApplyOpts{})
+	if removed != 0 || len(failures) != 1 {
+		t.Fatalf("want (0, one failure), got (%d, %v)", removed, failures)
+	}
+}

--- a/internal/agents/opencode/skills.go
+++ b/internal/agents/opencode/skills.go
@@ -1,0 +1,306 @@
+package opencode
+
+// skills.go installs the Gortex playbooks as OpenCode skills and the
+// Gortex slash-command pack as OpenCode commands.
+//
+// # `name` must equal the directory, or the skill is dropped
+//
+// OpenCode (1.18.18) globs `{skill,skills}/**/SKILL.md`, reads the
+// frontmatter, and rejects the skill outright when `name` is absent, is
+// not `^[a-z0-9]+(-[a-z0-9]+)*$`, or does not equal the name of the
+// directory holding the SKILL.md. The rejection is silent — the skill
+// simply never appears — so this file derives both halves from the same
+// value (skillpack.Skill.ID) rather than trusting the frontmatter that
+// arrived from the Claude source, and skills_test.go asserts the
+// equality over the whole corpus rather than a sample.
+//
+// # Only five frontmatter keys are recognised
+//
+// `name`, `description`, `license`, `compatibility`, `metadata`. Anything
+// else is ignored, so the envelope is held to `name` + `description`:
+// every extra key is one more thing to keep in sync for no behaviour.
+//
+// # Plural directory spellings
+//
+// The loader accepts both `skill/` and `skills/` (and `command/` /
+// `commands/`); the vendor docs use the plural, so we write the plural.
+// The one exception is the plugin, which goes in `plugin/` — see
+// plugin.go for why that one is singular.
+//
+// # Global root: ~/.config/opencode
+//
+// OpenCode also reads `~/.claude/skills` and `~/.agents/skills`, and the
+// codex adapter already fills the latter. We still write our own copy
+// under `~/.config/opencode/skills`: the `.agents` pack only exists when
+// Codex was detected on this machine, so relying on it would make the
+// OpenCode install silently depend on an unrelated agent being present.
+// The rendered bytes are identical to codex's (same two frontmatter keys,
+// same body), so a user with both hosts sees two byte-identical copies of
+// each skill rather than two that can drift.
+//
+// The `.config` path is joined onto Env.Home rather than resolved through
+// XDG_CONFIG_HOME, matching this adapter's own Detect and every other
+// adapter in this tree.
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/claudecode"
+	"github.com/zzet/gortex/internal/agents/internalutil"
+	"github.com/zzet/gortex/internal/agents/skillpack"
+)
+
+// skillFileName is the file OpenCode loads inside each skill directory.
+const skillFileName = "SKILL.md"
+
+// commandFileExt is the extension OpenCode globs for commands. The file's
+// base name *is* the command name — `gortex-explore.md` is invoked as
+// `/gortex-explore` — so nothing inside the file names it.
+const commandFileExt = ".md"
+
+// globalConfigDir is OpenCode's user-level config root.
+func globalConfigDir(home string) string {
+	return filepath.Join(home, ".config", "opencode")
+}
+
+func globalSkillsDir(home string) string   { return filepath.Join(globalConfigDir(home), "skills") }
+func globalCommandsDir(home string) string { return filepath.Join(globalConfigDir(home), "commands") }
+
+// projectSkillsDir is the repo-local skills root. Generated community
+// skills land here because they describe *this* repo and are worthless
+// machine-wide.
+func projectSkillsDir(root string) string {
+	return filepath.Join(root, ".opencode", "skills")
+}
+
+// Skills returns the curated Gortex playbook pack in host-neutral form.
+//
+// The bodies are single-sourced in internal/agents/claudecode and each
+// host re-wraps them in its own frontmatter dialect; skillpack does the
+// stripping. Reading claudecode's map directly from an adapter is the
+// established direction (codex and hermes do the same) — claudecode never
+// imports another adapter, so there is no cycle to trip over.
+func Skills() ([]skillpack.Skill, error) {
+	return skillpack.ParseAll(claudecode.GlobalSkills)
+}
+
+// Commands returns the slash-command pack in host-neutral form, keyed by
+// the command name (the file's base name, minus `.md`).
+//
+// The source is claudecode.GlobalSkills rather than
+// claudecode.SlashCommands wherever both carry the same id: the two hold
+// the same body, but only the skill map wraps it in frontmatter, and that
+// frontmatter is where the description lives. A command with no skill
+// twin falls back to its bare body and ships without a description.
+func Commands() ([]skillpack.Skill, error) {
+	raw := make(map[string]string, len(claudecode.SlashCommands))
+	for file, body := range claudecode.SlashCommands {
+		id := strings.TrimSuffix(file, commandFileExt)
+		if described, ok := claudecode.GlobalSkills[id]; ok {
+			body = described
+		}
+		raw[id] = body
+	}
+	return skillpack.ParseAll(raw)
+}
+
+// renderSkill puts OpenCode's frontmatter envelope in front of a neutral
+// skill body.
+//
+// `name` is taken from the ID, not from Skill.Name: the ID is also the
+// directory this file is written into, and OpenCode drops any skill whose
+// frontmatter name and containing directory disagree. Deriving both from
+// one value makes that mismatch unrepresentable.
+func renderSkill(s skillpack.Skill) string {
+	return skillpack.RenderFrontmatter([][2]string{
+		{"name", s.ID},
+		{"description", s.Description},
+	}) + "\n" + s.Body
+}
+
+// renderCommand puts OpenCode's command frontmatter in front of a neutral
+// body. `description` is the only key we set — `agent`, `model`,
+// `variant` and `subtask` all pin a command to a specific model or
+// sub-agent configuration, which is the user's call, not ours.
+//
+// A command with no description gets no frontmatter at all rather than an
+// empty `description:` line, which OpenCode would render as a blank entry
+// in the command picker.
+func renderCommand(c skillpack.Skill) string {
+	if c.Description == "" {
+		return c.Body
+	}
+	return skillpack.RenderFrontmatter([][2]string{
+		{"description", c.Description},
+	}) + "\n" + c.Body
+}
+
+// applySkills installs whichever artifact set belongs to this Env's mode.
+// The sets never overlap: the curated pack is machine-wide, the generated
+// community pack is repo-specific.
+func applySkills(env agents.Env, opts agents.ApplyOpts) ([]agents.FileAction, error) {
+	if env.Mode == agents.ModeGlobal {
+		return installCuratedPack(env, opts)
+	}
+	return installGeneratedSkills(env, opts), nil
+}
+
+// installCuratedPack writes the playbooks to
+// `~/.config/opencode/skills/<id>/SKILL.md` and the slash commands to
+// `~/.config/opencode/commands/<id>.md`.
+//
+// ModeGlobal only, mirroring claudecode and codex: the playbooks are
+// codebase-agnostic, so a `gortex init` that dropped 41 markdown files
+// into a repo would hand the user's teammates a pile of unrelated files
+// to review for no benefit.
+//
+// An existing file that differs from the shipped body is the user's and
+// is left alone (ActionSkip "customised"), the same never-clobber posture
+// as claudecode's writeAgentArtifact.
+func installCuratedPack(env agents.Env, opts agents.ApplyOpts) ([]agents.FileAction, error) {
+	skills, err := Skills()
+	if err != nil {
+		return nil, err
+	}
+	commands, err := Commands()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]agents.FileAction, 0, len(skills)+len(commands))
+
+	skillsRoot := globalSkillsDir(env.Home)
+	for _, s := range skills {
+		path := filepath.Join(skillsRoot, s.ID, skillFileName)
+		action, err := writeCuratedFile(env.Stderr, path, renderSkill(s), opts)
+		if err != nil {
+			return out, fmt.Errorf("skill %s: %w", s.ID, err)
+		}
+		out = append(out, action)
+	}
+
+	commandsRoot := globalCommandsDir(env.Home)
+	for _, c := range commands {
+		path := filepath.Join(commandsRoot, c.ID+commandFileExt)
+		action, err := writeCuratedFile(env.Stderr, path, renderCommand(c), opts)
+		if err != nil {
+			return out, fmt.Errorf("command %s: %w", c.ID, err)
+		}
+		out = append(out, action)
+	}
+	return out, nil
+}
+
+// installGeneratedSkills materialises the per-community skills the skills
+// generator produced, at `<root>/.opencode/skills/<DirName>/SKILL.md`.
+//
+// Flat, with no `generated/` grouping level, even though the glob would
+// recurse into one: the directory name is what OpenCode matches the
+// frontmatter `name` against, so a `generated/` parent buys nothing and
+// DirName already carries a `gortex-` prefix that keeps it clear of the
+// curated pack.
+//
+// A DirName that is not kebab-case is skipped with a warning rather than
+// written: OpenCode refuses such a name at load time, and refuses it
+// silently, so the file would sit on disk looking installed forever.
+//
+// WriteOwnedFile (not the never-clobber writer used for the curated pack)
+// because these track the current graph and must be regenerated on every
+// init; it reports ActionSkip "unchanged" for byte-identical content,
+// which is what keeps a re-run idempotent.
+func installGeneratedSkills(env agents.Env, opts agents.ApplyOpts) []agents.FileAction {
+	root := projectSkillsDir(env.Root)
+	out := make([]agents.FileAction, 0, len(env.GeneratedSkills))
+	for _, s := range env.GeneratedSkills {
+		if !skillpack.ValidID(s.DirName) {
+			internalutil.Warnf(env.Stderr, "skipping generated skill %q: OpenCode skill directories must be kebab-case", s.DirName)
+			continue
+		}
+		path := filepath.Join(root, s.DirName, skillFileName)
+		action, err := agents.WriteOwnedFile(env.Stderr, path, s.Content, opts)
+		if err != nil {
+			internalutil.Warnf(env.Stderr, "could not write generated skill %s: %v", s.DirName, err)
+			continue
+		}
+		out = append(out, action)
+	}
+	return out
+}
+
+// planSkills enumerates every skill / command file this adapter would
+// write for env.
+//
+// Plan is what `gortex doctor` and `--print-config` read — they never
+// call Apply — so a path Apply writes but Plan omits is invisible to
+// both, and a user debugging a missing skill has nothing to check
+// against.
+func planSkills(env agents.Env) ([]agents.FileAction, error) {
+	if env.Mode == agents.ModeGlobal {
+		if env.Home == "" {
+			return nil, nil
+		}
+		skills, err := Skills()
+		if err != nil {
+			return nil, err
+		}
+		commands, err := Commands()
+		if err != nil {
+			return nil, err
+		}
+		out := make([]agents.FileAction, 0, len(skills)+len(commands))
+		for _, s := range skills {
+			out = append(out, agents.FileAction{
+				Path:   filepath.Join(globalSkillsDir(env.Home), s.ID, skillFileName),
+				Action: agents.ActionWouldCreate,
+			})
+		}
+		for _, c := range commands {
+			out = append(out, agents.FileAction{
+				Path:   filepath.Join(globalCommandsDir(env.Home), c.ID+commandFileExt),
+				Action: agents.ActionWouldCreate,
+			})
+		}
+		return out, nil
+	}
+	if env.Root == "" {
+		return nil, nil
+	}
+	out := make([]agents.FileAction, 0, len(env.GeneratedSkills))
+	for _, s := range env.GeneratedSkills {
+		if !skillpack.ValidID(s.DirName) {
+			continue
+		}
+		out = append(out, agents.FileAction{
+			Path:   filepath.Join(projectSkillsDir(env.Root), s.DirName, skillFileName),
+			Action: agents.ActionWouldCreate,
+		})
+	}
+	return out, nil
+}
+
+// writeCuratedFile installs content at path only when nothing is there,
+// and never overwrites a file the user has edited.
+//
+// Replicated from codex's writeSkillFile rather than shared: both are
+// small, and hoisting them into the agents package would make a
+// never-clobber policy that each host should own its own copy of into a
+// cross-adapter contract nobody asked for.
+func writeCuratedFile(w io.Writer, path, content string, opts agents.ApplyOpts) (agents.FileAction, error) {
+	existing, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return agents.WriteIfNotExists(w, path, content, opts)
+	}
+	if err != nil {
+		return agents.FileAction{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	if string(existing) == content {
+		return agents.FileAction{Path: path, Action: agents.ActionSkip, Reason: "unchanged"}, nil
+	}
+	internalutil.Warnf(w, "keeping customised %s", path)
+	return agents.FileAction{Path: path, Action: agents.ActionSkip, Reason: "customised"}, nil
+}

--- a/internal/agents/opencode/skills.go
+++ b/internal/agents/opencode/skills.go
@@ -163,25 +163,19 @@ func applySkills(env agents.Env, opts agents.ApplyOpts) ([]agents.FileAction, er
 // An existing file that differs from the shipped body is the user's and
 // is left alone (ActionSkip "customised"), the same never-clobber posture
 // as claudecode's writeAgentArtifact.
+//
+// The skills half goes through the shared reconciler with a nil allowed
+// set — install materialises the whole pack, and `gortex instructions
+// switch` narrows it afterwards through SyncSkills, so the two can never
+// disagree about what belongs on disk.
 func installCuratedPack(env agents.Env, opts agents.ApplyOpts) ([]agents.FileAction, error) {
-	skills, err := Skills()
+	out, err := syncCuratedSkills(env.Stderr, globalSkillsDir(env.Home), nil, opts)
 	if err != nil {
-		return nil, err
+		return out, err
 	}
 	commands, err := Commands()
 	if err != nil {
-		return nil, err
-	}
-	out := make([]agents.FileAction, 0, len(skills)+len(commands))
-
-	skillsRoot := globalSkillsDir(env.Home)
-	for _, s := range skills {
-		path := filepath.Join(skillsRoot, s.ID, skillFileName)
-		action, err := writeCuratedFile(env.Stderr, path, renderSkill(s), opts)
-		if err != nil {
-			return out, fmt.Errorf("skill %s: %w", s.ID, err)
-		}
-		out = append(out, action)
+		return out, err
 	}
 
 	commandsRoot := globalCommandsDir(env.Home)
@@ -194,6 +188,53 @@ func installCuratedPack(env agents.Env, opts agents.ApplyOpts) ([]agents.FileAct
 		out = append(out, action)
 	}
 	return out, nil
+}
+
+// SyncSkills reshapes an ALREADY-INSTALLED `~/.config/opencode/skills`
+// tree to the allowed subset (nil = every shipped skill). This is the
+// entry point `gortex instructions switch` drives.
+//
+// A missing skills root is a silent no-op, not an install: switching a
+// profile must never conjure an OpenCode surface on a machine that never
+// ran `gortex install`, and most machines carry only one or two of the
+// supported hosts.
+//
+// Only skills are reconciled, not the command pack — matching Claude
+// Code, whose profile subset governs `~/.claude/skills` and leaves
+// `~/.claude/commands` whole. A slash command is invoked deliberately by
+// name; a skill is auto-selected into the model's context, which is the
+// cost an instruction profile exists to control.
+func SyncSkills(w io.Writer, home string, allowed []string, opts agents.ApplyOpts) ([]agents.FileAction, error) {
+	if home == "" {
+		return nil, nil
+	}
+	root := globalSkillsDir(home)
+	if _, err := os.Stat(root); err != nil {
+		return nil, nil
+	}
+	return syncCuratedSkills(w, root, allowed, opts)
+}
+
+// syncCuratedSkills is the one reconciler both entry points reach. The
+// deletion rule (never remove a customised file) lives in skillpack, not
+// here, so all four skill-aware hosts enforce it identically.
+func syncCuratedSkills(w io.Writer, root string, allowed []string, opts agents.ApplyOpts) ([]agents.FileAction, error) {
+	skills, err := Skills()
+	if err != nil {
+		return nil, err
+	}
+	rendered := make(map[string]string, len(skills))
+	for _, s := range skills {
+		rendered[s.ID] = renderSkill(s)
+	}
+	// KnownHashes stays unset: this pack has only ever shipped one
+	// rendering, so the byte compare against `rendered` is the complete
+	// definition of "still ours".
+	return skillpack.Sync(w, skillpack.SyncSpec{
+		Dir:      root,
+		FileName: skillFileName,
+		Rendered: rendered,
+	}, allowed, opts)
 }
 
 // installGeneratedSkills materialises the per-community skills the skills

--- a/internal/agents/opencode/skills_test.go
+++ b/internal/agents/opencode/skills_test.go
@@ -1,0 +1,285 @@
+package opencode
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/agentstest"
+	"github.com/zzet/gortex/internal/agents/claudecode"
+	"github.com/zzet/gortex/internal/agents/skillpack"
+)
+
+// recognisedFrontmatterKeys is the whole set OpenCode reads from a
+// SKILL.md. Anything else is ignored, so emitting one is dead weight the
+// next reader has to research.
+var recognisedFrontmatterKeys = map[string]bool{
+	"name": true, "description": true, "license": true,
+	"compatibility": true, "metadata": true,
+}
+
+// TestSkillNameEqualsDirectoryForWholeCorpus is the load-bearing
+// assertion of this package. OpenCode drops — silently — any skill whose
+// frontmatter `name` differs from its containing directory, so a single
+// sampled skill proves nothing: the whole corpus has to hold.
+func TestSkillNameEqualsDirectoryForWholeCorpus(t *testing.T) {
+	env, _ := agentstest.NewEnv(t)
+	env.Mode = agents.ModeGlobal
+	if _, err := installCuratedPack(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("install curated pack: %v", err)
+	}
+
+	root := globalSkillsDir(env.Home)
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("read %s: %v", root, err)
+	}
+	if len(entries) != len(claudecode.GlobalSkills) {
+		t.Fatalf("wrote %d skill dirs, want %d", len(entries), len(claudecode.GlobalSkills))
+	}
+	for _, entry := range entries {
+		dir := entry.Name()
+		if !entry.IsDir() {
+			t.Fatalf("%s is not a skill directory", dir)
+		}
+		if !skillpack.ValidID(dir) {
+			t.Fatalf("skill directory %q is not kebab-case; OpenCode rejects it", dir)
+		}
+		front := readFrontmatter(t, filepath.Join(root, dir, skillFileName))
+		if front["name"] != dir {
+			t.Fatalf("skill %s: frontmatter name %q != directory %q — OpenCode drops it", dir, front["name"], dir)
+		}
+		if !skillpack.ValidID(front["name"]) {
+			t.Fatalf("skill %s: name %q is not kebab-case", dir, front["name"])
+		}
+		if front["description"] == "" {
+			t.Fatalf("skill %s: empty description leaves a blank entry in the picker", dir)
+		}
+		assertOnlyRecognisedKeys(t, dir, front)
+	}
+}
+
+// TestCommandsAreNamedByFilename pins the two facts a command depends on:
+// the file's base name is the command name, and the only frontmatter key
+// we set is `description`.
+func TestCommandsAreNamedByFilename(t *testing.T) {
+	env, _ := agentstest.NewEnv(t)
+	env.Mode = agents.ModeGlobal
+	if _, err := installCuratedPack(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("install curated pack: %v", err)
+	}
+
+	root := globalCommandsDir(env.Home)
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("read %s: %v", root, err)
+	}
+	if len(entries) != len(claudecode.SlashCommands) {
+		t.Fatalf("wrote %d commands, want %d", len(entries), len(claudecode.SlashCommands))
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if filepath.Ext(name) != commandFileExt {
+			t.Fatalf("command %s: OpenCode only globs %s", name, commandFileExt)
+		}
+		stem := strings.TrimSuffix(name, commandFileExt)
+		if !skillpack.ValidID(stem) {
+			t.Fatalf("command %q would be invoked as /%s, which is not kebab-case", name, stem)
+		}
+		if _, ok := claudecode.SlashCommands[name]; !ok {
+			t.Fatalf("command %s has no source in claudecode.SlashCommands", name)
+		}
+		front := readFrontmatter(t, filepath.Join(root, name))
+		if front["description"] == "" {
+			t.Fatalf("command %s: no description — the picker shows a blank entry", name)
+		}
+		assertOnlyRecognisedKeys(t, name, front)
+		if front["name"] != "" {
+			t.Fatalf("command %s: emitted a `name` key; OpenCode names a command by its filename", name)
+		}
+	}
+}
+
+// TestCuratedPackIsGlobalOnly guards the split that keeps `gortex init`
+// from dropping 41 markdown files into somebody's repo.
+func TestCuratedPackIsGlobalOnly(t *testing.T) {
+	env, _ := agentstest.NewEnv(t)
+	a := New()
+	if _, err := a.Apply(env, agents.ApplyOpts{ForceDetect: true}); err != nil {
+		t.Fatalf("apply project: %v", err)
+	}
+
+	if _, err := os.Stat(globalSkillsDir(env.Home)); err == nil {
+		t.Fatalf("project mode wrote the curated skills pack to %s", globalSkillsDir(env.Home))
+	}
+	if _, err := os.Stat(globalCommandsDir(env.Home)); err == nil {
+		t.Fatalf("project mode wrote the curated commands pack to %s", globalCommandsDir(env.Home))
+	}
+	// The generated community skill IS repo-local, and flat.
+	generated := filepath.Join(projectSkillsDir(env.Root), "gortex-stub", skillFileName)
+	if _, err := os.Stat(generated); err != nil {
+		t.Fatalf("project mode did not write the generated skill at %s: %v", generated, err)
+	}
+	if _, err := os.Stat(filepath.Join(projectSkillsDir(env.Root), "generated")); err == nil {
+		t.Fatalf("generated skills must be flat — a `generated/` level breaks name==directory")
+	}
+	agentstest.AssertIdempotent(t, a, env)
+}
+
+// TestGeneratedSkillsAreProjectOnly is the mirror: `gortex install` must
+// not scatter repo-derived skills into the user's config.
+func TestGeneratedSkillsAreProjectOnly(t *testing.T) {
+	env, _ := agentstest.NewEnv(t)
+	env.Mode = agents.ModeGlobal
+	a := New()
+	if _, err := a.Apply(env, agents.ApplyOpts{ForceDetect: true}); err != nil {
+		t.Fatalf("apply global: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(env.Root, ".opencode", "skills")); err == nil {
+		t.Fatalf("global mode wrote repo-local skills into %s", env.Root)
+	}
+	if _, err := os.Stat(filepath.Join(globalSkillsDir(env.Home), "gortex-stub")); err == nil {
+		t.Fatalf("global mode installed a generated community skill into the user pack")
+	}
+	agentstest.AssertIdempotent(t, a, env)
+}
+
+// TestGeneratedSkillWithBadDirNameIsSkipped: OpenCode rejects a non-
+// kebab-case name silently, so the installer has to be the loud one.
+func TestGeneratedSkillWithBadDirNameIsSkipped(t *testing.T) {
+	env, buf := agentstest.NewEnv(t)
+	env.GeneratedSkills = append(env.GeneratedSkills, agents.GeneratedSkill{
+		CommunityID: "bad", Label: "Bad_Name", DirName: "Gortex_Bad Name",
+		Content: "---\nname: whatever\n---\nbody\n",
+	})
+	if _, err := New().Apply(env, agents.ApplyOpts{ForceDetect: true}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(projectSkillsDir(env.Root), "Gortex_Bad Name")); err == nil {
+		t.Fatalf("wrote a skill directory OpenCode will refuse to load")
+	}
+	if !strings.Contains(buf.String(), "kebab-case") {
+		t.Fatalf("skipping a bad skill must warn; stderr was:\n%s", buf.String())
+	}
+}
+
+// TestPlanEnumeratesEveryWrittenPath: Plan is what --dry-run and doctor
+// read, and neither ever calls Apply. A path Apply writes but Plan omits
+// is invisible to both.
+func TestPlanEnumeratesEveryWrittenPath(t *testing.T) {
+	for _, mode := range []agents.Mode{agents.ModeProject, agents.ModeGlobal} {
+		env, _ := agentstest.NewEnv(t)
+		env.Mode = mode
+		a := New()
+
+		plan, err := a.Plan(env)
+		if err != nil {
+			t.Fatalf("plan: %v", err)
+		}
+		planned := map[string]bool{}
+		for _, f := range plan.Files {
+			planned[f.Path] = true
+		}
+
+		res, err := a.Apply(env, agents.ApplyOpts{ForceDetect: true})
+		if err != nil {
+			t.Fatalf("apply: %v", err)
+		}
+		var missing []string
+		for _, f := range res.Files {
+			if !planned[f.Path] {
+				missing = append(missing, f.Path)
+			}
+		}
+		sort.Strings(missing)
+		if len(missing) > 0 {
+			t.Fatalf("mode %v: Apply wrote paths Plan never mentioned:\n%s", mode, strings.Join(missing, "\n"))
+		}
+	}
+}
+
+// TestDryRunWritesNothing: --dry-run has to be safe in both modes, and
+// the global mode is the one that writes an executable.
+func TestDryRunWritesNothing(t *testing.T) {
+	for _, mode := range []agents.Mode{agents.ModeProject, agents.ModeGlobal} {
+		env, _ := agentstest.NewEnv(t)
+		env.Mode = mode
+		res, err := New().Apply(env, agents.ApplyOpts{ForceDetect: true, DryRun: true})
+		if err != nil {
+			t.Fatalf("apply dry-run: %v", err)
+		}
+		if len(res.Files) == 0 {
+			t.Fatalf("mode %v: dry-run reported no planned files", mode)
+		}
+		for _, f := range res.Files {
+			if _, err := os.Stat(f.Path); err == nil {
+				t.Fatalf("mode %v: dry-run wrote %s", mode, f.Path)
+			}
+		}
+	}
+}
+
+// TestCustomisedCuratedFileIsKept: the curated pack is never clobbered,
+// so a user's edit survives the next `gortex install`.
+func TestCustomisedCuratedFileIsKept(t *testing.T) {
+	env, _ := agentstest.NewEnv(t)
+	env.Mode = agents.ModeGlobal
+	path := filepath.Join(globalSkillsDir(env.Home), "gortex-explore", skillFileName)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const mine = "---\nname: gortex-explore\ndescription: mine\n---\nmine\n"
+	if err := os.WriteFile(path, []byte(mine), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := New().Apply(env, agents.ApplyOpts{ForceDetect: true}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != mine {
+		t.Fatalf("clobbered a customised skill:\n%s", got)
+	}
+}
+
+// readFrontmatter parses the leading YAML block of a rendered artifact
+// into a flat key/value map. Deliberately naive — the renderer only ever
+// emits flat scalars, and a parser that accepted more would stop being a
+// check on what we emit.
+func readFrontmatter(t *testing.T, path string) map[string]string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	out := map[string]string{}
+	lines := strings.Split(string(data), "\n")
+	if len(lines) == 0 || lines[0] != "---" {
+		return out
+	}
+	for _, line := range lines[1:] {
+		if line == "---" {
+			break
+		}
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			t.Fatalf("%s: frontmatter line %q is not a scalar mapping", path, line)
+		}
+		out[strings.TrimSpace(key)] = strings.Trim(strings.TrimSpace(value), `"`)
+	}
+	return out
+}
+
+func assertOnlyRecognisedKeys(t *testing.T, name string, front map[string]string) {
+	t.Helper()
+	for key := range front {
+		if !recognisedFrontmatterKeys[key] {
+			t.Fatalf("%s: frontmatter key %q is not one OpenCode reads", name, key)
+		}
+	}
+}

--- a/internal/agents/opencode/skills_test.go
+++ b/internal/agents/opencode/skills_test.go
@@ -247,6 +247,116 @@ func TestCustomisedCuratedFileIsKept(t *testing.T) {
 	}
 }
 
+// profileSubset is the three-skill shape an instruction profile like
+// `localization` narrows the pack to.
+var profileSubset = []string{"gortex-explore", "gortex-guide", "gortex-debug"}
+
+// skillDirNames lists the skill directories that still hold a SKILL.md.
+// Directory presence alone is not the question a profile switch asks —
+// what the host loads is.
+func skillDirNames(t *testing.T, root string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(root)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("read dir %s: %v", root, err)
+	}
+	var out []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(root, e.Name(), skillFileName)); err == nil {
+			out = append(out, e.Name())
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestSyncSkillsNarrowsToProfileSubset is the point of the whole
+// exercise: `gortex instructions switch localization` must leave
+// OpenCode holding three playbooks, not twenty-one. Before this existed,
+// only Claude Code's picker shrank.
+func TestSyncSkillsNarrowsToProfileSubset(t *testing.T) {
+	env, _ := agentstest.NewEnv(t)
+	env.Mode = agents.ModeGlobal
+	if _, err := New().Apply(env, agents.ApplyOpts{ForceDetect: true}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	root := globalSkillsDir(env.Home)
+	if len(skillDirNames(t, root)) < len(profileSubset)+1 {
+		t.Fatalf("install left %v — too few skills for a subset to mean anything", skillDirNames(t, root))
+	}
+
+	if _, err := SyncSkills(env.Stderr, env.Home, profileSubset, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("SyncSkills: %v", err)
+	}
+	want := append([]string(nil), profileSubset...)
+	sort.Strings(want)
+	if got := skillDirNames(t, root); strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("after the switch %v remain, want %v", got, want)
+	}
+
+	// Commands are deliberately untouched: a slash command is invoked by
+	// name, so it costs nothing until it is asked for. Claude Code draws
+	// the same line between ~/.claude/skills and ~/.claude/commands.
+	if _, err := os.Stat(filepath.Join(globalCommandsDir(env.Home), "gortex-rename"+commandFileExt)); err != nil {
+		t.Fatalf("the profile switch pruned a slash command: %v", err)
+	}
+}
+
+// TestSyncSkillsKeepsCustomisedSkill: a profile is not worth a user's
+// edits. An out-of-profile playbook the user rewrote stays byte for
+// byte, and the switch warns instead of silently widening the surface.
+func TestSyncSkillsKeepsCustomisedSkill(t *testing.T) {
+	env, _ := agentstest.NewEnv(t)
+	env.Mode = agents.ModeGlobal
+	if _, err := New().Apply(env, agents.ApplyOpts{ForceDetect: true}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	path := filepath.Join(globalSkillsDir(env.Home), "gortex-rename", skillFileName)
+	const mine = "---\nname: gortex-rename\ndescription: mine\n---\nmy own steps\n"
+	if err := os.WriteFile(path, []byte(mine), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	log := &strings.Builder{}
+	if _, err := SyncSkills(log, env.Home, profileSubset, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("SyncSkills: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("customised skill was deleted to satisfy a profile: %v", err)
+	}
+	if string(got) != mine {
+		t.Fatalf("customised skill was rewritten:\n%s", got)
+	}
+	if !strings.Contains(log.String(), "gortex-rename") {
+		t.Fatalf("expected a warning naming the kept skill, got:\n%s", log.String())
+	}
+}
+
+// TestSyncSkillsWithoutAnInstalledRootIsANoOp: most machines run one or
+// two of the supported hosts. Switching a profile must not conjure an
+// OpenCode skills tree on a machine that never ran `gortex install`, and
+// must not fail because the tree is absent.
+func TestSyncSkillsWithoutAnInstalledRootIsANoOp(t *testing.T) {
+	env, _ := agentstest.NewEnv(t)
+	actions, err := SyncSkills(env.Stderr, env.Home, profileSubset, agents.ApplyOpts{})
+	if err != nil {
+		t.Fatalf("SyncSkills on an uninstalled machine: %v", err)
+	}
+	if len(actions) != 0 {
+		t.Fatalf("actions = %v, want none", actions)
+	}
+	if _, err := os.Stat(globalSkillsDir(env.Home)); !os.IsNotExist(err) {
+		t.Fatalf("a switch created the skills root (stat err = %v)", err)
+	}
+}
+
 // readFrontmatter parses the leading YAML block of a rendered artifact
 // into a flat key/value map. Deliberately naive — the renderer only ever
 // emits flat scalars, and a parser that accepted more would stop being a

--- a/internal/agents/render.go
+++ b/internal/agents/render.go
@@ -21,6 +21,43 @@ import (
 // `gortex agents render` command, so any change to an adapter's
 // generated MCP config, instructions, hooks, or skills surfaces as a
 // reviewable diff across every platform, not just Claude.
+//
+// What the fence covers (deliberately, and why):
+//
+//   - Both install modes. Every adapter is rendered twice — once in
+//     ModeProject (`gortex init`) and once in ModeGlobal (`gortex
+//     install`) — into two separate sandboxes, and the two manifests are
+//     concatenated. Both passes walk the sandbox HOME as well as the repo
+//     root, so a project-mode write into the user's home (codex's
+//     ~/.codex/config.toml) was always fenced; what was not fenced is
+//     everything behind the ModeGlobal branch — ~/.claude/skills, the
+//     user-level rule block and instruction profiles, the user-scope MCP
+//     registration.
+//   - Lifecycle hooks. InstallHooks is true, so each adapter's hook
+//     stanza is pinned. Note that Env.HookMode is honoured *only* by the
+//     claudecode adapter; every other adapter ignores it, so it is left
+//     empty here and no golden should be read as pinning a non-Claude
+//     hook posture.
+//   - Generated community skills. A fixed two-entry GeneratedSkills
+//     fixture makes per-community skill materialisation render, and its
+//     DirName values are valid slugs (^[a-z0-9]+(-[a-z0-9]+)*$) so
+//     adapters that reject malformed skill directory names (OpenCode,
+//     Copilot) are exercised on a name they must accept.
+//
+// Hermeticity and determinism are load-bearing here: a render must
+// never touch the developer's real HOME, and must never encode a value
+// that came from the regenerating developer's environment. renderPass
+// therefore pins the process environment (see pinRenderEnv) around
+// every Apply. A render that escapes the sandbox both corrupts the
+// developer's machine and renders an empty home/ manifest section, so
+// the escape hides itself — cmd/gortex's render tests assert against
+// exactly that.
+//
+// Consequence worth knowing before regenerating: because the ModeGlobal
+// pass materialises the instruction profiles into the sandbox HOME, the
+// claude-code golden now contains the profile bodies. Editing
+// internal/profiles prose therefore shows up as a claude-code golden
+// diff — that is the fence working, not noise.
 
 // RenderManifest renders each adapter into its own sandbox and returns a
 // normalised manifest per adapter, keyed by adapter name.
@@ -36,9 +73,70 @@ func RenderManifest(adapters []Adapter) (map[string]string, error) {
 	return out, nil
 }
 
-// renderOne applies a single adapter in a fresh sandbox and returns its
-// manifest. The HOME and repo-root temp dirs are removed afterwards.
+// renderPasses are the install modes every adapter is rendered through,
+// in emission order. Each pass gets its own sandbox and contributes a
+// block of mode-prefixed manifest keys.
+//
+// Key scheme: every manifest key is `<mode>/<home|root>/<relative
+// path>` — e.g. `project/root/.mcp.json`, `global/home/.claude/
+// settings.json`. Prefixing each key (rather than fencing the two
+// passes behind section banners) was chosen because it keeps every
+// manifest line self-describing: a grep for one line of a golden says
+// which mode produced it, and because the two blocks are serialised
+// independently a change confined to one mode produces a diff hunk
+// confined to that block instead of shifting the other mode's lines.
+// Project is emitted first because that is the order a user meets them
+// (`gortex init`, then `gortex install`).
+var renderPasses = []struct {
+	prefix string
+	mode   Mode
+}{
+	{prefix: "project", mode: ModeProject},
+	{prefix: "global", mode: ModeGlobal},
+}
+
+// renderSkillsRouting is the fixed community-routing payload every pass
+// feeds adapters, so the routing blocks render deterministically.
+const renderSkillsRouting = "- [example-community](.claude/skills/example/SKILL.md) — example routing block\n"
+
+// renderGeneratedSkills is the fixed per-community skill fixture. Two
+// entries (not one) so ordering / separator bugs in adapters that
+// serialise a list of skills surface in the golden. The DirName values
+// are deliberately valid skill slugs — `^[a-z0-9]+(-[a-z0-9]+)*$` —
+// because OpenCode and Copilot refuse to write anything else, and this
+// fixture is what proves they accept what the generator produces.
+func renderGeneratedSkills() []GeneratedSkill {
+	body := func(label string) string {
+		return "---\nname: gortex-" + label + "\n" +
+			"description: Example generated community skill used by the render drift fence.\n---\n\n" +
+			"# " + label + "\n\nRouting stub for the " + label + " community.\n"
+	}
+	return []GeneratedSkill{
+		{CommunityID: "c1", Label: "example-one", DirName: "gortex-example-one", Content: body("example-one")},
+		{CommunityID: "c2", Label: "example-two", DirName: "gortex-example-two", Content: body("example-two")},
+	}
+}
+
+// renderOne applies a single adapter once per install mode and returns
+// the concatenated manifest. Each pass renders into its own sandbox so
+// the project pass's files never leak into the global pass's section.
 func renderOne(a Adapter) (string, error) {
+	var b strings.Builder
+	for _, pass := range renderPasses {
+		m, err := renderPass(a, pass.mode, pass.prefix)
+		if err != nil {
+			return "", fmt.Errorf("%s mode: %w", pass.prefix, err)
+		}
+		b.WriteString(m)
+	}
+	return b.String(), nil
+}
+
+// renderPass applies a single adapter for one mode in a fresh sandbox
+// and returns its mode-prefixed manifest. The HOME and repo-root temp
+// dirs are removed afterwards, and the process environment is restored
+// before returning.
+func renderPass(a Adapter, mode Mode, prefix string) (string, error) {
 	home, err := os.MkdirTemp("", "gortex-render-home-")
 	if err != nil {
 		return "", err
@@ -50,33 +148,130 @@ func renderOne(a Adapter) (string, error) {
 	}
 	defer func() { _ = os.RemoveAll(root) }()
 
-	// Project mode is the default `gortex init` path and the one that
-	// renders the per-repo skill / instruction surfaces (where content
-	// drift lives). A fixed SkillsRouting payload makes the
-	// community-routing blocks render deterministically.
+	restoreEnv := pinRenderEnv(home)
+	defer restoreEnv()
+
 	env := Env{
-		Root:          root,
-		Home:          home,
-		Mode:          ModeProject,
-		HookCommand:   "gortex hook",
-		SkillsRouting: "- [example-community](.claude/skills/example/SKILL.md) — example routing block\n",
-		Stderr:        io.Discard,
+		Root:         root,
+		Home:         home,
+		Mode:         mode,
+		HookCommand:  "gortex hook",
+		InstallHooks: true,
+		// Only meaningful in ModeGlobal (adapters ignore it elsewhere);
+		// setting it there is what makes the global rule block and the
+		// generated instruction profiles part of the fence.
+		InstallGlobalInstructions: mode == ModeGlobal,
+		// Hermetic instruction-profile dir. Without this
+		// InstructionsDir(env) falls back to profiles.DefaultDir() —
+		// the real ~/.gortex/instructions — and the ModeGlobal render
+		// would both write to the developer's machine and encode
+		// whichever profile they last switched to.
+		InstructionsDir: filepath.Join(home, ".gortex", "instructions"),
+		SkillsRouting:   renderSkillsRouting,
+		GeneratedSkills: renderGeneratedSkills(),
+		Stderr:          io.Discard,
 	}
 	if _, err := a.Apply(env, ApplyOpts{ForceDetect: true}); err != nil {
 		return "", err
 	}
-	return manifestForDirs(home, root)
+	return manifestForDirs(home, root, prefix+"/")
+}
+
+// renderEnvPins is the process environment every render pass runs
+// under. It closes two classes of bug that only appear once ModeGlobal
+// and hooks are part of the fence:
+//
+//   - Sandbox escapes. $CLAUDE_CONFIG_DIR relocates the whole Claude
+//     Code user-level write (see claudecode.userClaudeConfigDir), and
+//     $KIMI_CODE_HOME does the same for Kimi. On a machine exporting
+//     either, the render would write into the developer's real config
+//     dir and the manifest's home/ section would render empty — an
+//     escape that hides itself. $HOME / $USERPROFILE / the Windows
+//     AppData pair are pinned and the XDG bases cleared too, so even an
+//     adapter that ignores Env.Home and calls os.UserHomeDir() /
+//     platform.DataDir() lands in the sandbox.
+//   - Env-sourced content. codex's hook command embeds
+//     $GORTEX_CODEX_HOOK_MODE at render time and profiles.ActiveName
+//     honours $GORTEX_INSTRUCTIONS_PROFILE, so without pinning, the
+//     goldens would encode the posture/profile of whoever regenerated
+//     them and CI would fail on a diff nobody can explain.
+//
+// The higher-precedence claudecode.SetConfigDirOverride seam cannot be
+// driven from here — claudecode imports this package, so the import can
+// only go the other way. The render tests in cmd/gortex clear that seam
+// (it is only ever set by `gortex install --claude-config-dir`, never
+// on the render path) so the pins below are authoritative.
+//
+// The config-dir variables are *unset* rather than repointed at the
+// sandbox, because they do more than relocate a directory:
+// $CLAUDE_CONFIG_DIR also moves ~/.claude.json into that directory, so
+// pinning it would make the goldens encode a layout no default install
+// produces. Unset plus a pinned $HOME lands every adapter on its real
+// default path, inside the sandbox.
+//
+// An empty value means "unset for the duration".
+func renderEnvPins(home string) map[string]string {
+	return map[string]string{
+		"HOME":        home, // Unix: os.UserHomeDir
+		"USERPROFILE": home, // Windows: os.UserHomeDir
+		// Windows: os.UserConfigDir / os.UserCacheDir read these two
+		// and ignore the XDG variables entirely.
+		"AppData":      filepath.Join(home, "AppData", "Roaming"),
+		"LocalAppData": filepath.Join(home, "AppData", "Local"),
+
+		"CLAUDE_CONFIG_DIR":           "",
+		"KIMI_CODE_HOME":              "",
+		"GORTEX_CODEX_HOOK_MODE":      "",
+		"GORTEX_INSTRUCTIONS_PROFILE": "",
+		"XDG_CONFIG_HOME":             "",
+		"XDG_DATA_HOME":               "",
+		"XDG_CACHE_HOME":              "",
+		"XDG_STATE_HOME":              "",
+	}
+}
+
+// pinRenderEnv applies renderEnvPins and returns a restore func that
+// puts every touched variable back exactly as it was (including
+// "was not set at all"). Renders are serial, so a plain
+// save/set/restore is enough.
+func pinRenderEnv(home string) func() {
+	pins := renderEnvPins(home)
+	prev := make(map[string]*string, len(pins))
+	for k, v := range pins {
+		if old, ok := os.LookupEnv(k); ok {
+			saved := old
+			prev[k] = &saved
+		} else {
+			prev[k] = nil
+		}
+		if v == "" {
+			_ = os.Unsetenv(k)
+			continue
+		}
+		_ = os.Setenv(k, v)
+	}
+	return func() {
+		for k, old := range prev {
+			if old == nil {
+				_ = os.Unsetenv(k)
+				continue
+			}
+			_ = os.Setenv(k, *old)
+		}
+	}
 }
 
 // manifestForDirs walks the sandbox HOME and repo root and builds a
 // sorted, normalised manifest. Each file becomes a `=== <key> ===`
 // header followed by its (sandbox-path-stripped) content; entries are
-// sorted by key so the manifest is deterministic.
-func manifestForDirs(home, root string) (string, error) {
+// sorted by key so the manifest is deterministic. keyPrefix is the
+// mode label ("project/" or "global/") every key carries.
+func manifestForDirs(home, root, keyPrefix string) (string, error) {
 	type entry struct{ key, content string }
 	var entries []entry
 
 	collect := func(base, prefix string) error {
+		prefix = keyPrefix + prefix
 		return filepath.WalkDir(base, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err

--- a/internal/agents/render_test.go
+++ b/internal/agents/render_test.go
@@ -1,0 +1,244 @@
+package agents
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// renderStubAdapter is a minimal Adapter that records every Env the
+// render sandbox hands it and drops one file into each sandbox dir, so
+// tests can assert on both the Env the fence supplies and the manifest
+// key scheme it produces without depending on a real adapter (which
+// this package cannot import — every adapter imports it).
+type renderStubAdapter struct {
+	envs    []Env
+	inApply func(env Env)
+}
+
+func (a *renderStubAdapter) Name() string    { return "render-stub" }
+func (a *renderStubAdapter) DocsURL() string { return "https://example.invalid/render-stub" }
+
+func (a *renderStubAdapter) Detect(Env) (bool, error) { return false, nil }
+
+func (a *renderStubAdapter) Plan(Env) (*Plan, error) { return &Plan{}, nil }
+
+func (a *renderStubAdapter) Apply(env Env, opts ApplyOpts) (*Result, error) {
+	a.envs = append(a.envs, env)
+	if a.inApply != nil {
+		a.inApply(env)
+	}
+	if err := os.WriteFile(filepath.Join(env.Root, "stub-root.txt"), []byte("root\n"), 0o644); err != nil {
+		return nil, err
+	}
+	homeDir := filepath.Join(env.Home, ".stub")
+	if err := os.MkdirAll(homeDir, 0o755); err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(filepath.Join(homeDir, "stub-home.txt"), []byte("home\n"), 0o644); err != nil {
+		return nil, err
+	}
+	return &Result{Name: a.Name(), Detected: true, Configured: true}, nil
+}
+
+// TestRenderCoversBothModes pins the widened fence contract: every
+// adapter is rendered once per install mode, with hooks on and a
+// generated-skill fixture supplied, so hook stanzas, community skills
+// and the ModeGlobal branch all end up in the golden.
+func TestRenderCoversBothModes(t *testing.T) {
+	stub := &renderStubAdapter{}
+	if _, err := renderOne(stub); err != nil {
+		t.Fatalf("renderOne: %v", err)
+	}
+
+	if len(stub.envs) != 2 {
+		t.Fatalf("expected one Apply per install mode, got %d", len(stub.envs))
+	}
+	project, global := stub.envs[0], stub.envs[1]
+	if project.Mode != ModeProject {
+		t.Errorf("first pass should be ModeProject, got %v", project.Mode)
+	}
+	if global.Mode != ModeGlobal {
+		t.Errorf("second pass should be ModeGlobal, got %v", global.Mode)
+	}
+
+	for i, env := range stub.envs {
+		if !env.InstallHooks {
+			t.Errorf("pass %d: InstallHooks must be true or no adapter renders its hook stanza", i)
+		}
+		if len(env.GeneratedSkills) != 2 {
+			t.Errorf("pass %d: expected the two-entry generated-skill fixture, got %d", i, len(env.GeneratedSkills))
+		}
+		if env.SkillsRouting == "" {
+			t.Errorf("pass %d: SkillsRouting must be seeded", i)
+		}
+		// InstructionsDir must live inside the sandbox home; empty would
+		// fall back to profiles.DefaultDir() (the real ~/.gortex).
+		if env.InstructionsDir == "" {
+			t.Errorf("pass %d: InstructionsDir must be pinned into the sandbox", i)
+		} else if !strings.HasPrefix(env.InstructionsDir, env.Home+string(os.PathSeparator)) {
+			t.Errorf("pass %d: InstructionsDir %q escapes sandbox home %q", i, env.InstructionsDir, env.Home)
+		}
+	}
+
+	if project.InstallGlobalInstructions {
+		t.Error("InstallGlobalInstructions is a ModeGlobal-only switch; it must be off in the project pass")
+	}
+	if !global.InstallGlobalInstructions {
+		t.Error("the global pass must set InstallGlobalInstructions or the user-level rule block never renders")
+	}
+	// Env.HookMode is honoured only by the claudecode adapter; the fence
+	// leaves it empty so no golden can be mistaken for pinning a
+	// non-Claude hook posture.
+	if global.HookMode != "" || project.HookMode != "" {
+		t.Error("HookMode must stay empty: only claudecode reads it, so setting it would pin nothing for other adapters")
+	}
+
+	// Each pass must get its own sandbox, otherwise the project pass's
+	// files show up again in the global pass's manifest section.
+	if project.Home == global.Home || project.Root == global.Root {
+		t.Error("each mode pass needs its own sandbox home/root")
+	}
+}
+
+// TestRenderGeneratedSkillFixtureIsAValidSlug guards the property the
+// OpenCode and Copilot adapters depend on: they refuse to materialise a
+// skill whose directory name is not a lowercase kebab slug, so the
+// fixture must be one or the fence proves nothing about them.
+func TestRenderGeneratedSkillFixtureIsAValidSlug(t *testing.T) {
+	slug := regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+	seen := map[string]bool{}
+	skills := renderGeneratedSkills()
+	if len(skills) < 2 {
+		t.Fatalf("fixture should carry at least two skills, got %d", len(skills))
+	}
+	for _, s := range skills {
+		if !slug.MatchString(s.DirName) {
+			t.Errorf("DirName %q is not a valid skill slug", s.DirName)
+		}
+		if s.Content == "" || s.CommunityID == "" || s.Label == "" {
+			t.Errorf("skill %q has an empty field: %+v", s.DirName, s)
+		}
+		if seen[s.DirName] {
+			t.Errorf("duplicate DirName %q", s.DirName)
+		}
+		seen[s.DirName] = true
+	}
+}
+
+// TestRenderManifestKeysAreModePrefixed pins the key scheme: every key
+// is `<mode>/<home|root>/<path>`, and the project block is emitted
+// before the global one so a change confined to one mode produces a
+// diff hunk confined to that block.
+func TestRenderManifestKeysAreModePrefixed(t *testing.T) {
+	got, err := renderOne(&renderStubAdapter{})
+	if err != nil {
+		t.Fatalf("renderOne: %v", err)
+	}
+
+	want := []string{
+		"=== project/root/stub-root.txt ===",
+		"=== project/home/.stub/stub-home.txt ===",
+		"=== global/root/stub-root.txt ===",
+		"=== global/home/.stub/stub-home.txt ===",
+	}
+	for _, w := range want {
+		if !strings.Contains(got, w) {
+			t.Errorf("manifest missing %q\n---\n%s", w, got)
+		}
+	}
+	if p, g := strings.Index(got, "=== project/"), strings.Index(got, "=== global/"); p < 0 || g < 0 || p > g {
+		t.Errorf("project block must be emitted before the global block (project=%d global=%d)", p, g)
+	}
+}
+
+// TestRenderPinsHostileEnvironment is the hermeticity + determinism
+// fence for the fence itself. Every variable below is one a developer
+// may legitimately have exported; each one, unpinned, either relocates
+// a ModeGlobal write out of the sandbox (so the manifest's home/
+// section renders empty and the escape hides itself) or bakes a local
+// posture into the goldens.
+func TestRenderPinsHostileEnvironment(t *testing.T) {
+	hostile := t.TempDir()
+	t.Setenv("HOME", hostile)
+	t.Setenv("USERPROFILE", hostile)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(hostile, "escaped-claude"))
+	t.Setenv("KIMI_CODE_HOME", filepath.Join(hostile, "escaped-kimi"))
+	t.Setenv("GORTEX_CODEX_HOOK_MODE", "suppress")
+	t.Setenv("GORTEX_INSTRUCTIONS_PROFILE", "full")
+	t.Setenv("XDG_DATA_HOME", filepath.Join(hostile, "escaped-xdg"))
+
+	stub := &renderStubAdapter{}
+	stub.inApply = func(env Env) {
+		if got := os.Getenv("HOME"); got != env.Home {
+			t.Errorf("HOME = %q during render, want the sandbox home %q", got, env.Home)
+		}
+		if got, err := os.UserHomeDir(); err != nil || got != env.Home {
+			t.Errorf("os.UserHomeDir() = %q (err %v) during render, want %q", got, err, env.Home)
+		}
+		for _, k := range []string{
+			// Cleared rather than repointed: both also relocate files
+			// (CLAUDE_CONFIG_DIR moves ~/.claude.json), so unsetting is
+			// what puts every adapter on its real default path inside
+			// the sandbox home.
+			"CLAUDE_CONFIG_DIR",
+			"KIMI_CODE_HOME",
+			"GORTEX_CODEX_HOOK_MODE",
+			"GORTEX_INSTRUCTIONS_PROFILE",
+			"XDG_DATA_HOME",
+		} {
+			if v, ok := os.LookupEnv(k); ok {
+				t.Errorf("%s must be unset during render, got %q", k, v)
+			}
+		}
+	}
+	if _, err := renderOne(stub); err != nil {
+		t.Fatalf("renderOne: %v", err)
+	}
+
+	// Restored exactly, including the sandbox HOME t.Setenv installed.
+	for k, want := range map[string]string{
+		"HOME":                        hostile,
+		"CLAUDE_CONFIG_DIR":           filepath.Join(hostile, "escaped-claude"),
+		"KIMI_CODE_HOME":              filepath.Join(hostile, "escaped-kimi"),
+		"GORTEX_CODEX_HOOK_MODE":      "suppress",
+		"GORTEX_INSTRUCTIONS_PROFILE": "full",
+		"XDG_DATA_HOME":               filepath.Join(hostile, "escaped-xdg"),
+	} {
+		if got := os.Getenv(k); got != want {
+			t.Errorf("%s = %q after render, want it restored to %q", k, got, want)
+		}
+	}
+
+	// Nothing may have been created in the hostile home beyond the
+	// variables' own parent dir, which we never wrote to.
+	entries, err := os.ReadDir(hostile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("render escaped the sandbox and wrote into the ambient home: %v", names)
+	}
+}
+
+// TestRenderRestoresUnsetEnvironment covers the other half of the
+// save/restore contract: a variable that was not set before the render
+// must not exist afterwards.
+func TestRenderRestoresUnsetEnvironment(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	if err := os.Unsetenv("CLAUDE_CONFIG_DIR"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := renderOne(&renderStubAdapter{}); err != nil {
+		t.Fatalf("renderOne: %v", err)
+	}
+	if v, ok := os.LookupEnv("CLAUDE_CONFIG_DIR"); ok {
+		t.Errorf("CLAUDE_CONFIG_DIR leaked out of the render as %q; it was unset before", v)
+	}
+}

--- a/internal/agents/skillpack/skillpack.go
+++ b/internal/agents/skillpack/skillpack.go
@@ -1,0 +1,317 @@
+// Package skillpack is the host-neutral representation of a Gortex
+// skill: an ID, a name, a description, and a markdown body with no
+// frontmatter attached.
+//
+// Every agent host (Claude Code, Hermes, Codex, OpenCode, GitHub
+// Copilot, …) ships the same 21 playbooks but demands its own
+// frontmatter dialect — different keys, different nesting, different
+// discovery metadata. Parsing one host's SKILL.md into this neutral
+// shape and re-rendering it per host keeps the *content* single-sourced
+// while each adapter owns only its own envelope.
+//
+// # Import direction: adapters -> skillpack, never the reverse
+//
+// This package MUST NOT import any adapter package
+// (internal/agents/claudecode, internal/agents/hermes, …). The skill
+// bodies stay where they are; callers pass the raw map in. The
+// tempting inversion — skillpack reaching into claudecode for the
+// bodies — deadlocks the moment an adapter wants to call back into
+// skillpack (a later phase adds a Sync entry point driven from
+// cmd/gortex), because Go rejects the import cycle. Keeping the arrow
+// one-way means any number of adapters can depend on skillpack without
+// ever constraining each other.
+//
+// Only the stdlib is imported here, deliberately: a leaf package with
+// no internal dependencies can never participate in a cycle.
+package skillpack
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Skill is one playbook, stripped of whatever host dialect it arrived
+// in. Body carries the markdown only — a host renders its own
+// frontmatter in front of it, so a Body that still began with "---"
+// would produce two stacked frontmatter blocks and a skill most hosts
+// silently ignore.
+type Skill struct {
+	ID          string // kebab-case identifier, e.g. "gortex-explore" — the map key and on-disk directory name
+	Name        string // frontmatter `name` field, usually equal to ID
+	Description string // frontmatter `description` field, unquoted and unescaped
+	Body        string // markdown body, with no frontmatter and no leading "---"
+}
+
+// idPattern is the identifier shape every host accepts. OpenCode and
+// GitHub Copilot both reject a skill whose name is not kebab-case
+// (uppercase, spaces and underscores are refused at load time), and a
+// rejected skill fails silently — it simply never appears in the
+// picker. Validating at parse time turns that into a loud error in our
+// own tests instead of a missing skill on a user's machine.
+var idPattern = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+
+// ValidID reports whether id is the kebab-case shape every supported
+// host accepts as a skill name.
+func ValidID(id string) bool { return idPattern.MatchString(id) }
+
+// ErrUnterminatedFrontmatter is returned when a document opens a
+// "---" frontmatter fence that is never closed. Guessing (treating the
+// whole file as either frontmatter or body) would silently install a
+// broken skill, so this is an error rather than a fallback.
+var ErrUnterminatedFrontmatter = errors.New("unterminated frontmatter")
+
+// Parse turns one Claude-style SKILL.md into a Skill: it splits the
+// leading YAML frontmatter off the markdown, and reads the `name` and
+// `description` scalars out of it.
+//
+// A document with no frontmatter at all is not an error — the whole
+// text becomes Body and the caller supplies name/description itself.
+// Only a fence that opens and never closes is rejected.
+func Parse(id, raw string) (Skill, error) {
+	if !ValidID(id) {
+		return Skill{}, fmt.Errorf("skillpack: invalid skill id %q: want kebab-case (%s)", id, idPattern)
+	}
+	front, body, err := splitFrontmatter(raw)
+	if err != nil {
+		return Skill{}, fmt.Errorf("skillpack: skill %q: %w", id, err)
+	}
+	return Skill{
+		ID:          id,
+		Name:        frontmatterField(front, "name"),
+		Description: frontmatterField(front, "description"),
+		Body:        body,
+	}, nil
+}
+
+// ParseAll parses a whole id -> SKILL.md map into an ID-sorted slice.
+// Sorting is what makes an install plan, a rendered artifact set and a
+// golden test reproducible: Go map iteration order is randomised, so a
+// caller ranging over the map directly would emit a different byte
+// order on every run.
+func ParseAll(raw map[string]string) ([]Skill, error) {
+	ids := make([]string, 0, len(raw))
+	for id := range raw {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	out := make([]Skill, 0, len(ids))
+	for _, id := range ids {
+		skill, err := Parse(id, raw[id])
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, skill)
+	}
+	return out, nil
+}
+
+// RenderFrontmatter emits a minimal YAML frontmatter block from ordered
+// key/value pairs, quoting values that need it.
+//
+// Ordered pairs rather than a fixed struct because the hosts disagree
+// about the envelope: Codex, OpenCode and Copilot all need `name` +
+// `description`, but each adds its own keys (and expects them in its
+// own order), so the shape belongs to the caller. Values are emitted as
+// plain YAML scalars — a host needing structured YAML (nested maps,
+// flow sequences) builds that block itself and uses QuoteYAMLValue for
+// the scalar leaves.
+//
+// Returns "" for no pairs: an empty "---\n---\n" block is not
+// something any host wants written to disk.
+func RenderFrontmatter(pairs [][2]string) string {
+	if len(pairs) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(fence + "\n")
+	for _, kv := range pairs {
+		b.WriteString(kv[0])
+		b.WriteString(": ")
+		b.WriteString(QuoteYAMLValue(kv[1]))
+		b.WriteString("\n")
+	}
+	b.WriteString(fence + "\n")
+	return b.String()
+}
+
+// QuoteYAMLValue renders s as a YAML scalar, double-quoting it unless
+// it is a bare token that is unambiguous in every YAML context.
+//
+// The rule is deliberately conservative — anything with a space, a
+// colon, a comment marker or any other punctuation gets quoted. Skill
+// descriptions are prose ("Gortex reference: available tools, …") and
+// an unquoted colon-space turns the line into a nested mapping, which
+// makes the host drop the skill.
+func QuoteYAMLValue(s string) string {
+	if isBareToken(s) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s) + 2)
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+// isBareToken reports whether s can be emitted unquoted. Only ASCII
+// identifier-ish tokens qualify (`gortex-explore`, `1.0.0`), and never
+// a token YAML would read as a bool/null — those are the values a host
+// would silently reinterpret.
+func isBareToken(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+		case c == '-' || c == '_' || c == '.' || c == '/':
+		default:
+			return false
+		}
+	}
+	if s[0] == '-' {
+		return false // a leading dash reads as a sequence entry
+	}
+	switch strings.ToLower(s) {
+	case "true", "false", "null", "yes", "no", "on", "off", "y", "n", "~":
+		return false
+	}
+	return true
+}
+
+// fence is the YAML frontmatter delimiter.
+const fence = "---"
+
+// splitFrontmatter separates a leading "---"-fenced YAML block from the
+// markdown that follows. The body is returned byte-for-byte as it
+// appeared after the closing fence — re-joining parsed lines would
+// normalise line endings and silently rewrite every skill we install.
+func splitFrontmatter(raw string) (front, body string, err error) {
+	first, rest, ok := cutLine(raw)
+	if !ok || !isFence(first) {
+		return "", raw, nil
+	}
+	// consumed tracks the start of the line under inspection, so the
+	// frontmatter slice can be cut without rebuilding it.
+	consumed := 0
+	for {
+		line, tail, ok := cutLine(rest[consumed:])
+		if !ok {
+			return "", "", ErrUnterminatedFrontmatter
+		}
+		if isFence(line) {
+			return rest[:consumed], tail, nil
+		}
+		consumed = len(rest) - len(tail)
+	}
+}
+
+// isFence matches a delimiter line, tolerating the CR of a CRLF file.
+// Skill sources authored on Windows (or round-tripped through a Windows
+// editor) otherwise parse as "no frontmatter" and ship their own YAML
+// as visible markdown.
+func isFence(line string) bool { return strings.TrimRight(line, "\r") == fence }
+
+// cutLine splits off the first line of s. ok is false only when s is
+// empty, so a final line without a trailing newline is still returned.
+func cutLine(s string) (line, rest string, ok bool) {
+	if s == "" {
+		return "", "", false
+	}
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i], s[i+1:], true
+	}
+	return s, "", true
+}
+
+// frontmatterField reads a single-line scalar out of a frontmatter
+// block. Only top-level keys match: an indented `description:` belongs
+// to a nested mapping (Hermes nests discovery metadata) and must not be
+// mistaken for the skill's own description.
+func frontmatterField(front, key string) string {
+	prefix := key + ":"
+	rest := front
+	for {
+		line, tail, ok := cutLine(rest)
+		if !ok {
+			return ""
+		}
+		if value, found := strings.CutPrefix(line, prefix); found {
+			return unquoteYAMLValue(strings.TrimSpace(strings.TrimRight(value, "\r")))
+		}
+		rest = tail
+	}
+}
+
+// unquoteYAMLValue decodes the quoted-scalar forms the skill sources
+// actually use. It is not a YAML parser: block scalars, anchors and
+// flow collections are returned verbatim, because no skill frontmatter
+// uses them and a half-implemented parser is worse than none.
+func unquoteYAMLValue(v string) string {
+	if len(v) < 2 {
+		return v
+	}
+	switch {
+	case v[0] == '"' && v[len(v)-1] == '"':
+		return unescapeDoubleQuoted(v[1 : len(v)-1])
+	case v[0] == '\'' && v[len(v)-1] == '\'':
+		return strings.ReplaceAll(v[1:len(v)-1], "''", "'")
+	}
+	return v
+}
+
+// unescapeDoubleQuoted reverses the escapes QuoteYAMLValue emits. An
+// escape it does not recognise is kept verbatim (backslash included)
+// rather than dropped, so an unexpected sequence survives a
+// parse/render round trip instead of quietly losing a character.
+func unescapeDoubleQuoted(s string) string {
+	if !strings.Contains(s, `\`) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] != '\\' || i+1 >= len(s) {
+			b.WriteByte(s[i])
+			continue
+		}
+		i++
+		switch s[i] {
+		case '"':
+			b.WriteByte('"')
+		case '\\':
+			b.WriteByte('\\')
+		case 'n':
+			b.WriteByte('\n')
+		case 'r':
+			b.WriteByte('\r')
+		case 't':
+			b.WriteByte('\t')
+		default:
+			b.WriteByte('\\')
+			b.WriteByte(s[i])
+		}
+	}
+	return b.String()
+}

--- a/internal/agents/skillpack/skillpack.go
+++ b/internal/agents/skillpack/skillpack.go
@@ -16,13 +16,14 @@
 // bodies stay where they are; callers pass the raw map in. The
 // tempting inversion — skillpack reaching into claudecode for the
 // bodies — deadlocks the moment an adapter wants to call back into
-// skillpack (a later phase adds a Sync entry point driven from
-// cmd/gortex), because Go rejects the import cycle. Keeping the arrow
-// one-way means any number of adapters can depend on skillpack without
-// ever constraining each other.
+// skillpack (Sync, in sync.go, is exactly that), because Go rejects the
+// import cycle. Keeping the arrow one-way means any number of adapters
+// can depend on skillpack without ever constraining each other.
 //
-// Only the stdlib is imported here, deliberately: a leaf package with
-// no internal dependencies can never participate in a cycle.
+// This file imports only the stdlib. sync.go additionally imports
+// internal/agents and internal/agents/internalutil for the shared file
+// actions, writers and log prefixes; see the note there for why those
+// two — and only those two — cannot close a cycle.
 package skillpack
 
 import (

--- a/internal/agents/skillpack/skillpack_test.go
+++ b/internal/agents/skillpack/skillpack_test.go
@@ -1,0 +1,296 @@
+// Package skillpack_test is deliberately an external test package: it
+// imports internal/agents/claudecode to assert the real skill corpus
+// parses, and skillpack itself must never import an adapter. Keeping
+// the assertion outside the package means a later phase can have
+// claudecode depend on skillpack without this file turning into an
+// import cycle.
+package skillpack_test
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/agents/claudecode"
+	"github.com/zzet/gortex/internal/agents/skillpack"
+)
+
+// TestParseAllClaudeSkills is the corpus test: every shipped skill must
+// survive the neutral round trip, because a skill that loses its name
+// or description is one a host silently drops from its picker, and a
+// body that still carries frontmatter renders two stacked blocks.
+func TestParseAllClaudeSkills(t *testing.T) {
+	skills, err := skillpack.ParseAll(claudecode.GlobalSkills)
+	if err != nil {
+		t.Fatalf("ParseAll(claudecode.GlobalSkills): %v", err)
+	}
+	if len(skills) != len(claudecode.GlobalSkills) {
+		t.Fatalf("parsed %d skills, want %d", len(skills), len(claudecode.GlobalSkills))
+	}
+
+	for _, skill := range skills {
+		if skill.Name == "" {
+			t.Errorf("%s: empty frontmatter name", skill.ID)
+		}
+		if skill.Description == "" {
+			t.Errorf("%s: empty frontmatter description", skill.ID)
+		}
+		if strings.HasPrefix(skill.Body, "---") {
+			t.Errorf("%s: body still starts with frontmatter:\n%.80s", skill.ID, skill.Body)
+		}
+		if skill.Body == "" {
+			t.Errorf("%s: empty body", skill.ID)
+		}
+	}
+}
+
+// TestParseAllIsIDSorted pins the ordering guarantee ParseAll exists
+// for: callers render install plans and golden artifacts from this
+// slice, and Go's randomised map iteration would otherwise reorder
+// them on every run.
+func TestParseAllIsIDSorted(t *testing.T) {
+	skills, err := skillpack.ParseAll(claudecode.GlobalSkills)
+	if err != nil {
+		t.Fatalf("ParseAll: %v", err)
+	}
+	for i := 1; i < len(skills); i++ {
+		if skills[i-1].ID >= skills[i].ID {
+			t.Fatalf("not ID-sorted at %d: %q then %q", i, skills[i-1].ID, skills[i].ID)
+		}
+	}
+}
+
+// TestSkillIDsAreKebabCase guards a real host constraint, not a style
+// preference: OpenCode and GitHub Copilot both refuse to load a skill
+// whose name is not kebab-case, and they refuse it silently.
+func TestSkillIDsAreKebabCase(t *testing.T) {
+	kebab := regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+	for id := range claudecode.GlobalSkills {
+		if !kebab.MatchString(id) {
+			t.Errorf("skill id %q is not kebab-case", id)
+		}
+		if !skillpack.ValidID(id) {
+			t.Errorf("skill id %q rejected by skillpack.ValidID", id)
+		}
+	}
+}
+
+// TestRoundTripReproducesSource proves Parse loses nothing a host needs
+// to rebuild the original file. Doing it over the whole corpus (not one
+// representative) is what lets an adapter re-render descriptions
+// through QuoteYAMLValue without shifting a single installed byte.
+func TestRoundTripReproducesSource(t *testing.T) {
+	skills, err := skillpack.ParseAll(claudecode.GlobalSkills)
+	if err != nil {
+		t.Fatalf("ParseAll: %v", err)
+	}
+	for _, skill := range skills {
+		got := skillpack.RenderFrontmatter([][2]string{
+			{"name", skill.Name},
+			{"description", skill.Description},
+		}) + skill.Body
+		if want := claudecode.GlobalSkills[skill.ID]; got != want {
+			t.Errorf("%s: round trip changed the file\n--- got ---\n%s\n--- want ---\n%s", skill.ID, firstLines(got, 6), firstLines(want, 6))
+		}
+	}
+}
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      string
+		raw     string
+		want    skillpack.Skill
+		wantErr bool
+	}{
+		{
+			name: "claude style",
+			id:   "gortex-explore",
+			raw:  "---\nname: gortex-explore\ndescription: \"Understand how code works.\"\n---\n# Explore\n\nbody\n",
+			want: skillpack.Skill{
+				ID:          "gortex-explore",
+				Name:        "gortex-explore",
+				Description: "Understand how code works.",
+				Body:        "# Explore\n\nbody\n",
+			},
+		},
+		{
+			// Not an error: a host may carry name/description out of band
+			// (a manifest, a directory name) and ship only markdown.
+			name: "no frontmatter",
+			id:   "plain-skill",
+			raw:  "# Just markdown\n\nno frontmatter here\n",
+			want: skillpack.Skill{ID: "plain-skill", Body: "# Just markdown\n\nno frontmatter here\n"},
+		},
+		{
+			name: "crlf line endings",
+			id:   "crlf-skill",
+			raw:  "---\r\nname: crlf-skill\r\ndescription: \"Windows authored.\"\r\n---\r\n# Body\r\n",
+			want: skillpack.Skill{
+				ID:          "crlf-skill",
+				Name:        "crlf-skill",
+				Description: "Windows authored.",
+				Body:        "# Body\r\n",
+			},
+		},
+		{
+			// The colon is why descriptions are quoted at all: unquoted,
+			// YAML reads "Gortex reference: tools" as a nested mapping.
+			name: "description containing a colon",
+			id:   "gortex-guide",
+			raw:  "---\nname: gortex-guide\ndescription: \"Gortex reference: available tools, graph schema.\"\n---\nbody\n",
+			want: skillpack.Skill{
+				ID:          "gortex-guide",
+				Name:        "gortex-guide",
+				Description: "Gortex reference: available tools, graph schema.",
+				Body:        "body\n",
+			},
+		},
+		{
+			name: "missing description",
+			id:   "bare-skill",
+			raw:  "---\nname: bare-skill\n---\nbody\n",
+			want: skillpack.Skill{ID: "bare-skill", Name: "bare-skill", Body: "body\n"},
+		},
+		{
+			// An indented key belongs to a nested mapping (Hermes nests
+			// its discovery metadata) and is not the skill's own field.
+			name: "nested key is not the top-level field",
+			id:   "nested-skill",
+			raw:  "---\nname: nested-skill\nmetadata:\n  hermes:\n    description: \"nested\"\n---\nbody\n",
+			want: skillpack.Skill{ID: "nested-skill", Name: "nested-skill", Body: "body\n"},
+		},
+		{
+			name: "single quoted description",
+			id:   "quoted-skill",
+			raw:  "---\nname: quoted-skill\ndescription: 'it''s quoted'\n---\nbody\n",
+			want: skillpack.Skill{ID: "quoted-skill", Name: "quoted-skill", Description: "it's quoted", Body: "body\n"},
+		},
+		{
+			name: "plain unquoted description",
+			id:   "plain-desc",
+			raw:  "---\nname: plain-desc\ndescription: no quotes here\n---\nbody\n",
+			want: skillpack.Skill{ID: "plain-desc", Name: "plain-desc", Description: "no quotes here", Body: "body\n"},
+		},
+		{
+			name:    "unterminated frontmatter",
+			id:      "broken-skill",
+			raw:     "---\nname: broken-skill\ndescription: \"never closed\"\n# body\n",
+			wantErr: true,
+		},
+		{
+			name:    "non kebab id",
+			id:      "Gortex_Explore",
+			raw:     "---\nname: x\n---\nbody\n",
+			wantErr: true,
+		},
+		{
+			name:    "empty id",
+			id:      "",
+			raw:     "body\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := skillpack.Parse(tt.id, tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Parse(%q) = %+v, want error", tt.id, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", tt.id, err)
+			}
+			if got != tt.want {
+				t.Errorf("Parse(%q)\n got %#v\nwant %#v", tt.id, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRenderFrontmatter(t *testing.T) {
+	tests := []struct {
+		name  string
+		pairs [][2]string
+		want  string
+	}{
+		{
+			name:  "quotes prose, leaves bare tokens alone",
+			pairs: [][2]string{{"name", "gortex-explore"}, {"description", "Understand how code works."}},
+			want:  "---\nname: gortex-explore\ndescription: \"Understand how code works.\"\n---\n",
+		},
+		{
+			name:  "colon forces quoting",
+			pairs: [][2]string{{"description", "Gortex reference: tools"}},
+			want:  "---\ndescription: \"Gortex reference: tools\"\n---\n",
+		},
+		{
+			name:  "caller order is preserved",
+			pairs: [][2]string{{"version", "1.0.0"}, {"name", "x-y"}},
+			want:  "---\nversion: 1.0.0\nname: x-y\n---\n",
+		},
+		{
+			name:  "escapes quotes and backslashes",
+			pairs: [][2]string{{"description", `say "hi" \ bye`}},
+			want:  "---\ndescription: \"say \\\"hi\\\" \\\\ bye\"\n---\n",
+		},
+		{
+			// An empty or bool-ish value must never go out bare: YAML
+			// would read it as null / true and the host would drop it.
+			name:  "empty and bool-ish values are quoted",
+			pairs: [][2]string{{"description", ""}, {"enabled", "true"}},
+			want:  "---\ndescription: \"\"\nenabled: \"true\"\n---\n",
+		},
+		{
+			name:  "no pairs renders nothing",
+			pairs: nil,
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := skillpack.RenderFrontmatter(tt.pairs); got != tt.want {
+				t.Errorf("RenderFrontmatter()\n got %q\nwant %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestQuoteYAMLValueRoundTrip checks the two halves of the frontmatter
+// codec agree: whatever QuoteYAMLValue emits, Parse must read back
+// unchanged. Hosts rely on that to re-render a description without
+// mutating it.
+func TestQuoteYAMLValueRoundTrip(t *testing.T) {
+	values := []string{
+		"Understand how code works.",
+		"Gortex reference: available tools, graph schema, and workflow.",
+		"Clear LSP diagnostics — one error, a file, or source.fixAll.",
+		"Preview an edit's blast radius on the shadow graph before writing.",
+		`a "quoted" word`,
+		`a \ backslash`,
+		"gortex-explore",
+		"",
+	}
+	for _, want := range values {
+		raw := "---\nname: round-trip\ndescription: " + skillpack.QuoteYAMLValue(want) + "\n---\nbody\n"
+		got, err := skillpack.Parse("round-trip", raw)
+		if err != nil {
+			t.Fatalf("Parse(%q): %v", raw, err)
+		}
+		if got.Description != want {
+			t.Errorf("round trip of %q gave %q (rendered %s)", want, got.Description, skillpack.QuoteYAMLValue(want))
+		}
+	}
+}
+
+func firstLines(s string, n int) string {
+	lines := strings.SplitN(s, "\n", n+1)
+	if len(lines) > n {
+		lines = lines[:n]
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/agents/skillpack/sync.go
+++ b/internal/agents/skillpack/sync.go
@@ -80,6 +80,24 @@ type SyncSpec struct {
 	// pruned. Optional: a pack that has only ever shipped one rendering
 	// leaves this nil and relies on the byte compare alone.
 	KnownHashes map[string]string
+
+	// DirFor overrides where one skill's directory lives, for a host
+	// that groups skills below the root instead of placing them
+	// directly under it — Hermes files each skill under a category
+	// (skills/<category>/<id>/). Optional; nil means <Dir>/<id>.
+	//
+	// It returns the directory, not the file, because pruning removes
+	// the directory whole and the reconciler must not have to guess how
+	// far up the tree the skill's own scope ends.
+	DirFor func(id string) string
+}
+
+// skillDir resolves one skill's directory under this spec.
+func (s SyncSpec) skillDir(id string) string {
+	if s.DirFor != nil {
+		return s.DirFor(id)
+	}
+	return filepath.Join(s.Dir, id)
 }
 
 // Sync reconciles a host's installed skill tree with the allowed
@@ -134,7 +152,7 @@ func Sync(w io.Writer, spec SyncSpec, allowed []string, opts agents.ApplyOpts) (
 	out := make([]agents.FileAction, 0, len(spec.Rendered))
 	for _, id := range sortedIDs(spec.Rendered) {
 		content := spec.Rendered[id]
-		dir := filepath.Join(spec.Dir, id)
+		dir := spec.skillDir(id)
 		path := filepath.Join(dir, fileName)
 
 		var (

--- a/internal/agents/skillpack/sync.go
+++ b/internal/agents/skillpack/sync.go
@@ -1,0 +1,227 @@
+package skillpack
+
+// sync.go reconciles one host's installed skill tree with the subset an
+// instruction profile allows. Every skill-aware host installs the same
+// playbooks under a different root in a different frontmatter dialect,
+// and every one of them needs the same three-way decision on each file:
+// install it, leave it alone, or remove it. Writing that decision once
+// is the point — it is the highest blast-radius rule in the installer,
+// because getting it wrong deletes a file off a user's machine.
+//
+// # Import direction: adapters -> skillpack, never the reverse
+//
+// This file relaxes the package's original stdlib-only rule to
+// internal/agents (Env/ApplyOpts/FileAction, and the atomic writers) and
+// internal/agents/internalutil (the shared log prefixes). Both are safe
+// because neither imports skillpack, and neither may start: internal/
+// agents is the parent every adapter depends on, so an
+// agents -> skillpack edge plus the adapters' skillpack -> agents edge
+// would be a cycle Go rejects.
+//
+// The rule that still holds without exception is the original one:
+// skillpack MUST NOT import an adapter package
+// (internal/agents/claudecode, internal/agents/codex, …). Adapters call
+// in; skillpack never calls out. That is what lets four hosts share this
+// reconciler without any of them depending on each other.
+//
+// # Why the rule is duplicated rather than shared with claudecode
+//
+// internal/agents/claudecode has its own copy of this logic
+// (SyncGlobalSkills + writeAgentArtifact), carrying migration hashes for
+// artifacts only Claude Code ever shipped. The behaviour here is a
+// faithful port of that rule — deliberately, byte-decision for
+// byte-decision — so the two cannot disagree about what gets deleted.
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/internalutil"
+)
+
+// defaultSkillFileName is the file the Agent Skills spec fixes inside
+// each skill directory. Used when a SyncSpec leaves FileName empty.
+const defaultSkillFileName = "SKILL.md"
+
+// SyncSpec describes one host's installed skill tree: where it lives,
+// what this host would write into it, and which bodies count as ours.
+type SyncSpec struct {
+	// Dir is the host's skills root. Each skill occupies
+	// <Dir>/<id>/<FileName>, and pruning removes <Dir>/<id> whole —
+	// a skill directory may carry auxiliary files (scripts, reference
+	// docs) that are meaningless once the SKILL.md is gone.
+	//
+	// An empty Dir makes Sync a no-op rather than an error: a host with
+	// no resolvable home is simply not installed on this machine.
+	Dir string
+
+	// Rendered maps skill ID -> the exact bytes THIS host installs.
+	// Per-host rather than a single shared body because each host
+	// demands its own frontmatter dialect, and the byte comparison that
+	// separates "still ours" from "the user edited it" is only
+	// meaningful against the bytes this host would have written.
+	Rendered map[string]string
+
+	// FileName is the file inside each skill directory. Every host
+	// supported today uses SKILL.md, but it stays a field so a host that
+	// spells it differently does not have to fork the reconciler.
+	// Empty means SKILL.md.
+	FileName string
+
+	// KnownHashes maps skill ID -> sha256 hex digests of bodies an
+	// EARLIER Gortex release shipped for that ID. A file matching one is
+	// still Gortex's, not the user's, so it may be refreshed in place or
+	// pruned. Optional: a pack that has only ever shipped one rendering
+	// leaves this nil and relies on the byte compare alone.
+	KnownHashes map[string]string
+}
+
+// Sync reconciles a host's installed skill tree with the allowed
+// subset. A nil allowed means "every shipped skill" — the install path
+// — and is not the same as an empty slice, which means "keep none".
+//
+// Per skill, in ID order (map order is randomised, and an install
+// report, a plan and a golden test all need the same sequence):
+//
+//   - in the subset and missing on disk -> installed;
+//   - in the subset and byte-identical -> left alone (ActionSkip
+//     "unchanged");
+//   - in the subset, differing, but matching a KnownHashes digest ->
+//     refreshed, because those bytes are a previous release's, not the
+//     user's;
+//   - in the subset and otherwise differing -> KEPT with a warning
+//     (ActionSkip "customised"): a re-install must never discard an
+//     edit the user made;
+//   - OUTSIDE the subset and still matching a shipped body -> deleted;
+//   - OUTSIDE the subset and customised -> KEPT with a warning.
+//
+// That last pair is the load-bearing rule. Enforcing a profile is worth
+// removing files Gortex itself wrote; it is never worth removing a
+// playbook a user rewrote. When the two goals conflict, the user's
+// bytes win and the profile stays slightly wider than requested.
+//
+// Under DryRun nothing touches disk and removals report
+// ActionWouldDelete.
+//
+// Returned actions are partial on error: a caller that reports progress
+// should still consume what came back before handling the error.
+func Sync(w io.Writer, spec SyncSpec, allowed []string, opts agents.ApplyOpts) ([]agents.FileAction, error) {
+	if spec.Dir == "" || len(spec.Rendered) == 0 {
+		return nil, nil
+	}
+	fileName := spec.FileName
+	if fileName == "" {
+		fileName = defaultSkillFileName
+	}
+
+	// A nil set means "no filtering at all"; an empty non-nil set means
+	// "nothing is allowed". Keeping those distinct is what lets the
+	// install path share this function with the profile switch.
+	var allowedSet map[string]bool
+	if allowed != nil {
+		allowedSet = make(map[string]bool, len(allowed))
+		for _, id := range allowed {
+			allowedSet[id] = true
+		}
+	}
+
+	out := make([]agents.FileAction, 0, len(spec.Rendered))
+	for _, id := range sortedIDs(spec.Rendered) {
+		content := spec.Rendered[id]
+		dir := filepath.Join(spec.Dir, id)
+		path := filepath.Join(dir, fileName)
+
+		var (
+			action agents.FileAction
+			err    error
+		)
+		if allowedSet != nil && !allowedSet[id] {
+			action, err = pruneSkill(w, dir, path, content, spec.KnownHashes[id], opts)
+		} else {
+			action, err = installSkill(w, path, content, spec.KnownHashes[id], opts)
+		}
+		if err != nil {
+			return out, fmt.Errorf("skillpack: skill %s: %w", id, err)
+		}
+		out = append(out, action)
+	}
+	return out, nil
+}
+
+// installSkill writes content at path unless something is already there
+// that Gortex did not write.
+func installSkill(w io.Writer, path, content, knownHash string, opts agents.ApplyOpts) (agents.FileAction, error) {
+	existing, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return agents.WriteIfNotExists(w, path, content, opts)
+	}
+	if err != nil {
+		return agents.FileAction{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	if string(existing) == content {
+		return agents.FileAction{Path: path, Action: agents.ActionSkip, Reason: "unchanged"}, nil
+	}
+	if knownHash != "" && bodyHash(existing) == knownHash {
+		// A previous release's body: ours to replace, so an upgrade
+		// actually delivers the new playbook.
+		return agents.WriteOwnedFile(w, path, content, opts)
+	}
+	internalutil.Warnf(w, "keeping customised skill %s", path)
+	return agents.FileAction{Path: path, Action: agents.ActionSkip, Reason: "customised"}, nil
+}
+
+// pruneSkill removes a skill the active profile excludes, but only when
+// the installed bytes are still one Gortex shipped.
+func pruneSkill(w io.Writer, dir, path, content, knownHash string, opts agents.ApplyOpts) (agents.FileAction, error) {
+	existing, err := os.ReadFile(path)
+	if err != nil {
+		// Not installed, or unreadable — either way there is nothing to
+		// prune. Deliberately not an error even for a permission
+		// failure: a profile switch must not fail because one host's
+		// tree is inaccessible, and refusing to delete is the safe
+		// direction for a file we cannot even read.
+		return agents.FileAction{Path: path, Action: agents.ActionSkip, Reason: "outside-profile"}, nil
+	}
+	if !isShippedBody(existing, content, knownHash) {
+		internalutil.Warnf(w, "keeping customised skill %s (outside the active profile)", path)
+		return agents.FileAction{Path: path, Action: agents.ActionSkip, Reason: "customised"}, nil
+	}
+	if opts.DryRun {
+		return agents.FileAction{Path: path, Action: agents.ActionWouldDelete, Keys: []string{"skill"}}, nil
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		return agents.FileAction{}, err
+	}
+	internalutil.Logf(w, "[gortex] removed skill %s (outside the active profile)", path)
+	return agents.FileAction{Path: path, Action: agents.ActionDelete, Keys: []string{"skill"}}, nil
+}
+
+// isShippedBody reports whether existing is a body Gortex wrote: either
+// the one this build renders, or one a previous release shipped.
+func isShippedBody(existing []byte, current, knownHash string) bool {
+	return string(existing) == current || (knownHash != "" && bodyHash(existing) == knownHash)
+}
+
+// bodyHash fingerprints an on-disk body for comparison against
+// SyncSpec.KnownHashes.
+func bodyHash(content []byte) string {
+	return fmt.Sprintf("%x", sha256.Sum256(content))
+}
+
+// sortedIDs orders a rendered map's keys. Go randomises map iteration,
+// so without this the same install would emit its actions — and its log
+// lines — in a different order every run.
+func sortedIDs(rendered map[string]string) []string {
+	ids := make([]string, 0, len(rendered))
+	for id := range rendered {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}

--- a/internal/agents/skillpack/sync_test.go
+++ b/internal/agents/skillpack/sync_test.go
@@ -1,0 +1,445 @@
+// sync_test.go stays in the external test package for the same reason
+// skillpack_test.go does: skillpack must never depend on an adapter, and
+// keeping the tests outside the package means an adapter that imports
+// skillpack can still be imported here without closing a cycle.
+package skillpack_test
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/skillpack"
+)
+
+const skillFile = "SKILL.md"
+
+// threeSkills is the rendered pack the table below reconciles: small
+// enough to assert on exhaustively, big enough that a subset is a real
+// subset.
+func threeSkills() map[string]string {
+	return map[string]string{
+		"gortex-explore": "---\nname: gortex-explore\n---\nexplore\n",
+		"gortex-guide":   "---\nname: gortex-guide\n---\nguide\n",
+		"gortex-debug":   "---\nname: gortex-debug\n---\ndebug\n",
+	}
+}
+
+func specFor(dir string, rendered map[string]string) skillpack.SyncSpec {
+	return skillpack.SyncSpec{Dir: dir, FileName: skillFile, Rendered: rendered}
+}
+
+// seedSkill materialises one skill on disk and returns its path.
+func seedSkill(t *testing.T, dir, id, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, id, skillFile)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+// installedIDs lists the skill directories that still hold a SKILL.md.
+// Directory presence alone is not the question a profile switch asks —
+// the skill is what the host loads.
+func installedIDs(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("read dir %s: %v", dir, err)
+	}
+	var out []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(dir, e.Name(), skillFile)); err == nil {
+			out = append(out, e.Name())
+		}
+	}
+	return out
+}
+
+// actionsByID keys a Sync result by the skill directory name, which is
+// the only stable identity across hosts with different roots.
+func actionsByID(actions []agents.FileAction) map[string]agents.FileAction {
+	out := make(map[string]agents.FileAction, len(actions))
+	for _, a := range actions {
+		out[filepath.Base(filepath.Dir(a.Path))] = a
+	}
+	return out
+}
+
+func readFileString(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+// TestSyncReconciliation is the table for the whole decision matrix.
+// Each case seeds a tree, runs one Sync, and asserts both the reported
+// action and what is left on disk — a reconciler that reports the right
+// action while leaving the wrong bytes is the failure mode that matters.
+func TestSyncReconciliation(t *testing.T) {
+	rendered := threeSkills()
+	const customised = "---\nname: gortex-guide\n---\nMY OWN STEPS\n"
+
+	for _, tc := range []struct {
+		name string
+		// seed runs before Sync and returns nothing; the tree it builds
+		// is the precondition under test.
+		seed       func(t *testing.T, dir string)
+		allowed    []string
+		opts       agents.ApplyOpts
+		wantAction map[string]agents.ActionKind
+		wantOnDisk []string
+		// wantBytes pins files whose content must survive verbatim.
+		wantBytes map[string]string
+	}{
+		{
+			name:    "install when missing",
+			seed:    func(*testing.T, string) {},
+			allowed: nil,
+			wantAction: map[string]agents.ActionKind{
+				"gortex-explore": agents.ActionCreate,
+				"gortex-guide":   agents.ActionCreate,
+				"gortex-debug":   agents.ActionCreate,
+			},
+			wantOnDisk: []string{"gortex-debug", "gortex-explore", "gortex-guide"},
+		},
+		{
+			name: "skip when identical",
+			seed: func(t *testing.T, dir string) {
+				for id, body := range rendered {
+					seedSkill(t, dir, id, body)
+				}
+			},
+			allowed: nil,
+			wantAction: map[string]agents.ActionKind{
+				"gortex-explore": agents.ActionSkip,
+				"gortex-guide":   agents.ActionSkip,
+				"gortex-debug":   agents.ActionSkip,
+			},
+			wantOnDisk: []string{"gortex-debug", "gortex-explore", "gortex-guide"},
+		},
+		{
+			name: "delete when outside profile and pristine",
+			seed: func(t *testing.T, dir string) {
+				for id, body := range rendered {
+					seedSkill(t, dir, id, body)
+				}
+			},
+			allowed: []string{"gortex-explore"},
+			wantAction: map[string]agents.ActionKind{
+				"gortex-explore": agents.ActionSkip,
+				"gortex-guide":   agents.ActionDelete,
+				"gortex-debug":   agents.ActionDelete,
+			},
+			wantOnDisk: []string{"gortex-explore"},
+		},
+		{
+			// The load-bearing case: enforcing a profile is worth
+			// deleting files Gortex wrote, never a playbook the user
+			// rewrote.
+			name: "keep when outside profile and customised",
+			seed: func(t *testing.T, dir string) {
+				for id, body := range rendered {
+					seedSkill(t, dir, id, body)
+				}
+				seedSkill(t, dir, "gortex-guide", customised)
+			},
+			allowed: []string{"gortex-explore"},
+			wantAction: map[string]agents.ActionKind{
+				"gortex-explore": agents.ActionSkip,
+				"gortex-guide":   agents.ActionSkip,
+				"gortex-debug":   agents.ActionDelete,
+			},
+			wantOnDisk: []string{"gortex-explore", "gortex-guide"},
+			wantBytes:  map[string]string{"gortex-guide": customised},
+		},
+		{
+			name: "keep customised inside profile",
+			seed: func(t *testing.T, dir string) {
+				seedSkill(t, dir, "gortex-guide", customised)
+			},
+			allowed: nil,
+			wantAction: map[string]agents.ActionKind{
+				"gortex-explore": agents.ActionCreate,
+				"gortex-guide":   agents.ActionSkip,
+				"gortex-debug":   agents.ActionCreate,
+			},
+			wantOnDisk: []string{"gortex-debug", "gortex-explore", "gortex-guide"},
+			wantBytes:  map[string]string{"gortex-guide": customised},
+		},
+		{
+			// A skill that was never installed cannot be pruned, and the
+			// attempt must not create the directory it is refusing to
+			// keep.
+			name:    "outside profile and never installed",
+			seed:    func(*testing.T, string) {},
+			allowed: []string{"gortex-explore"},
+			wantAction: map[string]agents.ActionKind{
+				"gortex-explore": agents.ActionCreate,
+				"gortex-guide":   agents.ActionSkip,
+				"gortex-debug":   agents.ActionSkip,
+			},
+			wantOnDisk: []string{"gortex-explore"},
+		},
+		{
+			name:    "dry run plans an install without writing",
+			seed:    func(*testing.T, string) {},
+			allowed: nil,
+			opts:    agents.ApplyOpts{DryRun: true},
+			wantAction: map[string]agents.ActionKind{
+				"gortex-explore": agents.ActionWouldCreate,
+				"gortex-guide":   agents.ActionWouldCreate,
+				"gortex-debug":   agents.ActionWouldCreate,
+			},
+			wantOnDisk: nil,
+		},
+		{
+			name: "dry run plans a prune without deleting",
+			seed: func(t *testing.T, dir string) {
+				for id, body := range rendered {
+					seedSkill(t, dir, id, body)
+				}
+			},
+			allowed: []string{"gortex-explore"},
+			opts:    agents.ApplyOpts{DryRun: true},
+			wantAction: map[string]agents.ActionKind{
+				"gortex-explore": agents.ActionSkip,
+				"gortex-guide":   agents.ActionWouldDelete,
+				"gortex-debug":   agents.ActionWouldDelete,
+			},
+			wantOnDisk: []string{"gortex-debug", "gortex-explore", "gortex-guide"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := filepath.Join(t.TempDir(), "skills")
+			tc.seed(t, dir)
+
+			var log strings.Builder
+			actions, err := skillpack.Sync(&log, specFor(dir, rendered), tc.allowed, tc.opts)
+			if err != nil {
+				t.Fatalf("Sync: %v", err)
+			}
+			if len(actions) != len(rendered) {
+				t.Fatalf("Sync reported %d actions, want one per shipped skill (%d)", len(actions), len(rendered))
+			}
+
+			got := actionsByID(actions)
+			for id, want := range tc.wantAction {
+				if got[id].Action != want {
+					t.Errorf("%s: action = %q (reason %q), want %q", id, got[id].Action, got[id].Reason, want)
+				}
+			}
+
+			onDisk := installedIDs(t, dir)
+			if strings.Join(onDisk, ",") != strings.Join(tc.wantOnDisk, ",") {
+				t.Errorf("installed = %v, want %v", onDisk, tc.wantOnDisk)
+			}
+			for id, want := range tc.wantBytes {
+				if got := readFileString(t, filepath.Join(dir, id, skillFile)); got != want {
+					t.Errorf("%s bytes changed:\n%s", id, got)
+				}
+			}
+		})
+	}
+}
+
+// TestSyncActionsAreIDOrdered pins the ordering the install report, the
+// plan and every golden test depend on. Go randomises map iteration, so
+// without an explicit sort this passes on most runs and fails on some.
+func TestSyncActionsAreIDOrdered(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "skills")
+	actions, err := skillpack.Sync(nil, specFor(dir, threeSkills()), nil, agents.ApplyOpts{})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	want := []string{"gortex-debug", "gortex-explore", "gortex-guide"}
+	for i, a := range actions {
+		if got := filepath.Base(filepath.Dir(a.Path)); got != want[i] {
+			t.Fatalf("action %d = %s, want %s (actions must be ID-sorted)", i, got, want[i])
+		}
+	}
+}
+
+// TestSyncIsIdempotent: `gortex install` re-runs after every upgrade and
+// `instructions switch` is re-runnable by hand, so a second pass must
+// report nothing but skips and touch no file.
+func TestSyncIsIdempotent(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "skills")
+	rendered := threeSkills()
+	allowed := []string{"gortex-explore"}
+
+	if _, err := skillpack.Sync(nil, specFor(dir, rendered), allowed, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("first Sync: %v", err)
+	}
+	before := installedIDs(t, dir)
+
+	actions, err := skillpack.Sync(nil, specFor(dir, rendered), allowed, agents.ApplyOpts{})
+	if err != nil {
+		t.Fatalf("second Sync: %v", err)
+	}
+	for _, a := range actions {
+		if a.Action != agents.ActionSkip {
+			t.Errorf("re-run reported %s for %s, want skip", a.Action, a.Path)
+		}
+	}
+	if after := installedIDs(t, dir); strings.Join(after, ",") != strings.Join(before, ",") {
+		t.Errorf("re-run changed the tree: %v -> %v", before, after)
+	}
+}
+
+// TestSyncCustomisedFileSurvivesEveryPass is the guard against the worst
+// outcome this code can produce: silently eating a user's work over
+// repeated upgrades. One pass keeping the file is not enough — the bug
+// class is a reconciler that keeps it once and prunes it on the next run
+// because it now compares against different bytes.
+func TestSyncCustomisedFileSurvivesEveryPass(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "skills")
+	rendered := threeSkills()
+	const mine = "---\nname: gortex-debug\n---\nmine, hands off\n"
+	path := seedSkill(t, dir, "gortex-debug", mine)
+
+	for pass := range 3 {
+		if _, err := skillpack.Sync(nil, specFor(dir, rendered), []string{"gortex-explore"}, agents.ApplyOpts{}); err != nil {
+			t.Fatalf("pass %d: %v", pass, err)
+		}
+		if got := readFileString(t, path); got != mine {
+			t.Fatalf("pass %d rewrote a customised skill:\n%s", pass, got)
+		}
+	}
+}
+
+// TestSyncWarnsWhenKeepingCustomisedSkill: the file surviving is only
+// half the contract. A user who asked for a three-skill profile and got
+// four needs to be told which one refused to go and why.
+func TestSyncWarnsWhenKeepingCustomisedSkill(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "skills")
+	rendered := threeSkills()
+	seedSkill(t, dir, "gortex-guide", "mine\n")
+
+	var log strings.Builder
+	if _, err := skillpack.Sync(&log, specFor(dir, rendered), []string{"gortex-explore"}, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if !strings.Contains(log.String(), "gortex-guide") || !strings.Contains(log.String(), "customised") {
+		t.Fatalf("expected a warning naming the kept skill, got:\n%s", log.String())
+	}
+}
+
+// TestSyncKnownHashesTreatAnOldBodyAsOurs covers the migration seam: a
+// SKILL.md left over from an earlier release differs from what this
+// build renders, but it is still Gortex's file — refreshable in profile,
+// prunable out of it. Without this, every upgrade would classify the
+// whole pack as "customised" and freeze it forever.
+func TestSyncKnownHashesTreatAnOldBodyAsOurs(t *testing.T) {
+	rendered := threeSkills()
+	const oldBody = "---\nname: gortex-guide\n---\nthe v1 wording\n"
+	oldHash := fmt.Sprintf("%x", sha256.Sum256([]byte(oldBody)))
+
+	spec := func(dir string) skillpack.SyncSpec {
+		s := specFor(dir, rendered)
+		s.KnownHashes = map[string]string{"gortex-guide": oldHash}
+		return s
+	}
+
+	t.Run("in profile: refreshed", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "skills")
+		path := seedSkill(t, dir, "gortex-guide", oldBody)
+		if _, err := skillpack.Sync(nil, spec(dir), nil, agents.ApplyOpts{}); err != nil {
+			t.Fatalf("Sync: %v", err)
+		}
+		if got := readFileString(t, path); got != rendered["gortex-guide"] {
+			t.Fatalf("a previous release's body was not refreshed:\n%s", got)
+		}
+	})
+
+	t.Run("outside profile: pruned", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "skills")
+		seedSkill(t, dir, "gortex-guide", oldBody)
+		if _, err := skillpack.Sync(nil, spec(dir), []string{"gortex-explore"}, agents.ApplyOpts{}); err != nil {
+			t.Fatalf("Sync: %v", err)
+		}
+		if installed := installedIDs(t, dir); len(installed) != 1 || installed[0] != "gortex-explore" {
+			t.Fatalf("installed = %v, want [gortex-explore]", installed)
+		}
+	})
+}
+
+// TestSyncEmptyAllowedRemovesEverything separates "nil = no filtering"
+// from "empty = keep none". They are one typo apart at every call site,
+// and confusing them either wipes a pack or ignores a profile.
+func TestSyncEmptyAllowedRemovesEverything(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "skills")
+	rendered := threeSkills()
+	for id, body := range rendered {
+		seedSkill(t, dir, id, body)
+	}
+	if _, err := skillpack.Sync(nil, specFor(dir, rendered), []string{}, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if installed := installedIDs(t, dir); len(installed) != 0 {
+		t.Fatalf("installed = %v, want none", installed)
+	}
+}
+
+// TestSyncPruneRemovesTheWholeSkillDirectory: a skill directory may hold
+// reference files beside its SKILL.md, and leaving those behind would
+// keep the host advertising a half-deleted skill.
+func TestSyncPruneRemovesTheWholeSkillDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "skills")
+	rendered := threeSkills()
+	seedSkill(t, dir, "gortex-guide", rendered["gortex-guide"])
+	extra := filepath.Join(dir, "gortex-guide", "reference.md")
+	if err := os.WriteFile(extra, []byte("aux\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := skillpack.Sync(nil, specFor(dir, rendered), []string{"gortex-explore"}, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "gortex-guide")); !os.IsNotExist(err) {
+		t.Fatalf("skill directory survived the prune (stat err = %v)", err)
+	}
+}
+
+// TestSyncWithoutADirIsANoOp: a host with no resolvable home is simply
+// not installed, and a profile switch must not turn that into an error.
+func TestSyncWithoutADirIsANoOp(t *testing.T) {
+	actions, err := skillpack.Sync(nil, skillpack.SyncSpec{Rendered: threeSkills()}, nil, agents.ApplyOpts{})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if len(actions) != 0 {
+		t.Fatalf("actions = %v, want none", actions)
+	}
+}
+
+// TestSyncDefaultsToSkillMd: FileName is a field so a future host can
+// rename the file, but every host today ships the Agent Skills spelling
+// and should not have to say so.
+func TestSyncDefaultsToSkillMd(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "skills")
+	spec := skillpack.SyncSpec{Dir: dir, Rendered: threeSkills()}
+	if _, err := skillpack.Sync(nil, spec, nil, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "gortex-explore", skillFile)); err != nil {
+		t.Fatalf("default file name is not %s: %v", skillFile, err)
+	}
+}

--- a/internal/audit/discover.go
+++ b/internal/audit/discover.go
@@ -18,10 +18,24 @@ func DefaultConfigPaths() []string {
 		".cursorrules",
 		".cursor/rules",
 		".github/copilot-instructions.md",
+		// Path-scoped Copilot instructions. The CLI reads every
+		// *.instructions.md under here in addition to the single
+		// copilot-instructions.md above, so auditing only the latter
+		// misses whatever a repo scoped to its TypeScript or Go files.
+		".github/instructions",
 		".windsurfrules",
 		".windsurf/rules",
 		".antigravity/rules",
 		".aider.conf.yml",
+		// Skill trees. These carry the same stale symbol refs and dead
+		// paths as a rules file, and Gortex now writes into them, so a
+		// drift audit that skips them under-reports its own output.
+		// `.agents/skills` is the cross-agent location Codex and
+		// OpenCode both read.
+		".agents/skills",
+		".opencode/skills",
+		".opencode/commands",
+		".github/skills",
 	}
 }
 

--- a/internal/hooks/copilot.go
+++ b/internal/hooks/copilot.go
@@ -1,0 +1,424 @@
+package hooks
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+)
+
+// copilot.go is the GitHub Copilot CLI hook wire protocol (@github/copilot
+// v1.0.80, docs.github.com/en/copilot/reference/hooks-reference). Copilot is
+// close enough to Claude Code to tempt a copy of the Claude handlers and
+// different enough that the copy would be silently wrong in three ways:
+//
+//   - The stdout response shape is per-event and FLAT. There is no
+//     hookSpecificOutput envelope: preToolUse answers with
+//     {"permissionDecision","permissionDecisionReason","modifiedArgs"},
+//     postToolUse with {"modifiedResult","additionalContext"},
+//     userPromptSubmitted with {"modifiedPrompt"} — and nothing else.
+//     Emitting Claude's envelope parses as an unknown object, so the hook
+//     would look healthy and deliver nothing.
+//   - Its built-in tool names are lowercase and its own vocabulary
+//     (view / bash / powershell / create / rg …), so the shared enrichment
+//     leaves — which switch on Claude's Read / Grep / Bash names — see
+//     nothing to classify until the names are mapped (copilotToolNames).
+//   - Its 14 lifecycle events are camelCase (PascalCase is also accepted
+//     since v1.0.6, so both spellings are accepted on input), which the
+//     hook-effectiveness allowlist does not know about
+//     (copilotTelemetryEvents).
+//
+// Exit-code contract: exit 0 means "parse stdout"; exit 2 denies with the
+// reason taken from stderr, and on preToolUse exit 2 is fail-closed — it
+// overrides an "allow" in stdout. Gortex never takes that door: the
+// documented stdout deny carries the same refusal plus the graph-tool
+// redirect as structured text the model is shown, whereas a stderr reason
+// is unstructured and an exit-2 fail-closed path turns any future bug in
+// this handler into a blocked agent. Timeouts fail open, which is the same
+// posture every other Gortex adapter takes on a malformed payload.
+const (
+	copilotEventSessionStart = "sessionStart"
+	copilotEventUserPrompt   = "userPromptSubmitted"
+	copilotEventPreToolUse   = "preToolUse"
+	copilotEventPostToolUse  = "postToolUse"
+	copilotEventAgentStop    = "agentStop"
+)
+
+// copilotToolNames maps Copilot's built-in tool vocabulary onto the Claude
+// names the shared enrichment leaves switch on. Every entry is load-bearing,
+// but `powershell` is the one whose absence would be invisible: it is the
+// shell tool on Windows, so omitting it leaves the entire Windows shell
+// surface — every cat / grep / find / sed the policy exists to redirect —
+// unenforced on a machine whose hook log looks perfectly healthy.
+//
+// Names outside this table (ask_user, web_fetch, web_search, update_todo)
+// pass through unchanged and fall out of enrich's switch as a no-op.
+var copilotToolNames = map[string]string{
+	"view":       "Read",
+	"grep":       "Grep",
+	"rg":         "Grep",
+	"glob":       "Glob",
+	"bash":       "Bash",
+	"powershell": "Bash",
+	"create":     "Write",
+	"edit":       "Edit",
+	"task":       "Task",
+}
+
+// copilotTelemetryEvents maps Copilot's event names onto the Claude
+// vocabulary before anything is logged. hookEffectivenessEvents is a
+// hardcoded allowlist of Claude's PascalCase names and
+// logHookEffectivenessReachability drops everything else, so a camelCase
+// "preToolUse" would be written nowhere — and `gortex doctor` would report
+// "configured but never ran" forever against a Copilot install that is
+// working perfectly. Normalising here (rather than widening the allowlist
+// with camelCase duplicates) also keeps one event's records in one bucket,
+// so Copilot and Claude sessions aggregate instead of splitting.
+var copilotTelemetryEvents = map[string]string{
+	copilotEventSessionStart: "SessionStart",
+	copilotEventUserPrompt:   "UserPromptSubmit",
+	copilotEventPreToolUse:   "PreToolUse",
+	copilotEventPostToolUse:  "PostToolUse",
+}
+
+// copilotInput decodes the Copilot hook payload. Copilot's documented keys
+// are camelCase (sessionId / toolName / toolArgs); the snake_case twins are
+// accepted alongside them because a Copilot hook is routinely configured by
+// copying a Claude Code hook entry, and a key mismatch would degrade the
+// whole integration to a silent no-op rather than to an error anyone sees.
+type copilotInput struct {
+	HookEventName      string `json:"hookEventName"`
+	HookEventNameSnake string `json:"hook_event_name"`
+	EventName          string `json:"event"`
+
+	SessionID      string `json:"sessionId"`
+	SessionIDSnake string `json:"session_id"`
+	CWD            string `json:"cwd"`
+
+	ToolName      string         `json:"toolName"`
+	ToolNameSnake string         `json:"tool_name"`
+	ToolArgs      map[string]any `json:"toolArgs"`
+	ToolInput     map[string]any `json:"tool_input"`
+
+	ToolResult   any `json:"toolResult"`
+	ToolResponse any `json:"tool_response"`
+
+	Prompt string `json:"prompt"`
+}
+
+func (in copilotInput) eventName() string {
+	return firstNonEmpty(in.HookEventName, in.HookEventNameSnake, in.EventName)
+}
+
+func (in copilotInput) sessionID() string {
+	return firstNonEmpty(in.SessionID, in.SessionIDSnake)
+}
+
+func (in copilotInput) toolName() string {
+	return firstNonEmpty(in.ToolName, in.ToolNameSnake)
+}
+
+func (in copilotInput) toolArgs() map[string]any {
+	if len(in.ToolArgs) > 0 {
+		return in.ToolArgs
+	}
+	return in.ToolInput
+}
+
+func (in copilotInput) toolResult() any {
+	if in.ToolResult != nil {
+		return in.ToolResult
+	}
+	return in.ToolResponse
+}
+
+// copilotPreToolUseResponse is Copilot's flat preToolUse answer. modifiedArgs
+// is declared for shape completeness; Gortex does not rewrite Copilot tool
+// arguments (the Codex rewrite posture is opt-in and Codex-specific).
+type copilotPreToolUseResponse struct {
+	PermissionDecision       string         `json:"permissionDecision,omitempty"`
+	PermissionDecisionReason string         `json:"permissionDecisionReason,omitempty"`
+	ModifiedArgs             map[string]any `json:"modifiedArgs,omitempty"`
+}
+
+// copilotPostToolUseResponse is Copilot's flat postToolUse answer. Only
+// additionalContext is used — replacing a tool's result would change what the
+// agent believes it ran.
+type copilotPostToolUseResponse struct {
+	ModifiedResult    any    `json:"modifiedResult,omitempty"`
+	AdditionalContext string `json:"additionalContext,omitempty"`
+}
+
+// copilotPromptResponse is the whole userPromptSubmitted channel. Copilot has
+// no additionalContext on this event, so graph context has to be carried
+// inside the prompt itself.
+type copilotPromptResponse struct {
+	ModifiedPrompt string `json:"modifiedPrompt"`
+}
+
+// copilotSessionStartResponse is the sessionStart channel.
+type copilotSessionStartResponse struct {
+	AdditionalContext string `json:"additionalContext"`
+}
+
+// RunCopilot reads one Copilot hook payload from stdin, answers on stdout,
+// and exits 0. Any read failure is a silent no-op — a hook must never break
+// the host agent's flow.
+func RunCopilot(port int, mode Mode) {
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return
+	}
+	out, code := handleCopilot(data, port, mode)
+	if out != "" {
+		fmt.Print(out)
+	}
+	if code != 0 {
+		os.Exit(code)
+	}
+}
+
+// handleCopilot is the testable core: parse the payload, route the event,
+// return the stdout body and the process exit code.
+//
+// Only the five events Gortex actually produces a payload for are
+// implemented — session-open, per-turn prompt, pre-tool decision, post-tool
+// enrichment, and turn-end. The other nine (userPromptTransformed,
+// postToolUseFailure, preCompact, subagentStart / subagentStop,
+// errorOccurred, permissionRequest, notification, sessionEnd) map to nothing
+// Gortex emits, so handling them would buy no capability and cost one
+// subprocess spawn per event; they fall through to empty stdout at exit 0.
+func handleCopilot(data []byte, port int, mode Mode) (string, int) {
+	var in copilotInput
+	if err := json.Unmarshal(data, &in); err != nil {
+		// Fail open: a payload we cannot parse is not a reason to stop a turn.
+		return "", 0
+	}
+
+	event := normalizeCopilotEvent(in.eventName())
+	if event == "" {
+		return "", 0
+	}
+
+	// Record the workspace for callServerTool's daemon-socket fallback, the
+	// same way the Codex and Kimi dispatchers do. Cleared on return so it
+	// never leaks across the sequential tests that share one process.
+	setHookCWD(in.CWD)
+	defer setHookCWD("")
+
+	switch event {
+	case copilotEventSessionStart:
+		return copilotSessionStart(in)
+	case copilotEventUserPrompt:
+		return copilotUserPrompt(in)
+	case copilotEventPreToolUse:
+		return copilotPreToolUse(in, port, mode)
+	case copilotEventPostToolUse:
+		return copilotPostToolUse(in)
+	case copilotEventAgentStop:
+		// Turn-end stop line. Copilot's agentStop answers only
+		// {"decision","reason"} — there is no context channel on it at all,
+		// so the post-task briefing (test targets, guards, dead code,
+		// coverage, contracts) has nowhere to land. Building it anyway would
+		// spend a fan-out of daemon round-trips per turn and then discard
+		// every byte, and "decision" is a stop-blocker, not a delivery
+		// vehicle: using it would turn a diagnostics briefing into a refusal
+		// to end the turn. So Copilot deliberately has no turn-end briefing.
+		return "", 0
+	default:
+		return "", 0
+	}
+}
+
+// normalizeCopilotEvent folds a Copilot event name to its canonical camelCase
+// spelling, or "" when the event is one of the nine Gortex does not answer.
+// The fold is case-insensitive because Copilot has accepted PascalCase event
+// names alongside camelCase since v1.0.6, so a real config carries either.
+func normalizeCopilotEvent(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "sessionstart":
+		return copilotEventSessionStart
+	case "userpromptsubmitted":
+		return copilotEventUserPrompt
+	case "pretooluse":
+		return copilotEventPreToolUse
+	case "posttooluse":
+		return copilotEventPostToolUse
+	case "agentstop":
+		return copilotEventAgentStop
+	default:
+		return ""
+	}
+}
+
+// copilotToolName maps one Copilot tool name into the Claude vocabulary,
+// leaving anything unrecognised untouched.
+func copilotToolName(name string) string {
+	if mapped, ok := copilotToolNames[strings.ToLower(strings.TrimSpace(name))]; ok {
+		return mapped
+	}
+	return strings.TrimSpace(name)
+}
+
+// copilotSessionStart injects the session orientation. It deliberately runs
+// even while the daemon is unreachable: buildSessionStartBriefing answers an
+// outage with the degraded "transport unreachable, rule-only enforcement"
+// block, which is the one message a session actually needs at that moment —
+// the same posture Claude's runSessionStart and the Pi bridge take.
+func copilotSessionStart(in copilotInput) (string, int) {
+	started := time.Now()
+	ctx := buildSessionStartBriefing(in.CWD)
+	logHookEffectiveness(copilotTelemetryEvents[copilotEventSessionStart],
+		ctx != "", daemonReachableFn(), 0, time.Since(started))
+	if ctx == "" {
+		return "", 0
+	}
+	return marshalCopilot(copilotSessionStartResponse{AdditionalContext: ctx}), 0
+}
+
+// copilotUserPrompt lowers the per-turn graph context into modifiedPrompt.
+//
+// This is the single most bug-prone lowering in the file: Copilot's
+// userPromptSubmitted answer has NO additionalContext field, so reusing
+// Claude's lowering compiles, emits well-formed JSON, passes a naive shape
+// assertion — and discards every byte of prompt-time context. The only
+// channel is the prompt itself, so the injected block is appended to the
+// user's own text and the whole thing is handed back.
+func copilotUserPrompt(in copilotInput) (string, int) {
+	started := time.Now()
+	daemonUp := daemonReachableFn()
+	out := ""
+	if daemonUp {
+		if ctx := buildUserPromptSubmitContext("UserPromptSubmit", in.Prompt); ctx != "" {
+			out = marshalCopilot(copilotPromptResponse{ModifiedPrompt: in.Prompt + "\n\n" + ctx})
+		}
+	}
+	logHookEffectiveness(copilotTelemetryEvents[copilotEventUserPrompt],
+		out != "", daemonUp, 0, time.Since(started))
+	return out, 0
+}
+
+// copilotPreToolUse runs the shared enrich + applyMode pipeline and lowers a
+// deny into Copilot's flat permissionDecision shape.
+//
+// Soft guidance has no channel on this event: preToolUse answers only with a
+// permission decision, its reason, and modifiedArgs. Riding advisory text on
+// permissionDecision "allow" would auto-approve a call the user's own
+// permission settings had not, and "ask" would put a confirmation prompt in
+// front of every advisory — so an advisory result is dropped here and the
+// equivalent guidance lands on postToolUse instead, where Copilot does have
+// an additionalContext channel.
+func copilotPreToolUse(in copilotInput, port int, mode Mode) (string, int) {
+	started := time.Now()
+	daemonUp := daemonReachableFn()
+
+	rawTool := in.toolName()
+	mappedTool := copilotToolName(rawTool)
+	input := HookInput{
+		HookEventName: "PreToolUse",
+		ToolName:      mappedTool,
+		ToolInput:     copilotToolInput(mappedTool, in.toolArgs()),
+		CWD:           in.CWD,
+		SessionID:     in.sessionID(),
+	}
+
+	out := ""
+	isGortexTool := isGortexMCPToolName(rawTool)
+	if isGortexTool && mode == ModeConsultUnlock {
+		// The consult-unlock marker is local state, so it is recorded even
+		// during an outage — exactly as the Pi bridge does.
+		markGraphConsulted(input.SessionID)
+	}
+	// Daemon outage: stand down (#486). Every deny this pipeline can produce
+	// mandates Gortex MCP tools; while the daemon cannot serve them, blocking
+	// a call and pointing at them deadlocks the agent.
+	if daemonUp {
+		if result := applyMode(input, isGortexTool, mode, enrich(input, port)); result.deny {
+			out = marshalCopilot(copilotPreToolUseResponse{
+				PermissionDecision:       "deny",
+				PermissionDecisionReason: result.reason,
+			})
+		}
+	}
+
+	logHookEffectiveness(copilotTelemetryEvents[copilotEventPreToolUse],
+		out != "", daemonUp, hookAlternationSegmentCount(input), time.Since(started))
+	return out, 0
+}
+
+// copilotPostToolUse appends graph context to a completed search / read, on
+// the one event where Copilot does carry an additionalContext channel.
+func copilotPostToolUse(in copilotInput) (string, int) {
+	started := time.Now()
+	daemonUp := daemonReachableFn()
+
+	out := ""
+	// Same stand-down as runPostToolUse's own gate (#486): the follow-ups
+	// need daemon answers and instruct "do not re-Read / re-Grep", which must
+	// not land while the daemon cannot serve the tools they point at.
+	if daemonUp {
+		mappedTool := copilotToolName(in.toolName())
+		ctx := postToolContext(postHookInput{
+			HookEventName: "PostToolUse",
+			ToolName:      mappedTool,
+			ToolInput:     copilotToolInput(mappedTool, in.toolArgs()),
+			ToolResponse:  in.toolResult(),
+			CWD:           in.CWD,
+			SessionID:     in.sessionID(),
+		})
+		if ctx != "" {
+			out = marshalCopilot(copilotPostToolUseResponse{AdditionalContext: ctx})
+		}
+	}
+
+	logHookEffectiveness(copilotTelemetryEvents[copilotEventPostToolUse],
+		out != "", daemonUp, 0, time.Since(started))
+	return out, 0
+}
+
+// copilotToolInput fills in the argument keys the shared enrichment leaves
+// switch on (file_path / pattern / command) when Copilot's own tool spelled
+// them differently. It is additive alias tolerance, not a rewrite: an
+// existing canonical key always wins, nothing is removed, and an argument
+// shape none of the aliases match simply yields no enrichment (fail open).
+func copilotToolInput(mappedTool string, args map[string]any) map[string]any {
+	if len(args) == 0 {
+		return args
+	}
+	out := cloneStringAnyMap(args)
+	switch mappedTool {
+	case "Read", "Write", "Edit":
+		copilotAliasKey(out, "file_path", "path", "filePath", "file")
+	case "Grep":
+		copilotAliasKey(out, "pattern", "query", "regex", "search")
+	case "Glob":
+		copilotAliasKey(out, "pattern", "glob", "query")
+	case "Bash":
+		copilotAliasKey(out, "command", "cmd", "script")
+	}
+	return out
+}
+
+func copilotAliasKey(args map[string]any, canonical string, aliases ...string) {
+	if value, ok := args[canonical].(string); ok && strings.TrimSpace(value) != "" {
+		return
+	}
+	for _, alias := range aliases {
+		if value, ok := args[alias].(string); ok && strings.TrimSpace(value) != "" {
+			args[canonical] = value
+			return
+		}
+	}
+}
+
+// marshalCopilot renders a per-event response. A marshal failure degrades to
+// empty stdout, which Copilot reads as "the hook had nothing to say".
+func marshalCopilot(response any) string {
+	out, err := json.Marshal(response)
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}

--- a/internal/hooks/copilot_test.go
+++ b/internal/hooks/copilot_test.go
@@ -1,0 +1,364 @@
+package hooks
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/zzet/gortex/internal/daemon"
+)
+
+func copilotPayload(t *testing.T, fields map[string]any) []byte {
+	t.Helper()
+	data, err := json.Marshal(fields)
+	if err != nil {
+		t.Fatalf("marshal copilot payload: %v", err)
+	}
+	return data
+}
+
+// stubPromptProbe feeds the per-turn prompt injection canned hits so the
+// prompt lowering can be asserted without a daemon.
+func stubPromptProbe(t *testing.T, hits []grepSymbolHit) {
+	t.Helper()
+	prev := userPromptProbe
+	userPromptProbe = func(string, time.Duration) ([]grepSymbolHit, error) { return hits, nil }
+	t.Cleanup(func() { userPromptProbe = prev })
+}
+
+// (d) Every Copilot built-in that maps onto a policy tool must be translated
+// before classification. `powershell` is the row that matters most: it is the
+// shell tool on Windows, so a missing entry silently unenforces the whole
+// Windows shell surface.
+func TestCopilotToolNameNormalisation(t *testing.T) {
+	cases := map[string]string{
+		"view":       "Read",
+		"grep":       "Grep",
+		"rg":         "Grep",
+		"glob":       "Glob",
+		"bash":       "Bash",
+		"powershell": "Bash",
+		"create":     "Write",
+		"edit":       "Edit",
+		"task":       "Task",
+		// Unmapped Copilot built-ins pass through and fall out of enrich's
+		// switch as a no-op rather than being misclassified.
+		"web_fetch":   "web_fetch",
+		"ask_user":    "ask_user",
+		"update_todo": "update_todo",
+	}
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			if got := copilotToolName(input); got != want {
+				t.Fatalf("copilotToolName(%q)=%q want %q", input, got, want)
+			}
+		})
+	}
+}
+
+// (d, end to end) A PowerShell command that reads indexed source must reach
+// the same deny a Bash command does — proof the table entry is actually wired
+// into the classification path, not just present in the map.
+func TestHandleCopilotPowerShellReadOfIndexedSourceDenies(t *testing.T) {
+	withDaemonReachable(t, true)
+	stubIndexedFile(t, true, 7)
+
+	out, code := handleCopilot(copilotPayload(t, map[string]any{
+		"hookEventName": "preToolUse",
+		"cwd":           "/repo",
+		"toolName":      "powershell",
+		"toolArgs":      map[string]any{"command": "cat internal/auth/token.go"},
+	}), 0, ModeDeny)
+
+	if code != 0 {
+		t.Fatalf("exit code=%d want 0", code)
+	}
+	decision := decodeCopilotPreToolUse(t, out)
+	if decision.PermissionDecision != "deny" {
+		t.Fatalf("powershell read of indexed source was not denied: %s", out)
+	}
+	if !strings.Contains(decision.PermissionDecisionReason, "reads indexed source") {
+		t.Fatalf("deny reason lost the shell-read redirect: %q", decision.PermissionDecisionReason)
+	}
+}
+
+// (b) A deny must arrive in Copilot's flat per-event shape and name the
+// Gortex tool that replaces the refused call.
+func TestHandleCopilotPreToolUseDeniesIndexedRead(t *testing.T) {
+	withDaemonReachable(t, true)
+	stubIndexedFile(t, true, 7)
+
+	// `view` carries its target as `path`; the Claude leaves switch on
+	// `file_path`, so the alias fill-in is exercised here too.
+	out, code := handleCopilot(copilotPayload(t, map[string]any{
+		"hookEventName": "preToolUse",
+		"sessionId":     "sess-copilot",
+		"cwd":           "/repo",
+		"toolName":      "view",
+		"toolArgs":      map[string]any{"path": "internal/auth/token.go"},
+	}), 0, ModeDeny)
+
+	if code != 0 {
+		t.Fatalf("exit code=%d want 0", code)
+	}
+	if strings.Contains(out, "hookSpecificOutput") {
+		t.Fatalf("Copilot answers flat, never in Claude's envelope: %s", out)
+	}
+	decision := decodeCopilotPreToolUse(t, out)
+	if decision.PermissionDecision != "deny" {
+		t.Fatalf("indexed Read was not denied: %s", out)
+	}
+	for _, want := range []string{"7 symbols indexed", `read(target:{symbol:`} {
+		if !strings.Contains(decision.PermissionDecisionReason, want) {
+			t.Fatalf("deny reason missing %q: %q", want, decision.PermissionDecisionReason)
+		}
+	}
+}
+
+// Copilot has accepted PascalCase event names alongside camelCase since
+// v1.0.6, so a real config carries either spelling.
+func TestHandleCopilotAcceptsPascalCaseEventNames(t *testing.T) {
+	withDaemonReachable(t, true)
+	stubIndexedFile(t, true, 3)
+
+	out, _ := handleCopilot(copilotPayload(t, map[string]any{
+		"hookEventName": "PreToolUse",
+		"cwd":           "/repo",
+		"toolName":      "view",
+		"toolArgs":      map[string]any{"path": "internal/auth/token.go"},
+	}), 0, ModeDeny)
+
+	if decodeCopilotPreToolUse(t, out).PermissionDecision != "deny" {
+		t.Fatalf("PascalCase event name was not recognised: %s", out)
+	}
+}
+
+// (a) The single most likely bug in this adapter: Copilot's
+// userPromptSubmitted has NO additionalContext channel, so reusing Claude's
+// lowering emits valid JSON and discards every byte of prompt-time context.
+func TestHandleCopilotUserPromptSubmittedUsesModifiedPrompt(t *testing.T) {
+	withDaemonReachable(t, true)
+	stubPromptProbe(t, []grepSymbolHit{
+		{Name: "ValidateToken", Kind: "function", FilePath: "internal/auth/token.go", Line: 42},
+	})
+
+	const prompt = "fix the token validation bug"
+	out, code := handleCopilot(copilotPayload(t, map[string]any{
+		"hookEventName": "userPromptSubmitted",
+		"cwd":           "/repo",
+		"prompt":        prompt,
+	}), 0, ModeDeny)
+
+	if code != 0 {
+		t.Fatalf("exit code=%d want 0", code)
+	}
+	if strings.Contains(out, "additionalContext") {
+		t.Fatalf("userPromptSubmitted has no additionalContext channel: %s", out)
+	}
+	var decoded copilotPromptResponse
+	if err := json.Unmarshal([]byte(out), &decoded); err != nil {
+		t.Fatalf("invalid userPromptSubmitted response %q: %v", out, err)
+	}
+	if !strings.HasPrefix(decoded.ModifiedPrompt, prompt) {
+		t.Fatalf("modifiedPrompt dropped the user's own text: %q", decoded.ModifiedPrompt)
+	}
+	for _, want := range []string{"relevant indexed symbols", "ValidateToken"} {
+		if !strings.Contains(decoded.ModifiedPrompt, want) {
+			t.Fatalf("modifiedPrompt missing %q: %q", want, decoded.ModifiedPrompt)
+		}
+	}
+}
+
+func TestHandleCopilotSessionStartEmitsAdditionalContext(t *testing.T) {
+	withDaemonReachable(t, true)
+	withFakeStatus(t, func() (*daemon.StatusResponse, error) {
+		return &daemon.StatusResponse{
+			Version: "1.0.0", Ready: true,
+			TrackedRepos: []daemon.TrackedRepoStatus{{Name: "repo", Path: "/tmp/repo", Workspace: "repo", Nodes: 10}},
+			Workspaces:   []daemon.WorkspaceSummary{{Slug: "repo"}},
+		}, nil
+	})
+
+	out, code := handleCopilot(copilotPayload(t, map[string]any{
+		"hookEventName": "sessionStart",
+		"cwd":           "/tmp/repo",
+	}), 0, ModeDeny)
+
+	if code != 0 {
+		t.Fatalf("exit code=%d want 0", code)
+	}
+	var decoded copilotSessionStartResponse
+	if err := json.Unmarshal([]byte(out), &decoded); err != nil {
+		t.Fatalf("invalid sessionStart response %q: %v", out, err)
+	}
+	if !strings.Contains(decoded.AdditionalContext, "Gortex Session Orientation") {
+		t.Fatalf("sessionStart lost the orientation briefing: %q", decoded.AdditionalContext)
+	}
+}
+
+func TestHandleCopilotPostToolUseEnrichesGrepOutput(t *testing.T) {
+	withDaemonReachable(t, true)
+	oldSummary := fileSummaryFn
+	fileSummaryFn = func(_, _ string) (*hookFileSummary, bool) {
+		return &hookFileSummary{Symbols: []summaryNode{
+			{Name: "ValidateToken", Kind: "function", StartLine: 1, EndLine: 10},
+		}}, true
+	}
+	t.Cleanup(func() { fileSummaryFn = oldSummary })
+
+	out, code := handleCopilot(copilotPayload(t, map[string]any{
+		"hookEventName": "postToolUse",
+		"cwd":           "/repo",
+		"toolName":      "rg",
+		"toolArgs":      map[string]any{"pattern": "ValidateToken"},
+		"toolResult":    "internal/auth/token.go:3:func ValidateToken()",
+	}), 0, ModeDeny)
+
+	if code != 0 {
+		t.Fatalf("exit code=%d want 0", code)
+	}
+	var decoded copilotPostToolUseResponse
+	if err := json.Unmarshal([]byte(out), &decoded); err != nil {
+		t.Fatalf("invalid postToolUse response %q: %v", out, err)
+	}
+	if !strings.Contains(decoded.AdditionalContext, "ValidateToken") {
+		t.Fatalf("postToolUse enrichment missing graph follow-up: %q", decoded.AdditionalContext)
+	}
+	if decoded.ModifiedResult != nil {
+		t.Fatalf("Gortex must never replace a Copilot tool result: %s", out)
+	}
+}
+
+// (f) Nine of Copilot's fourteen events map to nothing Gortex emits, and
+// agentStop has no context channel at all — all of them answer empty at 0.
+func TestHandleCopilotUnhandledEventsAreSilent(t *testing.T) {
+	withDaemonReachable(t, true)
+	for _, event := range []string{
+		"notification", "preCompact", "errorOccurred", "permissionRequest",
+		"subagentStart", "subagentStop", "postToolUseFailure",
+		"userPromptTransformed", "sessionEnd",
+		// agentStop is implemented but deliberately silent: its only
+		// documented fields are decision/reason, so a post-task briefing
+		// has nowhere to land.
+		"agentStop",
+	} {
+		t.Run(event, func(t *testing.T) {
+			out, code := handleCopilot(copilotPayload(t, map[string]any{
+				"hookEventName": event,
+				"cwd":           "/repo",
+			}), 0, ModeDeny)
+			if out != "" || code != 0 {
+				t.Fatalf("event %q must be a silent no-op, got out=%q code=%d", event, out, code)
+			}
+		})
+	}
+}
+
+// (c) Malformed stdin fails open: no output, exit 0, no panic.
+func TestHandleCopilotMalformedInputFailsOpen(t *testing.T) {
+	withDaemonReachable(t, true)
+	for _, payload := range []string{`{not json`, ``, `[]`, `{"hookEventName":42}`} {
+		out, code := handleCopilot([]byte(payload), 0, ModeDeny)
+		if out != "" || code != 0 {
+			t.Fatalf("payload %q must fail open, got out=%q code=%d", payload, out, code)
+		}
+	}
+}
+
+// (e) During a daemon outage the per-call posture stands down: every deny it
+// could produce mandates graph tools the daemon cannot serve (#486).
+func TestHandleCopilotStandsDownWhenDaemonUnreachable(t *testing.T) {
+	withDaemonReachable(t, false)
+	stubIndexedFile(t, true, 7)
+
+	for _, event := range []string{"preToolUse", "postToolUse", "userPromptSubmitted"} {
+		t.Run(event, func(t *testing.T) {
+			out, code := handleCopilot(copilotPayload(t, map[string]any{
+				"hookEventName": event,
+				"cwd":           "/repo",
+				"prompt":        "fix the token validation bug",
+				"toolName":      "view",
+				"toolArgs":      map[string]any{"path": "internal/auth/token.go"},
+				"toolResult":    "internal/auth/token.go:3:func ValidateToken()",
+			}), 0, ModeDeny)
+			if out != "" || code != 0 {
+				t.Fatalf("%s must stand down during an outage, got out=%q code=%d", event, out, code)
+			}
+		})
+	}
+}
+
+// (g) Copilot's camelCase event names are not in hookEffectivenessEvents, so
+// an unnormalised name is dropped by the writer and `gortex doctor` reports
+// "configured but never ran" against a working install forever.
+func TestCopilotTelemetryUsesTheClaudeEventVocabulary(t *testing.T) {
+	for copilotEvent, claudeEvent := range copilotTelemetryEvents {
+		if hookEffectivenessEvents[copilotEvent] {
+			t.Fatalf("the allowlist must not gain camelCase duplicates: %q", copilotEvent)
+		}
+		if !hookEffectivenessEvents[claudeEvent] {
+			t.Fatalf("%q normalises to %q, which the allowlist drops", copilotEvent, claudeEvent)
+		}
+	}
+
+	path := filepath.Join(t.TempDir(), "effectiveness.jsonl")
+	t.Setenv("GORTEX_HOOK_EFFECTIVENESS_LOG", path)
+	withDaemonReachable(t, true)
+	stubIndexedFile(t, true, 7)
+
+	if _, code := handleCopilot(copilotPayload(t, map[string]any{
+		"hookEventName": "preToolUse",
+		"cwd":           "/repo",
+		"toolName":      "view",
+		"toolArgs":      map[string]any{"path": "internal/auth/token.go"},
+	}), 0, ModeDeny); code != 0 {
+		t.Fatalf("exit code=%d want 0", code)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("a Copilot preToolUse must leave a hook-effectiveness record: %v", err)
+	}
+	var record hookEffectiveness
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(data))), &record); err != nil {
+		t.Fatalf("invalid effectiveness JSONL %q: %v", data, err)
+	}
+	if !hookEffectivenessEvents[record.Event] {
+		t.Fatalf("logged event %q is dropped by the allowlist", record.Event)
+	}
+	if record.Event != "PreToolUse" || !record.EmittedContext {
+		t.Fatalf("record=%+v", record)
+	}
+}
+
+// RunCopilot is the process entry point: stdin in, one flat response out,
+// exit 0.
+func TestRunCopilotReadsStdinAndWritesFlatResponse(t *testing.T) {
+	withDaemonReachable(t, true)
+	stubIndexedFile(t, true, 7)
+
+	payload := copilotPayload(t, map[string]any{
+		"hookEventName": "preToolUse",
+		"cwd":           "/repo",
+		"toolName":      "view",
+		"toolArgs":      map[string]any{"path": "internal/auth/token.go"},
+	})
+	out := captureStdout(t, func() {
+		withStdin(t, payload, func() { RunCopilot(0, ModeDeny) })
+	})
+	if decodeCopilotPreToolUse(t, out).PermissionDecision != "deny" {
+		t.Fatalf("RunCopilot did not emit the deny: %q", out)
+	}
+}
+
+func decodeCopilotPreToolUse(t *testing.T, out string) copilotPreToolUseResponse {
+	t.Helper()
+	var decoded copilotPreToolUseResponse
+	if err := json.Unmarshal([]byte(out), &decoded); err != nil {
+		t.Fatalf("invalid preToolUse response %q: %v", out, err)
+	}
+	return decoded
+}

--- a/internal/hooks/opencode.go
+++ b/internal/hooks/opencode.go
@@ -1,0 +1,79 @@
+package hooks
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+)
+
+// opencode.go is the Go side of the OpenCode (v1.18.18) integration.
+//
+// OpenCode has no lifecycle-hook configuration at all — there is no settings
+// key that runs a command on session start or before a tool call. Its only
+// extension point is a JS/TS plugin exposing `tool.execute.before` (throwing
+// from it blocks the call), `tool.execute.after`, `permission.ask` (returns
+// "ask" | "deny" | "allow"), `chat.message`, and a bus `event` hook. So
+// OpenCode gets the same treatment Pi does: the Gortex-owned bridge envelope
+// (pi.go), with a small JavaScript plugin that shells
+// `gortex hook --agent=opencode`, writes a BridgeEvent to stdin, and applies
+// the BridgeDecision it reads back — Block on `tool.execute.before` /
+// `permission.ask`, Orientation on the session event, AdditionalContext on
+// `chat.message`.
+//
+// Everything policy-shaped (the deny / enrich / consult-unlock / nudge
+// postures, indexed-source classification, telemetry) therefore lives in the
+// shared bridge core rather than in the plugin, where it would have to be
+// re-implemented in TypeScript and would drift.
+
+// openCodeToolNames maps OpenCode's built-in tool vocabulary onto the Claude
+// names the shared enrichment leaves switch on.
+//
+// The plugin is expected to send names already normalized (that is the
+// bridge contract), so this table is belt and braces — but a cheap one: if a
+// plugin build ever forwards OpenCode's own lowercase names instead, the
+// policy would otherwise classify nothing and the install would look healthy
+// while enforcing nothing. Already-normalized names miss the table and pass
+// through untouched, so applying it twice is a no-op.
+var openCodeToolNames = map[string]string{
+	"read":  "Read",
+	"write": "Write",
+	"edit":  "Edit",
+	"bash":  "Bash",
+	"grep":  "Grep",
+	"glob":  "Glob",
+	"task":  "Task",
+}
+
+// RunOpenCode reads a single bridge envelope from stdin, dispatches on the
+// event phase, and writes a decision to stdout. Any read/parse error is a
+// silent no-op (an empty decision) — a hook must never break the host
+// agent's flow.
+func RunOpenCode(port int, mode Mode) {
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		emitBridgeDecision(BridgeDecision{})
+		return
+	}
+	emitBridgeDecision(handleOpenCode(data, port, mode))
+}
+
+// handleOpenCode is the testable core: decode the envelope, normalize the
+// one host-specific field, and hand it to the shared bridge router.
+func handleOpenCode(data []byte, port int, mode Mode) BridgeDecision {
+	var ev BridgeEvent
+	if err := json.Unmarshal(data, &ev); err != nil {
+		return BridgeDecision{}
+	}
+	ev.ToolName = openCodeToolName(ev.ToolName)
+	return handleBridgeEvent(ev, port, mode)
+}
+
+// openCodeToolName maps one OpenCode tool name into the Claude vocabulary,
+// leaving anything unrecognised untouched.
+func openCodeToolName(name string) string {
+	if mapped, ok := openCodeToolNames[strings.ToLower(strings.TrimSpace(name))]; ok {
+		return mapped
+	}
+	return strings.TrimSpace(name)
+}

--- a/internal/hooks/opencode_test.go
+++ b/internal/hooks/opencode_test.go
@@ -1,0 +1,204 @@
+package hooks
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/daemon"
+)
+
+func TestHandleOpenCode_EnvelopeMapping(t *testing.T) {
+	withDaemonReachable(t, true)
+	stubIndexedFile(t, true, 7)
+	stubTrackedScope(t, true)
+	stubPromptProbe(t, []grepSymbolHit{
+		{Name: "ValidateToken", Kind: "function", FilePath: "internal/auth/token.go", Line: 42},
+	})
+	withFakeStatus(t, func() (*daemon.StatusResponse, error) {
+		return &daemon.StatusResponse{
+			Version: "1.0.0", Ready: true,
+			TrackedRepos: []daemon.TrackedRepoStatus{{Name: "repo", Path: "/tmp/repo", Workspace: "repo", Nodes: 10}},
+			Workspaces:   []daemon.WorkspaceSummary{{Slug: "repo"}},
+		}, nil
+	})
+
+	tests := []struct {
+		name    string
+		payload string
+		check   func(t *testing.T, d BridgeDecision)
+	}{
+		{
+			// tool.execute.before blocks by throwing, so a deny has to arrive
+			// as Block+Reason for the plugin to raise.
+			name:    "tool_call on indexed source blocks",
+			payload: `{"event":"tool_call","tool_name":"read","tool_input":{"file_path":"internal/auth/token.go"},"cwd":"/tmp/repo"}`,
+			check: func(t *testing.T, d BridgeDecision) {
+				if !d.Block {
+					t.Fatalf("indexed read was not blocked: %+v", d)
+				}
+				if !strings.Contains(d.Reason, `read(target:{symbol:`) {
+					t.Fatalf("block reason must name the graph replacement: %q", d.Reason)
+				}
+			},
+		},
+		{
+			// OpenCode's own hook names are dotted; a plugin forwarding them
+			// verbatim must land on the same slot.
+			name:    "dotted tool.execute.before is the same slot",
+			payload: `{"event":"tool.execute.before","tool_name":"read","tool_input":{"file_path":"internal/auth/token.go"},"cwd":"/tmp/repo"}`,
+			check: func(t *testing.T, d BridgeDecision) {
+				if !d.Block {
+					t.Fatalf("dotted event name was not routed: %+v", d)
+				}
+			},
+		},
+		{
+			name:    "permission.ask denies the same call",
+			payload: `{"event":"permission.ask","tool_name":"grep","tool_input":{"pattern":"ValidateToken"},"cwd":"/tmp/repo"}`,
+			check: func(t *testing.T, d BridgeDecision) {
+				if !d.Block || d.Reason == "" {
+					t.Fatalf("permission.ask on indexed source must deny: %+v", d)
+				}
+			},
+		},
+		{
+			name:    "session event returns orientation",
+			payload: `{"event":"session","cwd":"/tmp/repo"}`,
+			check: func(t *testing.T, d BridgeDecision) {
+				if !strings.Contains(d.Orientation, "Gortex Session Orientation") {
+					t.Fatalf("session event lost the orientation: %+v", d)
+				}
+				if d.Block {
+					t.Error("a session event must never block")
+				}
+			},
+		},
+		{
+			name:    "prompt event returns additional context",
+			payload: `{"event":"chat.message","prompt":"fix the token validation bug","cwd":"/tmp/repo"}`,
+			check: func(t *testing.T, d BridgeDecision) {
+				if !strings.Contains(d.AdditionalContext, "ValidateToken") {
+					t.Fatalf("prompt event lost the per-turn injection: %+v", d)
+				}
+				if d.Block {
+					t.Error("a prompt event must never block")
+				}
+			},
+		},
+		{
+			name:    "malformed JSON is an empty fail-open decision",
+			payload: `{not json`,
+			check: func(t *testing.T, d BridgeDecision) {
+				if d != (BridgeDecision{}) {
+					t.Fatalf("malformed JSON must fail open: %+v", d)
+				}
+			},
+		},
+		{
+			name:    "unknown event is a no-op",
+			payload: `{"event":"tool.execute.after","tool_name":"read","cwd":"/tmp/repo"}`,
+			check: func(t *testing.T, d BridgeDecision) {
+				if d != (BridgeDecision{}) {
+					t.Fatalf("unmapped event must be a no-op: %+v", d)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.check(t, handleOpenCode([]byte(tt.payload), 0, ModeDeny))
+		})
+	}
+}
+
+// The bridge contract says the plugin normalizes tool names; the table is the
+// safety net for a build that forwards OpenCode's own lowercase names, and it
+// must be a no-op on already-normalized input.
+func TestOpenCodeToolNameNormalisation(t *testing.T) {
+	cases := map[string]string{
+		"read": "Read", "write": "Write", "edit": "Edit", "bash": "Bash",
+		"grep": "Grep", "glob": "Glob", "task": "Task",
+		"Read": "Read", "webfetch": "webfetch", "todowrite": "todowrite",
+	}
+	for input, want := range cases {
+		if got := openCodeToolName(input); got != want {
+			t.Errorf("openCodeToolName(%q)=%q want %q", input, got, want)
+		}
+	}
+}
+
+func TestHandleOpenCode_StandsDownWhenDaemonUnreachable(t *testing.T) {
+	withDaemonReachable(t, false)
+	stubIndexedFile(t, true, 7)
+	stubTrackedScope(t, true)
+	stubPromptProbe(t, []grepSymbolHit{{Name: "ValidateToken", FilePath: "internal/auth/token.go", Line: 42}})
+
+	for _, payload := range []string{
+		`{"event":"tool_call","tool_name":"read","tool_input":{"file_path":"internal/auth/token.go"},"cwd":"/tmp/repo"}`,
+		`{"event":"chat.message","prompt":"fix the token validation bug","cwd":"/tmp/repo"}`,
+	} {
+		if d := handleOpenCode([]byte(payload), 0, ModeDeny); d != (BridgeDecision{}) {
+			t.Fatalf("outage must yield an empty decision for %s: %+v", payload, d)
+		}
+	}
+}
+
+func TestRunOpenCodeReadsStdinAndWritesDecision(t *testing.T) {
+	withDaemonReachable(t, true)
+	stubIndexedFile(t, true, 7)
+
+	payload := []byte(`{"event":"tool_call","tool_name":"read","tool_input":{"file_path":"internal/auth/token.go"},"cwd":"/tmp/repo"}`)
+	out := captureStdout(t, func() {
+		withStdin(t, payload, func() { RunOpenCode(0, ModeDeny) })
+	})
+	var decision BridgeDecision
+	if err := json.Unmarshal([]byte(out), &decision); err != nil {
+		t.Fatalf("invalid bridge decision %q: %v", out, err)
+	}
+	if !decision.Block {
+		t.Fatalf("RunOpenCode did not emit the block: %q", out)
+	}
+}
+
+// The bridge core wrote no telemetry at all before both hosts shared it,
+// which left a `gortex doctor` probe with no denominator — a working bridge
+// was indistinguishable from one that never fires. Pi gets the fix for free.
+func TestBridgeCoreLogsHookEffectivenessForBothHosts(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "effectiveness.jsonl")
+	t.Setenv("GORTEX_HOOK_EFFECTIVENESS_LOG", path)
+	withDaemonReachable(t, true)
+	stubIndexedFile(t, true, 7)
+
+	toolCall := `{"event":"tool_call","tool_name":"read","tool_input":{"file_path":"internal/auth/token.go"},"cwd":"/tmp/repo"}`
+	if d := handleOpenCode([]byte(toolCall), 0, ModeDeny); !d.Block {
+		t.Fatalf("precondition: expected a block, got %+v", d)
+	}
+	if d := handlePi([]byte(`{"event":"tool_call","tool_name":"Read","tool_input":{"file_path":"internal/auth/token.go"},"cwd":"/tmp/repo"}`), 0, ModeDeny); !d.Block {
+		t.Fatalf("precondition: expected a Pi block, got %+v", d)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("the bridge core must leave hook-effectiveness records: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("records=%d want 2 (one per bridged host): %s", len(lines), data)
+	}
+	for _, line := range lines {
+		var record hookEffectiveness
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("invalid effectiveness JSONL %q: %v", line, err)
+		}
+		if record.Event != "PreToolUse" || !hookEffectivenessEvents[record.Event] {
+			t.Fatalf("a tool_call must be logged under the allowlisted PreToolUse: %+v", record)
+		}
+		if !record.EmittedContext {
+			t.Fatalf("a block is an emitted decision: %+v", record)
+		}
+	}
+}

--- a/internal/hooks/pi.go
+++ b/internal/hooks/pi.go
@@ -4,29 +4,36 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"strings"
+	"time"
 )
 
-// pi.go is the Go side of the Pi (earendil-works/pi) integration. Pi has
-// no MCP support — the Gortex Pi extension (shipped by the `pi` agent
-// adapter) is a thin TypeScript bridge that, on each relevant lifecycle
-// event, shells `gortex hook --agent=pi`, writes a normalized event
-// envelope to stdin, and applies the decision it reads back from stdout.
+// pi.go carries the Gortex-owned *bridge* protocol: a neutral event envelope
+// on stdin and a decision on stdout, for a host that has no native hook
+// system of its own. Pi (earendil-works/pi) was the first such host and gave
+// the protocol its name; OpenCode (opencode.go) is the second and shares
+// every line of the core below.
 //
-// Keeping the decision logic here (rather than re-implementing it in
-// TypeScript) means the deny / enrich / consult-unlock / nudge postures
-// and the indexed-source classification stay in one place.
+// The shape exists because those hosts extend through a JS/TS plugin, not a
+// hook config. The plugin is a thin shim that, on each relevant lifecycle
+// event, shells `gortex hook --agent=<host>`, writes an envelope to stdin,
+// and applies the decision it reads back. Keeping the decision logic here
+// rather than re-implementing it in TypeScript is what keeps the deny /
+// enrich / consult-unlock / nudge postures and the indexed-source
+// classification identical across hosts.
 //
 // The wire contract is owned end-to-end by Gortex (this file plus the
-// embedded extension/index.ts), so it is deliberately minimal and already
-// normalized into the canonical Claude-Code tool vocabulary: the
-// extension maps Pi's own tool names and input keys onto Claude-Code's
-// tool names and the `file_path` / `pattern` / `command` shape that
-// `enrich` switches on, before sending so `enrich` can be reused unchanged.
+// embedded extensions), so it is deliberately minimal and already normalized
+// into the canonical Claude-Code tool vocabulary: the extension maps its
+// host's tool names and input keys onto Claude-Code's tool names and the
+// `file_path` / `pattern` / `command` shape that `enrich` switches on, before
+// sending, so `enrich` can be reused unchanged.
 
-// PiEvent is the normalized envelope the Pi extension writes to stdin.
-type PiEvent struct {
-	// Event is the lifecycle phase: "tool_call", "session_start",
-	// "before_agent_start", "tool_result", or "before_compact".
+// BridgeEvent is the normalized envelope a host extension writes to stdin.
+type BridgeEvent struct {
+	// Event is the lifecycle phase. Each host extension spells its phases
+	// its own way; bridgeEventSlot folds every accepted spelling onto the
+	// three slots the core answers (tool call, orientation, prompt).
 	Event string `json:"event"`
 
 	// ToolName / ToolInput carry a tool_call, already mapped into the
@@ -34,8 +41,8 @@ type PiEvent struct {
 	ToolName  string         `json:"tool_name,omitempty"`
 	ToolInput map[string]any `json:"tool_input,omitempty"`
 
-	// CWD is Pi's working directory — drives cwd-coverage messaging and
-	// the file-indexed lookup inside enrich.
+	// CWD is the host's working directory — drives cwd-coverage messaging
+	// and the file-indexed lookup inside enrich.
 	CWD string `json:"cwd,omitempty"`
 
 	// SessionID keys the per-session state store (consult-unlock marker,
@@ -43,68 +50,137 @@ type PiEvent struct {
 	// degrade to a fresh zero-value state).
 	SessionID string `json:"session_id,omitempty"`
 
+	// Prompt carries the user's turn text on a prompt event, so a bridged
+	// host gets the same per-turn "relevant indexed symbols" injection
+	// Claude and Codex get on UserPromptSubmit.
+	Prompt string `json:"prompt,omitempty"`
+
 	// IsGortexTool is set by the extension when the call targets one of
-	// the Gortex graph tools it registered. Pi gives those plain names
-	// (e.g. "search_symbols"), not the `mcp__gortex__` prefix Claude
-	// uses, so the extension flags them explicitly. Lets the
+	// the Gortex graph tools it registered. A bridged host gives those
+	// plain names (e.g. "search_symbols"), not the `mcp__gortex__` prefix
+	// Claude uses, so the extension flags them explicitly. Lets the
 	// consult-unlock handshake and the nudge streak-reset recognise a
 	// graph query the same way the in-process Claude hook does.
 	IsGortexTool bool `json:"is_gortex_tool,omitempty"`
 }
 
-// PiDecision is what RunPi writes to stdout. The extension applies it:
-// Block→deny the tool call with Reason; AdditionalContext→inject a soft
+// BridgeDecision is what a bridge run writes to stdout. The extension applies
+// it: Block→deny the tool call with Reason; AdditionalContext→inject a soft
 // tip; Orientation→inject as a tail user message before the next LLM call.
 // All fields are optional; an empty decision means "do nothing" (fail-open).
-type PiDecision struct {
+type BridgeDecision struct {
 	Block             bool   `json:"block,omitempty"`
 	Reason            string `json:"reason,omitempty"`
 	AdditionalContext string `json:"additional_context,omitempty"`
 	Orientation       string `json:"orientation,omitempty"`
 }
 
-// RunPi reads a single Pi event envelope from stdin, dispatches on the
-// event phase, and writes a PiDecision to stdout. Any read/parse error is
-// a silent no-op (emits an empty decision) — a hook must never break the
-// host agent's flow.
+// PiEvent and PiDecision are the names the protocol shipped under before a
+// second host adopted it. Kept as aliases so the Pi extension's documented
+// wire contract — and every caller written against it — stays valid.
+type (
+	PiEvent    = BridgeEvent
+	PiDecision = BridgeDecision
+)
+
+// bridgeSlot is the semantic phase an envelope resolves to. Hosts differ in
+// how many lifecycle events they expose and what they call them; the core
+// answers exactly three.
+type bridgeSlot int
+
+const (
+	bridgeSlotNone bridgeSlot = iota
+	bridgeSlotToolCall
+	bridgeSlotOrientation
+	bridgeSlotPrompt
+)
+
+// RunPi reads a single Pi event envelope from stdin, dispatches on the event
+// phase, and writes a decision to stdout. Any read/parse error is a silent
+// no-op (emits an empty decision) — a hook must never break the host agent's
+// flow.
 func RunPi(port int, mode Mode) {
 	data, err := io.ReadAll(os.Stdin)
 	if err != nil {
-		emitPiDecision(PiDecision{})
+		emitBridgeDecision(BridgeDecision{})
 		return
 	}
-	emitPiDecision(handlePi(data, port, mode))
+	emitBridgeDecision(handlePi(data, port, mode))
 }
 
-// handlePi is the testable core: parse the envelope, route by phase,
-// return the decision. Kept separate from RunPi so tests can drive it
-// with bytes and assert on the returned struct without touching stdio.
-func handlePi(data []byte, port int, mode Mode) PiDecision {
-	var ev PiEvent
+// handlePi is the Pi entry point into the shared bridge core. Pi's extension
+// sends the envelope verbatim — its tool names are already normalized — so
+// there is nothing host-specific left to do here.
+func handlePi(data []byte, port int, mode Mode) BridgeDecision {
+	return handleBridge(data, port, mode)
+}
+
+// handleBridge parses an envelope and routes it. Kept separate from the Run*
+// entry points so tests can drive it with bytes and assert on the returned
+// struct without touching stdio.
+func handleBridge(data []byte, port int, mode Mode) BridgeDecision {
+	var ev BridgeEvent
 	if err := json.Unmarshal(data, &ev); err != nil {
-		return PiDecision{}
+		return BridgeDecision{}
 	}
+	return handleBridgeEvent(ev, port, mode)
+}
 
-	switch ev.Event {
-	case "tool_call":
-		return piToolCall(ev, port, mode)
-	case "session_start", "before_agent_start", "before_compact":
-		// All three are "inject the orientation" moments; the extension
-		// injects the briefing as a tail user message.
-		ctx := buildSessionStartBriefing(ev.CWD)
-		if ctx == "" {
-			return PiDecision{}
-		}
-		return PiDecision{Orientation: ctx}
+// handleBridgeEvent routes an already-decoded envelope, so a host adapter can
+// normalize fields (OpenCode's tool names, for one) before the core runs.
+func handleBridgeEvent(ev BridgeEvent, port int, mode Mode) BridgeDecision {
+	switch bridgeEventSlot(ev.Event) {
+	case bridgeSlotToolCall:
+		return bridgeToolCall(ev, port, mode)
+	case bridgeSlotOrientation:
+		return bridgeOrientation(ev)
+	case bridgeSlotPrompt:
+		return bridgePrompt(ev)
 	default:
-		return PiDecision{}
+		return BridgeDecision{}
 	}
 }
 
-// piToolCall maps a normalized Pi tool_call onto the shared enrich +
-// applyMode pipeline and lowers the resulting enrichResult into a
-// PiDecision.
-func piToolCall(ev PiEvent, port int, mode Mode) PiDecision {
+// bridgeEventSlot folds every spelling the bridged hosts send onto one of the
+// three slots. Pi names its phases session_start / before_agent_start /
+// before_compact / tool_call; OpenCode's plugin hooks are tool.execute.before,
+// permission.ask and chat.message, and its bus event carries a session open.
+// All three orientation moments answer the same way — inject the briefing as
+// a tail user message — so they share a slot.
+func bridgeEventSlot(event string) bridgeSlot {
+	switch normalizeBridgeEvent(event) {
+	case "tool_call", "tool_execute_before", "permission_ask":
+		return bridgeSlotToolCall
+	case "session", "session_start", "session_open", "before_agent_start", "before_compact":
+		return bridgeSlotOrientation
+	case "prompt", "user_prompt", "chat_message":
+		return bridgeSlotPrompt
+	default:
+		return bridgeSlotNone
+	}
+}
+
+// normalizeBridgeEvent lower-cases the phase and folds the separators a
+// plugin author is likely to forward verbatim (OpenCode's own hook names are
+// dotted), so `tool.execute.before` and `tool_call` do not need two tables.
+func normalizeBridgeEvent(event string) string {
+	return strings.NewReplacer(".", "_", "-", "_", " ", "_").
+		Replace(strings.ToLower(strings.TrimSpace(event)))
+}
+
+// piToolCall is the Pi-named entry into the shared tool-call handler. The
+// name is pinned by the daemon-outage contract tests, which drive the Pi
+// posture through it directly.
+func piToolCall(ev BridgeEvent, port int, mode Mode) BridgeDecision {
+	return bridgeToolCall(ev, port, mode)
+}
+
+// bridgeToolCall maps a normalized tool_call onto the shared enrich +
+// applyMode pipeline and lowers the resulting enrichResult into a decision.
+func bridgeToolCall(ev BridgeEvent, port int, mode Mode) (decision BridgeDecision) {
+	started := time.Now()
+	daemonUp := daemonReachableFn()
+
 	input := HookInput{
 		HookEventName: "PreToolUse",
 		ToolName:      ev.ToolName,
@@ -113,12 +189,20 @@ func piToolCall(ev PiEvent, port int, mode Mode) PiDecision {
 		SessionID:     ev.SessionID,
 	}
 
-	// A Gortex graph tool call is the "symbolic" call the postures key
-	// off. Under consult-unlock it flips the per-session marker that
-	// unlocks fallback reads; it is always allowed through, so there is
-	// nothing else to decide.
-	isGortexTool := ev.IsGortexTool
-	if isGortexTool {
+	// Every other adapter logs one effectiveness record per invocation; the
+	// bridge used to log none at all, which left `gortex doctor` with no
+	// denominator and no way to tell a bridge that never fires from one that
+	// fires and stays quiet. Recording it here covers both bridged hosts.
+	defer func() {
+		logHookEffectiveness("PreToolUse", decision != (BridgeDecision{}), daemonUp,
+			hookAlternationSegmentCount(input), time.Since(started))
+	}()
+
+	// A Gortex graph tool call is the "symbolic" call the postures key off.
+	// Under consult-unlock it flips the per-session marker that unlocks
+	// fallback reads; it is always allowed through, so there is nothing else
+	// to decide.
+	if ev.IsGortexTool {
 		if mode == ModeConsultUnlock {
 			markGraphConsulted(ev.SessionID)
 		}
@@ -126,34 +210,64 @@ func piToolCall(ev PiEvent, port int, mode Mode) PiDecision {
 		// but only while the daemon is up. During an outage every adapter
 		// freezes the streak entirely (Claude's and Hermes' gates sit above
 		// their streak bookkeeping), so post-outage nudge behavior resumes
-		// exactly where it left off; resetting here would make Pi the one
-		// adapter whose streak drifts mid-outage (#486).
-		if mode == ModeAdaptiveNudge && daemonReachableFn() {
+		// exactly where it left off; resetting here would make the bridge
+		// the one adapter whose streak drifts mid-outage (#486).
+		if mode == ModeAdaptiveNudge && daemonUp {
 			_ = applyMode(input, true, mode, enrichResult{})
 		}
-		return PiDecision{}
+		return BridgeDecision{}
 	}
 
 	// Daemon outage: stand down (#486) — a block or advisory here would
 	// point at graph tools the daemon cannot serve. The consult-unlock
 	// marker above is local state and deliberately stays live.
-	if !daemonReachableFn() {
-		return PiDecision{}
+	if !daemonUp {
+		return BridgeDecision{}
 	}
 
-	result := applyMode(input, isGortexTool, mode, enrich(input, port))
+	result := applyMode(input, false, mode, enrich(input, port))
 	if result.deny {
-		return PiDecision{Block: true, Reason: result.reason}
+		return BridgeDecision{Block: true, Reason: result.reason}
 	}
 	if result.context != "" {
-		return PiDecision{AdditionalContext: result.context}
+		return BridgeDecision{AdditionalContext: result.context}
 	}
-	return PiDecision{}
+	return BridgeDecision{}
 }
 
-// emitPiDecision marshals a PiDecision to stdout. A marshal failure is
+// bridgeOrientation answers a session/orientation moment with the session
+// briefing. It runs during an outage too: buildSessionStartBriefing answers
+// an unreachable daemon with the degraded "rule-only enforcement" block,
+// which is exactly what a session opening into an outage needs to be told.
+func bridgeOrientation(ev BridgeEvent) BridgeDecision {
+	started := time.Now()
+	ctx := buildSessionStartBriefing(ev.CWD)
+	logHookEffectiveness("SessionStart", ctx != "", daemonReachableFn(), 0, time.Since(started))
+	if ctx == "" {
+		return BridgeDecision{}
+	}
+	return BridgeDecision{Orientation: ctx}
+}
+
+// bridgePrompt answers a per-turn prompt with the graph symbols relevant to
+// it, as soft context the extension injects ahead of the model call.
+func bridgePrompt(ev BridgeEvent) BridgeDecision {
+	started := time.Now()
+	daemonUp := daemonReachableFn()
+	ctx := ""
+	if daemonUp {
+		ctx = buildUserPromptSubmitContext("UserPromptSubmit", ev.Prompt)
+	}
+	logHookEffectiveness("UserPromptSubmit", ctx != "", daemonUp, 0, time.Since(started))
+	if ctx == "" {
+		return BridgeDecision{}
+	}
+	return BridgeDecision{AdditionalContext: ctx}
+}
+
+// emitBridgeDecision marshals a decision to stdout. A marshal failure is
 // swallowed — the extension treats empty/garbled output as a no-op.
-func emitPiDecision(d PiDecision) {
+func emitBridgeDecision(d BridgeDecision) {
 	out, err := json.Marshal(d)
 	if err != nil {
 		return

--- a/internal/skills/generator.go
+++ b/internal/skills/generator.go
@@ -88,18 +88,25 @@ func (g *Generator) GenerateAll() []GeneratedSkill {
 	return skills
 }
 
-// GenerateRouting produces the shared agent routing table between markers.
+// GenerateRouting produces the shared community-routing payload. Callers
+// embed this verbatim inside their own CommunitiesStartMarker/
+// CommunitiesEndMarker fence (agents.UpsertMarkedBlock) — this payload must
+// not carry a marker pair of its own, or every adapter ends up writing a
+// doubly-fenced block that the outer idempotent-replace can never clean up.
+//
+// The routing column names a graph query rather than a slash command:
+// slash commands only resolve on Claude Code, while every other adapter
+// this block reaches (Codex, Cursor, Windsurf, ...) only has the MCP/CLI
+// graph tools, so the invocation must work there too.
 func (g *Generator) GenerateRouting(skills []GeneratedSkill) string {
 	var sb strings.Builder
-	sb.WriteString("<!-- gortex:skills:start -->\n")
 	sb.WriteString("## Community Skills\n\n")
-	sb.WriteString("| Area | Description | Skill |\n")
-	sb.WriteString("|------|-------------|-------|\n")
+	sb.WriteString("| Area | Description | Explore |\n")
+	sb.WriteString("|------|-------------|---------|\n")
 	for _, s := range skills {
 		title := capitalizeWords(strings.ReplaceAll(s.Label, "-", " "))
-		fmt.Fprintf(&sb, "| %s | %d symbols | `/gortex-%s` |\n", title, g.CommunitySize(s.CommunityID), s.Label)
+		fmt.Fprintf(&sb, "| %s | %d symbols | `analyze(operation:\"communities\", id:\"%s\")` |\n", title, g.CommunitySize(s.CommunityID), s.CommunityID)
 	}
-	sb.WriteString("<!-- gortex:skills:end -->\n")
 	return sb.String()
 }
 
@@ -192,13 +199,17 @@ func (g *Generator) renderSkill(c analysis.Community, crossComm map[string]map[s
 		sb.WriteString("\n")
 	}
 
-	// How to explore.
+	// How to explore. Names the public facade tools (explore/analyze/
+	// relations), not the one-tool-per-operation names they front — the
+	// legacy names are implementation detail and drift as operations get
+	// regrouped, while the facade surface is the stable public contract
+	// every adapter is told to use (see facade_registry.go).
 	sb.WriteString("## How to Explore\n\n")
 	sb.WriteString("```\n")
-	fmt.Fprintf(&sb, "get_communities with id: \"%s\"\n", c.ID)
-	fmt.Fprintf(&sb, "smart_context with task: \"understand %s\", format: \"gcx\"\n", label)
+	fmt.Fprintf(&sb, "analyze(operation:\"communities\", id:\"%s\")\n", c.ID)
+	fmt.Fprintf(&sb, "explore(operation:\"context\", task:\"understand %s\", format:\"gcx\")\n", label)
 	if len(entryPoints) > 0 {
-		fmt.Fprintf(&sb, "find_usages with id: \"%s\", format: \"gcx\"\n", entryPoints[0])
+		fmt.Fprintf(&sb, "relations(operation:\"usages\", target:{symbol:\"%s\"}, format:\"gcx\")\n", entryPoints[0])
 	}
 	sb.WriteString("```\n\n")
 	sb.WriteString("_`format: \"gcx\"` returns the [GCX1 compact wire format](../../docs/wire-format.md) — round-trippable, ~27% fewer tokens than JSON. Drop it for JSON output; agents using `@gortex/wire` or the Go `github.com/gortexhq/gcx-go` package decode either._\n")

--- a/internal/skills/generator_test.go
+++ b/internal/skills/generator_test.go
@@ -138,12 +138,21 @@ func TestGenerateRouting(t *testing.T) {
 	skills := gen.GenerateAll()
 	routing := gen.GenerateRouting(skills)
 
-	assert.Contains(t, routing, "<!-- gortex:skills:start -->")
-	assert.Contains(t, routing, "<!-- gortex:skills:end -->")
 	assert.Contains(t, routing, "| Parser |")
 	assert.Contains(t, routing, "| Server |")
-	assert.Contains(t, routing, "`/gortex-parser`")
-	assert.Contains(t, routing, "`/gortex-server`")
+	assert.Contains(t, routing, "community-0")
+	assert.Contains(t, routing, "community-1")
+
+	// The payload must not fence itself — adapters wrap it in their own
+	// CommunitiesStartMarker/CommunitiesEndMarker (see
+	// internal/agents/instructions.go); a nested marker pair here would
+	// double-fence the block every adapter writes.
+	assert.NotContains(t, routing, "gortex:skills:")
+
+	// No slash-command invocation: it only resolves on Claude Code, and
+	// this block also reaches hosts (Codex, Cursor, Windsurf, ...) that
+	// have no such command.
+	assert.NotContains(t, routing, "/gortex-")
 }
 
 func TestGenerateAll_NilCommunities(t *testing.T) {
@@ -167,7 +176,26 @@ func TestGenerateAll_HowToExplore(t *testing.T) {
 	skills := gen.GenerateAll()
 	for _, s := range skills {
 		assert.True(t, strings.Contains(s.Content, "## How to Explore"), "skill %s should have How to Explore section", s.Label)
-		assert.True(t, strings.Contains(s.Content, "get_communities"), "skill %s should reference get_communities tool", s.Label)
-		assert.True(t, strings.Contains(s.Content, "smart_context"), "skill %s should reference smart_context tool", s.Label)
+		assert.True(t, strings.Contains(s.Content, "analyze(operation:"), "skill %s should reference the analyze facade tool", s.Label)
+		assert.True(t, strings.Contains(s.Content, "explore(operation:"), "skill %s should reference the explore facade tool", s.Label)
+	}
+}
+
+// TestGenerateAll_NoLegacyToolNames pins the facade migration: generated
+// skill bodies must steer agents at the public facade tools (explore,
+// search, read, relations, change, trace, recall), not the one-tool-per-
+// operation names those front. Legacy names are implementation detail that
+// drift as operations get regrouped in facade_registry.go; the facade
+// surface is the stable public contract every adapter is told to use.
+func TestGenerateAll_NoLegacyToolNames(t *testing.T) {
+	g, communities, processes := testGraph()
+	gen := New(communities, processes, g)
+
+	skills := gen.GenerateAll()
+	legacyNames := []string{"get_communities", "smart_context", "find_usages", "get_symbol_source"}
+	for _, s := range skills {
+		for _, legacy := range legacyNames {
+			assert.NotContains(t, s.Content, legacy, "skill %s should not reference legacy tool name %s", s.Label, legacy)
+		}
 	}
 }


### PR DESCRIPTION
A community user runs Claude Code, Codex, OpenCode and GitHub Copilot CLI, and gets the full Gortex integration in exactly one of them. This closes that.

Each host turned out to need something different, and two are more capable than the gap suggests:

| Host | Before | After |
| --- | --- | --- |
| `codex` | MCP + hooks + rule block, **0 skills** | 21 curated skills, per-community skills, 2 sub-agents |
| `opencode` | MCP + routing block only | 21 skills, 20 commands, and an enforcement bridge |
| `copilot-cli` | **no adapter at all** | new adapter: MCP, instructions, skills, sub-agents, hooks |

The existing `vscode` adapter targets Copilot *inside VS Code* and never probes the `copilot` binary, so the standalone CLI had no adapter. It is now the twentieth.

## Vendor facts that shape the code

Each of these is a place where the obvious implementation ships something that tests green and loads nothing:

- **Codex does not read `~/.codex/skills`.** That tree is configuration. Skills live in `.agents/skills`, `$HOME/.agents/skills` and `/etc/codex/skills`. A negative test asserts we never write to the ignored paths.
- **`~/.agents/skills` is a shared cross-agent root** that Codex and OpenCode both scan, so one write serves both. Copilot CLI dropped it in v1.0.66 and needs `~/.copilot/skills`; it also stopped reading home-level `~/.claude/*` in v1.0.36.
- **OpenCode rejects a skill whose frontmatter `name` differs from its directory.** The name is taken from the same value used as the directory, so the rule is unrepresentable to violate.
- **Copilot's `userPromptSubmitted` accepts only `modifiedPrompt`.** Reusing Claude's `additionalContext` lowering compiles, passes a shape test, and discards the whole payload.
- **Copilot hook entries carry separate `bash` and `powershell` commands**, and `powershell` is a first-class tool name. A POSIX-only entry leaves the entire Windows surface unenforced.
- **Copilot's `agentStop` has no context channel**, so there is no turn-end briefing on that host — recorded as a stop-line rather than faked.
- **Copilot discovers a repo `.mcp.json` ahead of its user config.** Gortex already writes one, without the required `type` and with a shell-style env value Copilot does not expand, so a stale entry shadowed the new adapter. It is reconciled in place.
- **OpenCode has no hook system at all.** Its only extension point is a JS plugin, so it gets one that speaks the same bridge protocol the Pi extension uses.
- **A Codex sub-agent file is rejected whole on one unknown key** (`deny_unknown_fields`), and its `mcp_servers` field is a table of full server definitions, not a list of names — the intuitive `mcp_servers = ["gortex"]` fails to deserialize and voids the entire agent. Four keys are emitted and `mcp_servers` is omitted, which is documented to inherit the session's servers. Codex has no per-agent allowlist, so there was nothing to gain by emitting it.

## Deliberate calls worth reviewing

- **Curated skills are user-level; only per-community skills go in the repo.** This matches what `claudecode` already does, so `gortex init` never drops 21 host-agnostic markdown files into a working tree for teammates to review.
- **The OpenCode bridge installs to `~/.config/opencode/plugin/gortex.js`, not `.opencode/`.** It is the only executable artifact Gortex writes and the repo-level directory is committed — a repo install would push a file that shells out on every tool call onto everyone who clones. It is gated on `InstallHooks`, so `--no-hooks` turns it off, and `uninstall` removes it.
- **Copilot artifacts default to `~/.copilot`, not `.github/`.** `.github/hooks/` and `.github/skills/` are committed and would run for every teammate.
- **`skillpack` imports no adapter package.** A later `skillpack.Sync` had to be callable from `claudecode`, so an edge the other way is a cycle. The rule is stated in the package doc.
- Only 5 of Copilot's 14 hook events are registered. The other nine map to nothing Gortex emits, and each one costs a subprocess spawn per occurrence.

## Bugs found and fixed on the way

- The community-routing block that **13 adapters already receive** was double-fenced, and advertised `/gortex-<label>` slash commands that exist on no host but Claude Code.
- `uninstall --global` was gated on Claude Code having artifacts, so a machine with only OpenCode configured was told there was nothing to uninstall.
- The render fence rendered neither user-scope artifacts, nor hook stanzas, nor generated skills — every artifact this branch adds would have shipped unpinned. Turning user-scope rendering on first required closing two escapes where `go test ./cmd/gortex` would have **written to the developer's real home**; a guard now fails the test if a render touches it, and it was verified to fail when the pin is removed.
- The codex hook command interpolates `GORTEX_CODEX_HOOK_MODE` at render time, so the golden encoded whichever posture the regenerating developer had exported.
- `hookEffectivenessEvents` is a PascalCase allowlist that silently drops anything else, which would have made `doctor` report "configured but never ran" forever on a working Copilot install.
- The Pi bridge core never wrote telemetry at all. The shared core now does, so Pi gets it too.
- `gortex instructions switch` reshaped only Claude Code's skills. Hermes had 20 skills that never shrank, and the three new hosts would have inherited the same gap.
- Adapter and skill counts in `docs/agents.md`, `docs/skills.md` and `README.md` were all stale; a guard now derives them from `buildRegistry()`.
- Dead `agents.AppendInstructions` removed — it could not update a block in place and wrote non-atomically, and a new adapter author would have copied it.

## Verification

`go build ./...`, `go vet ./...`, `golangci-lint`, `gofmt` — clean.
`go test ./...` — 184 packages, zero failures, exit 0.
`go test -race` on every touched package — clean.

Removal is by evidence, never by path: the skill trees are shared with the user's own skills, so an entry is deleted only when its bytes still match what we shipped. A customised copy is kept and reported, on install, on profile switch and on uninstall.

## Not done, and why

- **No manual verification against the real binaries.** Several of these surfaces can pass every unit test while loading nothing, because the failure mode is a path or a key the host silently ignores. Each needs one run against the real CLI before this is trusted in the wild: Codex `/skills` listing the pack, Copilot denying a grep with a reason that names the Gortex tool, OpenCode blocking the same grep with the bridge installed.

  For Codex there is a real oracle worth using: `codex doctor` reports a rejected agent file as a startup warning mentioning `agent role`, while the exit code stays 0 and everything else loads. `codex doctor 2>&1 | grep -i "agent role"` should print nothing.
- **OpenCode sub-agents.** Their `tools` map is keyed by tool name and the spelling for an MCP-served tool is unverified; a wrong key silently grants nothing.
- Repo-level `AGENTS.md` / `CLAUDE.md` routing blocks are still not stripped by `uninstall` — pre-existing, and it affects every adapter, so it does not belong in this branch.
