### PR TITLE
fix(mcp): cache index health scans

### DIFF
--- a/internal/mcp/index_health_cache.go
+++ b/internal/mcp/index_health_cache.go
@@ -1,0 +1,62 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+const indexHealthSnapshotTTL = 30 * time.Second
+
+type indexHealthCache struct {
+	mu         sync.RWMutex
+	payload    map[string]any
+	updatedAt  time.Time
+	refreshing bool
+}
+
+func (s *Server) indexHealthSnapshot() (map[string]any, time.Time, bool) {
+	s.indexHealth.mu.RLock()
+	defer s.indexHealth.mu.RUnlock()
+	if s.indexHealth.payload == nil {
+		return nil, time.Time{}, s.indexHealth.refreshing
+	}
+	return s.indexHealth.payload, s.indexHealth.updatedAt, s.indexHealth.refreshing
+}
+
+func (s *Server) refreshIndexHealthInBackground() {
+	s.indexHealth.mu.Lock()
+	if s.indexHealth.refreshing {
+		s.indexHealth.mu.Unlock()
+		return
+	}
+	s.indexHealth.refreshing = true
+	s.indexHealth.mu.Unlock()
+
+	go func() {
+		payload, err := s.buildIndexHealthPayloadCtx(context.Background())
+		s.indexHealth.mu.Lock()
+		defer s.indexHealth.mu.Unlock()
+		s.indexHealth.refreshing = false
+		if err == nil && payload != nil {
+			s.indexHealth.payload = payload
+			s.indexHealth.updatedAt = time.Now()
+		}
+	}()
+}
+
+func (s *Server) indexHealthNeedsRefresh(updatedAt time.Time) bool {
+	return updatedAt.IsZero() || time.Since(updatedAt) >= indexHealthSnapshotTTL
+}
+
+func compactIndexHealth(payload map[string]any, updatedAt time.Time, refreshing bool) string {
+	stale, _ := payload["stale_files"].([]string)
+	failures, _ := payload["parse_failures"].(map[string]string)
+	status := "ready"
+	if refreshing {
+		status = "refreshing"
+	}
+	return fmt.Sprintf("health=%v nodes=%v stale=%d failures=%d status=%s age=%ds\n",
+		payload["health_score"], payload["node_count"], len(stale), len(failures), status, int(time.Since(updatedAt).Seconds()))
+}

--- a/internal/mcp/index_health_cache_test.go
+++ b/internal/mcp/index_health_cache_test.go
@@ -1,0 +1,33 @@
+package mcp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIndexHealthNeedsRefresh(t *testing.T) {
+	s := &Server{}
+
+	assert.True(t, s.indexHealthNeedsRefresh(time.Time{}))
+	assert.False(t, s.indexHealthNeedsRefresh(time.Now()))
+	assert.True(t, s.indexHealthNeedsRefresh(time.Now().Add(-indexHealthSnapshotTTL-time.Second)))
+}
+
+func TestCompactIndexHealthUsesCachedPayload(t *testing.T) {
+	got := compactIndexHealth(map[string]any{
+		"health_score": 99.5,
+		"node_count":   42,
+		"stale_files":  []string{"a.go"},
+		"parse_failures": map[string]string{
+			"b.go": "parse error",
+		},
+	}, time.Now().Add(-2*time.Second), true)
+
+	assert.Contains(t, got, "health=99.5")
+	assert.Contains(t, got, "nodes=42")
+	assert.Contains(t, got, "stale=1")
+	assert.Contains(t, got, "failures=1")
+	assert.Contains(t, got, "status=refreshing")
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -423,6 +423,7 @@ type Server struct {
 	// periodic ticker. Eagerly constructed in NewServer; the daemon
 	// entrypoint wires the snapshot fn via AttachHealthSnapshot.
 	healthBroadcaster *healthBroadcaster
+	indexHealth       indexHealthCache
 
 	// staleRefsBroadcaster fans `notifications/stale_refs` per session
 	// when the watcher reports symbol churn in a file the session has

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -2996,25 +2996,29 @@ func (s *Server) handleIndexHealth(ctx context.Context, req mcp.CallToolRequest)
 	if s.indexer == nil {
 		return mcp.NewToolResultError("no indexer available"), nil
 	}
-	result, err := s.buildIndexHealthPayloadCtx(ctx)
-	if err != nil {
-		return mcp.NewToolResultError(
-			"index_health was cancelled before it finished: the scan is proportional to workspace size " +
-				"(one stat per tracked file plus a graph scan) and the caller's deadline expired first. " +
-				"Retry when indexing settles, or pass compact:true for the cheaper summary."), nil
+	if err := ctx.Err(); err != nil {
+		return mcp.NewToolResultError("index_health was cancelled before it finished: " + err.Error()), nil
+	}
+
+	result, updatedAt, refreshing := s.indexHealthSnapshot()
+	if result == nil || s.indexHealthNeedsRefresh(updatedAt) {
+		s.refreshIndexHealthInBackground()
+		result, updatedAt, refreshing = s.indexHealthSnapshot()
 	}
 
 	if isCompact(req) {
-		stale, _ := result["stale_files"].([]string)
-		failures, _ := result["parse_failures"].(map[string]string)
-		line := fmt.Sprintf("health=%.1f%% nodes=%d stale=%d failures=%d",
-			result["health_score"], result["node_count"], len(stale), len(failures))
-		if _, ok := result["recommendation"]; ok {
-			line += " [needs re-index]"
+		if result == nil {
+			return mcp.NewToolResultText("health=unknown nodes=unknown stale=unknown failures=unknown status=refreshing\n"), nil
 		}
-		return mcp.NewToolResultText(line + "\n"), nil
+		return mcp.NewToolResultText(compactIndexHealth(result, updatedAt, refreshing)), nil
 	}
 
+	if result == nil {
+		return s.respondJSONOrTOON(ctx, req, map[string]any{
+			"status":  "refreshing",
+			"message": "index health is being computed in the background; retry for the completed report",
+		})
+	}
 	return s.respondJSONOrTOON(ctx, req, result)
 }
 


### PR DESCRIPTION
## Summary
- make index_health requests return cached results instead of rescanning synchronously
- coalesce refreshes into one background scan with a 30-second snapshot TTL
- make compact mode return immediately with refresh status and snapshot age
- preserve cancellation behavior and add cache/compact tests

## Verification
- go build -o /tmp/gortex ./cmd/gortex/
- go test ./internal/mcp
- go test -race ./internal/mcp
- go test ./... reaches all packages but the pre-existing internal/graph worktree-fencing test fails because this workspace exposes .claude/worktrees paths outside the test indexer staging path.