### PR TITLE
tstypes: true up spool capacity hints and page-cap/deadline comments

### DIFF
--- a/internal/semantic/tstypes/fact_spool.go
+++ b/internal/semantic/tstypes/fact_spool.go
@@ -177,7 +177,7 @@ const (
 	classAliases
 	classCalls
 
-	factClassCount = int(classCalls) + 1
+	factClassCount = iota // 5 — auto-tracks any class added above
 )
 
 // marshalClassPayloads encodes one file's facts as per-class JSON arrays,

--- a/internal/semantic/tstypes/fact_spool.go
+++ b/internal/semantic/tstypes/fact_spool.go
@@ -16,6 +16,9 @@ import (
 // A page is deliberately capped by both files and encoded bytes. Facts from a
 // single source file are indivisible, but source parsing already rejects files
 // larger than maxFileBytes, so even that exception has a hard upstream bound.
+// The byte cap charges only the paged class's payloads; the imports side-fetch
+// that hydrates every non-imports page rides on top, so peak page bytes can
+// modestly exceed it.
 const (
 	tstypesFactPageFiles = 32
 	tstypesFactPageBytes = 4 << 20
@@ -173,6 +176,8 @@ const (
 	classMetas
 	classAliases
 	classCalls
+
+	factClassCount = int(classCalls) + 1
 )
 
 // marshalClassPayloads encodes one file's facts as per-class JSON arrays,
@@ -301,8 +306,8 @@ func (s *factSpool) appendFiles(records []stagedFileFacts) error {
 		end := min(start+tstypesSQLChunkRows, len(records))
 		fileValues := make([]string, 0, end-start)
 		fileArgs := make([]any, 0, (end-start)*2)
-		classValues := make([]string, 0, (end-start)*4)
-		classArgs := make([]any, 0, (end-start)*4*4)
+		classValues := make([]string, 0, (end-start)*factClassCount)
+		classArgs := make([]any, 0, (end-start)*factClassCount*4)
 		for _, record := range records[start:end] {
 			if record.facts == nil {
 				continue

--- a/internal/semantic/tstypes/provider_stream.go
+++ b/internal/semantic/tstypes/provider_stream.go
@@ -156,7 +156,10 @@ func (p *Provider) applyStagedFacts(ctx context.Context, g graph.Store, repoPref
 	// Coverage walk: every staged file, no payload decode. The supers phase
 	// no longer sees files without inheritance facts, so coverage counting
 	// cannot ride on it; this walk also pre-warms the per-file node groups
-	// for all four phases.
+	// for all four phases. It is the first work under the pass deadline and
+	// flushes no edges, so an expiry during it yields a zero-edge partial —
+	// accepted because the walk is decode-free: a budget too small for it
+	// could not have completed any apply phase either.
 	after := ""
 	for {
 		if err := ctx.Err(); err != nil {


### PR DESCRIPTION
The small remainders from the #530 review (the `rows.Err` one you already fixed in
d3fc1a51, together with the linter that keeps the whole class out).

- `appendFiles` sized its per-chunk slices for 4 classes per file when there are 5.
  Capacity hint only, as you noted — now derived from the enum (`factClassCount`) so a
  sixth class can't repeat the drift.
- The page-cap comment now states that the byte cap charges only the paged class's
  payloads and that the imports side-fetch rides on top, so peak page bytes can modestly
  exceed it — the cap's actual contract rather than the implied one.
- The coverage-walk comment now records the deadline trade-off from your review: the walk
  is the first work under the pass deadline and flushes no edges, so an expiry during it
  yields a zero-edge partial. Accepted rather than special-cased — the walk is decode-free,
  so a budget too small for it could not have completed any apply phase either. If you'd
  rather exempt the walk from the deadline outright, happy to do that instead, but it
  changes budget semantics and didn't seem worth it for a window this small.

No behavior change; `./internal/semantic/tstypes` green, gofmt clean.
