### PR TITLE
perf: bind resolved-conversion reindex as one json_each relation

### DIFF
--- a/internal/graph/store_sqlite/reindex_json_transport_test.go
+++ b/internal/graph/store_sqlite/reindex_json_transport_test.go
@@ -1,6 +1,8 @@
 package store_sqlite
 
 import (
+	"bytes"
+	"math"
 	"path/filepath"
 	"testing"
 
@@ -33,12 +35,13 @@ func TestResolvedConversionPayloadFidelity(t *testing.T) {
 	e3 := mk(3, graph.UnresolvedMarker+"Gamma")
 	store.AddBatch(nil, []*graph.Edge{e1, e2, e3})
 
-	// e1: quoted/unicode meta, integral confidence, terminal stamp set false.
+	// e1: quoted/unicode meta, integral confidence, terminal stamp set false —
+	// the false stamp must land as INTEGER 0, not NULL.
 	e1.To = "r/pkg/impl.cs::Alpha"
 	e1.Confidence = 1
 	e1.ConfidenceLabel = "exact"
 	e1.Origin = "resolved"
-	e1.Meta = map[string]any{"note": `sa"ys → ☂`, "n": float64(2)}
+	e1.Meta = map[string]any{"note": `sa"ys → ☂`, "n": float64(2), "resolve_terminal": false}
 	// e2: kind change rides the conversion; no meta; NULL terminal fields.
 	e2.To = "r/pkg/impl.cs::Beta"
 	e2.Kind = graph.EdgeReferences
@@ -59,6 +62,7 @@ func TestResolvedConversionPayloadFidelity(t *testing.T) {
 		confidence             float64
 		confTypeof, metaTypeof string
 		termTypeof             string
+		termValue              int
 		crossRepo              int
 		metaText               string
 	}
@@ -66,10 +70,12 @@ func TestResolvedConversionPayloadFidelity(t *testing.T) {
 		var f rowFacts
 		err := store.db.QueryRow(`SELECT to_id, kind, origin, confidence,
 			typeof(confidence), typeof(meta), typeof(resolve_terminal),
-			cross_repo, COALESCE(CAST(meta AS TEXT), '')
+			COALESCE(resolve_terminal, -1), cross_repo,
+			COALESCE(CAST(meta AS TEXT), '')
 			FROM edges WHERE file_path = ? AND line = ?`, file, line).
 			Scan(&f.to, &f.kind, &f.origin, &f.confidence, &f.confTypeof,
-				&f.metaTypeof, &f.termTypeof, &f.crossRepo, &f.metaText)
+				&f.metaTypeof, &f.termTypeof, &f.termValue, &f.crossRepo,
+				&f.metaText)
 		if err != nil {
 			t.Fatalf("line %d: %v", line, err)
 		}
@@ -85,6 +91,10 @@ func TestResolvedConversionPayloadFidelity(t *testing.T) {
 	}
 	if r1.metaTypeof != "blob" {
 		t.Fatalf("row1 meta typeof = %q, want blob", r1.metaTypeof)
+	}
+	if r1.termTypeof != "integer" || r1.termValue != 0 {
+		t.Fatalf("row1 resolve_terminal = %s/%d, want integer/0 (a false stamp must not decay to NULL)",
+			r1.termTypeof, r1.termValue)
 	}
 	// Byte fidelity against the production encoder: meta is a compact binary
 	// encoding, and the transport must deliver it bit-identical.
@@ -114,11 +124,116 @@ func TestResolvedConversionPayloadFidelity(t *testing.T) {
 	}
 }
 
-func containsStr(haystack, needle string) bool {
-	for i := 0; i+len(needle) <= len(haystack); i++ {
-		if haystack[i:i+len(needle)] == needle {
-			return true
+// TestReindexEdgesJSONUnsafePayloadsRideRepairPath pins the transport's
+// json-safety guard: values json.Marshal would corrupt — invalid UTF-8 in a
+// SET-side string (silently rewritten to U+FFFD, and committed because the
+// clean old key still matches), non-finite confidence (fails the whole
+// Marshal) — must bypass the json_each arm and ride the raw-binding
+// delete+insert repair path, without failing the batch or disturbing clean
+// rows.
+func TestReindexEdgesJSONUnsafePayloadsRideRepairPath(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "jsonsafe.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	const file = "r/pkg/caller.cs"
+	mk := func(i int, to string) *graph.Edge {
+		return &graph.Edge{
+			From: file + "::Caller", To: to, Kind: graph.EdgeCalls,
+			FilePath: file, Line: i, Confidence: 0.3, Origin: "heuristic",
 		}
 	}
-	return false
+	e1 := mk(1, graph.UnresolvedMarker+"Alpha")
+	e2 := mk(2, graph.UnresolvedMarker+"Beta")
+	e3 := mk(3, graph.UnresolvedMarker+"Gamma")
+	store.AddBatch(nil, []*graph.Edge{e1, e2, e3})
+
+	// e1: the resolved target id carries invalid UTF-8.
+	e1.To = "r/pkg/impl.cs::Al\xfffa"
+	e1.Confidence = 1
+	// e2: non-finite confidence; the row degrades like the old transport's
+	// worst case (NaN stores as NULL, NOT NULL rejects, OR IGNORE drops).
+	e2.To = "r/pkg/impl.cs::Beta"
+	e2.Confidence = math.NaN()
+	// e3: clean conversion sharing the batch.
+	e3.To = "r/pkg/impl.cs::Gamma"
+	e3.Confidence = 0.75
+
+	stats, err := store.reindexEdgesSetOriented([]graph.EdgeReindex{
+		{Edge: e1, OldTo: graph.UnresolvedMarker + "Alpha"},
+		{Edge: e2, OldTo: graph.UnresolvedMarker + "Beta"},
+		{Edge: e3, OldTo: graph.UnresolvedMarker + "Gamma"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	readTo := func(line int) string {
+		var to string
+		err := store.db.QueryRow(
+			`SELECT to_id FROM edges WHERE file_path = ? AND line = ?`,
+			file, line).Scan(&to)
+		if err != nil {
+			t.Fatalf("line %d: %v", line, err)
+		}
+		return to
+	}
+	if got := readTo(1); got != e1.To {
+		t.Fatalf("non-UTF-8 to_id = %q, want byte-exact %q", got, e1.To)
+	}
+	if got := readTo(3); got != "r/pkg/impl.cs::Gamma" {
+		t.Fatalf("clean row to_id = %q", got)
+	}
+	if stats.updatedRows != 1 {
+		t.Fatalf("updatedRows = %d, want 1 (only the clean row rides the json arm)",
+			stats.updatedRows)
+	}
+}
+
+// TestEncodeResolvedConversionRowsBounds pins the transport's two chunking
+// bounds: the row cap and the estimated-byte budget, including the
+// first-row-always-taken guarantee that keeps oversized rows progressing.
+func TestEncodeResolvedConversionRowsBounds(t *testing.T) {
+	mk := func(metaLen int) sqliteReindexMutation {
+		return sqliteReindexMutation{
+			oldKey: sqliteReindexKey{
+				fromID: "r/a.go::F", toID: graph.UnresolvedMarker + "X",
+				kind: "calls", filePath: "r/a.go", line: 1,
+			},
+			newRow: sqliteReindexRow{
+				key: sqliteReindexKey{
+					fromID: "r/a.go::F", toID: "r/b.go::X",
+					kind: "calls", filePath: "r/a.go", line: 1,
+				},
+				meta: bytes.Repeat([]byte{0xAB}, metaLen),
+			},
+			resolvedConversion: true,
+		}
+	}
+
+	// Oversized rows: each row's estimate alone exceeds the byte budget, so
+	// chunks degrade to one row each — never zero, so every call progresses.
+	big := mk(sqliteBatchMaxBoundBytes)
+	_, n, err := encodeResolvedConversionRows([]sqliteReindexMutation{big, big}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("oversized rows per chunk = %d, want 1", n)
+	}
+
+	// Small rows: the row cap binds before the byte budget.
+	small := make([]sqliteReindexMutation, reindexRowMaxChunkSize+5)
+	for i := range small {
+		small[i] = mk(0)
+	}
+	_, n, err = encodeResolvedConversionRows(small, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != reindexRowMaxChunkSize {
+		t.Fatalf("small rows per chunk = %d, want %d", n, reindexRowMaxChunkSize)
+	}
 }

--- a/internal/graph/store_sqlite/reindex_json_transport_test.go
+++ b/internal/graph/store_sqlite/reindex_json_transport_test.go
@@ -1,0 +1,124 @@
+package store_sqlite
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestResolvedConversionPayloadFidelity characterizes the resolved-conversion
+// update arm across the payload shapes the transport must not disturb: meta
+// bytes with JSON metacharacters and unicode, absent meta, integral-valued
+// confidence (REAL column, integer-looking number), NULL vs set terminal
+// fields, and the kind-change variant. Storage classes are asserted with
+// typeof() so a transport that silently retypes a column (TEXT meta, INTEGER
+// confidence) fails here rather than in production forensics.
+func TestResolvedConversionPayloadFidelity(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "fidelity.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	const file = `r/pkg\caller.cs`
+	mk := func(i int, to string) *graph.Edge {
+		return &graph.Edge{
+			From: file + "::Caller", To: to, Kind: graph.EdgeCalls,
+			FilePath: file, Line: i, Confidence: 0.3, Origin: "heuristic",
+		}
+	}
+	e1 := mk(1, graph.UnresolvedMarker+"Alpha")
+	e2 := mk(2, graph.UnresolvedMarker+"Beta")
+	e3 := mk(3, graph.UnresolvedMarker+"Gamma")
+	store.AddBatch(nil, []*graph.Edge{e1, e2, e3})
+
+	// e1: quoted/unicode meta, integral confidence, terminal stamp set false.
+	e1.To = "r/pkg/impl.cs::Alpha"
+	e1.Confidence = 1
+	e1.ConfidenceLabel = "exact"
+	e1.Origin = "resolved"
+	e1.Meta = map[string]any{"note": `sa"ys → ☂`, "n": float64(2)}
+	// e2: kind change rides the conversion; no meta; NULL terminal fields.
+	e2.To = "r/pkg/impl.cs::Beta"
+	e2.Kind = graph.EdgeReferences
+	e2.Confidence = 0.9
+	// e3: stays unresolved-shaped conversion partner for batch realism.
+	e3.To = "r/pkg/impl.cs::Gamma"
+	e3.Confidence = 0.75
+	e3.CrossRepo = true
+
+	store.ReindexEdges([]graph.EdgeReindex{
+		{Edge: e1, OldTo: graph.UnresolvedMarker + "Alpha"},
+		{Edge: e2, OldTo: graph.UnresolvedMarker + "Beta", OldKind: graph.EdgeCalls},
+		{Edge: e3, OldTo: graph.UnresolvedMarker + "Gamma"},
+	})
+
+	type rowFacts struct {
+		to, kind, origin       string
+		confidence             float64
+		confTypeof, metaTypeof string
+		termTypeof             string
+		crossRepo              int
+		metaText               string
+	}
+	readRow := func(line int) rowFacts {
+		var f rowFacts
+		err := store.db.QueryRow(`SELECT to_id, kind, origin, confidence,
+			typeof(confidence), typeof(meta), typeof(resolve_terminal),
+			cross_repo, COALESCE(CAST(meta AS TEXT), '')
+			FROM edges WHERE file_path = ? AND line = ?`, file, line).
+			Scan(&f.to, &f.kind, &f.origin, &f.confidence, &f.confTypeof,
+				&f.metaTypeof, &f.termTypeof, &f.crossRepo, &f.metaText)
+		if err != nil {
+			t.Fatalf("line %d: %v", line, err)
+		}
+		return f
+	}
+
+	r1 := readRow(1)
+	if r1.to != "r/pkg/impl.cs::Alpha" || r1.origin != "resolved" || r1.confidence != 1 {
+		t.Fatalf("row1 payload = %+v", r1)
+	}
+	if r1.confTypeof != "real" {
+		t.Fatalf("row1 confidence typeof = %q, want real", r1.confTypeof)
+	}
+	if r1.metaTypeof != "blob" {
+		t.Fatalf("row1 meta typeof = %q, want blob", r1.metaTypeof)
+	}
+	// Byte fidelity against the production encoder: meta is a compact binary
+	// encoding, and the transport must deliver it bit-identical.
+	_, blobMeta := extractPromotedEdgeMeta(e1.Meta)
+	wantMeta, err := encodeMeta(blobMeta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r1.metaText != string(wantMeta) {
+		t.Fatalf("row1 meta bytes = %q, want %q", r1.metaText, wantMeta)
+	}
+
+	r2 := readRow(2)
+	if r2.to != "r/pkg/impl.cs::Beta" || r2.kind != string(graph.EdgeReferences) {
+		t.Fatalf("row2 kind-change conversion = %+v", r2)
+	}
+	if r2.termTypeof != "null" {
+		t.Fatalf("row2 resolve_terminal typeof = %q, want null", r2.termTypeof)
+	}
+	if r2.metaTypeof != "null" {
+		t.Fatalf("row2 meta typeof = %q, want null", r2.metaTypeof)
+	}
+
+	r3 := readRow(3)
+	if r3.to != "r/pkg/impl.cs::Gamma" || r3.crossRepo != 1 || r3.confidence != 0.75 {
+		t.Fatalf("row3 payload = %+v", r3)
+	}
+}
+
+func containsStr(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/graph/store_sqlite/reindex_set.go
+++ b/internal/graph/store_sqlite/reindex_set.go
@@ -7,6 +7,8 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
+	"unicode/utf8"
 
 	"github.com/zzet/gortex/internal/graph"
 )
@@ -185,7 +187,7 @@ func (s *Store) reindexEdgesSetTransactionLocked(ctx context.Context, batch []gr
 		inserts = conversionPlan.fallbackInserts
 
 		updated, statements, repairDeletes, repairInserts, updateErr :=
-			updateSQLiteResolvedConversionsTxLimited(tx, mutations, conversionPlan, false, &variableLimit)
+			updateSQLiteResolvedConversionsTxLimited(tx, mutations, conversionPlan, false)
 		if updateErr != nil {
 			return stats, false, false, nil, updateErr
 		}
@@ -195,7 +197,7 @@ func (s *Store) reindexEdgesSetTransactionLocked(ctx context.Context, batch []gr
 		inserts = append(inserts, repairInserts...)
 
 		updated, statements, repairDeletes, repairInserts, updateErr =
-			updateSQLiteResolvedConversionsTxLimited(tx, mutations, conversionPlan, true, &variableLimit)
+			updateSQLiteResolvedConversionsTxLimited(tx, mutations, conversionPlan, true)
 		if updateErr != nil {
 			return stats, false, false, nil, updateErr
 		}
@@ -401,7 +403,6 @@ func updateSQLiteResolvedConversionsTxLimited(
 	mutations []sqliteReindexMutation,
 	plan sqliteResolvedConversionPlan,
 	updateKind bool,
-	variableLimit *int,
 ) (
 	updatedRows int,
 	statements int,
@@ -414,9 +415,19 @@ func updateSQLiteResolvedConversionsTxLimited(
 	}
 	candidates := make([]sqliteReindexMutation, 0, len(mutations))
 	for _, mutation := range mutations {
-		if plan.updateCandidate(mutation, updateKind) {
-			candidates = append(candidates, mutation)
+		if !plan.updateCandidate(mutation, updateKind) {
+			continue
 		}
+		if !jsonSafeResolvedConversion(mutation) {
+			// json.Marshal would corrupt this row (invalid UTF-8 rewrites to
+			// U+FFFD — fatal on a SET column, where the mangled value would
+			// commit — and a non-finite confidence fails the whole Marshal).
+			// The repair path binds raw bytes and keeps it exact.
+			repairDeletes = append(repairDeletes, mutation.oldKey)
+			repairInserts = append(repairInserts, mutation.newRow)
+			continue
+		}
+		candidates = append(candidates, mutation)
 	}
 	query := sqliteResolvedConversionUpdateJSONStatement(updateKind)
 	for start := 0; start < len(candidates); {
@@ -456,13 +467,39 @@ func updateSQLiteResolvedConversionsTxLimited(
 	return updatedRows, statements, repairDeletes, repairInserts, nil
 }
 
+// jsonSafeResolvedConversion reports whether every value the JSON transport
+// would carry survives json.Marshal byte-exact: strings must be valid UTF-8
+// (Marshal rewrites invalid bytes to U+FFFD — on a WHERE column that is a
+// self-healing miss, but on a SET column the mangled value would commit) and
+// confidence must be finite (Marshal rejects NaN/Inf outright). meta is
+// exempt — it rides hex-armored.
+func jsonSafeResolvedConversion(mutation sqliteReindexMutation) bool {
+	row := mutation.newRow
+	if math.IsNaN(row.confidence) || math.IsInf(row.confidence, 0) {
+		return false
+	}
+	for _, s := range []string{
+		mutation.oldKey.fromID, mutation.oldKey.toID, mutation.oldKey.kind,
+		mutation.oldKey.filePath, row.key.toID, row.key.kind,
+		row.confidenceLabel, row.origin, row.tier,
+		row.resolveTerminalReason.String, row.semanticSource.String,
+	} {
+		if !utf8.ValidString(s) {
+			return false
+		}
+	}
+	return true
+}
+
 // encodeResolvedConversionRows marshals a bounded prefix of the candidates as
 // one json_each relation: positional arrays in patch-column order. meta rides
 // hex-encoded — its compact binary encoding is not UTF-8-safe inside JSON,
 // and unhex() restores the exact bytes — while NULL-able columns become JSON
 // null. Bounded by reindexRowMaxChunkSize rows and sqliteBatchMaxBoundBytes
 // of estimated payload; the first row is always taken, so every call makes
-// progress.
+// progress. The estimate counts raw bytes and ignores JSON escaping
+// inflation (~2x on backslash-heavy ids) — it is a soft memory bound, far
+// below SQLite's bound-length limit, not an exact guard.
 func encodeResolvedConversionRows(candidates []sqliteReindexMutation, updateKind bool) (string, int, error) {
 	rows := make([]any, 0, minInt(len(candidates), reindexRowMaxChunkSize))
 	estimated := 0

--- a/internal/graph/store_sqlite/reindex_set.go
+++ b/internal/graph/store_sqlite/reindex_set.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -14,11 +16,9 @@ const (
 	// writes that cancel do not invalidate analysis or inflate receipts. SQL is
 	// issued in VALUES relations bounded by the probed connection variable
 	// limit and the shared argument-byte budget.
-	reindexKeyParamsPerRow                = 5
-	reindexRowParamsPerRow                = edgeInsertParams
-	reindexRowMaxChunkSize                = edgeInsertMaxChunkSize
-	reindexResolvedUpdateParamsPerRow     = 15
-	reindexResolvedKindUpdateParamsPerRow = 16
+	reindexKeyParamsPerRow = 5
+	reindexRowParamsPerRow = edgeInsertParams
+	reindexRowMaxChunkSize = edgeInsertMaxChunkSize
 )
 
 type sqliteReindexKey struct {
@@ -412,60 +412,19 @@ func updateSQLiteResolvedConversionsTxLimited(
 	if len(mutations) == 0 {
 		return 0, 0, nil, nil, nil
 	}
-	if variableLimit == nil || *variableLimit <= 0 {
-		fallback := sqliteFallbackVariableLimit
-		variableLimit = &fallback
+	candidates := make([]sqliteReindexMutation, 0, len(mutations))
+	for _, mutation := range mutations {
+		if plan.updateCandidate(mutation, updateKind) {
+			candidates = append(candidates, mutation)
+		}
 	}
-
-	paramsPerRow := reindexResolvedUpdateParamsPerRow
-	if updateKind {
-		paramsPerRow = reindexResolvedKindUpdateParamsPerRow
-	}
-	rowLimit := batchRowsForVariableLimit(*variableLimit, paramsPerRow, reindexRowMaxChunkSize)
-	for pos := 0; pos < len(mutations); {
-		chunkStart := pos
-		args := make([]any, 0, rowLimit*paramsPerRow)
-		argBytes := 0
-		rowCount := 0
-		for pos < len(mutations) && rowCount < rowLimit {
-			mutation := mutations[pos]
-			if !plan.updateCandidate(mutation, updateKind) {
-				pos++
-				continue
-			}
-			row := mutation.newRow
-			argStart := len(args)
-			args = append(args,
-				mutation.oldKey.fromID, mutation.oldKey.toID, mutation.oldKey.kind,
-				mutation.oldKey.filePath, mutation.oldKey.line, row.key.toID,
-			)
-			if updateKind {
-				args = append(args, row.key.kind)
-			}
-			args = append(args,
-				row.confidence, row.confidenceLabel, row.origin, row.tier,
-				row.crossRepo, row.meta, row.resolveTerminal, row.resolveTerminalReason, row.semanticSource,
-			)
-			rowBytes := sqliteBoundArgsBytes(args[argStart:])
-			if rowCount > 0 && argBytes+rowBytes > sqliteBatchMaxBoundBytes {
-				args = args[:argStart]
-				break
-			}
-			pos++
-			rowCount++
-			argBytes += rowBytes
+	query := sqliteResolvedConversionUpdateJSONStatement(updateKind)
+	for start := 0; start < len(candidates); {
+		payload, rowCount, encodeErr := encodeResolvedConversionRows(candidates[start:], updateKind)
+		if encodeErr != nil {
+			return updatedRows, statements, repairDeletes, repairInserts, encodeErr
 		}
-		if rowCount == 0 {
-			continue
-		}
-
-		query := sqliteResolvedConversionUpdateStatement(rowCount, updateKind)
-		result, execErr := tx.Exec(query, args...)
-		if tooManySQLVariables(execErr) && rowCount > 1 {
-			rowLimit = lowerBatchVariableLimit(variableLimit, paramsPerRow, rowCount)
-			pos = chunkStart
-			continue
-		}
+		result, execErr := tx.Exec(query, payload)
 		if execErr != nil {
 			return updatedRows, statements, repairDeletes, repairInserts, execErr
 		}
@@ -487,25 +446,117 @@ func updateSQLiteResolvedConversionsTxLimited(
 			// materializing RETURNING rows. Replaying the whole bounded chunk is
 			// exact: successful rows already occupy their destination, while
 			// missing sources and destination collisions are repaired below.
-			for _, mutation := range mutations[chunkStart:pos] {
-				if !plan.updateCandidate(mutation, updateKind) {
-					continue
-				}
+			for _, mutation := range candidates[start : start+rowCount] {
 				repairDeletes = append(repairDeletes, mutation.oldKey)
 				repairInserts = append(repairInserts, mutation.newRow)
 			}
 		}
+		start += rowCount
 	}
 	return updatedRows, statements, repairDeletes, repairInserts, nil
 }
 
-func sqliteResolvedConversionUpdateStatement(rowCount int, updateKind bool) string {
+// encodeResolvedConversionRows marshals a bounded prefix of the candidates as
+// one json_each relation: positional arrays in patch-column order. meta rides
+// hex-encoded — its compact binary encoding is not UTF-8-safe inside JSON,
+// and unhex() restores the exact bytes — while NULL-able columns become JSON
+// null. Bounded by reindexRowMaxChunkSize rows and sqliteBatchMaxBoundBytes
+// of estimated payload; the first row is always taken, so every call makes
+// progress.
+func encodeResolvedConversionRows(candidates []sqliteReindexMutation, updateKind bool) (string, int, error) {
+	rows := make([]any, 0, minInt(len(candidates), reindexRowMaxChunkSize))
+	estimated := 0
+	for _, mutation := range candidates {
+		if len(rows) >= reindexRowMaxChunkSize {
+			break
+		}
+		size := resolvedConversionRowEstimate(mutation)
+		if len(rows) > 0 && estimated+size > sqliteBatchMaxBoundBytes {
+			break
+		}
+		rows = append(rows, resolvedConversionJSONRow(mutation, updateKind))
+		estimated += size
+	}
+	encoded, err := json.Marshal(rows)
+	if err != nil {
+		return "", 0, err
+	}
+	return string(encoded), len(rows), nil
+}
+
+func resolvedConversionRowEstimate(mutation sqliteReindexMutation) int {
+	row := mutation.newRow
+	return len(mutation.oldKey.fromID) + len(mutation.oldKey.toID) +
+		len(mutation.oldKey.kind) + len(mutation.oldKey.filePath) +
+		len(row.key.toID) + len(row.key.kind) + len(row.confidenceLabel) +
+		len(row.origin) + len(row.tier) + 2*len(row.meta) +
+		len(row.resolveTerminalReason.String) + len(row.semanticSource.String) + 64
+}
+
+func resolvedConversionJSONRow(mutation sqliteReindexMutation, updateKind bool) []any {
+	row := mutation.newRow
+	out := make([]any, 0, 16)
+	out = append(out,
+		mutation.oldKey.fromID, mutation.oldKey.toID, mutation.oldKey.kind,
+		mutation.oldKey.filePath, mutation.oldKey.line, row.key.toID,
+	)
 	if updateKind {
-		return `WITH patch(
-		old_from_id, old_to_id, old_kind, file_path, line, new_to_id, new_kind,
-		confidence, confidence_label, origin, tier, cross_repo, meta,
-		resolve_terminal, resolve_terminal_reason, semantic_source
-	) AS (VALUES ` + multiValues(rowCount, reindexResolvedKindUpdateParamsPerRow) + `)
+		out = append(out, row.key.kind)
+	}
+	var meta any
+	if row.meta != nil {
+		meta = hex.EncodeToString(row.meta)
+	}
+	var terminal any
+	if row.resolveTerminal.Valid {
+		if row.resolveTerminal.Bool {
+			terminal = 1
+		} else {
+			terminal = 0
+		}
+	}
+	var reason any
+	if row.resolveTerminalReason.Valid {
+		reason = row.resolveTerminalReason.String
+	}
+	var semantic any
+	if row.semanticSource.Valid {
+		semantic = row.semanticSource.String
+	}
+	out = append(out,
+		row.confidence, row.confidenceLabel, row.origin, row.tier,
+		row.crossRepo, meta, terminal, reason, semantic,
+	)
+	return out
+}
+
+// sqliteResolvedConversionUpdateJSONStatement is the resolved-conversion
+// update arm over a json_each relation: the whole chunk rides ONE bound
+// variable, where the per-row VALUES form paid the driver's bind cost for
+// 15-16 parameters per row. meta travels hex-encoded (binary; see
+// encodeResolvedConversionRows) and unhex() restores the exact bytes; JSON
+// numbers and nulls land as INTEGER/REAL/NULL, with column affinity settling
+// confidence to REAL.
+func sqliteResolvedConversionUpdateJSONStatement(updateKind bool) string {
+	if updateKind {
+		return `WITH patch AS (SELECT
+		value ->> 0 AS old_from_id,
+		value ->> 1 AS old_to_id,
+		value ->> 2 AS old_kind,
+		value ->> 3 AS file_path,
+		value ->> 4 AS line,
+		value ->> 5 AS new_to_id,
+		value ->> 6 AS new_kind,
+		CAST(value ->> 7 AS REAL) AS confidence,
+		value ->> 8 AS confidence_label,
+		value ->> 9 AS origin,
+		value ->> 10 AS tier,
+		value ->> 11 AS cross_repo,
+		unhex(value ->> 12) AS meta,
+		value ->> 13 AS resolve_terminal,
+		value ->> 14 AS resolve_terminal_reason,
+		value ->> 15 AS semantic_source
+	FROM json_each(?))
 	UPDATE OR IGNORE edges AS e
 	SET to_id = p.new_to_id,
 		kind = p.new_kind,
@@ -525,11 +576,23 @@ func sqliteResolvedConversionUpdateStatement(rowCount int, updateKind bool) stri
 		AND e.file_path = p.file_path
 		AND e.line = p.line`
 	}
-	return `WITH patch(
-		old_from_id, old_to_id, kind, file_path, line, new_to_id,
-		confidence, confidence_label, origin, tier, cross_repo, meta,
-		resolve_terminal, resolve_terminal_reason, semantic_source
-	) AS (VALUES ` + multiValues(rowCount, reindexResolvedUpdateParamsPerRow) + `)
+	return `WITH patch AS (SELECT
+		value ->> 0 AS old_from_id,
+		value ->> 1 AS old_to_id,
+		value ->> 2 AS kind,
+		value ->> 3 AS file_path,
+		value ->> 4 AS line,
+		value ->> 5 AS new_to_id,
+		CAST(value ->> 6 AS REAL) AS confidence,
+		value ->> 7 AS confidence_label,
+		value ->> 8 AS origin,
+		value ->> 9 AS tier,
+		value ->> 10 AS cross_repo,
+		unhex(value ->> 11) AS meta,
+		value ->> 12 AS resolve_terminal,
+		value ->> 13 AS resolve_terminal_reason,
+		value ->> 14 AS semantic_source
+	FROM json_each(?))
 	UPDATE OR IGNORE edges AS e
 	SET to_id = p.new_to_id,
 		confidence = p.confidence,

--- a/internal/graph/store_sqlite/reindex_set_test.go
+++ b/internal/graph/store_sqlite/reindex_set_test.go
@@ -210,8 +210,11 @@ func TestReindexEdgesNetCancellationAcrossSQLChunksIsNoop(t *testing.T) {
 	assert.Equal(t, "preserve", persisted[0].Meta["opaque"])
 }
 
-func TestReindexEdgesUsesRuntimeVariableBudget(t *testing.T) {
+func TestReindexEdgesResolvedConversionChunksByRows(t *testing.T) {
 	const edgeCount = 2000
+	// The resolved-conversion arm rides one json_each variable per statement,
+	// so the connection variable limit no longer shapes it: both budget
+	// extremes must produce the identical row-bounded statement count.
 	for _, variableLimit := range []int{sqliteFallbackVariableLimit, sqliteBatchVariableHardCap} {
 		t.Run(fmt.Sprintf("limit_%d", variableLimit), func(t *testing.T) {
 			store := openReindexReceiptTestStore(t)
@@ -237,9 +240,10 @@ func TestReindexEdgesUsesRuntimeVariableBudget(t *testing.T) {
 
 			stats, err := store.reindexEdgesSetOriented(batch)
 			require.NoError(t, err)
-			updateRows := batchRowsForVariableLimit(variableLimit, reindexResolvedUpdateParamsPerRow, reindexRowMaxChunkSize)
 			assert.Zero(t, stats.selectStatements, "resolved conversions must not prefetch full edge rows")
-			assert.Equal(t, (edgeCount+updateRows-1)/updateRows, stats.updateStatements)
+			wantStatements := (edgeCount + reindexRowMaxChunkSize - 1) / reindexRowMaxChunkSize
+			assert.Equal(t, wantStatements, stats.updateStatements,
+				"json_each chunks by rows, not by the connection variable limit")
 			assert.Equal(t, edgeCount, stats.updatedRows)
 			assert.Zero(t, stats.deleteStatements)
 			assert.Zero(t, stats.insertStatements)
@@ -275,12 +279,23 @@ func TestReindexInsertChunksRespectBoundArgumentBytes(t *testing.T) {
 }
 
 func TestReindexEdgesDownshiftsConnectionVariableLimit(t *testing.T) {
+	// The resolved-conversion arm no longer binds per-row variables, so the
+	// downshift is exercised through the generic simulator path: mixing
+	// conversion directions disqualifies the fast path, and the prefetch /
+	// delete / insert arms still bind bounded per-row VALUES relations that
+	// must discover and persist a lowered connection limit.
 	store := openReindexReceiptTestStore(t)
 	oldEdges := make([]*graph.Edge, 0, 120)
 	batch := make([]graph.EdgeReindex, 0, 120)
 	for i := 0; i < 120; i++ {
 		from := fmt.Sprintf("repo/caller-%03d.go::Caller", i)
 		oldTo := fmt.Sprintf("unresolved::Old%03d", i)
+		newTo := fmt.Sprintf("repo/target-%03d.go::Target", i)
+		if i%2 == 1 {
+			// Reverse conversion (guard-revert shape) breaks direction
+			// uniformity for the whole batch.
+			oldTo, newTo = newTo, oldTo
+		}
 		oldEdges = append(oldEdges, &graph.Edge{
 			From: from, To: oldTo, Kind: graph.EdgeCalls,
 			FilePath: "repo/callers.go", Line: i + 1,
@@ -288,7 +303,7 @@ func TestReindexEdgesDownshiftsConnectionVariableLimit(t *testing.T) {
 		batch = append(batch, graph.EdgeReindex{
 			OldTo: oldTo,
 			Edge: &graph.Edge{
-				From: from, To: fmt.Sprintf("repo/target-%03d.go::Target", i),
+				From: from, To: newTo,
 				Kind: graph.EdgeCalls, FilePath: "repo/callers.go", Line: i + 1,
 			},
 		})
@@ -305,14 +320,11 @@ func TestReindexEdgesDownshiftsConnectionVariableLimit(t *testing.T) {
 
 	stats, err := store.reindexEdgesSetOriented(batch)
 	require.NoError(t, err)
-	assert.Equal(t, len(batch), stats.updatedRows)
-	assert.Zero(t, stats.deletedRows)
-	assert.Zero(t, stats.insertedRows)
+	assert.Equal(t, len(batch), stats.deletedRows)
+	assert.Equal(t, len(batch), stats.insertedRows)
+	assert.Zero(t, stats.updatedRows)
 	assert.LessOrEqual(t, store.batchVariableLimit, connectionLimit)
-	assert.Zero(t, stats.selectStatements, "resolved conversions must not prefetch full edge rows")
-	assert.Greater(t, stats.updateStatements, 1, "the first oversized update must downshift and retry")
-	assert.Zero(t, stats.deleteStatements)
-	assert.Zero(t, stats.insertStatements)
+	assert.Greater(t, stats.selectStatements, 1, "the first oversized prefetch must downshift and retry")
 	assert.Equal(t, len(batch), store.EdgeCount())
 }
 

--- a/internal/resolver/churn_shape.go
+++ b/internal/resolver/churn_shape.go
@@ -1,0 +1,32 @@
+package resolver
+
+import "github.com/zzet/gortex/internal/graph"
+
+// churnShapeClass splits the non-conversion ("churn") share of a pass's
+// reindex volume by what actually changed on the row, so the log can say
+// which store write path the volume needs: a moved (still-unresolved)
+// target rewrites the row identity, a kind promotion rewrites the key's
+// kind column, and a payload-only rewrite (confidence / origin / meta /
+// terminality) is servable by the attribute-only UPDATE arm of
+// ReindexEdges without touching the row identity at all.
+type churnShapeClass int
+
+const (
+	churnShapeRetarget churnShapeClass = iota
+	churnShapeKind
+	churnShapeAttrs
+)
+
+// churnShape classifies one non-conversion reindex. A target move dominates
+// a simultaneous kind change: identity rewrite cost is what the class
+// tracks, and a moved target forces it regardless of the kind.
+func churnShape(oldTo, newTo string, oldKind, newKind graph.EdgeKind) churnShapeClass {
+	switch {
+	case newTo != oldTo:
+		return churnShapeRetarget
+	case newKind != oldKind:
+		return churnShapeKind
+	default:
+		return churnShapeAttrs
+	}
+}

--- a/internal/resolver/churn_shape_test.go
+++ b/internal/resolver/churn_shape_test.go
@@ -1,0 +1,45 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestChurnShapeClassification(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		oldTo, newTo  string
+		oldKind, kind graph.EdgeKind
+		want          churnShapeClass
+	}{
+		{
+			name:  "unresolved retarget",
+			oldTo: graph.UnresolvedMarker + "Work", newTo: graph.UnresolvedMarker + "pkg::Work",
+			oldKind: graph.EdgeCalls, kind: graph.EdgeCalls,
+			want: churnShapeRetarget,
+		},
+		{
+			name:  "kind promotion, target unchanged",
+			oldTo: "pkg/a.go::Work", newTo: "pkg/a.go::Work",
+			oldKind: graph.EdgeCalls, kind: graph.EdgeReferences,
+			want: churnShapeKind,
+		},
+		{
+			name:  "payload-only rewrite",
+			oldTo: "pkg/a.go::Work", newTo: "pkg/a.go::Work",
+			oldKind: graph.EdgeCalls, kind: graph.EdgeCalls,
+			want: churnShapeAttrs,
+		},
+		{
+			name:  "retarget wins over kind change",
+			oldTo: graph.UnresolvedMarker + "A", newTo: graph.UnresolvedMarker + "B",
+			oldKind: graph.EdgeCalls, kind: graph.EdgeReferences,
+			want: churnShapeRetarget,
+		},
+	} {
+		if got := churnShape(tc.oldTo, tc.newTo, tc.oldKind, tc.kind); got != tc.want {
+			t.Fatalf("%s: churnShape = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -844,6 +844,11 @@ func (r *Resolver) ResolveAllContext(ctx context.Context) (*ResolveStats, error)
 	prepareElapsed := time.Duration(0)
 	workersElapsed := time.Duration(0)
 	applyElapsed := time.Duration(0)
+	applyLivenessElapsed := time.Duration(0)
+	applyNoteElapsed := time.Duration(0)
+	applyStoreElapsed := time.Duration(0)
+	applyPlaceholderElapsed := time.Duration(0)
+	applyGuardSpoolElapsed := time.Duration(0)
 	for {
 		if err := ctx.Err(); err != nil {
 			return resolveError(err)
@@ -995,6 +1000,7 @@ func (r *Resolver) ResolveAllContext(ctx context.Context) (*ResolveStats, error)
 			var liveJobs resolveJobLiveness
 			validateLiveJobs := false
 			if r.validateLiveness {
+				livenessStart := time.Now()
 				switch {
 				case !pageRevisionKnown:
 					// Unknown stores cannot prove that the page stayed stable.
@@ -1004,6 +1010,7 @@ func (r *Resolver) ResolveAllContext(ctx context.Context) (*ResolveStats, error)
 					liveJobs = pageLiveness
 					validateLiveJobs = true
 				}
+				applyLivenessElapsed += time.Since(livenessStart)
 			}
 			reindexBatch := make([]graph.EdgeReindex, 0, resolveJobCount(perWorkerJobs))
 			for i := range perWorkerJobs {
@@ -1037,9 +1044,15 @@ func (r *Resolver) ResolveAllContext(ctx context.Context) (*ResolveStats, error)
 				perWorkerJobs[i] = kept
 			}
 			if len(reindexBatch) > 0 {
+				noteStart := time.Now()
 				r.noteImportEdgeReindexes(reindexBatch)
+				applyNoteElapsed += time.Since(noteStart)
+				storeStart := time.Now()
 				r.graph.ReindexEdges(reindexBatch)
+				applyStoreElapsed += time.Since(storeStart)
+				placeholderStart := time.Now()
 				reconcilePlaceholderSources(r.graph, &r.placeholderSrcIdx, reindexBatch)
+				applyPlaceholderElapsed += time.Since(placeholderStart)
 				reindexTotal += len(reindexBatch)
 				if pageRevisionKnown {
 					// Ignore this pass's own committed mutations. A later delta
@@ -1051,7 +1064,9 @@ func (r *Resolver) ResolveAllContext(ctx context.Context) (*ResolveStats, error)
 				}
 			}
 			if guardSpoolErr == nil {
+				spoolStart := time.Now()
 				guardSpoolErr = guardSpool.appendJobs(perWorkerJobs)
+				applyGuardSpoolElapsed += time.Since(spoolStart)
 				if guardSpoolErr != nil {
 					r.logger.Error("resolver: append guard spool", zap.Error(guardSpoolErr))
 				}
@@ -1692,7 +1707,10 @@ func (r *Resolver) ResolveAllContext(ctx context.Context) (*ResolveStats, error)
 	// are otherwise unlogged — this is the split used to target cold-index
 	// resolve optimisation. page_load / prepare_indexes / compute_workers /
 	// commit_apply attribute compute_loop's interior; their shortfall against
-	// it is chunk-yield gaps, liveness validation, and loop bookkeeping.
+	// it is chunk-yield gaps and loop bookkeeping. The apply_* fields split
+	// commit_apply itself — liveness reads, import-invalidation notes, the
+	// store reindex write, placeholder reconcile, guard-spool append — with
+	// the remainder being the job-apply loop and guard bookkeeping.
 	r.logger.Info("resolver: pass complete",
 		zap.Duration("total", time.Since(passStart)),
 		zap.Duration("warm_lookup", warmElapsed),
@@ -1701,6 +1719,11 @@ func (r *Resolver) ResolveAllContext(ctx context.Context) (*ResolveStats, error)
 		zap.Duration("prepare_indexes", prepareElapsed),
 		zap.Duration("compute_workers", workersElapsed),
 		zap.Duration("commit_apply", applyElapsed),
+		zap.Duration("apply_liveness", applyLivenessElapsed),
+		zap.Duration("apply_note_reindex", applyNoteElapsed),
+		zap.Duration("apply_store_reindex", applyStoreElapsed),
+		zap.Duration("apply_placeholder", applyPlaceholderElapsed),
+		zap.Duration("apply_guard_spool", applyGuardSpoolElapsed),
 		zap.Int("terminal_loaded", terminalLoaded),
 		zap.Duration("deferred_lsp", lspElapsed),
 		zap.Duration("guard", tAfterGuard.Sub(tailStart)),

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -658,8 +658,12 @@ func (r *Resolver) ResolveAllContext(ctx context.Context) (*ResolveStats, error)
 	var pendingLoaded atomic.Int64
 	pendingTotal.Store(int64(pendingBefore))
 	terminalSkipped := 0
+	terminalLoaded := 0
+	loadElapsed := time.Duration(0)
 	streamDone := false
 	loadPendingPage := func() ([]*graph.Edge, error) {
+		loadStart := time.Now()
+		defer func() { loadElapsed += time.Since(loadStart) }()
 		for {
 			if err := ctx.Err(); err != nil {
 				return nil, err
@@ -681,6 +685,13 @@ func (r *Resolver) ResolveAllContext(ctx context.Context) (*ResolveStats, error)
 				var skipped int
 				pending, skipped = filterTerminalSkip(pending, r.scope)
 				terminalSkipped += skipped
+			}
+			// Durably-terminal edges that still enter compute — the volume a
+			// terminal skip on this pass's shape would have saved.
+			for _, e := range pending {
+				if edgeTerminalFlag(e) {
+					terminalLoaded++
+				}
 			}
 			pendingAfter += len(pending)
 			pendingLoaded.Store(int64(pendingAfter))
@@ -826,7 +837,13 @@ func (r *Resolver) ResolveAllContext(ctx context.Context) (*ResolveStats, error)
 	// origin upgrades, re-corrections of already-resolved edges).
 	reindexConversions := 0
 	reindexChurn := 0
+	churnRetargeted := 0
+	churnKindPromoted := 0
+	churnAttrsOnly := 0
 	warmElapsed := time.Duration(0)
+	prepareElapsed := time.Duration(0)
+	workersElapsed := time.Duration(0)
+	applyElapsed := time.Duration(0)
 	for {
 		if err := ctx.Err(); err != nil {
 			return resolveError(err)
@@ -845,7 +862,9 @@ func (r *Resolver) ResolveAllContext(ctx context.Context) (*ResolveStats, error)
 		var pageLiveness resolveJobLiveness
 		var pageDeferredLSP []deferredLSPEdge
 		if len(pending) > 0 {
+			prepareStart := time.Now()
 			sources := passIndexes.prepare(pending)
+			prepareElapsed += time.Since(prepareStart)
 			warmStart := time.Now()
 			r.warmLookupCacheWithSources(pending, sources)
 			warmElapsed += time.Since(warmStart)
@@ -872,6 +891,7 @@ func (r *Resolver) ResolveAllContext(ctx context.Context) (*ResolveStats, error)
 				}
 			}
 
+			workersStart := time.Now()
 			workers := runtime.NumCPU()
 			if workers < 1 {
 				workers = 1
@@ -960,9 +980,11 @@ func (r *Resolver) ResolveAllContext(ctx context.Context) (*ResolveStats, error)
 				}(w, scPending[start:end])
 			}
 			wg.Wait()
+			workersElapsed += time.Since(workersStart)
 			if err := ctx.Err(); err != nil {
 				return resolveError(err)
 			}
+			applyStart := time.Now()
 
 			// Apply this chunk's mutations under the lock. An edit during a PRIOR
 			// inter-chunk yield may have evicted an edge this chunk resolved;
@@ -1001,6 +1023,14 @@ func (r *Resolver) ResolveAllContext(ctx context.Context) (*ResolveStats, error)
 						reindexConversions++
 					} else {
 						reindexChurn++
+						switch churnShape(j.oldTo, j.newTo, j.oldKind, j.kind) {
+						case churnShapeRetarget:
+							churnRetargeted++
+						case churnShapeKind:
+							churnKindPromoted++
+						default:
+							churnAttrsOnly++
+						}
 					}
 					kept = append(kept, j)
 				}
@@ -1033,6 +1063,7 @@ func (r *Resolver) ResolveAllContext(ctx context.Context) (*ResolveStats, error)
 					}
 				}
 			}
+			applyElapsed += time.Since(applyStart)
 			for i := range perWorkerStats {
 				total.Resolved += perWorkerStats[i].Resolved
 				total.Unresolved += perWorkerStats[i].Unresolved
@@ -1424,6 +1455,9 @@ func (r *Resolver) ResolveAllContext(ctx context.Context) (*ResolveStats, error)
 		zap.Int("reindex_batch", reindexTotal),
 		zap.Int("reindex_conversions", reindexConversions),
 		zap.Int("reindex_churn", reindexChurn),
+		zap.Int("churn_retargeted", churnRetargeted),
+		zap.Int("churn_kind_promoted", churnKindPromoted),
+		zap.Int("churn_attrs_only", churnAttrsOnly),
 		zap.Int("super_chunk", superChunk),
 		zap.Int("lsp_deferred", lspDeferred),
 		zap.Int("lsp_attempted", lspResult.attempted),
@@ -1656,11 +1690,18 @@ func (r *Resolver) ResolveAllContext(ctx context.Context) (*ResolveStats, error)
 	// compute loop is parallel; the tail passes (guard, Go/lang attribution,
 	// dispatch, terminal reconcile) run serially under the resolve lock and
 	// are otherwise unlogged — this is the split used to target cold-index
-	// resolve optimisation.
+	// resolve optimisation. page_load / prepare_indexes / compute_workers /
+	// commit_apply attribute compute_loop's interior; their shortfall against
+	// it is chunk-yield gaps, liveness validation, and loop bookkeeping.
 	r.logger.Info("resolver: pass complete",
 		zap.Duration("total", time.Since(passStart)),
 		zap.Duration("warm_lookup", warmElapsed),
 		zap.Duration("compute_loop", loopElapsed),
+		zap.Duration("page_load", loadElapsed),
+		zap.Duration("prepare_indexes", prepareElapsed),
+		zap.Duration("compute_workers", workersElapsed),
+		zap.Duration("commit_apply", applyElapsed),
+		zap.Int("terminal_loaded", terminalLoaded),
 		zap.Duration("deferred_lsp", lspElapsed),
 		zap.Duration("guard", tAfterGuard.Sub(tailStart)),
 		zap.Duration("go_attribution", tAfterAttrib.Sub(tAfterGuard)),

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -730,6 +730,10 @@ func (r *Resolver) ResolveAllContext(ctx context.Context) (*ResolveStats, error)
 	}
 
 	passStart := time.Now()
+	// The first page fetched above predates the pass clock: drop it from
+	// page_load so the interior buckets stay inside compute_loop — on a
+	// scoped pass that first fetch dominates load time and would overrun it.
+	loadElapsed = 0
 	r.logger.Info("resolver: pass start",
 		zap.Int("pending", pendingBefore),
 		zap.Int("first_page", len(pending)),
@@ -1706,11 +1710,16 @@ func (r *Resolver) ResolveAllContext(ctx context.Context) (*ResolveStats, error)
 	// dispatch, terminal reconcile) run serially under the resolve lock and
 	// are otherwise unlogged — this is the split used to target cold-index
 	// resolve optimisation. page_load / prepare_indexes / compute_workers /
-	// commit_apply attribute compute_loop's interior; their shortfall against
-	// it is chunk-yield gaps and loop bookkeeping. The apply_* fields split
-	// commit_apply itself — liveness reads, import-invalidation notes, the
-	// store reindex write, placeholder reconcile, guard-spool append — with
-	// the remainder being the job-apply loop and guard bookkeeping.
+	// commit_apply attribute compute_loop's interior (page_load counts
+	// in-pass fetches only); their shortfall against it is chunk-yield gaps,
+	// revision loads, the set-oriented liveness preload, deferred-LSP
+	// spooling and post-interleave index refreshes. The apply_* fields split
+	// commit_apply itself — apply_liveness times only the unknown-store
+	// fallback (the set-oriented preload runs pre-workers, outside every
+	// bucket), then import-invalidation notes, the store reindex write,
+	// placeholder reconcile, guard-spool append — with the remainder being
+	// the job-apply loop, post-reindex revision reloads and guard
+	// bookkeeping.
 	r.logger.Info("resolver: pass complete",
 		zap.Duration("total", time.Since(passStart)),
 		zap.Duration("warm_lookup", warmElapsed),


### PR DESCRIPTION

Cold-index profiling on a large C# workspace (~8k files, ~1.7M pending edges, 2.2M-edge store) showed the resolve pass spending 44% of its wall time in the serial apply section, and a CPU profile put `modernc.org/sqlite.(*conn).bind` at 47% flat — parameter binding, 15–16 variables per row across ~516k resolved-conversion UPDATEs. This PR rebinds each bounded chunk as **one** JSON parameter and attributes the pass interior so the next bottleneck is measurable instead of guessable.

### Numbers

Benchmark (`BenchmarkReindexEdgesResolvedConversions50K`, in-repo, AMD 9950X):

| | before | after |
|---|---|---|
| ms/op (50k rows) | 1,925 | 694–738 (3 samples) |
| rows/s | ~26k | ~70k |
| allocs/op | 525k | 415k |

Production cold runs (same instrumentation on both sides, idle machine, store nuked):

| | step-0 | json transport | +apply split |
|---|---|---|---|
| `commit_apply` | 82.5 s | 63.6 s | 61.9 s |
| resolve phase | 198.0 s | 164.9 s | 163.5 s |

Enrichment outcome counters and coverage are digit-identical to full precision across all three runs. `reindex_conversions` drifts by ±~30 of 516k between runs — page-order sensitivity of conversion/churn classification, disclosed below.

### Transport design

`updateSQLiteResolvedConversionsTxLimited` now encodes each chunk as a JSON array of positional arrays, bound as a single variable and unpacked by a fixed statement:

```sql
WITH patch AS (SELECT value ->> 0 AS old_from_id, ..., unhex(value ->> 12) AS meta, ...
FROM json_each(?))
UPDATE OR IGNORE edges AS e SET ... WHERE ...
```

- **`meta` is a compact binary encoding, not JSON text** — string-embedding would corrupt it through UTF-8 replacement. It rides hex-encoded and `unhex()` restores the exact bytes; the fidelity test asserts byte-equality against the production encoder and `typeof(meta) = blob`. This sets a **SQLite ≥ 3.41 floor** (`unhex`); the bundled modernc build is 3.53.3.
- Integral-valued confidence would arrive as a JSON integer, so the statement CASTs it back to REAL (pinned with `typeof`).
- NULL-able columns travel as JSON null; `sql.NullBool`/`NullString` are converted manually (a `false` terminal stamp lands as INTEGER 0, pinned).
- SET/WHERE clauses, `UPDATE OR IGNORE`, and the RowsAffected-shortfall repair replay are unchanged from the VALUES form.
- **json-safety guard:** `json.Marshal` rewrites invalid UTF-8 to U+FFFD — a self-healing WHERE miss on the old-key side, but on a SET column the mangled value would commit — and rejects non-finite confidence outright. Rows that would be corrupted or rejected bypass the JSON arm and ride the existing delete+insert repair path, which binds raw bytes (test drives both shapes through `ReindexEdges`).
- Chunks are bounded by rows (512) and an estimated byte budget; the estimate deliberately ignores JSON escaping inflation (soft memory bound, far below SQLite's bound-length limit).

### Interior attribution (the instrumentation that found this)

`resolver: pass complete` gains `page_load` / `prepare_indexes` / `compute_workers` / `commit_apply`, plus an `apply_*` split of the apply section (`apply_liveness` / `apply_note_reindex` / `apply_store_reindex` / `apply_placeholder` / `apply_guard_spool`) and `terminal_loaded`; `resolver: compute done` gains churn shapes (`churn_retargeted` / `churn_kind_promoted` / `churn_attrs_only`). The code comment states exactly what each bucket covers and what rides in the shortfall. On this workspace the split reads: store reindex 49.7 s / placeholder reconcile 11.9 s / everything else < 0.3 s — so the follow-up target is inside `ReindexEdges` (production runs ~10.4k rows/s vs ~70k in the isolated bench on the same transport; the gap is table-size-dependent index maintenance and page-cache behavior, which these fields now make visible per run).

### Disclosed test renegotiations

- `TestReindexEdgesUsesRuntimeVariableBudget` → `TestReindexEdgesResolvedConversionChunksByRows`: the conversion arm no longer binds per-row variables, so the connection variable limit cannot shape it; the test now pins limit-independence (identical statement count at both budget extremes).
- `TestReindexEdgesDownshiftsConnectionVariableLimit`: re-fixtured to a mixed-direction batch so the downshift is exercised through the still-parameterized generic arms (prefetch/delete/insert); the update-arm downshift is dead code by design.
- Repair blast radius grew: a shortfall now replays up to 512 rows (previously ~65 under the variable limit), with the same acknowledged receipt over-recording semantics.

### Testing

- New: `TestResolvedConversionPayloadFidelity` (typeof storage classes, binary-meta byte fidelity, NULL terminals, kind-change variant — green on both transports), `TestReindexEdgesJSONUnsafePayloadsRideRepairPath` (watched red on the unguarded transport), `TestEncodeResolvedConversionRowsBounds`.
- Full Windows suite name-set diff vs the pre-branch failure baseline: no new failures attributable to the branch (one pre-existing environment-sensitive hooks test flips with a live user daemon; filed separately).
- `go vet`, `gofmt` clean; benchmark re-run after the safety guard showed no measurable cost.

Note: this branch touches `internal/resolver/resolver.go` alongside open #591 (different regions — pass-loop timers here, retention counters there); happy to rebase whichever lands second.
