### PR TITLE
perf: widen WAL auto-checkpoint spacing for index-write bursts

### DIFF
--- a/internal/graph/store_sqlite/reindex_seeded_bench_test.go
+++ b/internal/graph/store_sqlite/reindex_seeded_bench_test.go
@@ -1,0 +1,202 @@
+package store_sqlite
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Seeded variant of BenchmarkReindexEdgesResolvedConversions50K: the plain
+// bench reindexes into a fresh 50k-row store where every B-tree page stays in
+// the connection page cache and the sequential target ids insert nearly
+// sorted, so it overstates real-store reindex throughput several-fold. This
+// one fattens the table with a background corpus of production-length ids
+// first and binds the conversions to targets scattered across that keyspace,
+// then prices the FULL cost of a WAL auto-checkpoint spacing choice across
+// the three phases an index batch pays: the write burst
+// itself, the read-back of freshly written pages through the read pool (the
+// guard/enrichment/dispatch pattern — pages still resident in a large WAL
+// are served by wal-index probe + pread instead of the main file's mmap),
+// and the end-of-batch TRUNCATE drain (where a deferred checkpoint bill
+// lands). Spacing is set per run via PRAGMA on the writer connection, so the
+// DSN default under test does not bias the sweep.
+
+const (
+	seededBackgroundEdges = 1_000_000
+	seededConversionCount = 50_000
+	seededAddChunk        = 50_000
+)
+
+func seededBackgroundID(i int) string {
+	return fmt.Sprintf(`repo/area%02d/pkg%03d\file%03d.cs::Space%02d.Type%03d.Member%03d`,
+		i%97, i%911, i%499, i%89, i%997, i%701)
+}
+
+// buildSeededTemplate populates a template store once; iterations copy the
+// closed file instead of re-adding a million edges.
+func buildSeededTemplate(b *testing.B, path string) {
+	b.Helper()
+	store, err := Open(path)
+	if err != nil {
+		b.Fatal(err)
+	}
+	background := make([]*graph.Edge, 0, seededAddChunk)
+	for i := 0; i < seededBackgroundEdges; i++ {
+		background = append(background, &graph.Edge{
+			From: seededBackgroundID(i) + ".Caller", To: seededBackgroundID(i + 1),
+			Kind:     graph.EdgeCalls,
+			FilePath: fmt.Sprintf(`repo/area%02d/pkg%03d\file%03d.cs`, i%97, i%911, i%499),
+			Line:     i%3000 + 1,
+		})
+		if len(background) == seededAddChunk {
+			store.AddBatch(nil, background)
+			background = background[:0]
+		}
+	}
+	if len(background) > 0 {
+		store.AddBatch(nil, background)
+	}
+	unresolved := make([]*graph.Edge, 0, seededConversionCount)
+	for i := 0; i < seededConversionCount; i++ {
+		unresolved = append(unresolved, &graph.Edge{
+			From:     fmt.Sprintf(`repo/callers/pkg%03d\callers%05d.cs::Caller%05d.Invoke`, i%211, i, i),
+			To:       fmt.Sprintf("unresolved::Symbol%05d", i),
+			Kind:     graph.EdgeCalls,
+			FilePath: fmt.Sprintf(`repo/callers/pkg%03d\callers%05d.cs`, i%211, i),
+			Line:     i%400 + 1,
+		})
+	}
+	store.AddBatch(nil, unresolved)
+	if err := store.Close(); err != nil {
+		b.Fatal(err)
+	}
+}
+
+func copySeededTemplate(b *testing.B, src, dst string) {
+	b.Helper()
+	in, err := os.Open(src)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		b.Fatal(err)
+	}
+	if err := out.Close(); err != nil {
+		b.Fatal(err)
+	}
+}
+
+// readBackConversions probes every converted row through the read pool the
+// way the guard and enrichment passes do: one index-only probe of the fresh
+// edges_by_to leaf and one main-table row fetch. While those pages sit in a
+// large WAL they cost a wal-index lookup + pread each instead of an mmap
+// access — the read-side tax of wide checkpoint spacing.
+func readBackConversions(b *testing.B, store *Store, batch []graph.EdgeReindex) {
+	b.Helper()
+	for _, r := range batch {
+		var n int
+		if err := store.db.QueryRow(
+			`SELECT COUNT(*) FROM edges WHERE to_id = ? AND kind = ?`,
+			r.Edge.To, string(r.Edge.Kind)).Scan(&n); err != nil {
+			b.Fatal(err)
+		}
+		if n == 0 {
+			b.Fatalf("converted target %q not found", r.Edge.To)
+		}
+		var conf float64
+		if err := store.db.QueryRow(
+			`SELECT confidence FROM edges WHERE file_path = ? AND line = ?`,
+			r.Edge.FilePath, r.Edge.Line).Scan(&conf); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkReindexEdgesResolvedConversionsSeeded1M(b *testing.B) {
+	dir := b.TempDir()
+	template := filepath.Join(dir, "template.sqlite")
+	buildSeededTemplate(b, template)
+
+	// Conversions bind to existing background symbols, scattered across the
+	// keyspace by a multiplicative hash — the shape a resolve pass produces.
+	batch := make([]graph.EdgeReindex, 0, seededConversionCount)
+	for i := 0; i < seededConversionCount; i++ {
+		target := seededBackgroundID(int((uint32(i) * 2654435761) % seededBackgroundEdges))
+		batch = append(batch, graph.EdgeReindex{
+			OldTo: fmt.Sprintf("unresolved::Symbol%05d", i),
+			Edge: &graph.Edge{
+				From: fmt.Sprintf(`repo/callers/pkg%03d\callers%05d.cs::Caller%05d.Invoke`, i%211, i, i),
+				To:   target, Kind: graph.EdgeCalls,
+				FilePath:   fmt.Sprintf(`repo/callers/pkg%03d\callers%05d.cs`, i%211, i),
+				Line:       i%400 + 1,
+				Confidence: 0.95, Origin: "resolved",
+			},
+		})
+	}
+
+	for _, spacing := range []int{1000, 8000, 100000} {
+		b.Run(fmt.Sprintf("ckpt%d", spacing), func(b *testing.B) {
+			var writeTotal, readTotal, drainTotal time.Duration
+			b.ReportAllocs()
+			b.ReportMetric(seededConversionCount, "edges/op")
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				dbPath := filepath.Join(dir, fmt.Sprintf("run-%d-%d.sqlite", spacing, i))
+				copySeededTemplate(b, template, dbPath)
+				store, err := Open(dbPath)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if _, err := store.writerDB.Exec(
+					fmt.Sprintf("PRAGMA wal_autocheckpoint = %d", spacing)); err != nil {
+					_ = store.Close()
+					b.Fatal(err)
+				}
+				b.StartTimer()
+
+				phase := time.Now()
+				stats, err := store.reindexEdgesSetOriented(batch)
+				writeTotal += time.Since(phase)
+				if err != nil {
+					b.StopTimer()
+					_ = store.Close()
+					b.Fatal(err)
+				}
+				phase = time.Now()
+				readBackConversions(b, store, batch)
+				readTotal += time.Since(phase)
+				phase = time.Now()
+				if err := store.CheckpointWAL(); err != nil {
+					b.StopTimer()
+					_ = store.Close()
+					b.Fatal(err)
+				}
+				drainTotal += time.Since(phase)
+
+				b.StopTimer()
+				if stats.updatedRows != seededConversionCount || stats.deletedRows != 0 {
+					_ = store.Close()
+					b.Fatalf("unexpected fast-path stats: %+v", stats)
+				}
+				if err := store.Close(); err != nil {
+					b.Fatal(err)
+				}
+				_ = os.Remove(dbPath)
+			}
+			n := float64(b.N)
+			b.ReportMetric(float64(writeTotal.Milliseconds())/n, "write-ms/op")
+			b.ReportMetric(float64(readTotal.Milliseconds())/n, "read-ms/op")
+			b.ReportMetric(float64(drainTotal.Milliseconds())/n, "drain-ms/op")
+		})
+	}
+}

--- a/internal/graph/store_sqlite/sqlite_busy_test.go
+++ b/internal/graph/store_sqlite/sqlite_busy_test.go
@@ -760,3 +760,17 @@ func requireReindexedTarget(t *testing.T, store *Store, want string) {
 	require.Len(t, edges, 1)
 	assert.Equal(t, want, edges[0].To)
 }
+
+// TestWriterDSNSpacesWALAutoCheckpoints pins the widened auto-checkpoint
+// spacing on the writer DSN: the SQLite default (1000 pages ≈ 4 MB) forces a
+// checkpoint flush every few MB of a scattered index-write burst. Readers
+// never append to the WAL, so the reader DSN stays untouched.
+func TestWriterDSNSpacesWALAutoCheckpoints(t *testing.T) {
+	dsn := sqliteWriterDSN("x.sqlite")
+	if !strings.Contains(dsn, "_pragma=wal_autocheckpoint(8000)") {
+		t.Fatalf("writer DSN missing wal_autocheckpoint spacing: %s", dsn)
+	}
+	if strings.Contains(sqliteReaderDSN("x.sqlite"), "wal_autocheckpoint") {
+		t.Fatal("reader DSN should not carry wal_autocheckpoint")
+	}
+}

--- a/internal/graph/store_sqlite/sqlite_connections.go
+++ b/internal/graph/store_sqlite/sqlite_connections.go
@@ -54,11 +54,29 @@ func sqlitePerConnectionPragmas() string {
 	return fmt.Sprintf("%s&_pragma=mmap_size(%d)", sqlitePerConnectionPragmasBase, sqliteMmapBytes())
 }
 
+// sqliteWALAutoCheckpointPages spaces WAL auto-checkpoints at 8k pages
+// (~32 MiB). The SQLite default of 1000 pages (~4 MB) forces a checkpoint —
+// frames copied into the main file plus an mmap-view flush — every few MB of
+// a scattered write burst, so index-write bursts spend a measurable share of
+// their time in flush calls rather than row writes. Wider spacing is NOT
+// free, though: pages resident in a large WAL are served to readers by
+// wal-index probe + pread instead of the main file's mmap, and the deferred
+// frames come due as one big drain — at 100k pages the three-phase seeded
+// bench shows read-back +46% and a 330 ms drain, a net production loss.
+// 8k pages keeps the write-side win (~12%) with flat read-back and
+// negligible drain. journal_size_limit still truncates the WAL after every
+// checkpoint; the indexer checkpoints TRUNCATE at the end of each global
+// batch, at Compact and at Close. Readers never append to the WAL, so only
+// the writer DSN carries the override.
+const sqliteWALAutoCheckpointPages = 8000
+
 func sqliteWriterDSN(path string) string {
 	// IMMEDIATE reserves the single SQLite writer at BEGIN. It avoids the
 	// un-retryable DEFERRED read-to-write promotion/BUSY_SNAPSHOT class.
 	params := sqliteBusyPragma + "&_pragma=journal_mode(WAL)&" +
-		sqlitePerConnectionPragmas() + "&_pragma=journal_size_limit(67108864)&_txlock=immediate"
+		sqlitePerConnectionPragmas() + "&_pragma=journal_size_limit(67108864)" +
+		fmt.Sprintf("&_pragma=wal_autocheckpoint(%d)", sqliteWALAutoCheckpointPages) +
+		"&_txlock=immediate"
 	return sqliteDSN(path, params)
 }
 


### PR DESCRIPTION
While chasing cold-index times on my workspace I ran into something that might be worth a look — offering it as a suggestion with the measurement tooling attached, since all numbers below are from one machine (Windows, 16-core, NVMe, ~8k-file C# repo, 3+ GB store) and the trade-off could land differently on macOS or slower hardware.

**The observation:** the writer connection runs at SQLite's default `wal_autocheckpoint` of 1000 pages (~4 MB), so a scattered index-write burst — the resolve reindex, enrichment, end-batch — triggers a checkpoint every few MB of WAL. A CPU profile of the reindex phase on my box showed the checkpoint flush machinery (`FlushViewOfFile` + `FlushFileBuffers` on Windows) costing more than the row writes themselves.

**Why not just crank it up:** wider spacing is not free, and my first attempt proved it the hard way. At 100k pages (~400 MB WAL) the write burst got much faster — and a full cold reindex got *slower* overall: pages resident in a large WAL are served to readers by wal-index probe + `pread` instead of the main file's mmap (the guard and enrichment passes re-read exactly what was just written), and the deferred frames come due as one big end-of-batch drain. Write-only measurements can't see either cost. Disabling auto-checkpointing outright (`wal_autocheckpoint=0`, leaning on the explicit TRUNCATE checkpoints alone) is the same failure mode at its extreme — best write time, worst read-back and drain.

**The tooling:** the first commit adds a seeded three-phase benchmark that prices the full trade-off offline — a 1M-edge background corpus with scattered conversion targets, then per spacing value: the write burst, a read-back of every converted row through the read pool, and the end-of-batch TRUNCATE drain. Spacing is set per run via PRAGMA, so the sweep is independent of the DSN default. On my machine (ms per 50k conversions, medians):

| spacing | write | read-back | drain |
|---|---|---|---|
| 1000 (default) | 3,485 | 1,500 | 2 |
| **8000** | **3,074** | **1,481** | **4** |
| 100000 | 2,168 | 2,194 | 333 |

**The suggestion:** 8000 pages (~32 MB) — most of the write-side win, with read-back and drain flat. The second commit sets it as the writer-DSN default with the reasoning in a comment. Corroboration from two same-day cold reindexes of my workspace with an identical corpus (enrichment outcome counters digit-identical between runs): the store reindex section dropped 62.5 → 51.2 s (−18%) with the read-heavy phases and end-batch flat, total −15.4 s. WAL stays bounded: `journal_size_limit` still truncates after every checkpoint, and the indexer already checkpoints TRUNCATE at the end of each global batch, at Compact and at Close; the bulk-load path keeps its own stricter override. On small stores a batch's WAL never reaches either threshold before those explicit checkpoints run, so the wider default only changes behavior for large write bursts.

Caveats, honestly: single-machine Windows numbers; I run `GORTEX_SQLITE_MMAP_MB=4096`, which likely amplifies the read-side penalty that makes large values lose (at the 256 MiB default more reads pay `pread` regardless, so the penalty may be smaller and the optimum higher); and the value is one constant — if the bench lands elsewhere on your hardware, happy to adjust or drop this. No file overlap with #594; the bench runs on either transport.
