### PR TITLE
store_sqlite: normalize native separators in generated dir columns

### DIFF
--- a/internal/graph/store_sqlite/file_dir_backslash_test.go
+++ b/internal/graph/store_sqlite/file_dir_backslash_test.go
@@ -1,0 +1,216 @@
+package store_sqlite
+
+import (
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Stored paths keep their native separators: a Windows-written store holds
+// `repo/internal\pkg\file.go` — '/' after the repo prefix, '\' below it. The
+// generated dir columns must normalize separators before trimming, mirroring
+// graphpath.Dir (Norm + trim); otherwise every dir collapses to the repo
+// prefix and the receiver-rebind join degenerates from "same package dir"
+// to "same repo".
+func TestGeneratedDirColumnsNormalizeNativeSeparators(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "dir_cols.sqlite"))
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := s.Close(); err != nil {
+			t.Errorf("close store: %v", err)
+		}
+	})
+
+	nodeShapes := []struct {
+		filePath string
+		wantDir  string
+	}{
+		{`repo/pkg\types.go`, "repo/pkg"},
+		{`repo/pkg/types.go`, "repo/pkg"},
+		{`repo/a\b\deep.go`, "repo/a/b"},
+		{`solo.go`, "."},
+		{`native\solo.go`, "native"},
+	}
+	for i, sh := range nodeShapes {
+		s.AddNode(&graph.Node{
+			ID: fmt.Sprintf("n%d", i), Kind: graph.KindType, Name: "T",
+			FilePath: sh.filePath, Language: "go", RepoPrefix: "repo",
+		})
+	}
+	for i, sh := range nodeShapes {
+		var dir string
+		if err := s.db.QueryRow(`SELECT file_dir FROM nodes WHERE id = ?`, fmt.Sprintf("n%d", i)).Scan(&dir); err != nil {
+			t.Fatalf("read file_dir for %q: %v", sh.filePath, err)
+		}
+		if dir != sh.wantDir {
+			t.Errorf("file_dir(%q) = %q, want %q", sh.filePath, dir, sh.wantDir)
+		}
+	}
+
+	edgeShapes := []struct {
+		toID    string
+		wantDir string
+	}{
+		{`repo/pkg\types.go::Server`, "repo/pkg"},
+		{`repo/pkg/types.go::Server`, "repo/pkg"},
+	}
+	s.AddNode(&graph.Node{ID: "m", Kind: graph.KindMethod, Name: "M", FilePath: `repo/pkg\m.go`, Language: "go", RepoPrefix: "repo"})
+	for i, sh := range edgeShapes {
+		s.AddEdge(&graph.Edge{From: "m", To: sh.toID, Kind: graph.EdgeMemberOf, FilePath: `repo/pkg\m.go`, Line: i + 1})
+	}
+	for _, sh := range edgeShapes {
+		var dir sql.NullString
+		if err := s.db.QueryRow(`SELECT member_receiver_dir FROM edges WHERE to_id = ?`, sh.toID).Scan(&dir); err != nil {
+			t.Fatalf("read member_receiver_dir for %q: %v", sh.toID, err)
+		}
+		if !dir.Valid || dir.String != sh.wantDir {
+			t.Errorf("member_receiver_dir(%q) = %+v, want %q", sh.toID, dir, sh.wantDir)
+		}
+	}
+}
+
+// The rebind join must stay directory-scoped on native-separator paths: a
+// same-named type in another directory is not a candidate, and a phantom
+// whose only same-named type lives elsewhere stays put.
+func TestSQLiteRebindGoMethodReceiversNativeSeparatorPaths(t *testing.T) {
+	s := openReceiverRebindStore(t)
+	const (
+		canonical = `repo/pkg\types.go::Server`
+		decoy     = `repo/other\types.go::Server`
+		method    = `repo/pkg\methods.go::Server.Run`
+		phantom   = `repo/pkg\methods.go::Server`
+		strayM    = `repo/x\m.go::Widget.Do`
+		strayPh   = `repo/x\m.go::Widget`
+		wrongDirT = `repo/y\types.go::Widget`
+	)
+	s.AddBatch([]*graph.Node{
+		{ID: canonical, Kind: graph.KindType, Name: "Server", FilePath: `repo/pkg\types.go`, Language: "go", RepoPrefix: "repo"},
+		{ID: decoy, Kind: graph.KindType, Name: "Server", FilePath: `repo/other\types.go`, Language: "go", RepoPrefix: "repo"},
+		{ID: method, Kind: graph.KindMethod, Name: "Run", FilePath: `repo/pkg\methods.go`, Language: "go", RepoPrefix: "repo"},
+		{ID: strayM, Kind: graph.KindMethod, Name: "Do", FilePath: `repo/x\m.go`, Language: "go", RepoPrefix: "repo"},
+		{ID: wrongDirT, Kind: graph.KindType, Name: "Widget", FilePath: `repo/y\types.go`, Language: "go", RepoPrefix: "repo"},
+	}, []*graph.Edge{
+		{From: method, To: phantom, Kind: graph.EdgeMemberOf, FilePath: `repo/pkg\methods.go`, Line: 1},
+		{From: strayM, To: strayPh, Kind: graph.EdgeMemberOf, FilePath: `repo/x\m.go`, Line: 1},
+	})
+
+	changed, err := s.RebindGoMethodReceivers("")
+	if err != nil {
+		t.Fatalf("rebind: %v", err)
+	}
+	if changed != 1 {
+		t.Errorf("changed = %d, want 1 (only the same-directory bind)", changed)
+	}
+	if receiverEdge(t, s, method, canonical) == nil || receiverEdge(t, s, method, phantom) != nil {
+		t.Errorf("native-separator receiver was not rebound to same-dir type %q", canonical)
+	}
+	if receiverEdge(t, s, method, decoy) != nil {
+		t.Errorf("receiver bound to other-directory decoy %q", decoy)
+	}
+	if receiverEdge(t, s, strayM, strayPh) == nil || receiverEdge(t, s, strayM, wrongDirT) != nil {
+		t.Errorf("phantom without a same-directory type was captured by %q", wrongDirT)
+	}
+}
+
+// The pre-v12 dir expressions, verbatim: they trimmed at '/' only, so
+// native-separator paths collapsed the dir to the repo prefix. Kept as a
+// fixture so the migration path is exercised against the exact shape a
+// stale store carries.
+const (
+	staleFileDirColumnDDL = `file_dir TEXT GENERATED ALWAYS AS (
+    CASE WHEN file_path = '' THEN NULL
+         WHEN instr(file_path, '/') = 0 THEN '.'
+         WHEN rtrim(rtrim(file_path, replace(file_path, '/', '')), '/') = '' THEN '/'
+         ELSE rtrim(rtrim(file_path, replace(file_path, '/', '')), '/') END
+) VIRTUAL`
+
+	staleMemberReceiverDirColumnDDL = `member_receiver_dir TEXT GENERATED ALWAYS AS (
+    CASE WHEN kind <> 'member_of' OR instr(to_id, '::') <= 1
+              OR ` + memberReceiverNameExpr + ` = '' THEN NULL
+         WHEN instr(` + memberReceiverFileExpr + `, '/') = 0 THEN '.'
+         WHEN rtrim(rtrim(` + memberReceiverFileExpr + `,
+                         replace(` + memberReceiverFileExpr + `, '/', '')), '/') = '' THEN '/'
+         ELSE rtrim(rtrim(` + memberReceiverFileExpr + `,
+                         replace(` + memberReceiverFileExpr + `, '/', '')), '/') END
+) VIRTUAL`
+)
+
+// A store stamped with the previous schema version carries the stale dir
+// expressions; Open must rebuild both generated columns (and the index over
+// file_dir) so existing stores heal without a reindex.
+func TestSchemaMigrationNormalizesDirColumnSeparators(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "stale-dirs.sqlite")
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open raw database: %v", err)
+	}
+	if _, err := raw.Exec(schemaSQL); err != nil {
+		t.Fatalf("create base schema: %v", err)
+	}
+	for _, ddl := range []string{
+		`ALTER TABLE nodes ADD COLUMN ` + staleFileDirColumnDDL,
+		`ALTER TABLE edges ADD COLUMN ` + staleMemberReceiverDirColumnDDL,
+		`CREATE INDEX nodes_go_receiver_type ON nodes(repo_prefix, file_dir, name, id) WHERE language = 'go' AND kind IN ('type', 'interface') AND name <> '' AND file_path <> ''`,
+	} {
+		if _, err := raw.Exec(ddl); err != nil {
+			t.Fatalf("build stale store: %v", err)
+		}
+	}
+	if _, err := raw.Exec(`INSERT INTO nodes (id, kind, name, file_path, language, repo_prefix) VALUES
+        ('repo/pkg\types.go::T', 'type', 'T', 'repo/pkg\types.go', 'go', 'repo')`); err != nil {
+		t.Fatalf("seed stale node: %v", err)
+	}
+	if _, err := raw.Exec(`INSERT INTO edges (from_id, to_id, kind, file_path, line)
+        VALUES ('repo/pkg\m.go::T.M', 'repo/pkg\types.go::T', 'member_of', 'repo/pkg\m.go', 1)`); err != nil {
+		t.Fatalf("seed stale edge: %v", err)
+	}
+	if _, err := raw.Exec(`PRAGMA user_version = 11`); err != nil {
+		t.Fatalf("stamp stale version: %v", err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("close raw database: %v", err)
+	}
+
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("open stale store: %v", err)
+	}
+	var dir string
+	if err := s.db.QueryRow(`SELECT file_dir FROM nodes WHERE id = 'repo/pkg\types.go::T'`).Scan(&dir); err != nil {
+		t.Fatalf("read migrated file_dir: %v", err)
+	}
+	if dir != "repo/pkg" {
+		t.Errorf("migrated file_dir = %q, want %q", dir, "repo/pkg")
+	}
+	if err := s.db.QueryRow(`SELECT member_receiver_dir FROM edges WHERE to_id = 'repo/pkg\types.go::T'`).Scan(&dir); err != nil {
+		t.Fatalf("read migrated member_receiver_dir: %v", err)
+	}
+	if dir != "repo/pkg" {
+		t.Errorf("migrated member_receiver_dir = %q, want %q", dir, "repo/pkg")
+	}
+	var count int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = 'nodes_go_receiver_type'`).Scan(&count); err != nil || count != 1 {
+		t.Fatalf("nodes_go_receiver_type after migration count=%d err=%v, want 1,nil", count, err)
+	}
+	var version int
+	if err := s.writerDB.QueryRow(`PRAGMA user_version`).Scan(&version); err != nil || version != currentSchemaVersion {
+		t.Fatalf("post-migration user_version=%d err=%v, want %d,nil", version, err, currentSchemaVersion)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close migrated store: %v", err)
+	}
+
+	// A second open finds the current shape and must not error or re-alter.
+	s, err = Open(path)
+	if err != nil {
+		t.Fatalf("second migrated open: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("second migrated close: %v", err)
+	}
+}

--- a/internal/graph/store_sqlite/schema.go
+++ b/internal/graph/store_sqlite/schema.go
@@ -53,15 +53,20 @@ const (
 
 	// filepath.Dir for normalized graph paths, expressed with built-in SQLite
 	// string functions so it can back an index on existing databases without
-	// materializing or backfilling another copy of the value.
+	// materializing or backfilling another copy of the value. The file
+	// segment is separator-normalized like fileDirColumnDDL so the rebind
+	// join's two sides agree on native-separator stores; changing the
+	// expression needs a schemaMigrations entry, like file_dir.
+	memberReceiverNormFileExpr = `replace(` + memberReceiverFileExpr + `, '\', '/')`
+
 	memberReceiverDirColumnDDL = `member_receiver_dir TEXT GENERATED ALWAYS AS (
     CASE WHEN kind <> 'member_of' OR instr(to_id, '::') <= 1
               OR ` + memberReceiverNameExpr + ` = '' THEN NULL
-         WHEN instr(` + memberReceiverFileExpr + `, '/') = 0 THEN '.'
-         WHEN rtrim(rtrim(` + memberReceiverFileExpr + `,
-                         replace(` + memberReceiverFileExpr + `, '/', '')), '/') = '' THEN '/'
-         ELSE rtrim(rtrim(` + memberReceiverFileExpr + `,
-                         replace(` + memberReceiverFileExpr + `, '/', '')), '/') END
+         WHEN instr(` + memberReceiverNormFileExpr + `, '/') = 0 THEN '.'
+         WHEN rtrim(rtrim(` + memberReceiverNormFileExpr + `,
+                         replace(` + memberReceiverNormFileExpr + `, '/', '')), '/') = '' THEN '/'
+         ELSE rtrim(rtrim(` + memberReceiverNormFileExpr + `,
+                         replace(` + memberReceiverNormFileExpr + `, '/', '')), '/') END
 ) VIRTUAL`
 )
 
@@ -208,11 +213,20 @@ const isStubColumnDDL = `is_stub INTEGER GENERATED ALWAYS AS (
 // column. It adds no row payload and is migration-safe on populated stores;
 // the receiver-rebind join uses it to seek directly to Go types/interfaces in
 // the phantom receiver's package instead of loading every type into memory.
+// Stored paths keep the writing platform's native separators below the repo
+// prefix, so the expression normalizes '\' to '/' before trimming — the SQL
+// mirror of graphpath.Norm + Dir. Without it a Windows-written store
+// collapses every file_dir to the repo prefix and the rebind join
+// degenerates from "same package dir" to "same repo". Changing this
+// expression needs a schemaMigrations entry: a generated column on an
+// existing store is rebuilt, never altered in place.
+const fileDirSourceExpr = `replace(file_path, '\', '/')`
+
 const fileDirColumnDDL = `file_dir TEXT GENERATED ALWAYS AS (
     CASE WHEN file_path = '' THEN NULL
-         WHEN instr(file_path, '/') = 0 THEN '.'
-         WHEN rtrim(rtrim(file_path, replace(file_path, '/', '')), '/') = '' THEN '/'
-         ELSE rtrim(rtrim(file_path, replace(file_path, '/', '')), '/') END
+         WHEN instr(` + fileDirSourceExpr + `, '/') = 0 THEN '.'
+         WHEN rtrim(rtrim(` + fileDirSourceExpr + `, replace(` + fileDirSourceExpr + `, '/', '')), '/') = '' THEN '/'
+         ELSE rtrim(rtrim(` + fileDirSourceExpr + `, replace(` + fileDirSourceExpr + `, '/', '')), '/') END
 ) VIRTUAL`
 
 // nodeGeneratedColumns is the nodes-table sibling of edgeGeneratedColumns.

--- a/internal/graph/store_sqlite/schema_fts_state_migration_test.go
+++ b/internal/graph/store_sqlite/schema_fts_state_migration_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestOpenV10AddsSymbolFTSStateWithoutRebuildingCorpus(t *testing.T) {
-	if currentSchemaVersion != 11 {
-		t.Fatalf("currentSchemaVersion = %d, want 11 for the symbol FTS state migration", currentSchemaVersion)
+	if currentSchemaVersion < 11 {
+		t.Fatalf("currentSchemaVersion = %d, want >= 11 for the symbol FTS state migration", currentSchemaVersion)
 	}
 	var v11 *schemaMigration
 	for i := range schemaMigrations {

--- a/internal/graph/store_sqlite/schema_version.go
+++ b/internal/graph/store_sqlite/schema_version.go
@@ -32,7 +32,7 @@ import (
 // index changes in a way an old on-disk DB would not already have, and append a
 // matching schemaMigrations entry describing how to bring an older store
 // forward (in place, or by rebuild).
-const currentSchemaVersion = 11
+const currentSchemaVersion = 12
 
 // schemaMigration is one forward step. Exactly one strategy applies:
 //   - rebuild=true: the change introduces structure/data that can only come
@@ -79,6 +79,48 @@ var schemaMigrations = []schemaMigration{
 	// derived vector sidecar rather than discarding otherwise-valid topology.
 	{version: 10, name: "rebuild vector corpus ownership and parents", inPlace: rebuildVectorCorpusSchema},
 	{version: 11, name: "add symbol FTS normalization state", inPlace: createSymbolFTSNormalizationStateTable},
+	{version: 12, name: "normalize dir column separators", inPlace: normalizeDirColumnSeparators},
+}
+
+// normalizeDirColumnSeparators rebuilds the two generated dir columns whose
+// pre-v12 expressions trimmed at '/' only. Stored paths keep the writing
+// platform's native separators below the repo prefix, so a Windows-written
+// store collapsed both dirs to the repo prefix and the Go receiver-rebind
+// join degenerated from "same package dir" to "same repo". A generated
+// column cannot be redefined in place: drop the index over file_dir, drop
+// and re-add both columns with the current DDL, and recreate the index from
+// the shared always-live set so its DDL cannot drift. Idempotent — a re-run
+// re-adds the same expressions, and the existence guards tolerate a store
+// where a column is already absent or already current.
+func normalizeDirColumnSeparators(tx *sql.Tx) error {
+	if _, err := tx.Exec(`DROP INDEX IF EXISTS nodes_go_receiver_type`); err != nil {
+		return err
+	}
+	for _, col := range []struct{ table, name, ddl string }{
+		{"nodes", "file_dir", fileDirColumnDDL},
+		{"edges", "member_receiver_dir", memberReceiverDirColumnDDL},
+	} {
+		var count int
+		q := fmt.Sprintf(`SELECT COUNT(*) FROM pragma_table_xinfo('%s') WHERE name = ?`, col.table)
+		if err := tx.QueryRow(q, col.name).Scan(&count); err != nil {
+			return err
+		}
+		if count > 0 {
+			if _, err := tx.Exec(`ALTER TABLE ` + col.table + ` DROP COLUMN ` + col.name); err != nil {
+				return err
+			}
+		}
+		if _, err := tx.Exec(`ALTER TABLE ` + col.table + ` ADD COLUMN ` + col.ddl); err != nil {
+			return err
+		}
+	}
+	for _, idx := range bulkAlwaysLiveIndexes {
+		if idx.name == "nodes_go_receiver_type" {
+			_, err := tx.Exec(idx.ddl)
+			return err
+		}
+	}
+	return fmt.Errorf("nodes_go_receiver_type missing from bulkAlwaysLiveIndexes")
 }
 
 // createSymbolFTSNormalizationStateTable is the explicit v11 migration for


### PR DESCRIPTION
Fixes #593.

The `file_dir` and `member_receiver_dir` generated columns trim at the last `'/'`, but stored paths keep the writing platform's native separators below the repo prefix — a Windows-written store holds `repo/internal\pkg\file.go`. Both dirs therefore collapse to the repo prefix, and the receiver-rebind join (`c.file_dir = e.member_receiver_dir AND c.name = e.member_receiver`) degenerates from "a type with this name in the phantom receiver's package dir" to "a type with this name anywhere in the repo". Two failure modes, both pinned by tests:

- a unique same-named type in another directory is the only candidate the `HAVING COUNT(*) = 1` gate sees, so the method is rebound to the wrong package's type;
- any same-named pair anywhere in the repo makes the count ambiguous and suppresses the legitimate same-directory bind.

Scale on my Windows store: one repo with 6,176 distinct file paths carried only 23 distinct `file_dir` values, and 160,155 `member_of` rows shared 4 distinct `member_receiver_dir` values — essentially the repo prefixes. With the fix (cold reindex of the same workspace), the same three repos went from 23/12/1 distinct dirs to 1,304/263/22, and this repository's own Go graph resolves 5,862 receiver edges — 1,826 of them cross-file — with zero cross-directory binds and zero phantoms left behind.

**The fix** normalizes `'\'` to `'/'` before the trim in both expressions — the SQL mirror of `graphpath.Norm` + `Dir`, and a no-op for stores whose paths already use `'/'`. Because a generated column on an existing store can only be rebuilt, not altered, the change ships as schema v12: drop the `nodes_go_receiver_type` index, drop and re-add both columns with the current DDL, recreate the index from the shared always-live set so the DDL cannot drift. The columns are VIRTUAL (metadata-only) and the index is a small partial one (Go types/interfaces with names), so the one-time migration cost is that index rebuild.

Two honest notes:

- On a Windows store that already carries wrong binds from the collapsed join, the migration alone doesn't repair them: the candidate query skips edges whose target already looks like a type, so an earlier mis-bind is invisible to the rebind pass. Reindexing the affected Go repo re-emits the phantom targets and the pass then binds them correctly. macOS/Linux stores have nothing to heal.
- The v10 FTS-state migration test pinned `currentSchemaVersion == 11` exactly; relaxed to `>= 11` since its behavioral asserts already target `currentSchemaVersion`.

Tests: fresh-store expression coverage (native, `'/'`-joined, and separator-free paths for both columns), a rebind case with a same-named decoy type in another directory plus a phantom whose only homonym lives elsewhere (both previously mishandled), and a migration test that builds a store with the verbatim pre-v12 expressions + index, stamps v11, and asserts Open rebuilds columns, index, and version.
