### PR TITLE
Exempt Python dunders from dead-code analysis

### DIFF
--- a/internal/analysis/deadcode.go
+++ b/internal/analysis/deadcode.go
@@ -341,11 +341,16 @@ func FindDeadCode(g graph.Store, processes *ProcessResult, excludePatterns []str
 
 		// Skip implicitly-called constructors/initializers.
 		// Go: init() is called by the runtime.
-		// Python: __init__ is called when a class is instantiated.
+		// Python: every __dunder__ is invoked by the runtime or a builtin
+		// rather than through a written call site -- __init__ on
+		// instantiation, __repr__ by repr()/str(), __enter__/__exit__ by
+		// `with`, __len__ by len(), __iter__ by `for`. They therefore always
+		// look dead, the same way generated symbols and framework entry
+		// points do above.
 		if n.Name == "init" && n.Language == "go" {
 			continue
 		}
-		if n.Name == "__init__" && n.Language == "python" {
+		if n.Language == "python" && isPythonDunder(n.Name) {
 			continue
 		}
 
@@ -1003,6 +1008,15 @@ func isWellKnownInterfaceMethod(name, lang string) bool {
 		return false
 	}
 	return goWellKnownMethods[name]
+}
+
+// isPythonDunder reports whether name is a __dunder__ special method. Python
+// invokes these implicitly -- via an operator, a builtin, or a statement -- so
+// they carry no hand-written call site and always look dead to the graph.
+func isPythonDunder(name string) bool {
+	return len(name) > 4 &&
+		strings.HasPrefix(name, "__") &&
+		strings.HasSuffix(name, "__")
 }
 
 // isVendoredOrGenerated checks if a file is vendored or generated code that

--- a/internal/analysis/deadcode_test.go
+++ b/internal/analysis/deadcode_test.go
@@ -719,6 +719,64 @@ func TestDeadCode_GeneratedFilesExcluded(t *testing.T) {
 	assert.Empty(t, result, "symbols in generated files should be excluded")
 }
 
+// TestDeadCode_PythonDundersExcluded verifies that Python special methods are
+// not reported as dead. Python invokes them implicitly -- via an operator, a
+// builtin, or a statement -- so they never carry a written call site.
+func TestDeadCode_PythonDundersExcluded(t *testing.T) {
+	g := graph.New()
+
+	dunders := []string{
+		"__init__",  // instantiation
+		"__repr__",  // repr()
+		"__str__",   // str()/print()
+		"__eq__",    // ==
+		"__len__",   // len()
+		"__iter__",  // for
+		"__enter__", // with
+		"__exit__",  // with
+		"__bool__",  // truthiness
+		"__getitem__",
+	}
+
+	for _, name := range dunders {
+		g.AddNode(&graph.Node{
+			ID: "pkg/mod.py::Cls." + name, Kind: graph.KindMethod,
+			Name: name, FilePath: "pkg/mod.py", StartLine: 1, EndLine: 3,
+			Language: "python",
+		})
+	}
+
+	result := FindDeadCode(g, nil, nil)
+	assert.Empty(t, result, "python dunder methods should be excluded")
+}
+
+// TestDeadCode_PythonNonDundersStillReported guards the exemption against
+// over-reach: an ordinary uncalled helper is still dead, and so is a name that
+// merely starts with underscores.
+func TestDeadCode_PythonNonDundersStillReported(t *testing.T) {
+	g := graph.New()
+
+	// All leading-underscore, so the pre-existing "skip exported symbols" rule
+	// does not apply and only the dunder exemption is under test. None of these
+	// is a dunder: the name must both start and end with "__" and have
+	// something between.
+	for _, name := range []string{"_helper", "__private", "____"} {
+		g.AddNode(&graph.Node{
+			ID: "pkg/mod.py::" + name, Kind: graph.KindFunction,
+			Name: name, FilePath: "pkg/mod.py", StartLine: 1, EndLine: 3,
+			Language: "python",
+		})
+	}
+
+	result := FindDeadCode(g, nil, nil)
+	reported := make([]string, 0, len(result))
+	for _, entry := range result {
+		reported = append(reported, entry.Name)
+	}
+	assert.ElementsMatch(t, []string{"_helper", "__private", "____"}, reported,
+		"non-dunder python symbols should still be reported")
+}
+
 // TestDeadCode_MainFunctionExcluded verifies that Go main() is not reported as dead.
 func TestDeadCode_MainFunctionExcluded(t *testing.T) {
 	g := graph.New()


### PR DESCRIPTION
## Summary

Exempts Python dunder methods from `analyze dead_code`. Python invokes them implicitly — via an operator, a builtin, or a statement — so they carry no written call site and always look unreferenced to the graph.

`__init__` was already exempted for exactly this reason ([`deadcode.go:347`](https://github.com/zzet/gortex/blob/main/internal/analysis/deadcode.go#L347)); this generalises that special case to the rest of the protocol, alongside the existing exemptions for generated symbols and framework entry points that "always look dead" by construction.

Fixes #600.

## Changes

- `internal/analysis/deadcode.go` — replace the `__init__` special case with an `isPythonDunder` check, and widen the block comment to say why. New predicate placed with the other file-scope predicates.
- `internal/analysis/deadcode_test.go` — two tests: dunders are excluded, and non-dunders still get reported.

The predicate requires both affixes plus a non-empty stem:

```go
func isPythonDunder(name string) bool {
	return len(name) > 4 &&
		strings.HasPrefix(name, "__") &&
		strings.HasSuffix(name, "__")
}
```

so `_helper`, `__private`, `helper__` and `____` all stay reportable.

## Effect

Measured on four small first-party Python repos, where every `dead_code` hit was a dunder:

| | reported |
|---|---:|
| v0.47.0 | 6 |
| v0.63.3 | 2 |
| this branch | 0 |

(The drop from 6 to 2 is the v0.62.0 Python parser work — receiver typing from `self`/`cls` and module-level variable nodes — which fixed the `@property` and module-level-lambda cases. The two that remained were `__repr__`.)

## Trade-off

A genuinely unused `__repr__` will no longer be reported. That matches the preference stated in this file for false negatives over false positives — the same reasoning already applied to variables, fields and constants — and an unused dunder is cheap to carry. The alternative, a result set that is almost entirely dunders, makes the real findings easy to dismiss.

## Testing

- [x] All tests pass (`go test -race ./...`) — see note below
- [x] New tests added for new functionality
- [ ] Benchmarks run if performance-relevant — not performance-relevant (one string predicate on an existing per-node loop)

`go test -race ./internal/analysis/` passes clean. I ran the affected package rather than the whole suite; happy to run more if you'd like, but I did not want to report a full-suite pass I had not actually completed.

Also verified end to end: built the binary from this branch and re-ran `analyze dead_code` against the repos above, giving the 0 in the table.

`gofmt` is clean on `deadcode.go`. `deadcode_test.go` is listed by `gofmt -l`, but it already is on a pristine `main` checkout — the delta it wants is at pre-existing line 922 (`Node.Test`), untouched here. I left it alone rather than mixing an unrelated reformat into this PR.

## Checklist

- [x] Code follows existing patterns in the codebase
- [x] No unnecessary abstractions added
- [ ] Language extractor includes `Meta["methods"]` for interfaces (if applicable) — n/a
- [ ] Methods have `EdgeMemberOf` edges to their containing type (if applicable) — n/a
