### PR TITLE
lsp: match server answers to graph nodes across path-separator spellings

### DIFF
--- a/internal/semantic/lsp/enrich_confirm.go
+++ b/internal/semantic/lsp/enrich_confirm.go
@@ -125,13 +125,14 @@ func (p *Provider) groupConfirmTargets(nodesByID map[string]*graph.Node, targets
 // containment in the caller's span. Pure over its inputs, so it is safe to call
 // from the parallel sweep.
 func (p *Provider) confirmRefMatchesSite(refs []Location, absRoot, repoPrefix string, t enrichTarget) bool {
-	callerRel := nodeRelPath(t.node)
-	siteRel := edgeSiteRelPath(t.edge, repoPrefix, callerRel)
+	callerRel := viewPathKey(nodeRelPath(t.node))
+	siteRel := viewPathKey(edgeSiteRelPath(t.edge, repoPrefix, callerRel))
 	siteLine := t.edge.Line
 	for _, ref := range refs {
 		// uriToPath returns a repo-relative path while node/edge FilePaths are
-		// prefixed, so compare against stripped paths.
-		refPath := uriToPath(ref.URI, absRoot)
+		// prefixed, so compare against stripped paths — slash-normalized, since
+		// store rows may spell separators either way.
+		refPath := viewPathKey(uriToPath(ref.URI, absRoot))
 		refLine := ref.Range.Start.Line + 1
 		if siteLine > 0 {
 			if refPath == siteRel && refLine >= siteLine-1 && refLine <= siteLine+1 {

--- a/internal/semantic/lsp/graph_batch.go
+++ b/internal/semantic/lsp/graph_batch.go
@@ -1,9 +1,35 @@
 package lsp
 
 import (
+	"strings"
+
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/semantic"
 )
+
+// viewPathKey normalizes a graph file path for nodesByFile keying and
+// comparisons. Store vintages carry both separator spellings — older
+// Windows rows use `\` after the repo prefix while newer rows and every
+// URI-derived path use `/` — so any join between a server answer and a
+// node path must use the slash-normalized spelling. Mirrors the store's
+// own file_dir separator normalization.
+func viewPathKey(p string) string { return strings.ReplaceAll(p, `\`, "/") }
+
+// storePathSpellings returns the scoped-path spellings a store row may
+// carry for a repo-relative path: the slash spelling plus, when the rel
+// has separators, the backslash spelling older Windows rows use. Store
+// lookups by file_path are exact string matches, so a URI-derived
+// slash-relative path must query both.
+func storePathSpellings(repoPrefix, rel string) []string {
+	if rel == "" {
+		return nil
+	}
+	spellings := []string{scopedPath(repoPrefix, rel)}
+	if back := strings.ReplaceAll(rel, "/", `\`); back != rel {
+		spellings = append(spellings, scopedPath(repoPrefix, back))
+	}
+	return spellings
+}
 
 type lspEdgeKey struct {
 	from     string
@@ -46,24 +72,26 @@ func (v *lspGraphView) addNodes(nodes []*graph.Node) {
 		}
 		if old, exists := v.nodesByID[n.ID]; exists {
 			v.nodesByID[n.ID] = n
-			bucket := v.nodesByFile[old.FilePath]
+			oldKey, newKey := viewPathKey(old.FilePath), viewPathKey(n.FilePath)
+			bucket := v.nodesByFile[oldKey]
 			for i, candidate := range bucket {
 				if candidate.ID != n.ID {
 					continue
 				}
-				if old.FilePath == n.FilePath {
+				if oldKey == newKey {
 					bucket[i] = n
-					v.nodesByFile[old.FilePath] = bucket
+					v.nodesByFile[oldKey] = bucket
 				} else {
-					v.nodesByFile[old.FilePath] = append(bucket[:i], bucket[i+1:]...)
-					v.nodesByFile[n.FilePath] = append(v.nodesByFile[n.FilePath], n)
+					v.nodesByFile[oldKey] = append(bucket[:i], bucket[i+1:]...)
+					v.nodesByFile[newKey] = append(v.nodesByFile[newKey], n)
 				}
 				break
 			}
 			continue
 		}
 		v.nodesByID[n.ID] = n
-		v.nodesByFile[n.FilePath] = append(v.nodesByFile[n.FilePath], n)
+		key := viewPathKey(n.FilePath)
+		v.nodesByFile[key] = append(v.nodesByFile[key], n)
 	}
 }
 
@@ -83,6 +111,7 @@ func (v *lspGraphView) addEdges(edges []*graph.Edge) {
 }
 
 func (v *lspGraphView) matchNodeByFileLine(filePath string, line int) *graph.Node {
+	filePath = viewPathKey(filePath)
 	var best *graph.Node
 	bestSize := int(^uint(0) >> 1)
 	for _, n := range v.nodesByFile[filePath] {
@@ -118,6 +147,7 @@ func (v *lspGraphView) matchNodeByFileLine(filePath string, line int) *graph.Nod
 }
 
 func (v *lspGraphView) matchCallableByFileLine(filePath string, line int) *graph.Node {
+	filePath = viewPathKey(filePath)
 	callable := func(k graph.NodeKind) bool {
 		return k == graph.KindFunction || k == graph.KindMethod || k == graph.KindClosure
 	}
@@ -156,6 +186,7 @@ func (v *lspGraphView) matchCallableByFileLine(filePath string, line int) *graph
 }
 
 func (v *lspGraphView) findDeclarationNode(filePath string, oneBasedLine int, name string) *graph.Node {
+	filePath = viewPathKey(filePath)
 	var near *graph.Node
 	for _, n := range v.nodesByFile[filePath] {
 		if n == nil || n.Name != name {

--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -2829,12 +2829,15 @@ func (p *Provider) ConfirmSymbolRefs(g graph.Store, repoRoot string, n *graph.No
 		if otherPath == "" {
 			continue
 		}
-		path := scopedPath(n.RepoPrefix, otherPath)
-		if _, seen := seenPath[path]; seen {
-			continue
+		// Store rows may spell separators either way, and the file_path
+		// lookup is an exact match — fetch every spelling a row may carry.
+		for _, path := range storePathSpellings(n.RepoPrefix, otherPath) {
+			if _, seen := seenPath[path]; seen {
+				continue
+			}
+			seenPath[path] = struct{}{}
+			paths = append(paths, path)
 		}
-		seenPath[path] = struct{}{}
-		paths = append(paths, path)
 	}
 	if len(paths) == 0 {
 		return 0, nil

--- a/internal/semantic/lsp/windows_answer_join_test.go
+++ b/internal/semantic/lsp/windows_answer_join_test.go
@@ -1,0 +1,68 @@
+package lsp
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Graph FilePaths carry both separator spellings across store vintages —
+// older Windows rows use `\` after the repo prefix while newer rows and
+// every URI-derived path use `/` — so each join between a server answer
+// and a graph node must match across spellings. Before these pins, every
+// LSP answer on a backslash-spelled store missed its node: zero yield
+// from a perfectly answering server, and the productivity checkpoint then
+// cancelled the pass.
+
+func TestGraphViewLookupsMatchAcrossSeparatorSpellings(t *testing.T) {
+	iface := &graph.Node{ID: "n1", Kind: graph.KindInterface, Name: "IThing",
+		FilePath: `repo/pkg\IThing.cs`, StartLine: 5, EndLine: 20}
+	method := &graph.Node{ID: "n2", Kind: graph.KindMethod, Name: "Handle",
+		FilePath: "repo/pkg2/Impl.cs", StartLine: 8, EndLine: 30}
+	view := newLSPGraphView([]*graph.Node{iface, method}, nil)
+
+	if got := view.matchNodeByFileLine("repo/pkg/IThing.cs", 10); got != iface {
+		t.Fatalf("slash lookup vs backslash-spelled node: got %+v, want iface", got)
+	}
+	if got := view.matchCallableByFileLine(`repo/pkg2\Impl.cs`, 12); got != method {
+		t.Fatalf("backslash lookup vs slash-spelled node: got %+v, want method", got)
+	}
+	if got := view.findDeclarationNode("repo/pkg/IThing.cs", 5, "IThing"); got != iface {
+		t.Fatalf("findDeclarationNode across spellings: got %+v, want iface", got)
+	}
+}
+
+func TestStorePathSpellingsCoverBothSeparators(t *testing.T) {
+	got := storePathSpellings("repo", "a/b/C.cs")
+	want := []string{"repo/a/b/C.cs", `repo/a\b\C.cs`}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("spellings: got %q, want %q", got, want)
+	}
+	if got := storePathSpellings("repo", "C.cs"); len(got) != 1 || got[0] != "repo/C.cs" {
+		t.Fatalf("separator-free rel: got %q, want the single slash spelling", got)
+	}
+	if got := storePathSpellings("repo", ""); got != nil {
+		t.Fatalf("empty rel: got %q, want nil", got)
+	}
+}
+
+func TestConfirmRefMatchesSiteAcrossSeparatorSpellings(t *testing.T) {
+	absRoot := t.TempDir()
+	caller := &graph.Node{ID: "c1", Kind: graph.KindMethod, Name: "Caller",
+		RepoPrefix: "repo", FilePath: `repo/Domain\Svc.cs`, StartLine: 30, EndLine: 60}
+	edge := &graph.Edge{From: "c1", To: "t1", Kind: graph.EdgeCalls,
+		FilePath: `repo/Domain\Svc.cs`, Line: 42}
+	// The server answers with a URI, so the ref path comes back
+	// slash-spelled; the edge site is backslash-spelled.
+	ref := Location{
+		URI:   pathToURI(filepath.Join(absRoot, "Domain", "Svc.cs")),
+		Range: Range{Start: Position{Line: 41}},
+	}
+
+	p := &Provider{}
+	if !p.confirmRefMatchesSite([]Location{ref}, absRoot, "repo",
+		enrichTarget{node: caller, edge: edge}) {
+		t.Fatal("reference at the site line must confirm across separator spellings")
+	}
+}


### PR DESCRIPTION

## Symptom

On Windows, LSP enrichment could never land a single edge — `origin='lsp_resolved'`
stayed at 0 no matter what. The failure shape was misleading: the server spawned, loaded,
and answered flawlessly; the sweep sent its requests fine (outgoing paths go through
`filepath.Join`, which tolerates either separator); but **every answer was dropped on the
way back into the graph**. With zero staged or confirmed edges, `usefulYield` stayed 0 and
the productivity checkpoint concluded the server was unproductive:

```
LSP enrich: pass cut by productivity checkpoint — request volume flowed with near-zero
useful yield   window=120 windows_elapsed=1 requests=150 useful_yield=0
```

150 correct `textDocument/implementation` answers, all discarded, pass cancelled 145s into
a 5400s deadline.

To rule out the server I spoke raw LSP to csharp-ls against the same ~90-project solution:
`workspace/symbol` non-empty at T+30.5s, correct cross-solution `implementation` answer at
T+31.8s. The server was never the problem.

## Root cause

Graph `FilePath`s carry both separator spellings across store vintages — older Windows
rows use `\` after the repo prefix (`repo/pkg\File.cs`) while newer rows and every
URI-derived path use `/` (`URIToRepoRel` ends in `filepath.ToSlash`). The answer path
joined the two with exact string matches in three places:

1. `lspGraphView.nodesByFile` — keyed by verbatim `n.FilePath`, looked up with
   URI-derived slash paths (`matchNodeByFileLine`, `matchCallableByFileLine`,
   `findDeclarationNode`). Every lookup missed.
2. `confirmRefMatchesSite` — `refPath == siteRel` string equality between a URI-derived
   path and an edge's stored path. Every confirm failed.
3. The reference-hop batch feeding `GetFileNodesByPaths` — an exact `file_path IN (...)`
   query given slash spellings that backslash rows can never match.

Same bug class as the `file_dir` generated-column issue (#593), one layer up: any exact
join between a URI-derived path and a stored path silently drops everything on Windows.

## Fix

- `viewPathKey` slash-normalizes `nodesByFile` keys and every lookup entry point.
- `confirmRefMatchesSite` compares slash-normalized paths.
- `storePathSpellings` fetches both spellings in the reference-hop batch, since a
  mixed-vintage store can hold either.

## Results (same production store, same drill, before → after)

My production C# monorepo (~117k nodes), eager enrichment with the csharp-ls
solution-targeting branch also applied:

- LSP-origin edges: **0 → 33,841**, all at confidence 1.0 — calls 26,178,
  implements 3,426, overrides 2,944, extends 1,187, plus instantiates / references /
  annotated / typed_as / returns.
- Pass result: confirmed 5,474 existing heuristic edges, added 26,782 new ones,
  24,620 nodes enriched.
- The pass ran 84.5 minutes to its deadline instead of being cancelled at 2m25s; hover
  phase: 24,620 ok, 0 errors, 0 reconnects across 1,224 document opens.
- Battery on my counted fixture repo: byte-identical across runs, no regressions.

The fix is language-agnostic — the pyright/TS/gopls targeted phases hit the same joins,
which matches the `confirmed: 0` their passes always reported on Windows.

## Tests

`windows_answer_join_test.go`: view lookups across both spelling directions
(backslash-spelled node / slash lookup and the reverse), reference-confirm across
spellings, and the both-spellings helper. Full `go test ./...` at my Windows baseline.
