### PR TITLE
ci(release): stop and restart the daemon around cask upgrades

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -457,6 +457,28 @@ jobs:
             generate_completions_from_executable "gortex",
               shell_parameter_format: :cobra
 
+            # A running daemon holds the previous binary's image and the
+            # store lock across an upgrade; stop it first (only when one
+            # is actually answering) and restart onto the new binary after
+            # install. Fresh installs and CI never launch a daemon — the
+            # marker file records "was running" between the two hooks.
+            pre_install do
+              bin = File.join(HOMEBREW_PREFIX, "bin", "gortex")
+              next unless File.executable?(bin)
+              status = system_command(bin, args: ["daemon", "status"])
+              next unless status.success?
+              File.write(File.join(Dir.tmpdir, "gortex-cask-daemon-was-running"), "1")
+              system_command(bin, args: ["daemon", "stop"])
+            end
+            post_install do
+              marker = File.join(Dir.tmpdir, "gortex-cask-daemon-was-running")
+              if File.exist?(marker)
+                File.delete(marker)
+                system_command(File.join(HOMEBREW_PREFIX, "bin", "gortex"),
+                               args: ["daemon", "restart"])
+              end
+            end
+
             # No zap stanza required
           end
           EOF


### PR DESCRIPTION
## Summary

`brew upgrade gortex` replaces the binary while a running daemon keeps executing the old image — nothing restarts it, and nothing detects the skew (#609). PR #611 adds the detection layers; this PR closes the loop at the install path: the release pipeline's generated cask now stops a running daemon before the upgrade and restarts it onto the new binary afterwards.

Fixes the brew-upgrade leg of #609 (detection: #611).

## Changes

- `.github/workflows/release.yml` (the `Publish homebrew cask` heredoc template) gains guarded hooks in every generated `Casks/gortex.rb`:
  - `pre_install`: if a `gortex` binary exists AND `gortex daemon status` exits 0, write a tmp marker and run `gortex daemon stop` — releases the store lock and retires the old image before the swap.
  - `post_install`: if the marker exists, delete it and run `gortex daemon restart` (routes through the supervisor when launchd owns the daemon).
  - Fresh installs and CI never launch a daemon — both hooks no-op when no daemon was running.

## Testing

- [x] Template rendered with dummy shas and syntax-checked (`ruby -c` on the produced cask: Syntax OK); workflow YAML parses.
- [x] New tests — N/A (a YAML heredoc template; the Ruby is validated by rendering it).
- [ ] Runtime behavior lands at the next release cut, when the generated cask reaches `zzet/homebrew-tap`; a manual `brew upgrade` on macOS confirms then.

## Notes

- Deliberately targets the generator, not the tap file: the tap's cask is stamped out on every release and any hand edit would be overwritten.
- `daemon status` as the was-running probe reuses gortex's own socket resolution (no XDG path duplication in Ruby); it is bounded by the daemon's 30s control timeout.
