### PR TITLE
fix: report the launchd and Codex hook state these diagnostics can actually observe

### DIFF
--- a/cmd/gortex/daemon_service.go
+++ b/cmd/gortex/daemon_service.go
@@ -313,33 +313,250 @@ func uninstallLaunchd(w io.Writer) error {
 	return nil
 }
 
+// launchdDomains lists the launchd domains a user LaunchAgent can end up in,
+// most likely first.
+//
+// `launchctl load` bootstraps the agent into the *calling* process's domain:
+// a graphical login session puts it in gui/<uid>, an SSH or otherwise
+// non-graphical session puts it in user/<uid>. Both are queried so the answer
+// does not depend on which kind of session happens to be asking.
+func launchdDomains(uid int) []string {
+	return []string{fmt.Sprintf("gui/%d", uid), fmt.Sprintf("user/%d", uid)}
+}
+
+// launchdLookup is what one domain query established. The three-way split is
+// the whole point: launchctl reports "this domain has no such service" and
+// "I could not answer" with the same non-zero exit shape, and only the first
+// entitles this command to say the service is not loaded.
+type launchdLookup int
+
+const (
+	// launchdAbsent — launchctl answered, and the service is not in that domain.
+	launchdAbsent launchdLookup = iota
+	// launchdFound — launchctl answered and described the service.
+	launchdFound
+	// launchdUnreadable — the query itself failed, so nothing was established.
+	// Reaching launchd needs the bootstrap port, and a context that cannot
+	// get to it makes launchctl exit non-zero with no output at all — the
+	// shape `launchctl list` returns under a seatbelt sandbox that denies
+	// mach-lookup. `launchctl print` survives that particular sandbox, but
+	// anything else that cannot reach launchd has to land here rather than be
+	// mistaken for an absent service.
+	launchdUnreadable
+)
+
+// launchdProbe asks launchd about one service path ("gui/501/com.zzet.gortex")
+// and returns launchctl's combined output with its exit code. err is set only
+// when launchctl could not be executed at all.
+type launchdProbe func(servicePath string) (out string, exitCode int, err error)
+
+// launchctl exit codes for the two negative answers. They are checked
+// alongside the message text rather than instead of it, so a change to either
+// one still leaves the other pointing at the same conclusion.
+const (
+	launchctlNoSuchDomain  = 112
+	launchctlNoSuchService = 113
+)
+
+// launchctlPrintArgs builds the launchctl argv the probe runs. Split out so
+// the domain-explicit form is pinned by a test without a launchd to talk to —
+// the legacy `launchctl list <label>` this replaces searched only the caller's
+// own domain, and that is the defect, so the argv is the fix.
+func launchctlPrintArgs(servicePath string) []string {
+	return []string{"print", servicePath}
+}
+
+// launchctlPrint is the production probe. `launchctl print <domain>/<label>`
+// is domain-explicit, unlike the legacy `launchctl list <label>`, which only
+// ever searches the caller's own domain.
+func launchctlPrint(servicePath string) (string, int, error) {
+	out, err := exec.Command("launchctl", launchctlPrintArgs(servicePath)...).CombinedOutput()
+	if err == nil {
+		return string(out), 0, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return string(out), exitErr.ExitCode(), nil
+	}
+	return string(out), -1, err
+}
+
+// classifyLaunchctlPrint turns one probe result into a lookup outcome, plus a
+// reason worth printing when the query failed.
+//
+// Anything unrecognised degrades to launchdUnreadable rather than to
+// launchdAbsent. That is the safe direction: reporting "unknown" for a service
+// that is genuinely gone costs the user one extra command, while reporting
+// "not loaded" for a running one sends them to reload a healthy service.
+func classifyLaunchctlPrint(out string, exitCode int, err error) (launchdLookup, string) {
+	switch {
+	case err != nil:
+		return launchdUnreadable, fmt.Sprintf("could not run launchctl: %v", err)
+	case exitCode == 0:
+		return launchdFound, ""
+	case strings.Contains(out, "Could not find service"),
+		strings.Contains(out, "Could not find domain"),
+		exitCode == launchctlNoSuchService,
+		exitCode == launchctlNoSuchDomain:
+		return launchdAbsent, ""
+	}
+	if detail := launchctlFailureDetail(out); detail != "" {
+		return launchdUnreadable, fmt.Sprintf("launchctl exited %d: %s", exitCode, detail)
+	}
+	return launchdUnreadable, fmt.Sprintf(
+		"launchctl exited %d with no output, so launchd could not be queried from this session", exitCode)
+}
+
+// launchctlFailureDetail picks the most informative line out of a failed
+// launchctl run. "Bad request." is launchctl's own preamble and says nothing.
+func launchctlFailureDetail(out string) string {
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || line == "Bad request." {
+			continue
+		}
+		return line
+	}
+	return ""
+}
+
+// launchdServiceState is the part of a `launchctl print` report a status line
+// needs.
+type launchdServiceState struct {
+	State    string
+	PID      string
+	LastExit string
+}
+
+// parseLaunchctlPrint pulls those fields out of launchctl's nested, indented
+// report. Only the first occurrence of each key is taken: the resource and
+// jetsam coalition sub-blocks further down repeat `state = active`, and taking
+// the last one would report a running daemon as something else entirely.
+func parseLaunchctlPrint(out string) launchdServiceState {
+	var st launchdServiceState
+	for _, line := range strings.Split(out, "\n") {
+		key, value, ok := strings.Cut(strings.TrimSpace(line), " = ")
+		if !ok {
+			continue
+		}
+		switch key {
+		case "state":
+			if st.State == "" {
+				st.State = value
+			}
+		case "pid":
+			if st.PID == "" {
+				st.PID = value
+			}
+		case "last exit code":
+			if st.LastExit == "" {
+				st.LastExit = value
+			}
+		}
+	}
+	return st
+}
+
+// launchdServiceLoaded reports whether the LaunchAgent is bootstrapped into
+// any of the user's launchd domains. It is the lifecycle-routing counterpart
+// of reportLaunchdStatus, used to decide whether a supervisor owns the daemon.
+//
+// It collapses "absent" and "could not tell" into false on purpose. A caller
+// choosing between the supervised and the manual path has to pick one: the
+// manual path works whether or not a unit exists, while the supervised one
+// hard-fails when there is nothing to drive. Guessing "supervised" from a
+// query that failed would turn `daemon restart` into an error in exactly the
+// restricted contexts where it works today.
+func launchdServiceLoaded(uid int, probe launchdProbe) bool {
+	for _, domain := range launchdDomains(uid) {
+		out, code, err := probe(domain + "/" + daemonServiceName)
+		if lookup, _ := classifyLaunchctlPrint(out, code, err); lookup == launchdFound {
+			return true
+		}
+	}
+	return false
+}
+
 func statusLaunchd(w io.Writer) error {
 	path, err := launchdPlistPath()
 	if err != nil {
 		return err
 	}
-	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
-		fmt.Fprintf(w, "launchd: not installed (expected %s)\n", path)
-		return nil
-	}
-	fmt.Fprintf(w, "launchd: installed at %s\n", path)
+	return reportLaunchdStatus(w, path, os.Getuid(), launchctlPrint, daemon.IsRunning)
+}
 
-	// `launchctl list <label>` returns 0 and a plist-ish blob when loaded,
-	// non-zero otherwise.
-	out, err := exec.Command("launchctl", "list", daemonServiceName).CombinedOutput()
-	if err != nil {
-		fmt.Fprintln(w, "status: not loaded — try `launchctl load ~/Library/LaunchAgents/"+daemonServiceName+".plist`")
+// reportLaunchdStatus renders the service state from evidence it can actually
+// obtain. The probe and the daemon check are parameters so the whole decision
+// table is testable without a Mac, a login session, or an installed service.
+func reportLaunchdStatus(w io.Writer, plistPath string, uid int, probe launchdProbe, daemonRunning func() bool) error {
+	switch _, err := os.Stat(plistPath); {
+	case errors.Is(err, os.ErrNotExist):
+		fmt.Fprintf(w, "launchd: not installed (expected %s)\n", plistPath)
+		return nil
+	case err != nil:
+		// Same discipline as the launchd query below: an unreadable path is
+		// not evidence of an installed unit, and claiming one would put the
+		// rest of this report on a foundation nothing established.
+		fmt.Fprintf(w, "launchd: unknown — could not read %s (%v)\n", plistPath, err)
 		return nil
 	}
-	fmt.Fprintln(w, "status: loaded")
-	// Extract PID and LastExitStatus lines for a concise summary.
-	for _, line := range strings.Split(string(out), "\n") {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "\"PID\"") || strings.HasPrefix(line, "\"LastExitStatus\"") {
-			fmt.Fprintln(w, "  "+line)
+	fmt.Fprintf(w, "launchd: installed at %s\n", plistPath)
+
+	domains := launchdDomains(uid)
+	var unreadable []string
+	for _, domain := range domains {
+		out, code, err := probe(domain + "/" + daemonServiceName)
+		switch lookup, reason := classifyLaunchctlPrint(out, code, err); lookup {
+		case launchdFound:
+			state := parseLaunchctlPrint(out)
+			fmt.Fprintf(w, "status: loaded in %s\n", domain)
+			for _, field := range []struct{ label, value string }{
+				{"state", state.State},
+				{"pid", state.PID},
+				{"last exit code", state.LastExit},
+			} {
+				if field.value != "" {
+					fmt.Fprintf(w, "  %s: %s\n", field.label, field.value)
+				}
+			}
+			// A loaded unit that is not currently running says nothing about
+			// whether a daemon is serving the user — one started outside
+			// launchd looks identical from here, and reporting only launchd's
+			// view of a stopped unit implies nothing is up.
+			if state.State != "running" {
+				noteRunningDaemon(w, daemonRunning)
+			}
+			return nil
+		case launchdUnreadable:
+			unreadable = append(unreadable, fmt.Sprintf("%s: %s", domain, reason))
 		}
 	}
+
+	if len(unreadable) > 0 {
+		// At least one domain could not be queried, so "not loaded" is not a
+		// conclusion this command has earned — and neither is the advice that
+		// follows from it.
+		fmt.Fprintln(w, "status: unknown — launchd could not be queried")
+		for _, line := range unreadable {
+			fmt.Fprintln(w, "  "+line)
+		}
+	} else {
+		fmt.Fprintf(w, "status: not loaded (checked %s)\n", strings.Join(domains, ", "))
+		fmt.Fprintf(w, "  fix: launchctl load -w %s (or re-run `gortex daemon install-service`)\n", plistPath)
+	}
+
+	noteRunningDaemon(w, daemonRunning)
 	return nil
+}
+
+// noteRunningDaemon adds the one fact left when launchd is not reporting a
+// running service. The unit is only one of the ways the daemon runs, and
+// stopping at launchd's answer would let this command imply nothing is running
+// while a manually started daemon serves the user perfectly well.
+func noteRunningDaemon(w io.Writer, daemonRunning func() bool) {
+	if daemonRunning() {
+		fmt.Fprintln(w, "  note: a gortex daemon is answering on its socket — see `gortex daemon status`")
+	}
 }
 
 // --- systemd --user (Linux) ----------------------------------------------

--- a/cmd/gortex/daemon_service_status_test.go
+++ b/cmd/gortex/daemon_service_status_test.go
@@ -1,0 +1,460 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The fixtures below are verbatim `launchctl print` output captured on macOS
+// 25.5 from an agent loaded exactly the way installLaunchd loads one. They are
+// the reason this file exists: the previous status check asked
+// `launchctl list <label>`, which only ever searches the caller's own domain,
+// so a LaunchAgent running in gui/<uid> looked absent to anything asking from
+// another domain — or from a sandbox that cannot reach launchd at all.
+
+const launchctlPrintRunning = `gui/501/com.zzet.gortex = {
+	active count = 1
+	path = /Users/example/Library/LaunchAgents/com.zzet.gortex.plist
+	type = LaunchAgent
+	state = running
+
+	program = /opt/homebrew/bin/gortex
+
+	domain = gui/501 [100022]
+	runs = 1
+	pid = 27574
+	last exit code = (never exited)
+
+	resource coalition = {
+		ID = 282739
+		type = resource
+		state = active
+		active count = 1
+	}
+
+	jetsam coalition = {
+		ID = 282740
+		type = jetsam
+		state = active
+		active count = 1
+	}
+}
+`
+
+const launchctlPrintNotRunning = `gui/501/com.zzet.gortex = {
+	active count = 0
+	path = /Users/example/Library/LaunchAgents/com.zzet.gortex.plist
+	type = LaunchAgent
+	state = not running
+
+	runs = 1
+	last exit code = 0
+
+	resource coalition = {
+		type = resource
+		state = active
+	}
+}
+`
+
+const launchctlPrintNoService = "Bad request.\nCould not find service \"com.zzet.gortex\" in domain for uid: 501\n"
+
+const launchctlPrintNoDomain = "Bad request.\nCould not find domain for user gui: 99999\n"
+
+// probeScript answers each service path with a canned launchctl result, and
+// records the paths it was asked about so a test can pin which domains were
+// actually queried.
+type probeScript struct {
+	answers map[string]struct {
+		out  string
+		code int
+		err  error
+	}
+	fallback struct {
+		out  string
+		code int
+		err  error
+	}
+	asked []string
+}
+
+func newProbeScript(fallbackOut string, fallbackCode int, fallbackErr error) *probeScript {
+	s := &probeScript{answers: map[string]struct {
+		out  string
+		code int
+		err  error
+	}{}}
+	s.fallback.out, s.fallback.code, s.fallback.err = fallbackOut, fallbackCode, fallbackErr
+	return s
+}
+
+func (s *probeScript) answer(servicePath, out string, code int, err error) *probeScript {
+	s.answers[servicePath] = struct {
+		out  string
+		code int
+		err  error
+	}{out, code, err}
+	return s
+}
+
+func (s *probeScript) probe(servicePath string) (string, int, error) {
+	s.asked = append(s.asked, servicePath)
+	if a, ok := s.answers[servicePath]; ok {
+		return a.out, a.code, a.err
+	}
+	return s.fallback.out, s.fallback.code, s.fallback.err
+}
+
+// installedPlist writes a plist into a temp dir so reportLaunchdStatus gets
+// past its "is it installed" gate without touching the real LaunchAgents dir.
+func installedPlist(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), daemonServiceName+".plist")
+	if err := os.WriteFile(path, []byte("<plist/>\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func captureLaunchdStatus(t *testing.T, plistPath string, probe launchdProbe, daemonUp bool) string {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := reportLaunchdStatus(&buf, plistPath, 501, probe, func() bool { return daemonUp }); err != nil {
+		t.Fatalf("reportLaunchdStatus: %v", err)
+	}
+	return buf.String()
+}
+
+// TestServiceStatusFindsAgentInGUIDomain is the reported bug: an agent that
+// launchd is running in gui/<uid> was reported as not loaded, and the fix that
+// was then recommended would have bounced a healthy service.
+func TestServiceStatusFindsAgentInGUIDomain(t *testing.T) {
+	script := newProbeScript(launchctlPrintNoService, 113, nil).
+		answer("gui/501/"+daemonServiceName, launchctlPrintRunning, 0, nil)
+
+	got := captureLaunchdStatus(t, installedPlist(t), script.probe, true)
+
+	for _, want := range []string{"status: loaded in gui/501", "state: running", "pid: 27574", "last exit code: (never exited)"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "not loaded") {
+		t.Errorf("a running service was reported as not loaded:\n%s", got)
+	}
+	if strings.Contains(got, "launchctl load") {
+		t.Errorf("recommended loading a service that is already running:\n%s", got)
+	}
+	if len(script.asked) != 1 || script.asked[0] != "gui/501/"+daemonServiceName {
+		t.Errorf("the GUI domain should be asked first and answer conclusively, asked %v", script.asked)
+	}
+}
+
+// TestServiceStatusFallsBackToUserDomain covers an agent bootstrapped from a
+// non-graphical session, which lands in user/<uid> instead.
+func TestServiceStatusFallsBackToUserDomain(t *testing.T) {
+	script := newProbeScript("", 0, nil).
+		answer("gui/501/"+daemonServiceName, launchctlPrintNoService, 113, nil).
+		answer("user/501/"+daemonServiceName, launchctlPrintRunning, 0, nil)
+
+	got := captureLaunchdStatus(t, installedPlist(t), script.probe, false)
+
+	if !strings.Contains(got, "status: loaded in user/501") {
+		t.Errorf("service in the user domain not found:\n%s", got)
+	}
+	if len(script.asked) != 2 {
+		t.Errorf("both domains should be queried, asked %v", script.asked)
+	}
+}
+
+// TestServiceStatusReportsUnknownWhenLaunchdCannotBeQueried pins the sandboxed
+// case: launchctl exits non-zero with no output at all because a seatbelt
+// profile denies the mach-lookup it needs. Nothing was established, so the
+// command must not claim the service is absent, and must not hand out a
+// remedy that follows only from absence.
+func TestServiceStatusReportsUnknownWhenLaunchdCannotBeQueried(t *testing.T) {
+	script := newProbeScript("", 1, nil)
+
+	got := captureLaunchdStatus(t, installedPlist(t), script.probe, true)
+
+	if !strings.Contains(got, "status: unknown") {
+		t.Errorf("an unanswerable query must not become a verdict:\n%s", got)
+	}
+	if strings.Contains(got, "not loaded") {
+		t.Errorf("claimed the service is absent without evidence:\n%s", got)
+	}
+	if strings.Contains(got, "launchctl load") {
+		t.Errorf("recommended loading on no evidence:\n%s", got)
+	}
+	if !strings.Contains(got, "gui/501: launchctl exited 1 with no output") {
+		t.Errorf("the reason the query failed was swallowed:\n%s", got)
+	}
+	if !strings.Contains(got, "answering on its socket") {
+		t.Errorf("a reachable daemon is the one fact left, and it was dropped:\n%s", got)
+	}
+}
+
+// TestServiceStatusReportsUnreachableLaunchctl covers launchctl missing from
+// PATH — an exec failure rather than a non-zero exit.
+func TestServiceStatusReportsUnreachableLaunchctl(t *testing.T) {
+	script := newProbeScript("", -1, errors.New(`exec: "launchctl": executable file not found in $PATH`))
+
+	got := captureLaunchdStatus(t, installedPlist(t), script.probe, false)
+
+	if !strings.Contains(got, "status: unknown") || !strings.Contains(got, "could not run launchctl") {
+		t.Errorf("an unrunnable launchctl must be reported as such:\n%s", got)
+	}
+	if strings.Contains(got, "answering on its socket") {
+		t.Errorf("the daemon is down; no note should claim otherwise:\n%s", got)
+	}
+}
+
+// TestServiceStatusReportsNotLoadedWhenBothDomainsAnswer is the case where
+// "not loaded" is the truth: launchctl answered for every domain and none of
+// them has the service.
+func TestServiceStatusReportsNotLoadedWhenBothDomainsAnswer(t *testing.T) {
+	plist := installedPlist(t)
+	script := newProbeScript(launchctlPrintNoService, 113, nil)
+
+	got := captureLaunchdStatus(t, plist, script.probe, false)
+
+	if !strings.Contains(got, "status: not loaded (checked gui/501, user/501)") {
+		t.Errorf("expected a conclusive not-loaded verdict naming both domains:\n%s", got)
+	}
+	if !strings.Contains(got, "launchctl load -w "+plist) {
+		t.Errorf("the remedy must name the installed plist, not a guessed path:\n%s", got)
+	}
+}
+
+// TestServiceStatusReportsMissingPlist keeps the never-installed case ahead of
+// any launchd query.
+func TestServiceStatusReportsMissingPlist(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), daemonServiceName+".plist")
+	script := newProbeScript(launchctlPrintRunning, 0, nil)
+
+	got := captureLaunchdStatus(t, missing, script.probe, false)
+
+	if !strings.Contains(got, "launchd: not installed") {
+		t.Errorf("expected a not-installed report:\n%s", got)
+	}
+	if len(script.asked) != 0 {
+		t.Errorf("launchd should not be queried for a service that was never installed, asked %v", script.asked)
+	}
+}
+
+func TestClassifyLaunchctlPrint(t *testing.T) {
+	cases := []struct {
+		name       string
+		out        string
+		code       int
+		err        error
+		want       launchdLookup
+		wantReason string
+	}{
+		{name: "running", out: launchctlPrintRunning, code: 0, want: launchdFound},
+		{name: "loaded but stopped", out: launchctlPrintNotRunning, code: 0, want: launchdFound},
+		{name: "no such service", out: launchctlPrintNoService, code: 113, want: launchdAbsent},
+		{name: "no such domain", out: launchctlPrintNoDomain, code: 112, want: launchdAbsent},
+		{
+			name:       "no output",
+			code:       1,
+			want:       launchdUnreadable,
+			wantReason: "launchctl exited 1 with no output, so launchd could not be queried from this session",
+		},
+		{
+			name:       "unrecognised failure",
+			out:        "Bad request.\nSomething else went wrong\n",
+			code:       9,
+			want:       launchdUnreadable,
+			wantReason: "launchctl exited 9: Something else went wrong",
+		},
+		{
+			name:       "exec failure",
+			code:       -1,
+			err:        errors.New("boom"),
+			want:       launchdUnreadable,
+			wantReason: "could not run launchctl: boom",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, reason := classifyLaunchctlPrint(tc.out, tc.code, tc.err)
+			if got != tc.want {
+				t.Errorf("lookup = %v, want %v", got, tc.want)
+			}
+			if reason != tc.wantReason {
+				t.Errorf("reason = %q, want %q", reason, tc.wantReason)
+			}
+		})
+	}
+}
+
+// TestParseLaunchctlPrintIgnoresCoalitionBlocks pins the parsing trap: the
+// coalition sub-blocks further down the report carry their own `state` key, so
+// a last-one-wins read would report a running service as "active".
+func TestParseLaunchctlPrintIgnoresCoalitionBlocks(t *testing.T) {
+	got := parseLaunchctlPrint(launchctlPrintRunning)
+	if got.State != "running" {
+		t.Errorf("State = %q, want %q", got.State, "running")
+	}
+	if got.PID != "27574" {
+		t.Errorf("PID = %q, want %q", got.PID, "27574")
+	}
+	if got.LastExit != "(never exited)" {
+		t.Errorf("LastExit = %q, want %q", got.LastExit, "(never exited)")
+	}
+
+	stopped := parseLaunchctlPrint(launchctlPrintNotRunning)
+	if stopped.State != "not running" {
+		t.Errorf("State = %q, want %q", stopped.State, "not running")
+	}
+	if stopped.PID != "" {
+		t.Errorf("a stopped service has no pid, got %q", stopped.PID)
+	}
+	if stopped.LastExit != "0" {
+		t.Errorf("LastExit = %q, want %q", stopped.LastExit, "0")
+	}
+}
+
+func TestLaunchdDomainsPreferGUI(t *testing.T) {
+	got := launchdDomains(501)
+	want := []string{"gui/501", "user/501"}
+	if len(got) != len(want) {
+		t.Fatalf("domains = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("domains = %v, want %v", got, want)
+		}
+	}
+}
+
+// TestLaunchdServiceLoadedSeesTheGUIDomain is the routing half of the same
+// defect. defaultServiceActive gates whether `daemon stop` / `daemon restart`
+// drive the supervisor or fall back to the manual path, and the manual path
+// on a supervised daemon orphans it from the unit that owns it. Asking only
+// the caller's own domain answered "no supervisor" for a service launchd was
+// running.
+func TestLaunchdServiceLoadedSeesTheGUIDomain(t *testing.T) {
+	script := newProbeScript(launchctlPrintNoService, 113, nil).
+		answer("gui/501/"+daemonServiceName, launchctlPrintRunning, 0, nil)
+
+	if !launchdServiceLoaded(501, script.probe) {
+		t.Error("a service running in gui/501 must count as supervised")
+	}
+}
+
+func TestLaunchdServiceLoadedSeesTheUserDomain(t *testing.T) {
+	script := newProbeScript("", 0, nil).
+		answer("gui/501/"+daemonServiceName, launchctlPrintNoService, 113, nil).
+		answer("user/501/"+daemonServiceName, launchctlPrintNotRunning, 0, nil)
+
+	if !launchdServiceLoaded(501, script.probe) {
+		t.Error("a loaded-but-stopped service in user/501 is still owned by launchd")
+	}
+}
+
+// TestLaunchdServiceLoadedIsFalseWhenNotFoundOrUnknown pins the deliberate
+// collapse: the manual lifecycle path works with or without a unit, while the
+// supervised one hard-fails when there is nothing to drive, so an unanswerable
+// query must not be read as "supervised".
+func TestLaunchdServiceLoadedIsFalseWhenNotFoundOrUnknown(t *testing.T) {
+	absent := newProbeScript(launchctlPrintNoService, 113, nil)
+	if launchdServiceLoaded(501, absent.probe) {
+		t.Error("no domain has the service, so no supervisor owns the daemon")
+	}
+	if len(absent.asked) != 2 {
+		t.Errorf("both domains should be asked before concluding, asked %v", absent.asked)
+	}
+
+	unreadable := newProbeScript("", 1, nil)
+	if launchdServiceLoaded(501, unreadable.probe) {
+		t.Error("an unanswerable query must not be reported as supervised")
+	}
+}
+
+// TestLaunchctlPrintArgsIsDomainExplicit pins the argv itself, which is the
+// whole fix: `launchctl list <label>` resolves against the caller's own
+// bootstrap domain, `launchctl print <domain>/<label>` against the one named.
+// Every other test here drives an injected probe, so without this the wiring
+// could regress to `list` with the suite still green.
+func TestLaunchctlPrintArgsIsDomainExplicit(t *testing.T) {
+	got := launchctlPrintArgs("gui/501/" + daemonServiceName)
+	want := []string{"print", "gui/501/" + daemonServiceName}
+	if len(got) != len(want) {
+		t.Fatalf("args = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("args = %v, want %v", got, want)
+		}
+	}
+	if got[0] == "list" {
+		t.Fatal("`launchctl list` searches only the caller's own domain")
+	}
+}
+
+// TestServiceStatusNotesRunningDaemonForALoadedStoppedUnit — a unit that is
+// loaded but not running looks identical, from launchd, to one with no daemon
+// behind it. Reporting only launchd's view of a stopped unit implies nothing
+// is up, which is the same omission the not-loaded path already guards.
+func TestServiceStatusNotesRunningDaemonForALoadedStoppedUnit(t *testing.T) {
+	script := newProbeScript(launchctlPrintNoService, 113, nil).
+		answer("gui/501/"+daemonServiceName, launchctlPrintNotRunning, 0, nil)
+
+	got := captureLaunchdStatus(t, installedPlist(t), script.probe, true)
+
+	if !strings.Contains(got, "state: not running") {
+		t.Fatalf("expected launchd's own view:\n%s", got)
+	}
+	if !strings.Contains(got, "answering on its socket") {
+		t.Errorf("a reachable daemon behind a stopped unit was not reported:\n%s", got)
+	}
+
+	// A genuinely running unit needs no such note — launchd already said so.
+	running := newProbeScript(launchctlPrintNoService, 113, nil).
+		answer("gui/501/"+daemonServiceName, launchctlPrintRunning, 0, nil)
+	if out := captureLaunchdStatus(t, installedPlist(t), running.probe, true); strings.Contains(out, "answering on its socket") {
+		t.Errorf("redundant note on an already-running service:\n%s", out)
+	}
+}
+
+// TestServiceStatusReportsAnUnreadablePlist keeps the installed/not-installed
+// gate to the same discipline as the launchd query: a stat that failed for any
+// other reason establishes neither answer.
+func TestServiceStatusReportsAnUnreadablePlist(t *testing.T) {
+	dir := t.TempDir()
+	blocked := filepath.Join(dir, "blocked")
+	if err := os.Mkdir(blocked, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	plist := filepath.Join(blocked, daemonServiceName+".plist")
+	if err := os.WriteFile(plist, []byte("<plist/>\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Removing search permission makes Stat fail with EACCES rather than ENOENT.
+	if err := os.Chmod(blocked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(blocked, 0o755) })
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+
+	script := newProbeScript(launchctlPrintRunning, 0, nil)
+	got := captureLaunchdStatus(t, plist, script.probe, false)
+
+	if !strings.Contains(got, "launchd: unknown") {
+		t.Errorf("an unreadable plist path must not be reported as installed:\n%s", got)
+	}
+	if strings.Contains(got, "not installed") {
+		t.Errorf("nor as absent:\n%s", got)
+	}
+	if len(script.asked) != 0 {
+		t.Errorf("launchd should not be queried on an inconclusive gate, asked %v", script.asked)
+	}
+}

--- a/cmd/gortex/daemon_supervisor.go
+++ b/cmd/gortex/daemon_supervisor.go
@@ -56,8 +56,15 @@ func defaultServiceActive() bool {
 		if _, err := os.Stat(path); err != nil {
 			return false
 		}
-		// `launchctl list <label>` exits 0 when the agent is loaded.
-		return exec.Command("launchctl", "list", daemonServiceName).Run() == nil
+		// Ask the domains the agent is actually bootstrapped into. The legacy
+		// `launchctl list <label>` searches only the caller's own domain, so
+		// it reported a loaded agent as absent and sent stop and restart down
+		// the manual path — which is precisely what this detector exists to
+		// avoid, because a hand-started daemon orphans itself from the unit
+		// that owns it. defaultServiceStop and defaultServiceRestart below
+		// already address the service by its full domain path; this brings
+		// the detector that gates them into line.
+		return launchdServiceLoaded(os.Getuid(), launchctlPrint)
 	default:
 		return false
 	}

--- a/cmd/gortex/doctor_runtime.go
+++ b/cmd/gortex/doctor_runtime.go
@@ -57,13 +57,27 @@ type doctorAgentRuntime struct {
 // doctorAgentInstall is the shape both adapters' Inspect calls lower into, so
 // the renderer does not branch per agent.
 type doctorAgentInstall struct {
-	ConfigPath        string         `json:"config_path"`
-	ConfigPresent     bool           `json:"config_present"`
-	MCPServer         bool           `json:"mcp_server"`
-	Hooks             map[string]int `json:"hooks"`
-	InstructionsPath  string         `json:"instructions_path,omitempty"`
-	InstructionsWired bool           `json:"instructions_wired"`
-	ShadowedBy        string         `json:"shadowed_by,omitempty"`
+	ConfigPath    string         `json:"config_path"`
+	ConfigPresent bool           `json:"config_present"`
+	MCPServer     bool           `json:"mcp_server"`
+	Hooks         map[string]int `json:"hooks"`
+	// HookSources is the per-file breakdown behind Hooks. An agent that reads
+	// hooks from more than one file needs it: the merged count alone cannot
+	// say which file a hook came from, nor that two of them declare the same
+	// hook twice.
+	HookSources []doctorHookSource `json:"hook_sources,omitempty"`
+	// HooksDisabled marks a config that switches hook execution off.
+	HooksDisabled     bool   `json:"hooks_disabled,omitempty"`
+	InstructionsPath  string `json:"instructions_path,omitempty"`
+	InstructionsWired bool   `json:"instructions_wired"`
+	ShadowedBy        string `json:"shadowed_by,omitempty"`
+}
+
+// doctorHookSource is one file an agent reads hook declarations from.
+type doctorHookSource struct {
+	Path  string         `json:"path"`
+	Hooks map[string]int `json:"hooks,omitempty"`
+	Total int            `json:"total"`
 }
 
 type doctorSavings struct {
@@ -147,14 +161,16 @@ func doctorAgentProbes(home string) []agentProbe {
 				install: doctorAgentInstall{
 					ConfigPath: state.ConfigPath, ConfigPresent: state.ConfigPresent,
 					MCPServer: state.MCPServer, Hooks: state.Hooks,
+					HookSources: codexHookSources(state), HooksDisabled: state.HooksDisabled,
 					InstructionsPath: state.InstructionsPath, InstructionsWired: state.InstructionsWired,
 					ShadowedBy: state.ShadowedBy,
 				},
 				// Codex is the one harness that gates hook execution on an
 				// explicit per-hook approval.
-				requiresTrust: true,
-				trustRemedy:   codex.TrustRemedy,
-				adoption:      doctor.ScanCodexSessions(doctor.CodexHome(), since, 10),
+				requiresTrust:       true,
+				trustRemedy:         codex.TrustRemedy,
+				hooksDisabledRemedy: codex.HooksDisabledRemedy,
+				adoption:            doctor.ScanCodexSessions(doctor.CodexHome(), since, 10),
 			}, activity, now)
 		}},
 		{agent: hooks.AgentClaudeCode, run: func(since time.Time, activity hooks.EffectivenessSummary, now time.Time) doctorAgentRuntime {
@@ -224,13 +240,57 @@ func doctorAgentProbes(home string) []agentProbe {
 	}
 }
 
+// codexHookSources lowers the adapter's per-file hook breakdown into the
+// renderer's shape.
+func codexHookSources(state codex.InstallState) []doctorHookSource {
+	out := make([]doctorHookSource, 0, len(state.HookSources))
+	for _, src := range state.HookSources {
+		out = append(out, doctorHookSource{Path: src.Path, Hooks: src.Hooks, Total: src.Total})
+	}
+	return out
+}
+
+// duplicateHookDeclarations reports the lifecycle events declared in more than
+// one hook file, and the files that declare them.
+//
+// The unit is the event, not the file. Two files each carrying Gortex hooks is
+// a valid split as long as they declare different events — only an event
+// present in both is merged into two runs. Answering this per file instead
+// would flag that split and send the user to delete working hooks.
+func duplicateHookDeclarations(sources []doctorHookSource) (events, files []string) {
+	perEvent := map[string]int{}
+	for _, src := range sources {
+		for event, n := range src.Hooks {
+			if n > 0 {
+				perEvent[event]++
+			}
+		}
+	}
+	for event, declaringFiles := range perEvent {
+		if declaringFiles > 1 {
+			events = append(events, event)
+		}
+	}
+	if len(events) == 0 {
+		return nil, nil
+	}
+	sort.Strings(events)
+	for _, src := range sources {
+		if src.Total > 0 {
+			files = append(files, src.Path)
+		}
+	}
+	return events, files
+}
+
 type agentRuntimeInput struct {
-	agent         string
-	hookEvents    []string
-	install       doctorAgentInstall
-	requiresTrust bool
-	trustRemedy   string
-	adoption      doctor.Adoption
+	agent               string
+	hookEvents          []string
+	install             doctorAgentInstall
+	requiresTrust       bool
+	trustRemedy         string
+	hooksDisabledRemedy string
+	adoption            doctor.Adoption
 }
 
 func buildAgentRuntime(in agentRuntimeInput, activity hooks.EffectivenessSummary, now time.Time) doctorAgentRuntime {
@@ -238,6 +298,9 @@ func buildAgentRuntime(in agentRuntimeInput, activity hooks.EffectivenessSummary
 		in.install.ConfigPath = doctorPath(in.install.ConfigPath)
 		in.install.InstructionsPath = doctorPath(in.install.InstructionsPath)
 		in.install.ShadowedBy = doctorPath(in.install.ShadowedBy)
+		for i := range in.install.HookSources {
+			in.install.HookSources[i].Path = doctorPath(in.install.HookSources[i].Path)
+		}
 	}
 	out := doctorAgentRuntime{
 		Agent:      in.agent,
@@ -246,11 +309,19 @@ func buildAgentRuntime(in agentRuntimeInput, activity hooks.EffectivenessSummary
 		Activity:   activity.ForAgent(in.agent),
 		Adoption:   in.adoption,
 	}
+	duplicateEvents, duplicateFiles := duplicateHookDeclarations(in.install.HookSources)
 	out.Findings = doctor.Diagnose(doctor.AgentHooks{
-		Agent:                in.agent,
-		Configured:           in.install.Hooks,
-		RequiresTrust:        in.requiresTrust,
-		TrustRemedy:          in.trustRemedy,
+		Agent:               in.agent,
+		Configured:          in.install.Hooks,
+		RequiresTrust:       in.requiresTrust,
+		TrustRemedy:         in.trustRemedy,
+		HooksDisabled:       in.install.HooksDisabled,
+		HooksDisabledRemedy: in.hooksDisabledRemedy,
+		DuplicateHookEvents: duplicateEvents,
+		// ConfigPath is the file the adapter's installer rewrites, so it is
+		// the one a duplicate must NOT be cleaned out of.
+		DuplicateHookSources: duplicateFiles,
+		ManagedHookFile:      in.install.ConfigPath,
 		InstructionsPath:     in.install.InstructionsPath,
 		InstructionsWired:    in.install.InstructionsWired,
 		InstructionsShadowed: in.install.ShadowedBy,
@@ -376,6 +447,19 @@ func printAgentRuntime(w io.Writer, a doctorAgentRuntime, summary hooks.Effectiv
 		for _, event := range a.HookEvents {
 			fmt.Fprintf(w, "    %s hook %-17s %d configured\n", mark(a.Install.Hooks[event] > 0), event, a.Install.Hooks[event])
 		}
+	}
+	// Naming the files the counts came from is what bounds them. Without it a
+	// zero reads as "nothing is configured anywhere" when it can only ever
+	// mean "nothing in the files listed here".
+	if len(a.Install.HookSources) > 0 {
+		parts := make([]string, 0, len(a.Install.HookSources))
+		for _, src := range a.Install.HookSources {
+			parts = append(parts, fmt.Sprintf("%s (%d)", src.Path, src.Total))
+		}
+		fmt.Fprintf(w, "      counted in %s\n", joinComma(parts))
+	}
+	if a.Install.HooksDisabled {
+		fmt.Fprintf(w, "    %s hook execution is turned off in %s\n", glyphWarn, a.Install.ConfigPath)
 	}
 	if a.Install.InstructionsPath != "" {
 		fmt.Fprintf(w, "    %s rule block in %s\n", mark(a.Install.InstructionsWired), a.Install.InstructionsPath)

--- a/cmd/gortex/doctor_runtime_test.go
+++ b/cmd/gortex/doctor_runtime_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 	"github.com/zzet/gortex/internal/agents/codex"
 	"github.com/zzet/gortex/internal/agents/copilotcli"
 	"github.com/zzet/gortex/internal/agents/opencode"
+	"github.com/zzet/gortex/internal/doctor"
 	"github.com/zzet/gortex/internal/hooks"
 	"github.com/zzet/gortex/internal/testenv"
 )
@@ -209,6 +211,202 @@ func TestDoctorRuntimeReportsInstallStateForEveryHost(t *testing.T) {
 	for _, agent := range []string{codex.Name, hooks.AgentClaudeCode, copilotcli.Name, opencode.Name} {
 		if !strings.Contains(string(blob), `"agent":"`+agent+`"`) {
 			t.Errorf("the --json report never names %s", agent)
+		}
+	}
+}
+
+// codexHomeWithHooksJSON writes a Codex home whose only Gortex hooks live in
+// hooks.json — the representation Codex supports and Gortex does not write.
+func codexHomeWithHooksJSON(t *testing.T, home, configTOML string) string {
+	t.Helper()
+	dir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hooksJSON := filepath.Join(dir, "hooks.json")
+	body := `{
+  "hooks": {
+    "SessionStart": [
+      {"hooks": [{"type": "command", "command": "/tmp/test-gortex hook --agent=codex --mode=enrich"}]}
+    ],
+    "UserPromptSubmit": [
+      {"hooks": [{"type": "command", "command": "/tmp/test-gortex hook --agent=codex --mode=enrich"}]}
+    ]
+  }
+}
+`
+	if err := os.WriteFile(hooksJSON, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(configTOML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Everything else about this home is healthy, so any reinstall advice
+	// doctor produces can only be about the hooks.
+	rules := "<!-- gortex:rules:start -->\nMANDATORY: Use Gortex MCP\n<!-- gortex:rules:end -->\n"
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(rules), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return hooksJSON
+}
+
+// TestDoctorCountsCodexHooksDeclaredInJSON is the reported false negative at
+// the level the user sees it: a machine whose Codex hooks are configured in
+// hooks.json was told it had none, and sent to `gortex install` — which would
+// have added a second declaration of the hooks it already had.
+func TestDoctorCountsCodexHooksDeclaredInJSON(t *testing.T) {
+	home := t.TempDir()
+	testenv.SandboxAt(t, home)
+	hooksJSON := codexHomeWithHooksJSON(t, home, "[features]\nhooks = true\n")
+
+	got := codexRuntime(t, collectRuntime(home, 7))
+
+	if got.Install.Hooks["SessionStart"] == 0 {
+		t.Errorf("SessionStart reported 0 configured while %s declares one", hooksJSON)
+	}
+	if got.Install.Hooks["UserPromptSubmit"] == 0 {
+		t.Error("UserPromptSubmit reported 0 configured while hooks.json declares one")
+	}
+	assertNoDoctorFinding(t, got, "has no Gortex lifecycle hooks configured")
+	assertNoDoctorRemedy(t, got, "gortex install")
+
+	// The counts must also say which files they came from, so a zero can
+	// never be read as "nothing anywhere".
+	var buf bytes.Buffer
+	printAgentRuntime(&buf, got, hooks.EffectivenessSummary{})
+	if !strings.Contains(buf.String(), hooksJSON) {
+		t.Errorf("the report does not name %s:\n%s", hooksJSON, buf.String())
+	}
+}
+
+// TestDoctorWarnsAboutDuplicateCodexHookDeclarations — once both files declare
+// the same hooks, Codex merges them and runs each one twice. Nothing else on
+// the machine reports that except a Codex startup warning.
+func TestDoctorWarnsAboutDuplicateCodexHookDeclarations(t *testing.T) {
+	home := t.TempDir()
+	testenv.SandboxAt(t, home)
+	env := agents.Env{
+		Root:         t.TempDir(),
+		Home:         home,
+		HookCommand:  "/tmp/test-gortex hook",
+		Mode:         agents.ModeGlobal,
+		InstallHooks: true,
+	}
+	if _, err := codex.New().Apply(env, agents.ApplyOpts{ForceDetect: true}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	// Only hooks.json is added here; config.toml keeps what Apply wrote.
+	hooksJSON := filepath.Join(home, ".codex", "hooks.json")
+	body := `{"hooks": {"SessionStart": [{"hooks": [{"type": "command", "command": "/tmp/test-gortex hook --agent=codex --mode=enrich"}]}]}}`
+	if err := os.WriteFile(hooksJSON, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := codexRuntime(t, collectRuntime(home, 7))
+
+	found := doctorFinding(t, got, "in both")
+	for _, want := range []string{"SessionStart", hooksJSON, filepath.Join(home, ".codex", "config.toml"), "once per declaration"} {
+		if !strings.Contains(found.Summary, want) {
+			t.Errorf("summary should name %q, got %q", want, found.Summary)
+		}
+	}
+	// SessionStart is the only event in both files; the other four live only
+	// in config.toml and are working configuration.
+	for _, untouched := range []string{"PreToolUse", "PostToolUse", "Stop", "UserPromptSubmit"} {
+		if strings.Contains(found.Summary, untouched) {
+			t.Errorf("%s is declared once, so it is not a duplicate: %q", untouched, found.Summary)
+		}
+	}
+	if !strings.Contains(found.Remedy, hooksJSON) {
+		t.Errorf("remedy must point at the file `gortex install` does not rewrite, got %q", found.Remedy)
+	}
+}
+
+// TestDoctorDoesNotCallDisjointHookFilesADuplicate is the destructive case the
+// per-file version of this finding produced: hooks split across the two files
+// with no event in common. Nothing runs twice, and a remedy phrased around the
+// files would have deleted every hook in one of them.
+func TestDoctorDoesNotCallDisjointHookFilesADuplicate(t *testing.T) {
+	home := t.TempDir()
+	testenv.SandboxAt(t, home)
+	dir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// hooks.json declares SessionStart only; config.toml declares PreToolUse only.
+	hooksJSON := filepath.Join(dir, "hooks.json")
+	body := `{"hooks": {"SessionStart": [{"hooks": [{"type": "command", "command": "/tmp/test-gortex hook --agent=codex --mode=enrich"}]}]}}`
+	if err := os.WriteFile(hooksJSON, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	config := "[features]\nhooks = true\n\n" +
+		"[[hooks.PreToolUse]]\nmatcher = \"Bash\"\n\n" +
+		"[[hooks.PreToolUse.hooks]]\ntype = \"command\"\n" +
+		"command = \"/tmp/test-gortex hook --agent=codex --mode=enrich\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "config.toml"), []byte(config), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := codexRuntime(t, collectRuntime(home, 7))
+
+	if got.Install.Hooks["SessionStart"] != 1 || got.Install.Hooks["PreToolUse"] != 1 {
+		t.Fatalf("fixture is wrong: %+v", got.Install.Hooks)
+	}
+	assertNoDoctorFinding(t, got, "in both")
+}
+
+// TestDoctorReportsCodexHooksTurnedOff — hooks that are declared and switched
+// off must not be diagnosed as untrusted; the remedy for the two is different.
+func TestDoctorReportsCodexHooksTurnedOff(t *testing.T) {
+	home := t.TempDir()
+	testenv.SandboxAt(t, home)
+	codexHomeWithHooksJSON(t, home, "[features]\nhooks = false\n")
+
+	got := codexRuntime(t, collectRuntime(home, 7))
+
+	found := doctorFinding(t, got, "hook execution is turned off")
+	if !strings.Contains(found.Remedy, "[features]") {
+		t.Errorf("remedy should name the feature switch, got %q", found.Remedy)
+	}
+	assertNoDoctorFinding(t, got, "none has run")
+}
+
+func codexRuntime(t *testing.T, runtime doctorRuntime) doctorAgentRuntime {
+	t.Helper()
+	for _, a := range runtime.Agents {
+		if a.Agent == codex.Name {
+			return a
+		}
+	}
+	t.Fatal("doctor reported nothing for codex")
+	return doctorAgentRuntime{}
+}
+
+func doctorFinding(t *testing.T, agent doctorAgentRuntime, substr string) doctor.Finding {
+	t.Helper()
+	for _, f := range agent.Findings {
+		if strings.Contains(f.Summary, substr) {
+			return f
+		}
+	}
+	t.Fatalf("no finding containing %q in %+v", substr, agent.Findings)
+	return doctor.Finding{}
+}
+
+func assertNoDoctorFinding(t *testing.T, agent doctorAgentRuntime, substr string) {
+	t.Helper()
+	for _, f := range agent.Findings {
+		if strings.Contains(f.Summary, substr) {
+			t.Fatalf("unexpected finding %q: %+v", substr, f)
+		}
+	}
+}
+
+func assertNoDoctorRemedy(t *testing.T, agent doctorAgentRuntime, remedy string) {
+	t.Helper()
+	for _, f := range agent.Findings {
+		if f.Remedy == remedy {
+			t.Fatalf("doctor recommended %q for %q", remedy, f.Summary)
 		}
 	}
 }

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -365,6 +365,21 @@ untrusted-hook signature, reported as a blocker with the `/hooks` remedy.
 an issue, `--json` emits it machine-readably, and the exit status is non-zero
 when a blocker is found.
 
+Codex takes hook declarations from two files per configuration layer —
+`~/.codex/hooks.json` and inline `[hooks]` tables in `~/.codex/config.toml` —
+and **merges** them when both are present, running every hook declared in both
+once per declaration. Gortex only ever writes the inline TOML representation,
+but `gortex doctor` counts both and prints the file each count came from, so a
+hooks.json-only setup is never reported as having no hooks. Splitting different
+events across the two files is fine and reported as such; only an event declared
+in *both* actually runs twice, and that is what doctor warns about — naming the
+event, and pointing the cleanup at `hooks.json`, since `gortex install` rewrites
+config.toml. `gortex install` and `gortex init --hooks-only` say the same thing
+at the moment they would create such a duplicate; the hooks.json entries are
+yours, so neither touches them. `[features] hooks = false` turns hook execution off
+wholesale and is reported as a blocker in its own right, rather than as an
+untrusted-hook signature.
+
 When hooks are enabled
 (the default), Codex receives user-level hooks. The default posture remains
 advisory. A team can opt into `deny`, `rewrite`, or `suppress` by setting

--- a/internal/agents/codex/adapter.go
+++ b/internal/agents/codex/adapter.go
@@ -219,6 +219,11 @@ func (a *Adapter) Apply(env agents.Env, opts agents.ApplyOpts) (*agents.Result, 
 	if hooksChanged {
 		res.Warnings = append(res.Warnings, codexHookTrustNotice)
 	}
+	if env.InstallHooks {
+		if notice := codexDuplicateHookFileNotice(path); notice != "" {
+			res.Warnings = append(res.Warnings, notice)
+		}
+	}
 
 	// User-level instructions → ~/.codex/AGENTS.md. This is the surface
 	// that makes Codex reach for the graph tools on every turn; see
@@ -264,6 +269,32 @@ func (a *Adapter) Apply(env agents.Env, opts agents.ApplyOpts) (*agents.Result, 
 
 	res.Configured = true
 	return res, nil
+}
+
+// codexDuplicateHookFileNotice reports that the hooks.json beside configPath
+// already declares Gortex hooks, which Codex merges with the inline [hooks]
+// tables written into configPath — running each event declared in both once
+// per declaration.
+//
+// Keyed off configPath rather than the home directory because Codex merges per
+// layer: the repo-local pair merges with each other, not with the user's.
+//
+// The installer still writes its own representation: that is what it was asked
+// to do, and the hooks.json entries are the user's, not ours to edit. Saying so
+// is the part that was missing, because the only other signal is a startup
+// warning inside Codex that nobody attributes to `gortex install`.
+func codexDuplicateHookFileNotice(configPath string) string {
+	if configPath == "" {
+		return ""
+	}
+	hooksJSON := filepath.Join(filepath.Dir(configPath), "hooks.json")
+	src, ok := inspectJSONHookFile(hooksJSON)
+	if !ok || src.Total == 0 {
+		return ""
+	}
+	return fmt.Sprintf(
+		"%s already declares %d Gortex hook(s); Codex merges it with the [hooks] tables in %s, so any event declared in both runs twice — remove those events from %s",
+		hooksJSON, src.Total, filepath.Base(configPath), hooksJSON)
 }
 
 func codexHasDirectToolNamespaces(root map[string]any) bool {
@@ -655,6 +686,11 @@ func InstallHooksOnly(w io.Writer, configPath string, env agents.Env, opts agent
 	}
 	if action.Action != agents.ActionSkip {
 		action.Keys = []string{"hooks"}
+	}
+	// `init --hooks-only` writes the same inline tables Apply does, so it can
+	// create the same silent duplicate and has to say the same thing.
+	if notice := codexDuplicateHookFileNotice(configPath); notice != "" {
+		internalutil.Warnf(w, "%s", notice)
 	}
 	return action, nil
 }

--- a/internal/agents/codex/inspect.go
+++ b/internal/agents/codex/inspect.go
@@ -1,6 +1,7 @@
 package codex
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,16 +21,54 @@ import (
 // nothing about whether any of it runs. That question is answered by the
 // hook invocation log, and the two are only meaningful together.
 type InstallState struct {
-	ConfigPath    string         `json:"config_path"`
-	ConfigPresent bool           `json:"config_present"`
-	MCPServer     bool           `json:"mcp_server"`
-	Hooks         map[string]int `json:"hooks"`
+	ConfigPath    string `json:"config_path"`
+	ConfigPresent bool   `json:"config_present"`
+	MCPServer     bool   `json:"mcp_server"`
+	// HooksPath is the hooks.json Codex reads alongside config.toml.
+	HooksPath string `json:"hooks_path,omitempty"`
+	// Hooks is the per-event count merged across every source in
+	// HookSources — the number of Gortex entries Codex ends up running.
+	Hooks map[string]int `json:"hooks"`
+	// HookSources is the per-file breakdown behind Hooks, in the order Codex
+	// discovers the files. Callers that act on a file must read this rather
+	// than Hooks: acting on config.toml because of entries that live in
+	// hooks.json is how a merged total misleads.
+	HookSources []HookSource `json:"hook_sources,omitempty"`
+	// HooksDisabled reports the `[features] hooks = false` opt-out, which
+	// stops every hook above from running no matter how well it is declared.
+	HooksDisabled bool `json:"hooks_disabled"`
 	// InstructionsPath is the file Codex will actually load; ShadowedBy is
 	// set when an override file takes precedence over the one Gortex writes,
 	// which turns a correctly-installed rule block into dead text.
 	InstructionsPath  string `json:"instructions_path,omitempty"`
 	InstructionsWired bool   `json:"instructions_wired"`
 	ShadowedBy        string `json:"shadowed_by,omitempty"`
+}
+
+// HookSource is one file Codex reads hook declarations from, with the
+// Gortex-authored entries found in it.
+//
+// Codex takes hooks from a hooks.json *and* from inline [hooks] tables in
+// config.toml, and merges the two when both are in the same layer — so every
+// hook declared twice runs twice. Counting per file is what lets a caller see
+// that, and what keeps "Gortex wrote these" (config.toml, the only
+// representation this package writes) apart from "the user wrote these".
+type HookSource struct {
+	Path string `json:"path"`
+	// Format is "json" for a hooks.json and "toml" for inline [hooks].
+	Format string         `json:"format"`
+	Hooks  map[string]int `json:"hooks"`
+	Total  int            `json:"total"`
+}
+
+// HookCountIn reports the Gortex hooks declared in one specific file.
+func (s InstallState) HookCountIn(path string) int {
+	for _, src := range s.HookSources {
+		if src.Path == path {
+			return src.Total
+		}
+	}
+	return 0
 }
 
 // HookEvents are the lifecycle events this adapter installs, in the order
@@ -40,9 +79,31 @@ var HookEvents = []string{"SessionStart", "UserPromptSubmit", "PreToolUse", "Pos
 // TrustRemedy is how a user approves hooks Codex is skipping.
 const TrustRemedy = "run `/hooks` inside Codex, review the gortex entries, and trust them"
 
+// HooksDisabledRemedy is how a user turns Codex hook execution back on.
+const HooksDisabledRemedy = "set `hooks = true` under `[features]` in ~/.codex/config.toml"
+
+// UserHookFiles names the user-layer files Codex reads hook declarations
+// from, in discovery order.
+//
+// Codex also reads a repo layer (<repo>/.codex/hooks.json and
+// <repo>/.codex/config.toml). That is deliberately outside this package's
+// scope: Inspect answers "what is installed for this user", and folding in a
+// repo-local file would make that answer depend on whichever directory doctor
+// happened to run in.
+func UserHookFiles(home string) (hooksJSON, configTOML string) {
+	return filepath.Join(home, ".codex", "hooks.json"),
+		filepath.Join(home, ".codex", "config.toml")
+}
+
 // Inspect reads the Codex config and instructions file under home. Every
 // failure degrades to "not configured" rather than an error: doctor's job is
 // to describe a broken machine, not to fail on one.
+//
+// Hooks are counted from every user-layer file Codex reads them from, not
+// only from the inline [hooks] tables this package writes. Reading one of the
+// two representations and reporting the other as absent turns a healthy
+// JSON-configured machine into a false alarm — and into advice to install a
+// second, duplicate representation.
 func Inspect(home string) InstallState {
 	state := InstallState{Hooks: map[string]int{}}
 	if home == "" {
@@ -51,7 +112,11 @@ func Inspect(home string) InstallState {
 	for _, event := range HookEvents {
 		state.Hooks[event] = 0
 	}
-	state.ConfigPath = filepath.Join(home, ".codex", "config.toml")
+	state.HooksPath, state.ConfigPath = UserHookFiles(home)
+
+	if src, ok := inspectJSONHookFile(state.HooksPath); ok {
+		state.HookSources = append(state.HookSources, src)
+	}
 
 	if data, err := os.ReadFile(state.ConfigPath); err == nil {
 		state.ConfigPresent = true
@@ -60,7 +125,14 @@ func Inspect(home string) InstallState {
 			if servers, ok := root["mcp_servers"].(map[string]any); ok {
 				_, state.MCPServer = servers["gortex"]
 			}
-			countGortexHooks(root, state.Hooks)
+			state.HooksDisabled = hooksFeatureDisabled(root)
+			state.HookSources = append(state.HookSources, hookSourceFrom(state.ConfigPath, "toml", root))
+		}
+	}
+
+	for _, src := range state.HookSources {
+		for event, n := range src.Hooks {
+			state.Hooks[event] += n
 		}
 	}
 
@@ -81,6 +153,56 @@ func Inspect(home string) InstallState {
 			strings.Contains(text, "MANDATORY: Use Gortex MCP")
 	}
 	return state
+}
+
+// inspectJSONHookFile reads a Codex hooks.json.
+//
+// Its root carries the same "hooks" table keyed by event name that config.toml
+// does, so the writer's own recognisers apply unchanged. The bool reports only
+// whether the file exists — a file that exists but does not parse is returned
+// with no entries, which is also what Codex will run from it.
+func inspectJSONHookFile(path string) (HookSource, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return HookSource{}, false
+	}
+	src := HookSource{Path: path, Format: "json", Hooks: map[string]int{}}
+	root := map[string]any{}
+	if json.Unmarshal(data, &root) != nil {
+		return src, true
+	}
+	countGortexHooks(root, src.Hooks)
+	src.Total = totalHooks(src.Hooks)
+	return src, true
+}
+
+// hookSourceFrom tallies one already-parsed configuration root.
+func hookSourceFrom(path, format string, root map[string]any) HookSource {
+	src := HookSource{Path: path, Format: format, Hooks: map[string]int{}}
+	countGortexHooks(root, src.Hooks)
+	src.Total = totalHooks(src.Hooks)
+	return src
+}
+
+// hooksFeatureDisabled reports the `[features] hooks = false` opt-out. Codex
+// runs hooks by default, so only an explicit false counts — an absent key is
+// not a disabled feature.
+func hooksFeatureDisabled(root map[string]any) bool {
+	features, ok := root["features"].(map[string]any)
+	if !ok {
+		return false
+	}
+	enabled, ok := features["hooks"].(bool)
+	return ok && !enabled
+}
+
+// totalHooks sums a per-event count.
+func totalHooks(hooks map[string]int) int {
+	total := 0
+	for _, n := range hooks {
+		total += n
+	}
+	return total
 }
 
 // countGortexHooks tallies Gortex-authored entries per event, reusing the

--- a/internal/agents/codex/inspect_test.go
+++ b/internal/agents/codex/inspect_test.go
@@ -1,8 +1,10 @@
 package codex
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/zzet/gortex/internal/agents"
@@ -122,5 +124,279 @@ func TestInspectSurvivesBrokenConfig(t *testing.T) {
 	}
 	if got := Inspect(filepath.Join(env.Home, "nope")); got.ConfigPresent {
 		t.Errorf("missing home should report nothing, got %+v", got)
+	}
+}
+
+// writeCodexHooksJSON writes the hooks.json Codex reads alongside config.toml.
+// The shape is Codex's documented one: a "hooks" table keyed by event name,
+// each event holding matcher groups whose "hooks" list carries the handlers.
+func writeCodexHooksJSON(t *testing.T, home, command string) string {
+	t.Helper()
+	path := filepath.Join(home, ".codex", "hooks.json")
+	body := `{
+  "description": "hooks for this machine",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {"type": "command", "command": "` + command + `", "timeout": 5}
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {"type": "command", "command": "` + command + `", "timeout": 5}
+        ]
+      }
+    ]
+  }
+}
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestInspectCountsHooksDeclaredInJSON is the reported false negative. Codex
+// reads hooks from hooks.json as well as from inline [hooks] tables, and
+// reading only the latter reported a working JSON-configured machine as
+// having no hooks at all — which then recommended installing a second,
+// duplicate representation of the hooks it already had.
+func TestInspectCountsHooksDeclaredInJSON(t *testing.T) {
+	env := codexGlobalEnv(t)
+	hooksPath := writeCodexHooksJSON(t, env.Home, "gortex hook --agent=codex --mode=enrich")
+
+	state := Inspect(env.Home)
+
+	if state.Hooks["SessionStart"] != 1 {
+		t.Errorf("SessionStart=%d, want 1 — the hook is declared in %s", state.Hooks["SessionStart"], hooksPath)
+	}
+	if state.Hooks["PreToolUse"] != 1 {
+		t.Errorf("PreToolUse=%d, want 1", state.Hooks["PreToolUse"])
+	}
+	if state.HooksPath != hooksPath {
+		t.Errorf("HooksPath=%q want %q", state.HooksPath, hooksPath)
+	}
+	if got := state.HookCountIn(hooksPath); got != 2 {
+		t.Errorf("HookCountIn(hooks.json)=%d, want 2", got)
+	}
+	if len(state.HookSources) != 1 || state.HookSources[0].Path != hooksPath {
+		t.Errorf("HookSources=%+v, want just %s", state.HookSources, hooksPath)
+	}
+}
+
+// TestInspectMergesHookSources pins the counts Codex actually ends up with
+// when both representations exist, and keeps the per-file breakdown intact so
+// a caller can still tell them apart.
+func TestInspectMergesHookSources(t *testing.T) {
+	env := codexGlobalEnv(t)
+	env.InstallGlobalInstructions = true
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	hooksPath := writeCodexHooksJSON(t, env.Home, "gortex hook --agent=codex --mode=enrich")
+	configPath := codexConfigPath(env)
+
+	state := Inspect(env.Home)
+
+	if state.Hooks["SessionStart"] != 2 {
+		t.Errorf("SessionStart=%d, want 2 (one per file) — Codex merges same-layer hook files", state.Hooks["SessionStart"])
+	}
+	if got := state.HookCountIn(hooksPath); got != 2 {
+		t.Errorf("HookCountIn(hooks.json)=%d, want 2", got)
+	}
+	if got := state.HookCountIn(configPath); got == 0 {
+		t.Error("the inline [hooks] Apply wrote are not attributed to config.toml")
+	}
+	if len(state.HookSources) != 2 {
+		t.Fatalf("HookSources=%+v, want both files", state.HookSources)
+	}
+	if state.HookSources[0].Path != hooksPath || state.HookSources[1].Path != configPath {
+		t.Errorf("HookSources lists %s then %s, want hooks.json first (Codex discovery order)",
+			state.HookSources[0].Path, state.HookSources[1].Path)
+	}
+}
+
+// TestInspectIgnoresForeignJSONHooks keeps the JSON reader as strict as the
+// TOML one: crediting Gortex for somebody else's hook would mask a missing one.
+func TestInspectIgnoresForeignJSONHooks(t *testing.T) {
+	env := codexGlobalEnv(t)
+	hooksPath := writeCodexHooksJSON(t, env.Home, "/usr/local/bin/some-other-tool notify")
+
+	state := Inspect(env.Home)
+
+	if got := totalHooks(state.Hooks); got != 0 {
+		t.Errorf("counted %d foreign hook(s) as Gortex's", got)
+	}
+	if got := state.HookCountIn(hooksPath); got != 0 {
+		t.Errorf("HookCountIn(hooks.json)=%d, want 0", got)
+	}
+	if state.HookSources[0].Total != 0 {
+		t.Errorf("hooks.json source Total=%d, want 0", state.HookSources[0].Total)
+	}
+}
+
+// TestInspectSurvivesBrokenHooksJSON — a hooks.json Codex cannot parse runs no
+// hooks, so reporting none from it is the effective truth, and it must not
+// take the rest of the report down with it.
+func TestInspectSurvivesBrokenHooksJSON(t *testing.T) {
+	env := codexGlobalEnv(t)
+	env.InstallGlobalInstructions = true
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	hooksPath := filepath.Join(env.Home, ".codex", "hooks.json")
+	if err := os.WriteFile(hooksPath, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	state := Inspect(env.Home)
+
+	if got := state.HookCountIn(hooksPath); got != 0 {
+		t.Errorf("HookCountIn(broken hooks.json)=%d, want 0", got)
+	}
+	if state.Hooks["SessionStart"] == 0 {
+		t.Error("a broken hooks.json hid the hooks config.toml really has")
+	}
+	if !state.MCPServer {
+		t.Error("a broken hooks.json must not affect the rest of the report")
+	}
+}
+
+// TestInspectReportsHooksTurnedOff covers the mirror-image of the missing
+// count: hooks are declared, and Codex is configured not to run any of them.
+func TestInspectReportsHooksTurnedOff(t *testing.T) {
+	env := codexGlobalEnv(t)
+	path := codexConfigPath(env)
+	if err := os.WriteFile(path, []byte("[features]\nhooks = false\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if state := Inspect(env.Home); !state.HooksDisabled {
+		t.Error("`[features] hooks = false` turns hook execution off and must be reported")
+	}
+
+	if err := os.WriteFile(path, []byte("[features]\nhooks = true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if state := Inspect(env.Home); state.HooksDisabled {
+		t.Error("hooks = true is not disabled")
+	}
+
+	if err := os.WriteFile(path, []byte("[features]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if state := Inspect(env.Home); state.HooksDisabled {
+		t.Error("Codex runs hooks by default, so an absent key is not a disabled feature")
+	}
+}
+
+// TestGlobalArtifactsStaysScopedToTheFileItEdits — RemoveGlobal only rewrites
+// config.toml, so listing it because hooks.json carries Gortex entries would
+// promise the uninstall wizard a deletion that never happens.
+func TestGlobalArtifactsStaysScopedToTheFileItEdits(t *testing.T) {
+	env := codexGlobalEnv(t)
+	configPath := codexConfigPath(env)
+	if err := os.WriteFile(configPath, []byte("model = \"gpt-5\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeCodexHooksJSON(t, env.Home, "gortex hook --agent=codex --mode=enrich")
+
+	if state := Inspect(env.Home); totalHooks(state.Hooks) == 0 {
+		t.Fatal("fixture is wrong: the hooks.json entries should be counted")
+	}
+	for _, path := range GlobalArtifacts(env.Home) {
+		if path == configPath {
+			t.Fatalf("config.toml listed for removal, but the Gortex hooks are in hooks.json: %v", GlobalArtifacts(env.Home))
+		}
+	}
+}
+
+// TestApplyWarnsWhenItWouldDuplicateHooksJSON — the installer still writes its
+// own inline representation (the hooks.json entries are the user's), but Codex
+// merges the two and then runs each hook twice, so it has to say so.
+func TestApplyWarnsWhenItWouldDuplicateHooksJSON(t *testing.T) {
+	env := codexGlobalEnv(t)
+	hooksPath := writeCodexHooksJSON(t, env.Home, "gortex hook --agent=codex --mode=enrich")
+
+	res, err := New().Apply(env, agents.ApplyOpts{})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	var notice string
+	for _, w := range res.Warnings {
+		if strings.Contains(w, hooksPath) {
+			notice = w
+		}
+	}
+	if notice == "" {
+		t.Fatalf("no warning naming %s in %v", hooksPath, res.Warnings)
+	}
+	if !strings.Contains(notice, "twice") {
+		t.Errorf("the warning must name the consequence, got %q", notice)
+	}
+
+	// A machine without a hooks.json must stay quiet.
+	clean := codexGlobalEnv(t)
+	cleanRes, err := New().Apply(clean, agents.ApplyOpts{})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	for _, w := range cleanRes.Warnings {
+		if strings.Contains(w, "hooks.json") {
+			t.Errorf("unexpected duplicate warning with no hooks.json on disk: %q", w)
+		}
+	}
+}
+
+// TestInstallHooksOnlyWarnsAboutTheSameDuplicate — `gortex init --hooks-only`
+// writes the same inline tables Apply does, through a different entry point,
+// so it can create the same silent duplicate and has to say the same thing.
+func TestInstallHooksOnlyWarnsAboutTheSameDuplicate(t *testing.T) {
+	env := codexGlobalEnv(t)
+	hooksPath := writeCodexHooksJSON(t, env.Home, "gortex hook --agent=codex --mode=enrich")
+	configPath := codexConfigPath(env)
+
+	var out bytes.Buffer
+	if _, err := InstallHooksOnly(&out, configPath, env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("install hooks: %v", err)
+	}
+	if !strings.Contains(out.String(), hooksPath) {
+		t.Errorf("no duplicate warning naming %s:\n%s", hooksPath, out.String())
+	}
+	if !strings.Contains(out.String(), "twice") {
+		t.Errorf("the warning must name the consequence:\n%s", out.String())
+	}
+
+	// Without a hooks.json there is no duplicate to warn about.
+	clean := codexGlobalEnv(t)
+	var quiet bytes.Buffer
+	if _, err := InstallHooksOnly(&quiet, codexConfigPath(clean), clean, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("install hooks: %v", err)
+	}
+	if strings.Contains(quiet.String(), "hooks.json") {
+		t.Errorf("unexpected duplicate warning:\n%s", quiet.String())
+	}
+}
+
+// TestDuplicateNoticeFollowsTheConfigLayer — Codex merges hook files per
+// layer, so the notice must compare a config.toml against the hooks.json
+// beside it, not against the user's.
+func TestDuplicateNoticeFollowsTheConfigLayer(t *testing.T) {
+	env := codexGlobalEnv(t)
+	writeCodexHooksJSON(t, env.Home, "gortex hook --agent=codex --mode=enrich")
+
+	repoConfig := filepath.Join(t.TempDir(), ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(repoConfig), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if notice := codexDuplicateHookFileNotice(repoConfig); notice != "" {
+		t.Errorf("the user's hooks.json does not merge with a repo-local config.toml: %q", notice)
+	}
+	if notice := codexDuplicateHookFileNotice(codexConfigPath(env)); notice == "" {
+		t.Error("the hooks.json beside the config does merge with it")
 	}
 }

--- a/internal/agents/codex/remove.go
+++ b/internal/agents/codex/remove.go
@@ -122,8 +122,12 @@ func GlobalArtifacts(home string) []string {
 	// in config.toml nowhere else.
 	configPath := filepath.Join(home, ".codex", "config.toml")
 	state := Inspect(home)
+	// Scoped to this file on purpose. Inspect's merged Hooks count also
+	// carries entries from hooks.json, which RemoveGlobal does not touch and
+	// Gortex never wrote — counting those here would list config.toml for a
+	// deletion that would not happen.
 	if state.ConfigPresent &&
-		(state.MCPServer || configuredHookCount(state.Hooks) > 0 || codexFileContains(configPath, codexGortexToolNamespace)) {
+		(state.MCPServer || state.HookCountIn(configPath) > 0 || codexFileContains(configPath, codexGortexToolNamespace)) {
 		present = append(present, configPath)
 	}
 	if ins := GlobalInstructionsPath(home); codexFileContains(ins, agents.GlobalRulesStartMarker) {
@@ -361,14 +365,6 @@ func isShippedCodexFile(path, shipped string) bool {
 // sitting next to a skill we deleted keeps its directory alive.
 func pruneEmptyDir(dir string) {
 	_ = os.Remove(dir)
-}
-
-func configuredHookCount(hooks map[string]int) int {
-	total := 0
-	for _, n := range hooks {
-		total += n
-	}
-	return total
 }
 
 func codexFileContains(path, needle string) bool {

--- a/internal/doctor/findings.go
+++ b/internal/doctor/findings.go
@@ -3,6 +3,7 @@ package doctor
 import (
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/zzet/gortex/internal/hooks"
@@ -68,6 +69,27 @@ type AgentHooks struct {
 	// InstructionsShadowed is set when the agent will read a different file
 	// instead, making the block above dead text.
 	InstructionsShadowed string
+	// HooksDisabled marks a harness whose configuration switches hook
+	// execution off wholesale. It explains an idle install completely, so it
+	// must pre-empt the trust and PATH remedies — both of which would send
+	// the user to fix something that is not broken.
+	HooksDisabled bool
+	// HooksDisabledRemedy is how to switch execution back on.
+	HooksDisabledRemedy string
+	// DuplicateHookEvents names the lifecycle events declared in more than one
+	// hook file of the same configuration layer, and DuplicateHookSources the
+	// files involved.
+	//
+	// Two files both carrying hooks is not itself a defect — splitting
+	// disjoint events across them is a valid configuration, and only an event
+	// declared twice actually runs twice. Keying the finding on the files
+	// alone would tell such a user to delete working hooks.
+	DuplicateHookEvents  []string
+	DuplicateHookSources []string
+	// ManagedHookFile is the file the installer rewrites. The durable fix for
+	// a duplicate is to drop the event from the *other* file, because this one
+	// is restored on the next install.
+	ManagedHookFile string
 }
 
 // Diagnose turns the collected evidence into ordered findings, most
@@ -99,10 +121,29 @@ func Diagnose(agent AgentHooks, summary hooks.EffectivenessSummary, adoption Ado
 		ambiguous += summary.AmbiguousRuns(event)
 	}
 
+	// Reported whether or not anything is configured. A harness told not to
+	// run hooks will not run the ones it has, and will not run the ones
+	// `gortex install` would add either — so this stands beside the
+	// nothing-configured warning rather than replacing it.
+	if agent.HooksDisabled {
+		if configured > 0 {
+			add(SeverityBlocker, agent.HooksDisabledRemedy,
+				"%d %s hook(s) are configured but hook execution is turned off in its configuration.",
+				configured, agent.Agent)
+		} else {
+			add(SeverityBlocker, agent.HooksDisabledRemedy,
+				"%s has hook execution turned off in its configuration.", agent.Agent)
+		}
+	}
+
 	switch {
 	case configured == 0:
 		add(SeverityWarn, "gortex install",
 			"%s has no Gortex lifecycle hooks configured.", agent.Agent)
+	case agent.HooksDisabled:
+		// Every rule below asks why configured hooks did not run. The finding
+		// above already answered, and these remedies — trust them, check PATH
+		// — would send the user to fix something that is not broken.
 	case ran == 0 && ambiguous > 0:
 		// The window straddles the upgrade that introduced attribution: runs
 		// exist, they just cannot be assigned. Say so rather than accuse.
@@ -124,7 +165,13 @@ func Diagnose(agent AgentHooks, summary hooks.EffectivenessSummary, adoption Ado
 
 	// A per-event zero while other events ran is a narrower version of the
 	// same problem: one hook's definition changed, so only its trust lapsed.
-	if ran > 0 {
+	//
+	// Skipped when execution is turned off, for the same reason the switch
+	// above skips its silence rules. `ran > 0` survives the switch being
+	// flipped — runs earlier in the window still count — so without this the
+	// trust remedy reappears event by event on a machine that simply has
+	// hooks disabled.
+	if ran > 0 && !agent.HooksDisabled {
 		for _, event := range events {
 			stats := activity.events[event]
 			if stats.Runs > 0 || activity.ambiguous(event) {
@@ -153,6 +200,22 @@ func Diagnose(agent AgentHooks, summary hooks.EffectivenessSummary, adoption Ado
 			add(SeverityWarn, "",
 				"%s ran %d time(s) and injected context 0 times — it fires but has nothing to say.", event, stats.Runs)
 		}
+	}
+
+	// One event declared in two files of the same layer is not a cosmetic
+	// duplicate: harnesses that merge their hook files run each declaration,
+	// so that event's work happens twice and the user pays for it twice.
+	//
+	// Named per event, and the remedy points away from the managed file. The
+	// events that live in only one file are working configuration, and a
+	// remedy phrased as "clean up one of these two files" would take them out
+	// along with the duplicate.
+	if len(agent.DuplicateHookEvents) > 0 && len(agent.DuplicateHookSources) > 1 {
+		add(SeverityWarn, duplicateHookRemedy(agent),
+			"%s declares %s in both %s — it merges hook files in the same layer, so each of those runs once per declaration.",
+			agent.Agent,
+			strings.Join(agent.DuplicateHookEvents, " and "),
+			strings.Join(agent.DuplicateHookSources, " and "))
 	}
 
 	if agent.InstructionsShadowed != "" {
@@ -188,6 +251,24 @@ func Diagnose(agent AgentHooks, summary hooks.EffectivenessSummary, adoption Ado
 		return severityRank(findings[i].Severity) < severityRank(findings[j].Severity)
 	})
 	return findings
+}
+
+// duplicateHookRemedy names the file to take the duplicated events out of, and
+// only those events.
+//
+// It points at the file the installer does NOT rewrite. Cleaning the managed
+// one looks like it worked and is undone by the next `gortex install`, which
+// is worse than not advising at all — the user pays for the edit twice and
+// still has the duplicate.
+func duplicateHookRemedy(agent AgentHooks) string {
+	events := strings.Join(agent.DuplicateHookEvents, " and ")
+	for _, path := range agent.DuplicateHookSources {
+		if path != agent.ManagedHookFile {
+			return fmt.Sprintf("remove %s from %s — %s is rewritten by `gortex install`",
+				events, path, agent.ManagedHookFile)
+		}
+	}
+	return fmt.Sprintf("keep one declaration of %s", events)
 }
 
 // HasBlocker reports whether any finding is a blocker — the command's exit

--- a/internal/doctor/findings_test.go
+++ b/internal/doctor/findings_test.go
@@ -366,3 +366,130 @@ func TestWhollyAmbiguousWindowReportsUncertainty(t *testing.T) {
 		t.Errorf("must not accuse on evidence that cannot decide: %+v", findings)
 	}
 }
+
+// TestHooksTurnedOffPreemptsTheTrustRemedy — an agent configured not to run
+// hooks explains an idle install completely. Sending the user to approve
+// hooks, or to check PATH, would be advice about something that is not broken.
+func TestHooksTurnedOffPreemptsTheTrustRemedy(t *testing.T) {
+	agent := codexAgent()
+	agent.HooksDisabled = true
+	agent.HooksDisabledRemedy = "set `hooks = true` under `[features]`"
+
+	findings := Diagnose(agent, activity(nil), Adoption{}, time.Now())
+
+	got := findingWith(t, findings, "hook execution is turned off")
+	if got.Severity != SeverityBlocker {
+		t.Errorf("severity=%s want BLOCKER", got.Severity)
+	}
+	if got.Remedy != agent.HooksDisabledRemedy {
+		t.Errorf("remedy=%q want %q", got.Remedy, agent.HooksDisabledRemedy)
+	}
+	assertNoFindingWith(t, findings, "none has run")
+	assertNoFindingWith(t, findings, "has no Gortex lifecycle hooks configured")
+}
+
+// TestHooksTurnedOffWithNothingConfigured keeps the missing-install case
+// ahead of the feature switch: there is nothing for the switch to stop.
+func TestHooksTurnedOffWithNothingConfigured(t *testing.T) {
+	agent := codexAgent()
+	agent.Configured = map[string]int{}
+	agent.HooksDisabled = true
+	agent.HooksDisabledRemedy = "set `hooks = true` under `[features]`"
+
+	findings := Diagnose(agent, activity(nil), Adoption{}, time.Now())
+
+	// Both facts matter: there is nothing installed, AND installing would not
+	// help until execution is switched back on.
+	findingWith(t, findings, "has no Gortex lifecycle hooks configured")
+	off := findingWith(t, findings, "hook execution turned off")
+	if off.Severity != SeverityBlocker {
+		t.Errorf("severity=%s want BLOCKER", off.Severity)
+	}
+}
+
+// TestDuplicateHookEventIsAWarning — an event declared in two files of one
+// layer runs twice, because the agent merges the files. Nothing else on the
+// machine names that except a startup warning inside the agent.
+func TestDuplicateHookEventIsAWarning(t *testing.T) {
+	agent := codexAgent()
+	agent.DuplicateHookEvents = []string{"SessionStart"}
+	agent.DuplicateHookSources = []string{"/home/u/.codex/hooks.json", "/home/u/.codex/config.toml"}
+	agent.ManagedHookFile = "/home/u/.codex/config.toml"
+
+	findings := Diagnose(agent, activity(map[string]hooks.EventActivity{
+		"SessionStart": {Runs: 3, Emitted: 3},
+	}), Adoption{}, time.Now())
+
+	got := findingWith(t, findings, "declares SessionStart in both")
+	if got.Severity != SeverityWarn {
+		t.Errorf("severity=%s want WARN", got.Severity)
+	}
+	for _, want := range []string{"hooks.json", "config.toml", "once per declaration"} {
+		if !strings.Contains(got.Summary, want) {
+			t.Errorf("summary should name %q, got %q", want, got.Summary)
+		}
+	}
+	// Cleaning the managed file is undone by the next install, so the remedy
+	// has to point at the other one.
+	if !strings.Contains(got.Remedy, "remove SessionStart from /home/u/.codex/hooks.json") {
+		t.Errorf("remedy should send the user to the unmanaged file, got %q", got.Remedy)
+	}
+	if strings.Contains(got.Remedy, "remove SessionStart from /home/u/.codex/config.toml") {
+		t.Errorf("remedy points at the file `gortex install` rewrites: %q", got.Remedy)
+	}
+}
+
+// TestDisjointHookSourcesAreNotADuplicate is the case that made the per-file
+// version of this finding dangerous: two files, no shared event, nothing
+// running twice — and a remedy phrased around the files would have deleted
+// four working hooks to fix a duplicate that did not exist.
+func TestDisjointHookSourcesAreNotADuplicate(t *testing.T) {
+	agent := codexAgent()
+	agent.DuplicateHookEvents = nil
+	agent.DuplicateHookSources = []string{"/home/u/.codex/hooks.json", "/home/u/.codex/config.toml"}
+	agent.ManagedHookFile = "/home/u/.codex/config.toml"
+
+	findings := Diagnose(agent, activity(map[string]hooks.EventActivity{
+		"SessionStart": {Runs: 3, Emitted: 3},
+	}), Adoption{}, time.Now())
+
+	assertNoFindingWith(t, findings, "in both")
+}
+
+// TestSingleHookSourceIsNotADuplicate — the ordinary install declares its
+// hooks in exactly one file. One declaring file can never be a duplicate, no
+// matter what events it carries.
+func TestSingleHookSourceIsNotADuplicate(t *testing.T) {
+	agent := codexAgent()
+	agent.DuplicateHookEvents = []string{"SessionStart"}
+	agent.DuplicateHookSources = []string{"/home/u/.codex/config.toml"}
+	agent.ManagedHookFile = "/home/u/.codex/config.toml"
+
+	findings := Diagnose(agent, activity(map[string]hooks.EventActivity{
+		"SessionStart": {Runs: 3, Emitted: 3},
+	}), Adoption{}, time.Now())
+
+	assertNoFindingWith(t, findings, "in both")
+}
+
+// TestHooksTurnedOffSuppressesThePerEventTrustRemedy closes the gap the switch
+// alone left open: `ran > 0` survives the switch being flipped, because runs
+// earlier in the window still count, and the per-event rule then handed out
+// the trust remedy event by event on a machine that simply has hooks off.
+func TestHooksTurnedOffSuppressesThePerEventTrustRemedy(t *testing.T) {
+	agent := codexAgent()
+	agent.HooksDisabled = true
+	agent.HooksDisabledRemedy = "set `hooks = true` under `[features]`"
+
+	findings := Diagnose(agent, activity(map[string]hooks.EventActivity{
+		"SessionStart": {Runs: 3, Emitted: 3},
+	}), Adoption{}, time.Now())
+
+	findingWith(t, findings, "hook execution is turned off")
+	assertNoFindingWith(t, findings, "configured but never ran, while other hooks did")
+	for _, f := range findings {
+		if strings.Contains(f.Remedy, "/hooks") {
+			t.Errorf("trust remedy offered while execution is turned off: %+v", f)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #616.

Two diagnostics reported a healthy setup as absent and then recommended reconfiguring it. Both are fixed here, one commit each, with separate regression tests so they stay independently testable.

## `gortex daemon service-status` reported a running LaunchAgent as not loaded

`statusLaunchd` asked `launchctl list <label>` and treated any non-zero exit as "not loaded". `launchctl list` is the legacy, domain-implicit form: it searches only the bootstrap domain of the process that calls it. A LaunchAgent installed by `install-service` lives in `gui/<uid>`, so anything asking from another domain got a miss for a service that was loaded and running — and was then told to load it again.

Measured on macOS 25.5 with an agent loaded exactly the way `installLaunchd` loads one:

| lookup | exit |
| --- | --- |
| `launchctl print gui/501/<label>` | `0` — `state = running` |
| `launchctl print user/501/<label>` | `113` — not found |

A second trigger produces the same wrong answer from a different direction. Under a seatbelt sandbox that denies `mach-lookup`, launchctl cannot reach the bootstrap port:

```
sandbox-exec -f deny-mach-lookup.sb launchctl list  <gui-loaded-label>  -> exit 1, no output
sandbox-exec -f deny-mach-lookup.sb launchctl print gui/501/<label>     -> exit 0, full report
```

Three weaknesses compounded into the report: the lookup was domain-implicit, every non-zero exit meant the same thing, and the reason was discarded on the error path.

**Now:** `launchctl print <domain>/<label>` is queried against `gui/<uid>` then `user/<uid>`, and the answer is split three ways — found, authoritatively absent, or unreadable. Only the second earns a remedy. Anything unrecognised
degrades to *unknown*, which is the safe direction: reporting "unknown" for a service that is genuinely gone costs one extra command, while reporting "not loaded" for a running one sends the user to bounce a healthy service.

```
$ gortex daemon service-status          # loaded
launchd: installed at /Users/…/Library/LaunchAgents/com.zzet.gortex.plist
status: loaded in gui/501
  state: running
  pid: 66061
  last exit code: (never exited)

$ gortex daemon service-status          # genuinely not loaded
status: not loaded (checked gui/501, user/501)
  fix: launchctl load -w /Users/…/com.zzet.gortex.plist (or re-run `gortex daemon install-service`)
  note: a gortex daemon is answering on its socket — see `gortex daemon status`
```

That last line matters on its own: the unit is only one of the ways the daemon runs, and stopping at the launchd answer let the command imply nothing was running while a manually started daemon served the user fine. It is printed
behind a loaded-but-stopped unit too, which from launchd alone is indistinguishable from having nothing running.

### The same probe also gated lifecycle routing

`defaultServiceActive` decides whether `daemon stop`, `daemon restart` and `purge` drive the supervisor or fall back to the manual path — and the manual path on a supervised daemon is what orphans it from the unit that owns it,
which is the whole reason that detector exists. It ran the identical `launchctl list <label>`, so it missed a service in `gui/<uid>` exactly as the status report did, while `defaultServiceStop` and `defaultServiceRestart` already addressed the service by its full `gui/<uid>/<label>` path. The detector now asks the way the paths it gates do.

It collapses "absent" and "could not tell" into "not supervised", deliberately: the manual path works with or without a unit, while the supervised one hard-fails when there is nothing to drive.

## Codex hook inspection reported zero hooks for a `hooks.json` setup

`codex.Inspect` read one file: `~/.codex/config.toml`. Codex reads hooks from four places — `~/.codex/hooks.json`, inline `[hooks]` in `~/.codex/config.toml`, and the same pair under `<repo>/.codex/` — and **merges** same-layer hook files.

The zero flowed straight into the finding engine:

```go
case configured == 0:
    add(SeverityWarn, "gortex install",
        "%s has no Gortex lifecycle hooks configured.", agent.Agent)
```

So a working `hooks.json` install was told to run `gortex install`, which writes inline TOML — producing exactly the same-layer duplication Codex warns about at startup. The diagnostic manufactured the misconfiguration it existed to detect.

That Codex really does load `hooks.json` is visible in its own trust ledger, which is keyed per source file:

```toml
[hooks.state.'/Users/…/.codex/hooks.json:session_start:0:0']
trusted_hash = 'sha256:…'
```

**Now:** both user-level files are read, and `InstallState` carries a per-file breakdown alongside the merged count. The breakdown is load-bearing, not cosmetic:

- `gortex doctor` prints the files each count came from, so a zero can no longer be read as "nothing anywhere" — `counted in ~/.codex/hooks.json (0), ~/.codex/config.toml (5)`.
- The uninstall preview asks for the count **in config.toml specifically**. That is the only file `RemoveGlobal` rewrites, and listing it because of entries that live in `hooks.json` would promise a deletion that never happens. Fixing the count alone would have introduced that bug.
- Doctor warns when the two files declare **the same event**. The unit is the event, not the file: splitting different events across the two is a valid configuration, and only an event present in both is merged into two runs. The remedy names the file the installer does *not* rewrite, because cleaning the managed one looks like it worked and returns on the next install.
- `gortex install` and `gortex init --hooks-only` say the same thing at the moment they would create the duplicate, per configuration layer. Both still write their own representation — the `hooks.json` entries are the user's.

The repo layer stays deliberately out of scope, and the doc comment says so: `Inspect` answers "what is installed for this user", and folding in a repo-local file would make that answer depend on whichever directory doctor ran in.

Also fixed here because it is the same defect pointing the other way: `[features] hooks = false` was ignored, so hooks that are declared and switched off were diagnosed as *untrusted* and the user was sent through an approval flow
that could not have helped. It is now reported whether or not anything is configured — installing hooks into a harness that will not run them is no better — and it suppresses the silence rules that would otherwise hand out the trust
remedy, including the per-event one, which fires on runs recorded before the switch was flipped.

## Verification

- Confirmed against the real thing, not only in tests: a genuinely loaded LaunchAgent (found in `gui/501`, including under the sandbox that broke the old check), and a live `~/.codex` with hooks in both representations.
- Every fix was checked by reverting it underneath its test — nine separate neuters (collapse non-zero exits to "absent"; search only the caller's domain; read only `config.toml`; key duplicates per file; point the remedy at the managed file; drop the disabled-hooks gate; assume "installed" on a failed stat; drop the stopped-unit note; drop the `--hooks-only` notice) each turn the matching tests red.
- The argv itself is pinned: every other launchd test drives an injected probe, so without that the wiring could regress to `list` with the suite still green.
- `go build ./...`, `go test` and `go test -race` on `cmd/gortex`, `internal/agents/...` and `internal/doctor`, plus `golangci-lint run` — clean, rebased on current `main`.
