### PR TITLE
blame, hooks: make tests hermetic on Windows and beside a live daemon

### DIFF
--- a/internal/blame/blame_test.go
+++ b/internal/blame/blame_test.go
@@ -427,7 +427,5 @@ func (e *cmdError) Error() string {
 }
 
 func writeFile(path, content string) error {
-	cmd := exec.Command("sh", "-c", "cat > "+path)
-	cmd.Stdin = strings.NewReader(content)
-	return cmd.Run()
+	return os.WriteFile(path, []byte(content), 0o600)
 }

--- a/internal/hooks/pretool_enforcement_test.go
+++ b/internal/hooks/pretool_enforcement_test.go
@@ -68,6 +68,10 @@ func TestEnrichGrepDeniesAnyPatternInTrackedScope(t *testing.T) {
 
 func TestEnrichGrepUntrackedRegexFallsBackSoftly(t *testing.T) {
 	stubTrackedScope(t, false)
+	// The probe must never reach a live daemon — a real index with hits
+	// for a segment of the pattern would flip this soft path to a deny.
+	stubProbe(t, nil, nil)
+	redirectTelemetry(t)
 
 	result := enrichGrep(map[string]any{"pattern": "e.x|ex"}, 0, "/untracked")
 	if result.deny || result.context == "" {


### PR DESCRIPTION
Two test-hermeticity fixes from running the suite on my Windows box with a live gortex daemon and a populated user-scope index. Both defects are in test code only; both exist on current main.

## `internal/blame`: fixture writes through `sh` scatter `package main` files into the package dir (Windows)

The `writeFile` helper piped fixture content through `sh -c "cat > <path>"`. On Windows, `sh` consumes the backslashes of the `t.TempDir()` path as escape characters, so the redirect target collapses into a single relative filename created in the test's cwd — `internal/blame/` itself — with MSYS mapping the now-illegal drive colon to U+F03A:

```
?? "internal/blame/D\357\200\272CacheTempTestEnrichGraph_StampsLastAuthored...main.go"
```

The three `TestEnrichGraph_*` tests fail (the repo fixture file was never written, so `git add main.go` errors), and the stray files declare `package main`, which breaks compilation of every package importing `internal/blame` — `internal/hooks` and `internal/mcp` fail with `found packages main (…) and blame (blame.go)`. Fixed by writing fixtures with `os.WriteFile`, as the same file already does in `TestEnrichGraph_CachesPathNormalization`. On macOS/Linux the `sh` detour happens to work, which is why this never surfaced upstream.

## `internal/hooks`: `TestEnrichGrepUntrackedRegexFallsBackSoftly` probes the live daemon

The test stubbed scope tracking but left `grepProbe` on `probeViaDaemon`, so its soft/deny outcome depends on whatever the machine's real index contains. With a live daemon whose index has symbol hits for the `ex` segment of `e.x|ex`, `probeSegments` answers with hits and the expected soft fallback flips to a deny — printing live index content into the failure output. Fixed the way the package's other probe tests isolate: `stubProbe(t, nil, nil)` keeps the probed-miss soft path exercised deterministically, and `redirectTelemetry(t)` sends the miss record to a scratch file instead of the real hook log.

## Verification (Windows 11, `go test -count=1`)

- Watched both fail before the fix: blame's three `TestEnrichGraph_*` failures plus the stray files above; the hooks test denying with live-index hits on clean main (fix stashed, then popped).
- After: `./internal/blame/` passes and leaves `git status` clean; the hooks test passes with the daemon up.
- FAIL name-set comparison against clean main on the same box: `internal/hooks` differs by exactly the fixed test; `internal/mcp`'s name-set is identical. My box has a pre-existing environment failure bucket (symlink privilege, path-separator, and other live-daemon-dependent tests) that this change doesn't touch — I'm chasing the live-daemon bucket separately and can follow up if that turns into something upstreamable.
