### PR TITLE
fix(agents): stop making Gortex a hard dependency of Codex startup

### DIFF
--- a/cmd/gortex/testdata/agent-render/codex.txt
+++ b/cmd/gortex/testdata/agent-render/codex.txt
@@ -49,7 +49,6 @@ type = 'command'
 [mcp_servers.gortex]
 args = ['mcp']
 command = 'gortex'
-required = true
 startup_timeout_sec = 90
 
 [mcp_servers.gortex.env]
@@ -649,7 +648,6 @@ type = 'command'
 [mcp_servers.gortex]
 args = ['mcp']
 command = 'gortex'
-required = true
 startup_timeout_sec = 90
 
 [mcp_servers.gortex.env]

--- a/docs/mcp-facade-v1.md
+++ b/docs/mcp-facade-v1.md
@@ -459,7 +459,7 @@ Requirements:
 8. Each MCP-capable integration harness SHOULD compare the raw MCP roster with the functions exposed by its client bridge. If the bridge drops a tool, telemetry and diagnostics MUST identify the missing facade rather than recommend an uncallable name.
 9. A Bash-only harness with no native MCP function exposure MUST be able to invoke the same compact names and argument objects through `gortex call`; this CLI path is a direct mirror, not a translation to legacy tool names.
 10. An agent adapter MUST use the host's supported eager/direct namespace control when the host otherwise defers MCP tools. Discovery in a settings screen or a successful raw `tools/list` is not sufficient: the facade functions MUST be present in the model-visible callable registry on the first turn.
-11. An agent adapter SHOULD mark Gortex as required when the host supports required MCP servers. Startup or discovery failure must fail visibly instead of silently leaving the agent with source-access guidance that it cannot follow.
+11. An agent adapter MUST NOT make Gortex a hard precondition for the host starting. Startup or discovery failure should fail visibly rather than silently leaving the agent with source-access guidance it cannot follow, but "visibly" MUST stop short of taking the host down: a coding assistant that cannot be started is worse than one running without graph tools. Where a host offers a required-server flag (Codex's `required`), the adapter MUST leave it alone — Gortex has ordinary states, such as a stopped daemon, in which its server does not answer the initialize handshake. Surface that state through `gortex doctor` instead.
 12. Guidance installed for an MCP-capable host MUST NOT recommend daemon startup or the Bash mirror when a Gortex callable handle is missing. That state is a host integration failure and MUST be surfaced. `gortex call` remains the mirror only for a harness that genuinely has no MCP transport.
 
 For Codex 0.142.0 and newer, `gortex init` adds the current `mcp__gortex`
@@ -467,11 +467,23 @@ namespace and its non-prefixed `gortex` form to
 `features.code_mode.direct_only_tool_namespaces` without removing
 user-configured namespaces. This is the host-supported bypass for deferral: the
 active Gortex namespace remains a direct model tool even when other MCP
-namespaces are available only through tool search. The adapter also writes
-`required = true` and a startup timeout long enough for Gortex's bounded daemon
-autostart. Older Codex releases reject that field, so the adapter version-gates
-it rather than invalidating their config. These are transport/host settings,
-not agent instructions and not part of the facade request schema.
+namespaces are available only through tool search. Older Codex releases reject
+that field, so the adapter version-gates it rather than invalidating their
+config.
+
+The adapter also writes a startup timeout long enough for Gortex's bounded
+daemon autostart, and pins `command` to the absolute path of the installed
+binary. Codex launches the server itself, so the bare name is only resolvable
+when Codex inherits the PATH `gortex init` ran under — a GUI-launched Codex
+does not.
+
+Releases v0.61.0 through v0.63.x also wrote `required = true`. That was a
+mistake: Codex aborts the session outright when a required server fails to
+initialize, so a stopped daemon or an unresolvable binary stopped the CLI from
+starting at all (gortexhq/gortex#607). The adapter now removes the flag from
+its own entry on the next `gortex install` / `gortex init`, and never writes
+it. An explicit user `required = false` is preserved. These are transport/host
+settings, not agent instructions and not part of the facade request schema.
 
 ## 13. Telemetry and privacy
 

--- a/internal/agents/codex/adapter.go
+++ b/internal/agents/codex/adapter.go
@@ -310,20 +310,24 @@ func codexHasDirectToolNamespaces(root map[string]any) bool {
 	return exists
 }
 
-// upsertCodexMCPServer makes Gortex a required Codex dependency and gives its
-// first-start daemon path enough time to publish the initial snapshot. Codex's
-// default MCP startup timeout can expire before that path's 60-second wait.
-// Existing Gortex-authored launch, environment, approval, and tool-timeout
-// settings are preserved; only these two availability invariants are managed.
+// upsertCodexMCPServer registers Gortex and gives its first-start daemon path
+// enough time to publish the initial snapshot: Codex's default MCP startup
+// timeout can expire before that path's 60-second wait. Existing
+// Gortex-authored launch, environment, approval, and tool-timeout settings are
+// preserved; only the startup timeout is managed, plus the one-time removal of
+// the `required` flag earlier releases wrote (see pruneManagedCodexRequired).
+//
+// The command is pinned to an absolute path rather than the bare name, because
+// Codex launches this process itself and its PATH is not the PATH `gortex init`
+// ran under — see ResolveGortexLaunchBinary.
 func upsertCodexMCPServer(root map[string]any, opts agents.ApplyOpts) bool {
 	servers, ok := root["mcp_servers"].(map[string]any)
 	if !ok {
 		servers = make(map[string]any)
 	}
 	desired := map[string]any{
-		"command":             "gortex",
+		"command":             agents.ResolveGortexLaunchBinary(),
 		"args":                []string{"mcp"},
-		"required":            true,
 		"startup_timeout_sec": codexMCPStartupTimeoutSeconds,
 		"env": map[string]any{
 			"GORTEX_INDEX_WORKERS": "8",
@@ -343,8 +347,10 @@ func upsertCodexMCPServer(root map[string]any, opts agents.ApplyOpts) bool {
 		return false
 	}
 	changed := migrateCodexFacadeToolApprovals(entry)
-	if required, _ := entry["required"].(bool); !required {
-		entry["required"] = true
+	if pruneManagedCodexRequired(entry) {
+		changed = true
+	}
+	if pinCodexBareGortexCommand(entry) {
 		changed = true
 	}
 	if !codexStartupTimeoutAtLeast(entry["startup_timeout_sec"], codexMCPStartupTimeoutSeconds) {
@@ -356,6 +362,67 @@ func upsertCodexMCPServer(root map[string]any, opts agents.ApplyOpts) bool {
 		root["mcp_servers"] = servers
 	}
 	return changed
+}
+
+// pruneManagedCodexRequired removes the `required = true` flag that gortex
+// v0.61.0 through v0.63.x wrote into its own Codex MCP entry, and reports
+// whether it removed anything.
+//
+// Codex treats a required MCP server as a hard precondition for the session:
+// if the server does not complete the initialize handshake, Codex aborts with
+// "Failed to initialize session: required MCP servers failed to initialize"
+// and the whole CLI does not start. The intent was that a broken integration
+// should fail loudly rather than leave the agent with graph-tool instructions
+// it cannot follow, but the flag makes ordinary Gortex states fatal to the
+// user's editor:
+//
+//   - the daemon is not running, so `gortex mcp` fails closed and exits
+//     without answering initialize — the state after `gortex daemon stop`,
+//     under GORTEX_AUTOSTART=0, and during the spawn-failure cooldown;
+//   - the binary is not on the PATH Codex was launched with;
+//   - the handshake outruns startup_timeout_sec on a cold daemon start.
+//
+// None of those are Codex's to recover from, and a coding assistant must not
+// be able to take its host down. Without the flag the same failures degrade to
+// a Codex session with no Gortex tools, which `gortex doctor` reports.
+//
+// Only `true` is pruned. A user who has written `required = false` keeps it:
+// that value is already the safe posture, and rewriting it would repeat the
+// mistake this function exists to undo. See gortexhq/gortex#607.
+func pruneManagedCodexRequired(entry map[string]any) bool {
+	if required, ok := entry["required"].(bool); !ok || !required {
+		return false
+	}
+	delete(entry, "required")
+	return true
+}
+
+// pinCodexBareGortexCommand upgrades the bare `command = "gortex"` that
+// earlier releases wrote to the absolute path of the installed binary, and
+// reports whether it rewrote anything.
+//
+// The bare name only resolves if the process that launches Codex inherited the
+// PATH `gortex init` ran under. A GUI-launched Codex does not, so the server
+// silently never starts and the session has no Gortex tools. Pinning is the
+// same choice the hook writer in this file already makes.
+//
+// Only the bare name is rewritten. An absolute path is left alone whether a
+// user pinned a specific build or an earlier run pinned it: re-pinning on every
+// install would overwrite a deliberate choice to serve one that is almost
+// always identical.
+func pinCodexBareGortexCommand(entry map[string]any) bool {
+	cmd, _ := entry["command"].(string)
+	if cmd != "gortex" && cmd != "gortex.exe" {
+		// A path (ours or the user's), or a wrapper we do not own.
+		return false
+	}
+	pinned := agents.ResolveGortexLaunchBinary()
+	if pinned == cmd {
+		// Nothing installed that we can name more precisely.
+		return false
+	}
+	entry["command"] = pinned
+	return true
 }
 
 // migrateCodexFacadeToolApprovals upgrades per-tool approval entries from the

--- a/internal/agents/codex/adapter_test.go
+++ b/internal/agents/codex/adapter_test.go
@@ -60,7 +60,7 @@ func TestCodexWritesMcpServersTOMLTable(t *testing.T) {
 	agentstest.AssertIdempotent(t, a, env)
 }
 
-func TestCodexMakesGortexToolsDirectAndRequired(t *testing.T) {
+func TestCodexMakesGortexToolsDirectWithoutHardDependency(t *testing.T) {
 	env := codexGlobalEnv(t)
 	env.InstallHooks = false
 	a := New()
@@ -71,8 +71,13 @@ func TestCodexMakesGortexToolsDirectAndRequired(t *testing.T) {
 	cfg := readCodexConfig(t, env)
 	servers := cfg["mcp_servers"].(map[string]any)
 	server := servers["gortex"].(map[string]any)
-	if server["required"] != true {
-		t.Fatalf("mcp_servers.gortex.required=%v want true", server["required"])
+	// A required server Codex cannot start aborts the whole session, so a
+	// Gortex outage would take the user's CLI down with it (#607).
+	if _, exists := server["required"]; exists {
+		t.Fatalf("Gortex must not declare itself a required Codex dependency: %#v", server)
+	}
+	if want := agents.ResolveGortexLaunchBinary(); server["command"] != want {
+		t.Fatalf("mcp_servers.gortex.command=%v want %q", server["command"], want)
 	}
 	if server["startup_timeout_sec"] != int64(codexMCPStartupTimeoutSeconds) {
 		t.Fatalf("mcp_servers.gortex.startup_timeout_sec=%v want %d", server["startup_timeout_sec"], codexMCPStartupTimeoutSeconds)
@@ -127,8 +132,10 @@ command = "other"
 	}
 	servers := cfg["mcp_servers"].(map[string]any)
 	server := servers["gortex"].(map[string]any)
-	if server["command"] != "gortex" {
-		t.Fatalf("custom command changed: %#v", server)
+	// The seed's bare "gortex" is what earlier releases wrote, not a user
+	// choice, so it is upgraded to the absolute path Codex can always find.
+	if want := agents.ResolveGortexLaunchBinary(); server["command"] != want {
+		t.Fatalf("command=%v want the pinned launch binary %q", server["command"], want)
 	}
 	args, ok := codexStringList(server["args"])
 	if !ok || len(args) != 2 || args[1] != "--custom" {
@@ -137,8 +144,9 @@ command = "other"
 	if server["tool_timeout_sec"] != int64(321) {
 		t.Fatalf("custom tool timeout changed: %#v", server)
 	}
-	if server["required"] != true {
-		t.Fatalf("required=%v want true", server["required"])
+	// An explicit opt-out is already the safe posture; only `true` is pruned.
+	if server["required"] != false {
+		t.Fatalf("user's required=false was not preserved: %#v", server)
 	}
 	if server["startup_timeout_sec"] != int64(codexMCPStartupTimeoutSeconds) {
 		t.Fatalf("startup timeout=%v want %d", server["startup_timeout_sec"], codexMCPStartupTimeoutSeconds)
@@ -229,9 +237,8 @@ func TestCodexMCPServerPreservesLongerStartupTimeout(t *testing.T) {
 	root := map[string]any{
 		"mcp_servers": map[string]any{
 			"gortex": map[string]any{
-				"command":             "gortex",
+				"command":             agents.ResolveGortexLaunchBinary(),
 				"args":                []any{"mcp"},
-				"required":            true,
 				"startup_timeout_sec": int64(180),
 			},
 		},
@@ -242,6 +249,87 @@ func TestCodexMCPServerPreservesLongerStartupTimeout(t *testing.T) {
 	server := root["mcp_servers"].(map[string]any)["gortex"].(map[string]any)
 	if server["startup_timeout_sec"] != int64(180) {
 		t.Fatalf("longer startup timeout changed: %#v", server)
+	}
+}
+
+// TestCodexUpgradeRemovesRequiredFlag covers the migration for everyone who
+// already ran an affected release: their config carries `required = true` on
+// disk, so leaving it there would keep their Codex unable to start whenever
+// the daemon is down (#607).
+func TestCodexUpgradeRemovesRequiredFlag(t *testing.T) {
+	env := codexGlobalEnv(t)
+	env.InstallHooks = false
+	path := codexConfigPath(env)
+	seed := `[mcp_servers.gortex]
+args = ['mcp']
+command = 'gortex'
+required = true
+startup_timeout_sec = 90
+
+[mcp_servers.gortex.env]
+GORTEX_INDEX_WORKERS = '8'
+`
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	server := readCodexConfig(t, env)["mcp_servers"].(map[string]any)["gortex"].(map[string]any)
+	if _, exists := server["required"]; exists {
+		t.Fatalf("upgrade left the session-blocking required flag behind: %#v", server)
+	}
+	if server["startup_timeout_sec"] != int64(codexMCPStartupTimeoutSeconds) {
+		t.Fatalf("startup timeout lost during the migration: %#v", server)
+	}
+}
+
+func TestCodexPruneManagedRequired(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		entry   map[string]any
+		changed bool
+		want    any
+		present bool
+	}{
+		{name: "managed true is removed", entry: map[string]any{"required": true}, changed: true},
+		{name: "explicit opt-out is preserved", entry: map[string]any{"required": false}, want: false, present: true},
+		{name: "absent stays absent", entry: map[string]any{}},
+		{
+			// A non-boolean is a shape we did not write and cannot judge.
+			name: "non-boolean is left alone", entry: map[string]any{"required": "yes"},
+			want: "yes", present: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := pruneManagedCodexRequired(tc.entry); got != tc.changed {
+				t.Fatalf("changed=%v want %v", got, tc.changed)
+			}
+			got, present := tc.entry["required"]
+			if present != tc.present || (present && got != tc.want) {
+				t.Fatalf("required=(%#v, present=%v) want (%#v, present=%v)", got, present, tc.want, tc.present)
+			}
+		})
+	}
+}
+
+func TestCodexPinsBareGortexCommandOnly(t *testing.T) {
+	pinned := agents.ResolveGortexLaunchBinary()
+	if pinned == "gortex" {
+		t.Skip("no installed gortex binary to pin to on this machine")
+	}
+	entry := map[string]any{"command": "gortex"}
+	if !pinCodexBareGortexCommand(entry) {
+		t.Fatal("bare command should be pinned to the installed binary")
+	}
+	if entry["command"] != pinned {
+		t.Fatalf("command=%v want %q", entry["command"], pinned)
+	}
+	// An absolute path is a deliberate choice — a user's, or an earlier run's.
+	absolute := map[string]any{"command": "/opt/custom/build/gortex"}
+	if pinCodexBareGortexCommand(absolute) {
+		t.Fatalf("an absolute command must survive: %#v", absolute)
 	}
 }
 
@@ -281,8 +369,11 @@ func TestCodexOldVersionSkipsUnsupportedDirectNamespaceConfig(t *testing.T) {
 		t.Fatalf("Codex 0.141 must not receive unsupported features.code_mode fields: %#v", cfg["features"])
 	}
 	server := cfg["mcp_servers"].(map[string]any)["gortex"].(map[string]any)
-	if server["required"] != true || server["startup_timeout_sec"] != int64(codexMCPStartupTimeoutSeconds) {
-		t.Fatalf("version gate must not weaken MCP startup safety: %#v", server)
+	if server["startup_timeout_sec"] != int64(codexMCPStartupTimeoutSeconds) {
+		t.Fatalf("version gate must not weaken the MCP startup timeout: %#v", server)
+	}
+	if _, exists := server["required"]; exists {
+		t.Fatalf("old Codex must not receive the session-blocking required flag either: %#v", server)
 	}
 }
 

--- a/internal/agents/mcp.go
+++ b/internal/agents/mcp.go
@@ -188,6 +188,26 @@ func resolveGortexCommandFrom(exe string, exeErr error, lookPath string, lookErr
 // than the bare name. The returned value is a bare binary reference
 // with no subcommand — callers append " hook" (and any --mode suffix).
 func ResolveGortexHookBinary() string {
+	return ResolveGortexLaunchBinary()
+}
+
+// ResolveGortexLaunchBinary returns the gortex binary reference to bake
+// into an MCP server stanza for a host that launches the server itself
+// rather than through the user's login shell. It is the same value (and
+// the same decision core) as ResolveGortexHookBinary; the two names
+// exist so each call site reads as what it is.
+//
+// ResolveGortexCommand is the wrong resolver for such a host. It
+// collapses to the bare "gortex" whenever PATH resolves to the running
+// binary — correct for Claude Code, which keys OAuth tokens on the
+// command string and must match the portable project template, but the
+// bare name is only findable if the launching process inherits the PATH
+// that `gortex init` ran under. A GUI-launched host does not: on macOS
+// it inherits launchd's PATH, which carries neither Homebrew's
+// /opt/homebrew/bin nor ~/.local/bin nor ~/go/bin, so the spawn fails
+// with ENOENT. Pinning the absolute path is what the hook writer
+// already does for exactly this reason (gortexhq/gortex#607).
+func ResolveGortexLaunchBinary() string {
 	exe, exeErr := os.Executable()
 	lp, lpErr := exec.LookPath("gortex")
 	return resolveGortexHookBinaryFrom(exe, exeErr, lp, lpErr, sameFile)


### PR DESCRIPTION
Fixes #607.

## The bug

`gortex init` / `gortex install` wrote this into `~/.codex/config.toml`:

```toml
[mcp_servers.gortex]
args = ['mcp']
command = 'gortex'          # bare name — resolved from Codex's PATH at launch
required = true             # Codex: abort the session if this server fails
startup_timeout_sec = 90
```

In Codex, `required = true` is not a warning. If the server does not finish the initialize handshake, Codex aborts:

```
Error: Fatal error: Failed to initialize session: required MCP servers failed to initialize: gortex: …
```

The CLI does not start at all. So a Gortex hiccup took the user's editor down with it.

## Three triggers, all ordinary Gortex states

Reproduced against Codex 0.147.0 with `CODEX_HOME=<sandbox> codex debug prompt-input "hi"`, which renders a session locally and starts MCP servers — no model call, no API spend.

| Trigger | Codex output |
|---|---|
| **Daemon not running.** `gortex mcp` fails closed and exits 1 without answering `initialize`: *"gortex daemon is unavailable and embedded MCP mode is disabled by default"*. That is the state after `gortex daemon stop`, under `GORTEX_AUTOSTART=0`, and during the 5 s spawn-failure cooldown. | `…failed to initialize: gortex: handshaking with MCP server failed: connection closed` |
| **`gortex` not on the PATH Codex sees.** A GUI-launched Codex inherits launchd's PATH; `/etc/paths` carries neither `/opt/homebrew/bin` nor `~/.local/bin` nor `~/go/bin`. | `…failed to initialize: gortex: No such file or directory (os error 2)` |
| **Handshake slower than 90 s** on a cold daemon start (the autostart path waits up to 60 s for the socket, then may fall through to an embedded index). | `…failed to initialize: gortex: timed out handshaking with MCP server` |

The second one is self-inflicted in a specific way: the **hooks** written into the same file were already pinned to an absolute path, precisely because "a hook fires in a shell whose PATH may not match install time". The MCP entry, which Codex launches the same way, kept the bare name.

The issue body's other symptom — *"none of the required callable tools are registered"* — is the same launch failure with `required = false`: Codex starts, prints nothing at all, and simply has no `mcp__gortex__*` tools.

And the obvious workaround did not stick: the adapter force-reset a user's `required = false` back to `true` on every run, while carefully preserving their `command`, `args`, `env` and `tool_timeout_sec`.

## The fix

- **Never write `required`.** A coding assistant must not be able to stop its host from starting. Without the flag the same failures degrade to a Codex session with no Gortex tools — which `gortex doctor` reports.
- **Remove our own `required = true` on the next install**, so configs already on disk recover instead of staying broken. Only `true` is pruned; an explicit user `required = false` is preserved, and a non-boolean shape we did not write is left alone.
- **Pin `command` to the installed binary's absolute path**, and upgrade a bare `command = "gortex"` from an earlier release in place. An absolute path is never rewritten — that is either a user's choice or an earlier run's.
- Update the facade doc, which previously told adapters they *should* mark Gortex required.

`ResolveGortexLaunchBinary` is a named alias for the hook resolver's decision core, so both call sites read as what they are. `ResolveGortexCommand` stays as is — Claude Code keys OAuth tokens on the command string and needs the bare name to match the portable project template.

## Verification

Same sandboxes that reproduced the bug, now with the patched binary:

| Case | Before | After |
|---|---|---|
| Clean install | `required = true`, `command = 'gortex'` | no `required`, `command = '/opt/homebrew/bin/gortex'` |
| Config carrying `required = true` | unchanged | flag removed, bare command pinned |
| Codex under a launchd-style PATH | `Fatal error: …No such file or directory` | starts, `exit=0` |
| Codex with the daemon unavailable | `Fatal error: …connection closed` | starts, `exit=0` |

To prove the pinned command makes the server *actually start* rather than fail silently, the launchd-PATH case was re-run with `required = true` put back as a probe — it passes, where the bare name gave ENOENT.

Tests: `go test -race ./internal/agents/... ./cmd/gortex/` green; `golangci-lint run` clean on both trees. New coverage for the migration, the prune's boundary cases, and bare-vs-absolute command pinning; the render golden is regenerated.

## Out of scope

`gortex mcp` exiting rather than serving a degraded surface when the daemon is down is left alone — with `required` gone it is no longer fatal, and changing the fail-closed policy deserves its own change.
