### PR TITLE
fix(temporal): match repo-local env-helper names case-insensitively

### DIFF
--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -38,3 +38,35 @@ The Go and Java extractors tag Temporal call sites with a `via` Meta value on th
 | `temporal.query-call` | caller → running workflow | `client.QueryWorkflow` | `query` | consumer edge |
 
 Extra Meta on these edges: `temporal_registered_name` (the `RegisterOptions{Name}` override that is the actual dispatch key), `temporal_register_plural` (a `RegisterActivities(&Struct{})` registration whose exported methods are each promoted), and `temporal_name_origin=env_default` (a dispatch name resolved from an env-var-with-literal-default, landed at the speculative tier). Node roles are stamped as `temporal_role` (`activity` / `workflow` / `activity_interface` / `workflow_interface` / `signal` / `query` / `update`). Aliased `import wf "go.temporal.io/sdk/workflow"` receivers are canonicalised before detection.
+
+### Repo-local env-helper allow-list (Go)
+
+A workflow often picks its activity name through a project-local env-or-default helper rather than a literal:
+
+```go
+name := wfutils.GetEnvOrDefault("ACTIVITY_NAME", "ChargeCard")
+workflow.ExecuteActivity(ctx, name)
+```
+
+The Go extractor recognises a small built-in set of such helper names (`GetEnvOrDefault`, `GetEnvOrDefaultValue`, `EnvOr`, `GetenvDefault`, `GetEnvDefault`) and takes the second argument as the dispatch name. A recognised name is stamped `temporal_env_source=allowlist` and the resolver lands the edge at the **inferred (visible)** tier. Any other helper whose name merely contains `env` falls back to `temporal_env_source=heuristic`, which stays at the **speculative (hidden)** tier.
+
+To promote your own helper names into the allow-list tier, declare them per repository:
+
+```yaml
+# .gortex/temporal-allowlist.yaml  — git-ignore this file
+env_helpers:
+  - GetEnvOrFallback
+  - ActivityNameFor
+```
+
+The file is read **only** when the opt-in gate is set, because a checked-out repository could otherwise change how the indexer attributes dispatch:
+
+```bash
+export GORTEX_ALLOW_LOCAL_TEMPORAL=1
+```
+
+Notes:
+
+- Declare the **bare function name**, without a package qualifier: only the trailing identifier of the call site is matched, so `ActivityNameFor` covers both `ActivityNameFor(...)` and `cfgutil.ActivityNameFor(...)`. Matching is **case-insensitive**, same as the built-in names.
+- The list is loaded once per indexed repository, at the repository root, and applies to that repository only — a multi-repo daemon never leaks one repo's names into another. Editing the file takes effect on the next daemon start.
+- Everything fails soft: gate unset, file missing, or file malformed all mean "no extra names". The built-in list and the heuristic still apply, so you never lose edges by getting this wrong — you only lose the promotion to the visible tier.

--- a/internal/indexer/extraction_options_test.go
+++ b/internal/indexer/extraction_options_test.go
@@ -127,3 +127,54 @@ func TestRepositoryExtractionOptionsIsolationAndOverlayParity(t *testing.T) {
 		}
 	}
 }
+
+// TestRepositoryExtractionOptionsMatchHelperCaseInsensitively walks the whole
+// opt-in chain — env gate, repo-local allow-list file, indexer options, Go
+// extractor — and asserts a declared helper name matches its call site
+// regardless of capitalisation. A case near-miss used to fail silently: the
+// dispatch fell back to the hidden "heuristic" tier when the callee carried an
+// "env" marker, and left the graph entirely when it did not.
+func TestRepositoryExtractionOptionsMatchHelperCaseInsensitively(t *testing.T) {
+	t.Setenv(config.LocalTemporalOptInEnv, "true")
+
+	for _, testCase := range []struct {
+		name     string
+		declared string
+		callSite string
+	}{
+		{name: "exact", declared: "CorpEnvLookup", callSite: "CorpEnvLookup"},
+		{name: "declared lower", declared: "corpenvlookup", callSite: "CorpEnvLookup"},
+		{name: "declared upper", declared: "CORPENVLOOKUP", callSite: "CorpEnvLookup"},
+		// No "env" marker in the name, so a miss here drops the edge's env
+		// attribution entirely instead of degrading it to the heuristic tier.
+		{name: "no env marker", declared: "getCorpValue", callSite: "GetCorpValue"},
+		// Entries are bare function names; only the call site's trailing
+		// identifier is matched, so a package-qualified call still resolves.
+		{name: "package qualified call", declared: "corpEnvLookup", callSite: "cfgutil.CorpEnvLookup"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeIndexerTemporalAllowlist(t, root, testCase.declared)
+
+			reg := parser.NewRegistry()
+			languages.RegisterAll(reg)
+			idx := New(graph.New(), reg, config.IndexConfig{}, zap.NewNop())
+			idx.SetRootPath(root)
+			defer idx.Close()
+
+			result, err := idx.ExtractBuffer("go", "sample.go", indexerTemporalSource(testCase.callSite))
+			if err != nil {
+				t.Fatal(err)
+			}
+			meta := indexerTemporalMeta(result)
+			if meta == nil {
+				t.Fatalf("declared %q vs call site %q: Temporal edge missing",
+					testCase.declared, testCase.callSite)
+			}
+			if got := meta["temporal_env_source"]; got != "allowlist" {
+				t.Fatalf("declared %q vs call site %q: temporal_env_source = %#v, want %q",
+					testCase.declared, testCase.callSite, got, "allowlist")
+			}
+		})
+	}
+}

--- a/internal/parser/languages/golang.go
+++ b/internal/parser/languages/golang.go
@@ -357,9 +357,13 @@ func (e *GoExtractor) Extract(filePath string, src []byte) (*parser.ExtractionRe
 // mutating this shared extractor. Configured Temporal helpers extend the
 // built-in helper set for this extraction only.
 func (e *GoExtractor) ExtractWithOptions(filePath string, src []byte, opts parser.ExtractionOptions) (*parser.ExtractionResult, error) {
+	// Keys are lower-cased so a repo-local helper name matches its call site
+	// the same case-insensitive way a built-in goEnvHelperNames entry does.
+	// Without this, `env_helpers: [getCorpValue]` silently fails to promote a
+	// `GetCorpValue(...)` dispatch — see goEnvHelperDefaultLiteral.
 	envHelperExtra := make(map[string]bool)
 	for _, name := range opts.TemporalEnvHelpers() {
-		envHelperExtra[name] = true
+		envHelperExtra[strings.ToLower(name)] = true
 	}
 	tree, err := parser.ParseFile(src, e.lang)
 	if err != nil {

--- a/internal/parser/languages/golang_temporal.go
+++ b/internal/parser/languages/golang_temporal.go
@@ -1254,7 +1254,7 @@ func goEnvHelperDefaultLiteral(call *sitter.Node, src []byte, extra map[string]b
 			break
 		}
 	}
-	if !matched && extra[callee] {
+	if !matched && extra[strings.ToLower(callee)] {
 		matched = true
 	}
 	if !matched {

--- a/internal/parser/languages/golang_temporal_options_test.go
+++ b/internal/parser/languages/golang_temporal_options_test.go
@@ -98,12 +98,27 @@ func Run(ctx workflow.Context) {
 		t.Fatalf("constant reference = %#v", got)
 	}
 
-	wrongCase, err := ext.ExtractWithOptions("case.go", temporalOptionSource("CorporateHelper", ""), parser.NewExtractionOptions([]string{"corporatehelper"}))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := temporalDispatchMeta(t, wrongCase)["temporal_env_source"]; got != nil {
-		t.Fatalf("case-insensitive local match = %#v", got)
+	// A repo-local allow-list entry matches its call site case-insensitively,
+	// exactly like a built-in goEnvHelperNames entry does. The YAML author
+	// must not have to reproduce the call site's capitalisation: a near-miss
+	// used to fail silently, dropping the dispatch to the hidden heuristic
+	// tier (or off the graph entirely for a name without an "env" marker).
+	for _, tc := range []struct{ entry, callSite string }{
+		{entry: "corporatehelper", callSite: "CorporateHelper"},
+		{entry: "CorporateHelper", callSite: "corporatehelper"},
+	} {
+		mixedCase, err := ext.ExtractWithOptions(
+			"case.go",
+			temporalOptionSource(tc.callSite, ""),
+			parser.NewExtractionOptions([]string{tc.entry}),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := temporalDispatchMeta(t, mixedCase)["temporal_env_source"]; got != "allowlist" {
+			t.Fatalf("entry %q vs call site %q: source = %#v, want %q",
+				tc.entry, tc.callSite, got, "allowlist")
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #524.

## What the issue reported

#524 said the repo-local Temporal env-helper allow-list had a loader, an env gate and a sink, but no path connecting them — so setting `GORTEX_ALLOW_LOCAL_TEMPORAL` and writing `.gortex/temporal-allowlist.yaml` produced "no error and no effect".

The plumbing half of that was already fixed on `main` by `3fd50479` ("feat(indexer): isolate parser config and lifecycle"), which replaced the dead `GoExtractor.SetEnvHelperNames` setter with per-request `parser.ExtractionOptions` threaded through all three parse routes.

## What was still broken

That refactor dropped the lower-casing on **both** sides of the allow-list lookup. Built-in helper names are matched with `strings.EqualFold`; user-supplied names were matched with a raw, case-sensitive map lookup:

```go
for _, name := range goEnvHelperNames {
    if strings.EqualFold(callee, name) { matched = true; break }   // built-in: case-insensitive
}
if !matched && extra[callee] { matched = true }                    // user: case-SENSITIVE
```

Both doc comments still described the intended behaviour ("compared case-insensitively", "lower-cased keys"), so only the code had drifted.

The failure mode is silent, and it reproduces exactly the symptom the issue complained about — a user gets no error and, effectively, no effect:

| `env_helpers` entry | call site | `temporal_env_source` before | after |
|---|---|---|---|
| `CorpEnvLookup` | `CorpEnvLookup(...)` | `allowlist` | `allowlist` |
| `corpenvlookup` | `CorpEnvLookup(...)` | `heuristic` (hidden tier) | `allowlist` |
| `getCorpValue` | `GetCorpValue(...)` | *(no env attribution)* | `allowlist` |

A near-miss demotes the dispatch to the hidden speculative tier when the callee name happens to contain `env`, and strips its env attribution entirely when it does not — which is the opposite of what declaring the name is for.

## The fix

- Lower-case the keys where `envHelperExtra` is built, and lower-case the callee at lookup. Built-in and user-supplied names now behave identically.
- Flip the assertion in `golang_temporal_options_test.go` that had locked the case-sensitive behaviour in, and cover both directions.
- Add `TestRepositoryExtractionOptionsMatchHelperCaseInsensitively`, which walks the whole opt-in chain — env gate → allow-list file → indexer options → Go extractor — over four case shapes plus a package-qualified call site.
- Document the feature in `docs/contracts.md`. The env gate and the file shape appeared nowhere outside source comments, so the issue's "documented user surface" premise was never true.

No behaviour change for repositories that do not opt in: the gate, the missing file and the malformed file all still fail soft.

## Verification

Both new assertions were checked against neutered source (fix reverted, tests kept) — the case-mismatch cases fail and the exact-case cases pass, so the tests catch the real defect rather than restating the code.

```
go build ./...                                                              ok
go test ./internal/parser/... ./internal/indexer/... ./internal/config/... \
        ./internal/resolver/...                        5261 passed, 40 packages
golangci-lint run ./internal/parser/... ./internal/indexer/...   no issues
```
