### PR TITLE
feat(mcp): disk-verified SHA-256 receipts for single-file mutations

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -293,6 +293,71 @@ over a very large tree, or `ask` against a slow local model.
 | `set_planning_mode` | Switch the session between a guaranteed no-writes planning phase and editing mode |
 | `workflow` | Drive a phase-enforcement state machine (explore → implement → verify) — editing tools are gated until the implement phase |
 
+### Content hashes: five fields, five meanings
+
+Several tools return a hash and none of them are interchangeable. Pick by what
+you need to prove, not by which field is nearest.
+
+| Field | Algorithm | Covers | Observed when |
+|---|---|---|---|
+| `base_sha` (request) | git blob SHA-1 | the full file the caller read earlier | — (a value you supply) |
+| `new_sha` (response) | git blob SHA-1 | the bytes the tool was **about to** write | **before** the write |
+| `content_sha256` (`read_file`) | SHA-256 | the full file on disk | during the read |
+| `before_sha256` / `after_sha256` (mutations) | SHA-256 | the full file on disk, before and after | before / **after** the write |
+| `etag` | SHA-256 of the response payload | the returned representation, not the file | as the response is built |
+
+Two consequences worth internalising:
+
+- **`new_sha` is a pipelining token, not physical evidence.** It is a git blob
+  SHA-1 (`sha1("blob <len>\0" + data)`, the same value `git hash-object` prints)
+  computed from the in-memory buffer *before* `AtomicWriteFile` runs. It is what
+  you feed to the next call's `base_sha`. It is not a SHA-256, it is not read
+  back from disk, and `dry_run` returns one for bytes that were never written.
+- **`etag` is not a file hash.** It covers the JSON response — window, elision,
+  redaction and all — so two reads of an unchanged file with different options
+  carry different ETags.
+
+To prove what is actually on disk, ask for it explicitly with
+`physical_evidence: true` (see below). Anything else is a prediction or a
+cache key.
+
+### Disk-verified receipts (`physical_evidence`)
+
+`read_file`, `edit_file`, `write_file` and `edit_symbol` accept
+`physical_evidence: true` (with an optional `digest`, `sha256` only, which is
+also the default). The read side returns `content_sha256` plus `hash_scope`,
+`content_source`, `same_buffer_as_content` and `resolved_path`; the mutation
+side returns `before_sha256` / `after_sha256` re-read from disk **after** the
+atomic write, plus `resolved_path`, `byte_count` and `verified_at`. Both are
+`hash_algorithm: sha256`, `hash_scope: full_file`, `content_source: disk`.
+
+Contract details that matter for an evidence workflow:
+
+- **The mutation digest is an observation, not a prediction.** The file is read
+  back through the same hardened path `read_file` uses — non-regular files
+  refused, symlink resolution recorded, repo-root confinement re-checked against
+  the target that supplied the bytes.
+- **A creating `write_file` reports `before_absent: true`** instead of a
+  `before_sha256`, so "no prior bytes" is distinguishable from "not requested".
+- **`dry_run` + `physical_evidence` is refused.** A dry run writes nothing, so
+  there are no disk bytes to attest.
+- **Evidence failure never fails the call.** If the read-back cannot be
+  completed or confinement is violated, the write is still reported as applied
+  and the response carries `evidence_error` with no digests — failing the call
+  would invite a retry that applies the edit twice.
+- **Secret-shaped config leaves are withheld.** `before_sha256` digests bytes
+  the caller did not supply, so a `.env`-shaped file refuses the receipt (the
+  edit itself still works). Read its digest with
+  `read_file{allow_secrets: true}` if you genuinely need it.
+- Multi-file mutations (`rename_symbol`, `batch_edit`) do not yet take the flag;
+  `batch_edit`'s transaction journal carries its own `before_sha256` /
+  `after_sha256`, computed from in-memory buffers for crash recovery — not a
+  disk observation.
+
+Whether the graph caught up with the write is a separate question, answered by
+the `reindexed` / `reindex_pending` / `reindex_generation` fields every mutation
+already returns.
+
 ## Agent-optimized (token efficiency)
 
 | Tool | Description |

--- a/internal/mcp/batch_transaction_journal.go
+++ b/internal/mcp/batch_transaction_journal.go
@@ -33,8 +33,7 @@ func batchManifestPath(transactionID string) string {
 }
 
 func digestBatchBytes(content []byte) string {
-	sum := sha256.Sum256(content)
-	return hex.EncodeToString(sum[:])
+	return sha256Hex(content)
 }
 
 func (s *Server) persistBatchManifest(receipt batchTransactionReceipt) error {

--- a/internal/mcp/mutation_evidence.go
+++ b/internal/mcp/mutation_evidence.go
@@ -1,0 +1,122 @@
+package mcp
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// errEvidenceDryRun refuses the one combination that cannot mean anything: a
+// dry run writes no bytes, so there is nothing on disk for a receipt to attest.
+const errEvidenceDryRun = "physical_evidence requires a real write; dry_run leaves no disk bytes to attest"
+
+// errEvidenceSecretIntent withholds a receipt whose before-digest would attest
+// a config file's secret-shaped values. read_file already requires explicit
+// intent to hash such a file; the mutation path must not become the way around
+// that check.
+const errEvidenceSecretIntent = "physical_evidence is withheld for a config file carrying secret-shaped values; " +
+	"read its digest with read_file{allow_secrets:true} if you genuinely need it"
+
+// Parameter blurbs are shared constants because the cold tools/list byte
+// ceiling is measured, and three copies of the same sentence is pure tax.
+const (
+	mutationEvidenceParamDescription = "Return a disk-verified receipt: before_sha256/after_sha256 re-read from disk " +
+		"after the write (not the buffer that was meant to be written), plus resolved path and byte count. Default: false."
+	evidenceDigestParamDescription = "Digest for physical_evidence. Only sha256 is supported; defaults to sha256."
+)
+
+// sha256Hex is the canonical physical-evidence digest: raw SHA-256 over the
+// exact byte buffer, lowercase hex. Deliberately NOT gitBlobSHA — that helper
+// is a git blob SHA-1 drift anchor with a length-prefixed header, and the two
+// must never be confused for each other on the wire.
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// parsePhysicalEvidenceRequest parses the shared physical_evidence / digest
+// contract. read_file and every single-file mutation handler go through this
+// one function so the surfaces cannot drift into accepting different digest
+// vocabularies, and so an option a handler does not implement fails loudly
+// instead of being silently dropped — a caller that asked for a receipt and got
+// an ordinary response back has no way to tell the difference otherwise.
+func parsePhysicalEvidenceRequest(req mcp.CallToolRequest) (bool, error) {
+	requested := req.GetBool("physical_evidence", false)
+	digest := strings.ToLower(strings.TrimSpace(req.GetString("digest", "")))
+	if digest != "" && !requested {
+		return false, errors.New("digest requires physical_evidence=true")
+	}
+	if requested && digest != "" && digest != "sha256" {
+		return false, fmt.Errorf("unsupported physical evidence digest %q; only sha256 is supported", digest)
+	}
+	return requested, nil
+}
+
+// guardMutationEvidenceIntent refuses a receipt that would publish a digest of
+// secret-shaped config values the caller never supplied.
+//
+// Only the pre-write content needs the gate. after_sha256 covers bytes the
+// caller itself authored, and new_sha already publishes an equivalent digest of
+// exactly those bytes, so gating it would buy nothing. before_sha256 is the
+// genuinely new capability: today base_sha can only confirm one guess per call,
+// whereas a published digest can be attacked offline.
+//
+// Runs before the write, so a refusal never leaves a mutated file behind.
+func (s *Server) guardMutationEvidenceIntent(language, relPath string, before []byte) error {
+	if _, wouldRedact := s.maybeRedactConfigLeaf(language, relPath, false, string(before)); wouldRedact {
+		return errors.New(errEvidenceSecretIntent)
+	}
+	return nil
+}
+
+// attachMutationPhysicalEvidence records a digest of the bytes that are on disk
+// after the write, read back through the same hardened helper read_file uses,
+// instead of a digest of the buffer the handler intended to write. That is the
+// whole distinction the receipt is claiming: new_sha is a prediction computed
+// before AtomicWriteFile, after_sha256 is an observation made after it.
+//
+// The write has already landed by the time this runs, so a failure here is
+// reported as evidence_error on an otherwise truthful success response, never
+// as a call failure — failing the call would invite a retry that applies the
+// same edit twice.
+func (s *Server) attachMutationPhysicalEvidence(resp map[string]any, absPath string, before []byte, beforeExisted bool) {
+	read := readPhysicalFileEvidence
+	if s.physicalEvidenceOverride != nil {
+		read = s.physicalEvidenceOverride
+	}
+	_, evidence, err := read(absPath)
+	if err == nil {
+		// Confinement is re-checked against the target that actually supplied
+		// the hashed bytes. resolveFilePath already confined absPath, but a
+		// symlink can be retargeted between that resolution and this read-back,
+		// and only a guard on the resolved target sees it. Same two guards, same
+		// order, as the read path — a new file-touching sink that skips them is
+		// exactly the shape of this project's two published advisories.
+		err = s.guardResolvedPathWithinRepo(absPath, evidence.resolvedPath)
+	}
+	if err == nil {
+		err = s.guardSymlinkWithinRepo(absPath)
+	}
+	if err != nil {
+		resp["evidence_error"] = err.Error()
+		return
+	}
+	if beforeExisted {
+		resp["before_sha256"] = sha256Hex(before)
+	} else {
+		resp["before_absent"] = true
+	}
+	resp["after_sha256"] = evidence.contentSHA256
+	resp["hash_algorithm"] = "sha256"
+	resp["hash_scope"] = "full_file"
+	resp["content_source"] = "disk"
+	resp["disk_verified"] = true
+	resp["resolved_path"] = evidence.resolvedPath
+	resp["byte_count"] = evidence.byteCount
+	resp["verified_at"] = evidence.readAt.Format(time.RFC3339Nano)
+}

--- a/internal/mcp/mutation_physical_evidence_test.go
+++ b/internal/mcp/mutation_physical_evidence_test.go
@@ -1,0 +1,352 @@
+package mcp
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// diskSHA256 hashes the file the way an operator would — an independent read,
+// not the buffer the handler happened to keep. Every assertion below compares
+// the receipt against this, so a receipt that merely echoes the handler's own
+// intent cannot pass.
+func diskSHA256(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:])
+}
+
+// The point of the receipt is that after_sha256 describes bytes on disk, so it
+// is checked against an independent read of the file rather than against the
+// content the call was given.
+func TestEditFilePhysicalEvidenceMatchesDiskAfterWrite(t *testing.T) {
+	srv, dir := setupTestServer(t)
+	target := filepath.Join(dir, "notes.txt")
+	original := []byte("alpha\nbeta\n")
+	require.NoError(t, os.WriteFile(target, original, 0o644))
+
+	beforeSum := sha256.Sum256(original)
+
+	result := callTool(t, srv, "edit_file", map[string]any{
+		"path": "notes.txt", "old_string": "beta", "new_string": "gamma",
+		"physical_evidence": true, "digest": "sha256",
+	})
+	require.False(t, result.IsError, toolResultText(result))
+	got := decodeFileOpsResult(t, result)
+
+	require.Equal(t, "applied", got["status"])
+	require.Equal(t, hex.EncodeToString(beforeSum[:]), got["before_sha256"])
+	require.Equal(t, diskSHA256(t, target), got["after_sha256"])
+	require.Equal(t, "sha256", got["hash_algorithm"])
+	require.Equal(t, "full_file", got["hash_scope"])
+	require.Equal(t, "disk", got["content_source"])
+	require.Equal(t, true, got["disk_verified"])
+	require.Equal(t, float64(len("alpha\ngamma\n")), got["byte_count"])
+	require.NotEmpty(t, got["resolved_path"])
+
+	_, err := time.Parse(time.RFC3339Nano, got["verified_at"].(string))
+	require.NoError(t, err)
+
+	// new_sha stays what it always was — a git blob SHA-1 of the proposed
+	// bytes — and must not be confused for the physical digest.
+	require.NotEqual(t, got["new_sha"], got["after_sha256"])
+	require.Len(t, got["new_sha"], 40)
+	require.Len(t, got["after_sha256"], 64)
+}
+
+// A create has no prior bytes, and the receipt must say so rather than omit
+// before_sha256 and leave the caller unable to tell "absent" from "not asked".
+func TestWriteFilePhysicalEvidenceOnCreateReportsBeforeAbsent(t *testing.T) {
+	srv, dir := setupTestServer(t)
+
+	result := callTool(t, srv, "write_file", map[string]any{
+		"path": "fresh.txt", "content": "brand new\n", "physical_evidence": true,
+	})
+	require.False(t, result.IsError, toolResultText(result))
+	got := decodeFileOpsResult(t, result)
+
+	require.Equal(t, "created", got["status"])
+	require.Equal(t, true, got["before_absent"])
+	require.NotContains(t, got, "before_sha256")
+	require.Equal(t, diskSHA256(t, filepath.Join(dir, "fresh.txt")), got["after_sha256"])
+}
+
+// Overwriting an existing file must attest the bytes that were replaced.
+func TestWriteFilePhysicalEvidenceOnOverwriteDigestsPriorBytes(t *testing.T) {
+	srv, dir := setupTestServer(t)
+	target := filepath.Join(dir, "doc.md")
+	original := []byte("# old\n")
+	require.NoError(t, os.WriteFile(target, original, 0o644))
+	beforeSum := sha256.Sum256(original)
+
+	result := callTool(t, srv, "write_file", map[string]any{
+		"path": "doc.md", "content": "# new\n", "physical_evidence": true,
+	})
+	require.False(t, result.IsError, toolResultText(result))
+	got := decodeFileOpsResult(t, result)
+
+	require.Equal(t, "overwritten", got["status"])
+	require.Equal(t, hex.EncodeToString(beforeSum[:]), got["before_sha256"])
+	require.Equal(t, diskSHA256(t, target), got["after_sha256"])
+}
+
+func TestEditSymbolPhysicalEvidenceMatchesDiskAfterWrite(t *testing.T) {
+	srv, dir := setupTestServer(t)
+	target := filepath.Join(dir, "main.go")
+	beforeSum := sha256.Sum256(func() []byte {
+		content, err := os.ReadFile(target)
+		require.NoError(t, err)
+		return content
+	}())
+
+	result := callTool(t, srv, "edit_symbol", map[string]any{
+		"id": "main.go::helper", "old_source": "func helper() {}",
+		"new_source": "func helper() { _ = 1 }", "physical_evidence": true,
+	})
+	require.False(t, result.IsError, toolResultText(result))
+	got := decodeFileOpsResult(t, result)
+
+	require.Equal(t, "applied", got["status"])
+	require.Equal(t, hex.EncodeToString(beforeSum[:]), got["before_sha256"])
+	require.Equal(t, diskSHA256(t, target), got["after_sha256"])
+}
+
+// Without the flag the response shape is exactly what it was before, so the
+// receipt cannot quietly become always-on.
+func TestMutationWithoutEvidenceFlagCarriesNoReceipt(t *testing.T) {
+	srv, dir := setupTestServer(t)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("alpha\n"), 0o644))
+
+	result := callTool(t, srv, "edit_file", map[string]any{
+		"path": "notes.txt", "old_string": "alpha", "new_string": "beta",
+	})
+	require.False(t, result.IsError, toolResultText(result))
+	got := decodeFileOpsResult(t, result)
+
+	for _, field := range []string{
+		"before_sha256", "after_sha256", "hash_algorithm", "hash_scope",
+		"content_source", "disk_verified", "resolved_path", "byte_count", "verified_at",
+	} {
+		require.NotContains(t, got, field)
+	}
+	require.NotEmpty(t, got["new_sha"])
+}
+
+// Every refusal below must also leave the file untouched: an option the handler
+// cannot honour has to be rejected before the atomic write, not after it.
+func TestMutationEvidenceRefusalsWriteNothing(t *testing.T) {
+	original := "alpha\nbeta\n"
+
+	for name, extra := range map[string]map[string]any{
+		"unsupported_digest":   {"physical_evidence": true, "digest": "md5"},
+		"digest_without_flag":  {"digest": "sha256"},
+		"dry_run_has_no_bytes": {"physical_evidence": true, "dry_run": true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			srv, dir := setupTestServer(t)
+			target := filepath.Join(dir, "notes.txt")
+			require.NoError(t, os.WriteFile(target, []byte(original), 0o644))
+
+			args := map[string]any{"path": "notes.txt", "old_string": "beta", "new_string": "gamma"}
+			for key, value := range extra {
+				args[key] = value
+			}
+			result := callTool(t, srv, "edit_file", args)
+
+			require.True(t, result.IsError, "an option the handler cannot honour must fail loudly, not be dropped")
+			content, err := os.ReadFile(target)
+			require.NoError(t, err)
+			require.Equal(t, original, string(content), "a refused call must not have written")
+		})
+	}
+}
+
+// write_file takes the same refusals, including on the create path where there
+// is no prior file to protect but still no receipt to issue.
+func TestWriteFileEvidenceRefusesDryRunAndBadDigest(t *testing.T) {
+	for name, extra := range map[string]map[string]any{
+		"unsupported_digest":  {"physical_evidence": true, "digest": "sha1"},
+		"digest_without_flag": {"digest": "sha256"},
+		"dry_run":             {"physical_evidence": true, "dry_run": true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			srv, dir := setupTestServer(t)
+			args := map[string]any{"path": "fresh.txt", "content": "x\n"}
+			for key, value := range extra {
+				args[key] = value
+			}
+			result := callTool(t, srv, "write_file", args)
+
+			require.True(t, result.IsError, toolResultText(result))
+			_, err := os.Stat(filepath.Join(dir, "fresh.txt"))
+			require.True(t, os.IsNotExist(err), "a refused write must not have created the file")
+		})
+	}
+}
+
+// before_sha256 is a digest of bytes the caller did not supply, so a secrets
+// file needs the same explicit intent read_file demands. The refusal has to
+// land before the write, or the gate would cost the caller their edit.
+func TestMutationEvidenceWithheldForSecretConfigLeaf(t *testing.T) {
+	srv, dir := setupTestServer(t)
+	secrets := "# local development environment\nPASSWORD=hunter2\nAPI_TOKEN=sk-live-abcdef\n"
+	target := filepath.Join(dir, ".env")
+	require.NoError(t, os.WriteFile(target, []byte(secrets), 0o600))
+
+	result := callTool(t, srv, "edit_file", map[string]any{
+		"path": ".env", "old_string": "hunter2", "new_string": "hunter3",
+		"physical_evidence": true,
+	})
+	require.True(t, result.IsError, "a secrets file must not yield a mutation receipt")
+
+	body := toolResultText(result)
+	sum := sha256.Sum256([]byte(secrets))
+	require.NotContains(t, body, hex.EncodeToString(sum[:]),
+		"the refusal must not carry the digest it refused to issue")
+
+	content, err := os.ReadFile(target)
+	require.NoError(t, err)
+	require.Equal(t, secrets, string(content), "the gate must refuse before the write, not after")
+}
+
+// The same edit without the receipt still works, so the gate is scoped to the
+// digest rather than blocking edits to config files.
+func TestSecretConfigLeafStillEditableWithoutEvidence(t *testing.T) {
+	srv, dir := setupTestServer(t)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".env"),
+		[]byte("PASSWORD=hunter2\n"), 0o600))
+
+	result := callTool(t, srv, "edit_file", map[string]any{
+		"path": ".env", "old_string": "hunter2", "new_string": "hunter3",
+	})
+	require.False(t, result.IsError, toolResultText(result))
+}
+
+// The post-write read-back is a second file-touching sink, and a symlink can be
+// retargeted between path resolution and that read. Hand back a resolution
+// outside every repo root — what a won race produces — and require the receipt
+// to be withheld. The write itself already landed, so the call must still
+// report success rather than invite a retry that edits twice.
+func TestMutationEvidenceRefusesOutOfRepoResolutionAfterWrite(t *testing.T) {
+	srv, dir := setupTestServer(t)
+	target := filepath.Join(dir, "notes.txt")
+	require.NoError(t, os.WriteFile(target, []byte("alpha\nbeta\n"), 0o644))
+
+	outside := filepath.Join(t.TempDir(), "outside.txt")
+	require.NoError(t, os.WriteFile(outside, []byte("outside"), 0o600))
+	resolvedOutside, err := filepath.EvalSymlinks(outside)
+	require.NoError(t, err)
+
+	srv.physicalEvidenceOverride = func(string) ([]byte, physicalReadEvidence, error) {
+		return []byte("outside"), physicalReadEvidence{
+			resolvedPath:  resolvedOutside,
+			contentSHA256: "0000000000000000000000000000000000000000000000000000000000000000",
+			byteCount:     len("outside"),
+			readAt:        time.Unix(0, 0).UTC(),
+		}, nil
+	}
+
+	result := callTool(t, srv, "edit_file", map[string]any{
+		"path": "notes.txt", "old_string": "beta", "new_string": "gamma",
+		"physical_evidence": true,
+	})
+	require.False(t, result.IsError, "the write landed; the call must report it truthfully")
+	got := decodeFileOpsResult(t, result)
+
+	require.Equal(t, "applied", got["status"])
+	require.Contains(t, got, "evidence_error")
+	require.Contains(t, got["evidence_error"], "outside every indexed repository root")
+	require.NotContains(t, got, "after_sha256")
+	require.NotContains(t, got, "resolved_path")
+	require.NotContains(t, got, "before_sha256")
+
+	// The edit itself is real and unaffected by the withheld receipt.
+	content, err := os.ReadFile(target)
+	require.NoError(t, err)
+	require.Equal(t, "alpha\ngamma\n", string(content))
+}
+
+// AtomicWriteFile writes exactly the buffer it is handed, so on a healthy run a
+// digest of that buffer and a digest of the file are identical — which means
+// the happy-path tests alone cannot tell the two apart, and a regression that
+// hashed the intended bytes would sail through them. Force the two to disagree:
+// the receipt must carry what the disk read-back reported, never a digest the
+// handler could have computed from its own buffer.
+func TestMutationEvidenceComesFromTheDiskReadBack(t *testing.T) {
+	srv, dir := setupTestServer(t)
+	target := filepath.Join(dir, "notes.txt")
+	require.NoError(t, os.WriteFile(target, []byte("alpha\nbeta\n"), 0o644))
+	resolvedTarget, err := filepath.EvalSymlinks(target)
+	require.NoError(t, err)
+
+	const sentinel = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+	srv.physicalEvidenceOverride = func(string) ([]byte, physicalReadEvidence, error) {
+		return []byte("whatever is really on disk"), physicalReadEvidence{
+			resolvedPath:  resolvedTarget,
+			contentSHA256: sentinel,
+			byteCount:     4242,
+			readAt:        time.Unix(0, 0).UTC(),
+		}, nil
+	}
+
+	result := callTool(t, srv, "edit_file", map[string]any{
+		"path": "notes.txt", "old_string": "beta", "new_string": "gamma",
+		"physical_evidence": true,
+	})
+	require.False(t, result.IsError, toolResultText(result))
+	got := decodeFileOpsResult(t, result)
+
+	require.Equal(t, sentinel, got["after_sha256"],
+		"after_sha256 must come from the disk read-back, not from the buffer the handler wrote")
+	require.Equal(t, float64(4242), got["byte_count"])
+	require.NotEqual(t, diskSHA256(t, target), got["after_sha256"])
+}
+
+// A read-back that cannot be completed at all is reported the same way: the
+// mutation stands, the receipt does not.
+func TestMutationEvidenceReportsReadBackFailure(t *testing.T) {
+	srv, dir := setupTestServer(t)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("alpha\nbeta\n"), 0o644))
+
+	srv.physicalEvidenceOverride = func(string) ([]byte, physicalReadEvidence, error) {
+		return nil, physicalReadEvidence{}, os.ErrPermission
+	}
+
+	result := callTool(t, srv, "edit_file", map[string]any{
+		"path": "notes.txt", "old_string": "beta", "new_string": "gamma",
+		"physical_evidence": true,
+	})
+	require.False(t, result.IsError, toolResultText(result))
+	got := decodeFileOpsResult(t, result)
+
+	require.Equal(t, "applied", got["status"])
+	require.Contains(t, got, "evidence_error")
+	require.NotContains(t, got, "after_sha256")
+}
+
+// The options have to reach the published schema, or an agent can only find
+// them by guessing.
+func TestMutationPhysicalEvidenceIsPublishedByFacadeSchema(t *testing.T) {
+	srv, _ := setupTestServer(t)
+
+	for _, operation := range []string{"file", "write", "symbol"} {
+		t.Run(operation, func(t *testing.T) {
+			spec, ok := srv.facades.operation("edit", operation)
+			require.True(t, ok, "edit.%s must be a registered facade operation", operation)
+			capability := srv.facadeCapability(spec, true)
+			schema := capability["input_schema"].(map[string]any)
+			properties := schema["properties"].(map[string]any)
+			options := properties["options"].(map[string]any)
+			fields := options["properties"].(map[string]any)
+			require.Contains(t, fields, "physical_evidence")
+			require.Contains(t, fields, "digest")
+		})
+	}
+}

--- a/internal/mcp/tools_coding.go
+++ b/internal/mcp/tools_coding.go
@@ -125,6 +125,8 @@ func (s *Server) registerCodingTools() {
 			mcp.WithString("new_source", mcp.Required(), mcp.Description("Replacement source fragment")),
 			mcp.WithString("base_sha", mcp.Description("Optional git blob SHA-1 the caller observed at read time. When set, the call refuses to write if the on-disk file's current SHA differs (drift guard against silent clobbers).")),
 			mcp.WithBoolean("dry_run", mcp.Description("Validate the edit and return a unified-diff preview without writing (status: would_apply). Use to review the change before committing it.")),
+			mcp.WithBoolean("physical_evidence", mcp.Description(mutationEvidenceParamDescription)),
+			mcp.WithString("digest", mcp.Description(evidenceDigestParamDescription)),
 		),
 		s.handleEditSymbol,
 	)
@@ -138,7 +140,7 @@ func (s *Server) registerCodingTools() {
 			mcp.WithBoolean("compress_bodies", mcp.Description("Replace function/method bodies with elided stubs (default: false)")),
 			mcp.WithBoolean("allow_secrets", mcp.Description("Serve secret-shaped values in config / data-leaf files (.env, *.yaml, *.toml, *.properties, ...) verbatim. By default such values are withheld and only their keys are shown. Default: false.")),
 			mcp.WithBoolean("physical_evidence", mcp.Description("Return disk evidence. Includes SHA-256, byte count, resolved path, provenance, and same-buffer status for the full regular file. The digest covers raw disk bytes before transforms or editor overlays. Default: false.")),
-			mcp.WithString("digest", mcp.Description("Select the digest. Only sha256 is supported; defaults to sha256 when physical_evidence=true.")),
+			mcp.WithString("digest", mcp.Description(evidenceDigestParamDescription)),
 			mcp.WithString("keep", mcp.Description("Comma-separated symbol names, IDs, or node kinds whose bodies stay verbatim when compress_bodies is set — every other body in the file is still stubbed. Ignored unless compress_bodies is true.")),
 			mcp.WithString("fidelity_globs", mcp.Description(fidelityGlobsParamDescription)),
 			mcp.WithNumber("max_lines", mcp.Description("When the file exceeds this many lines, collapse runs of leaf statements inside function bodies into `… N lines elided …` markers while keeping declarations and the control-flow skeleton. Falls back to a plain head cut for non-code files. Omit or 0 to disable.")),
@@ -159,6 +161,8 @@ func (s *Server) registerCodingTools() {
 			mcp.WithBoolean("dry_run", mcp.Description("Validate the replacement and report what would change without writing (default: false)")),
 			mcp.WithString("base_sha", mcp.Description("Optional git blob SHA-1 the caller observed at read time. When set, the call refuses to write if the on-disk file's current SHA differs (drift guard against silent clobbers).")),
 			mcp.WithBoolean("allow_parse_errors", mcp.Description("Bypass the pre-write parse gate. By default an edit that would introduce new tree-sitter parse errors (leaving the file more syntactically broken than before) is refused before the atomic write; set true to write anyway.")),
+			mcp.WithBoolean("physical_evidence", mcp.Description(mutationEvidenceParamDescription)),
+			mcp.WithString("digest", mcp.Description(evidenceDigestParamDescription)),
 		),
 		s.handleEditFile,
 	)
@@ -171,6 +175,8 @@ func (s *Server) registerCodingTools() {
 			mcp.WithBoolean("dry_run", mcp.Description("Report would_create / would_overwrite without writing (default: false)")),
 			mcp.WithString("base_sha", mcp.Description("Optional git blob SHA-1 the caller observed at read time. When set, write_file refuses to overwrite a divergent on-disk file (or write to a path the caller expected to exist but no longer does). Drift guard against silent clobbers on existing files; leave empty when creating a new file.")),
 			mcp.WithBoolean("allow_parse_errors", mcp.Description("Bypass the pre-write parse gate. By default a write that would introduce new tree-sitter parse errors (relative to the prior content, or any error in a brand-new file) is refused before the atomic write; set true to write anyway.")),
+			mcp.WithBoolean("physical_evidence", mcp.Description(mutationEvidenceParamDescription)),
+			mcp.WithString("digest", mcp.Description(evidenceDigestParamDescription)),
 		),
 		s.handleWriteFile,
 	)
@@ -2811,6 +2817,13 @@ func (s *Server) handleEditSymbol(ctx context.Context, req mcp.CallToolRequest) 
 	}
 	baseSHA := normalizeExpectedSHA(req.GetString("base_sha", ""))
 	dryRun := req.GetBool("dry_run", false)
+	evidenceRequested, evidenceErr := parsePhysicalEvidenceRequest(req)
+	if evidenceErr != nil {
+		return mcp.NewToolResultError(evidenceErr.Error()), nil
+	}
+	if evidenceRequested && dryRun {
+		return mcp.NewToolResultError(errEvidenceDryRun), nil
+	}
 
 	if oldSource == newSource {
 		return mcp.NewToolResultError("old_source and new_source are identical"), nil
@@ -2846,6 +2859,13 @@ func (s *Server) handleEditSymbol(ctx context.Context, req mcp.CallToolRequest) 
 	}
 	if baseSHA != "" && gitBlobSHA(content) != baseSHA {
 		return mcp.NewToolResultError(errBaseSHADrift), nil
+	}
+	// Before anything is written, so a withheld receipt never leaves a
+	// half-applied edit behind.
+	if evidenceRequested {
+		if err := s.guardMutationEvidenceIntent(s.detectLanguageForPath(ctx, absPath, node.FilePath), node.FilePath, content); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
 	}
 
 	fileStr := string(content)
@@ -2998,6 +3018,9 @@ func (s *Server) handleEditSymbol(ctx context.Context, req mcp.CallToolRequest) 
 		resp["reindex_error"] = reindexOutcome.Err.Error()
 	}
 	s.attachMutationFreshness(resp, node.FilePath, absPath, reindexOutcome)
+	if evidenceRequested {
+		s.attachMutationPhysicalEvidence(resp, absPath, content, true)
+	}
 	return s.respondJSONOrTOON(ctx, req, resp)
 }
 

--- a/internal/mcp/tools_fileops.go
+++ b/internal/mcp/tools_fileops.go
@@ -751,6 +751,13 @@ func (s *Server) handleEditFile(ctx context.Context, req mcp.CallToolRequest) (*
 	replaceAll := req.GetBool("replace_all", false)
 	dryRun := req.GetBool("dry_run", false)
 	baseSHA := normalizeExpectedSHA(req.GetString("base_sha", ""))
+	evidenceRequested, evidenceErr := parsePhysicalEvidenceRequest(req)
+	if evidenceErr != nil {
+		return mcp.NewToolResultError(evidenceErr.Error()), nil
+	}
+	if evidenceRequested && dryRun {
+		return mcp.NewToolResultError(errEvidenceDryRun), nil
+	}
 
 	absPath, relPath, resolveErr := s.resolveFilePath(rawPath)
 	if resolveErr != nil {
@@ -771,6 +778,13 @@ func (s *Server) handleEditFile(ctx context.Context, req mcp.CallToolRequest) (*
 	// overlay-push error shape so callers can re-read and retry.
 	if baseSHA != "" && gitBlobSHA(content) != baseSHA {
 		return mcp.NewToolResultError(errBaseSHADrift), nil
+	}
+	// Before anything is written, so a withheld receipt never leaves a
+	// half-applied edit behind.
+	if evidenceRequested {
+		if err := s.guardMutationEvidenceIntent(s.detectLanguageForPath(ctx, absPath, relPath), relPath, content); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
 	}
 	fileStr := string(content)
 
@@ -882,6 +896,9 @@ func (s *Server) handleEditFile(ctx context.Context, req mcp.CallToolRequest) (*
 		resp["reindex_error"] = reindexOutcome.Err.Error()
 	}
 	s.attachMutationFreshness(resp, relPath, absPath, reindexOutcome)
+	if evidenceRequested {
+		s.attachMutationPhysicalEvidence(resp, absPath, content, true)
+	}
 	return s.respondJSONOrTOON(ctx, req, resp)
 }
 
@@ -896,6 +913,13 @@ func (s *Server) handleWriteFile(ctx context.Context, req mcp.CallToolRequest) (
 	}
 	dryRun := req.GetBool("dry_run", false)
 	baseSHA := normalizeExpectedSHA(req.GetString("base_sha", ""))
+	evidenceRequested, evidenceErr := parsePhysicalEvidenceRequest(req)
+	if evidenceErr != nil {
+		return mcp.NewToolResultError(evidenceErr.Error()), nil
+	}
+	if evidenceRequested && dryRun {
+		return mcp.NewToolResultError(errEvidenceDryRun), nil
+	}
 
 	absPath, relPath, resolveErr := s.resolveFilePath(rawPath)
 	if resolveErr != nil {
@@ -939,13 +963,23 @@ func (s *Server) handleWriteFile(ctx context.Context, req mcp.CallToolRequest) (
 	contentBytes := []byte(content)
 	newSHA := gitBlobSHA(contentBytes)
 
+	// Read the prior bytes once: the parse gate compares against them, and an
+	// evidence receipt digests them as before_sha256.
+	var priorContent []byte
+	if fileExists {
+		priorContent, _ = os.ReadFile(absPath)
+	}
+	// Before anything is written, so a withheld receipt never leaves an
+	// overwritten file behind.
+	if evidenceRequested && fileExists {
+		if err := s.guardMutationEvidenceIntent(s.detectLanguageForPath(ctx, absPath, relPath), relPath, priorContent); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+	}
+
 	allowParseErrors := req.GetBool("allow_parse_errors", false)
 	var gate parseGateResult
 	if parseGateEnabled() {
-		var priorContent []byte
-		if fileExists {
-			priorContent, _ = os.ReadFile(absPath)
-		}
 		gate = checkParseGate(relPath, priorContent, contentBytes)
 		if gate.Blocked && !allowParseErrors && !dryRun {
 			return mcp.NewToolResultError(parseGateError(relPath, gate)), nil
@@ -1000,6 +1034,9 @@ func (s *Server) handleWriteFile(ctx context.Context, req mcp.CallToolRequest) (
 		resp["reindex_error"] = reindexOutcome.Err.Error()
 	}
 	s.attachMutationFreshness(resp, relPath, absPath, reindexOutcome)
+	if evidenceRequested {
+		s.attachMutationPhysicalEvidence(resp, absPath, priorContent, fileExists)
+	}
 	return s.respondJSONOrTOON(ctx, req, resp)
 }
 
@@ -1262,18 +1299,9 @@ func (s *Server) handleReadFile(ctx context.Context, req mcp.CallToolRequest) (*
 		return mcp.NewToolResultError(fmt.Sprintf("path %q is a directory", rawPath)), nil
 	}
 
-	physicalEvidenceRequested := req.GetBool("physical_evidence", false)
-	digest := strings.ToLower(strings.TrimSpace(req.GetString("digest", "")))
-	if digest != "" && !physicalEvidenceRequested {
-		return mcp.NewToolResultError("digest requires physical_evidence=true"), nil
-	}
-	if physicalEvidenceRequested {
-		if digest == "" {
-			digest = "sha256"
-		}
-		if digest != "sha256" {
-			return mcp.NewToolResultError(fmt.Sprintf("unsupported physical evidence digest %q; only sha256 is supported", digest)), nil
-		}
+	physicalEvidenceRequested, evidenceErr := parsePhysicalEvidenceRequest(req)
+	if evidenceErr != nil {
+		return mcp.NewToolResultError(evidenceErr.Error()), nil
 	}
 
 	var diskContent []byte

--- a/internal/mcp/tools_list_budget_test.go
+++ b/internal/mcp/tools_list_budget_test.go
@@ -53,7 +53,16 @@ const (
 // follow-up reader). Measured cost after the addition: 27883 bytes —
 // the ceiling keeps ~300 bytes of slack, so any further description
 // creep still fails loudly.
-const agentPresetByteCeiling = 28200
+//
+// Re-based 28200 → 28850 when edit_file and write_file gained the
+// physical_evidence / digest receipt options (the mutation half of the
+// disk-verified SHA-256 contract read_file already carries). The tool
+// count did not change; two options on two floor tools did. Measured
+// cost after the addition: 28527 bytes, keeping the same ~300 bytes of
+// slack. Note the blurbs are shared constants and the schema compactor
+// is not monotonic in description length — a shorter blurb measured
+// *larger* here (28551), so shrink by measuring, never by eyeballing.
+const agentPresetByteCeiling = 28850
 
 // localizationPresetByteCeiling is the hard budget for the diet
 // localization preset (the `localization` instruction profile's tool


### PR DESCRIPTION
Closes the mutation half of #545. The read half shipped in v0.63.4 (#554, #584); this is the other side of the same contract.

## The problem

`read_file` could already prove what was on disk. The mutation tools could not.

They returned `new_sha`, which is a **git blob SHA-1** (`sha1("blob <len>\0" + data)`, the value `git hash-object` prints) computed from the in-memory buffer **before** `AtomicWriteFile` runs. It is a pipelining token for the next call's `base_sha` — not evidence. `dry_run` returns one for bytes that were never written.

Worse, `physical_evidence` was **silently dropped** on the mutation path: passing it returned an ordinary response with no receipt and no error, so a caller had no way to tell it had been ignored. On the read path the same option fails loudly.

An agent needing to attest bytes therefore had to shell out to `sha256sum` / `Get-FileHash` and read back — slower, platform-specific, and a time-of-check/time-of-use gap.

## What this adds

`edit_file`, `write_file` and `edit_symbol` accept `physical_evidence: true` (plus optional `digest`, `sha256` only, also the default) and return:

```
before_sha256, after_sha256      # re-read from disk AFTER the write
hash_algorithm, hash_scope, content_source, disk_verified
resolved_path, byte_count, verified_at
```

A creating `write_file` reports `before_absent: true` instead of a before digest, so "no prior bytes" is distinguishable from "not requested".

## Security posture

Both of this repo's published advisories are the same mistake: **a file-touching sink that skips repo-root confinement** — the write path in CVE-2026-62964, and the indexer walk plus `search_text`'s trigram sink in GHSA-6vhf-4wcm-2r83. This PR adds a new sink (the post-write read-back), so it was built to that lesson:

- The read-back goes through `readPhysicalFileEvidence` — the same hardened helper `read_file` uses (non-regular files refused, `O_NONBLOCK` open, double-hash drift detection, restat).
- It then re-applies **both** confinement guards to the target that actually supplied the hashed bytes. `resolveFilePath` confined the path already, but a symlink can be retargeted between that resolution and the read-back, and only a post-read guard on the resolved target catches it. Deleting those two guards is mutation-tested, and the unguarded response is observed leaking a `resolved_path` outside every repo root.
- **No new secrets oracle.** `before_sha256` digests bytes the caller did not supply, and `base_sha` can only confirm one guess per call, so a `.env`-shaped config leaf is withheld exactly as `read_file` withholds it. `after_sha256` needs no gate — `new_sha` already publishes an equivalent digest of exactly those bytes. The edit itself still works; only the receipt is withheld.

## Never costs the caller their edit

The write has landed by the time the read-back runs. So everything refusable — unsupported digest, `digest` without the flag, `dry_run`, secret leaves — is refused **before** anything is written, and a failure in the read-back itself is reported as `evidence_error` on an otherwise truthful `applied` response rather than as a call failure. Failing the call would invite a retry that applies the same edit twice.

## Tests

21 tests, each mutation-checked rather than merely read:

| Mutation | Caught by |
|---|---|
| delete both post-write confinement guards | `RefusesOutOfRepoResolutionAfterWrite` |
| neuter the secret-intent gate | `WithheldForSecretConfigLeaf` |
| hash the intended buffer, not the read-back | `ComesFromTheDiskReadBack` + `MatchesDiskAfterWrite` |

`AtomicWriteFile` writes exactly the buffer it is handed, so a digest of that buffer and a digest of the file are identical on a healthy run — the happy-path tests alone cannot tell them apart. `ComesFromTheDiskReadBack` forces the two to disagree through the existing `physicalEvidenceOverride` seam, so a regression that hashed the intended bytes is caught. Every refusal test asserts the file is byte-identical afterwards.

`go test ./internal/mcp` green (77 s), `-race` green on the affected surface, `golangci-lint` 0 issues, `gofmt` clean on changed files.

## Docs

`new_sha`, `base_sha`, `content_sha256`, `before`/`after_sha256` and `etag` were used interchangeably while meaning five different things — two algorithms, three scopes, and the difference between observed-before and observed-after a write. `docs/mcp.md` gains a table keyed by what each field proves and when it was observed, plus the two that actually bite: `new_sha` is a pipelining token, and `etag` covers the JSON response, not the file.

## Notes for review

- **Byte ceiling re-based 28200 → 28850.** Two options on two agent-floor tools; measured 28527, keeping the same ~300 bytes of slack the previous re-base kept. Worth knowing: the schema compactor is **not monotonic** in description length — a *shorter* blurb measured *larger* (28551), so shrink by measuring, never by eyeballing. Noted in the constant's comment.
- **No `graph_reindexed` synonym.** #545 asks for one, but `reindexed` / `reindex_pending` / `reindex_generation` already answer it; a duplicate field would be noise.
- **Deliberately out of scope**, and stated in the docs: multi-file mutations (`rename_symbol`, `batch_edit`), plus `git_state`, `index_state` and `indexed_sha256`. `batch_edit`'s journal already carries its own `before_sha256` / `after_sha256`, computed from in-memory buffers for crash recovery — not a disk observation, and left alone here.
- `digestBatchBytes` folds into the shared `sha256Hex`, and `read_file` now shares the one option parser, so the read and mutation vocabularies cannot drift apart.
