### PR TITLE
diff: report deleted, renamed, and non-symbol file changes

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -325,7 +325,7 @@ Gortex captures every large tool response into a bounded per-session ring; these
 |------|-------------|
 | `get_communities` | Functional clusters (Louvain). Without `id`: list all. With `id`: members and cohesion for one community. Members and files are clamped to the session workspace; the partition is global, so a `repo`/`project`/`scope` narrowing is widened to the workspace and the response discloses it |
 | `get_processes` | Discovered execution flows. Without `id`: list all. With `id`: step-by-step trace. Clamped to the session workspace and narrowed further by `repo`/`project`/`scope` — out-of-scope steps are excised by subtree so the surviving chain keeps its real call shape |
-| `detect_changes` | Git diff mapped to affected symbols |
+| `detect_changes` | Git diff mapped to affected symbols, plus a file-level view (`changed_files` / `file_changes` with added/modified/deleted/renamed) that stays populated for changes carrying no indexed symbol. Untracked and ignored files are not observed — every scope reads `git diff`. |
 | `index_repository` | Index or re-index a repository path |
 | `reindex_repository` | Incrementally re-index a tracked repository — whole-root, or scoped to an optional `paths` subset. Multi-repo aware |
 | `contracts` | API contracts. `action: "list"` (default): detected HTTP/gRPC/GraphQL/topics/WebSocket/env/OpenAPI. `action: "check"`: orphan providers/consumers |

--- a/internal/analysis/diffmap.go
+++ b/internal/analysis/diffmap.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -14,10 +15,38 @@ import (
 )
 
 // DiffHunk represents a changed range in a file.
+//
+// StartLine/EndLine are new-side (post-change) line numbers, except when
+// Deleted is set: a deleted file has no new side at all, so its range is the
+// old-side span the file occupied before it was removed. That is the span
+// that joins the still-indexed pre-delete symbols.
 type DiffHunk struct {
 	FilePath  string `json:"file_path"`
 	StartLine int    `json:"start_line"`
 	EndLine   int    `json:"end_line"`
+	Deleted   bool   `json:"deleted,omitempty"`
+}
+
+// FileChangeKind classifies one file entry in a diff.
+type FileChangeKind string
+
+const (
+	FileAdded    FileChangeKind = "added"
+	FileModified FileChangeKind = "modified"
+	FileDeleted  FileChangeKind = "deleted"
+	FileRenamed  FileChangeKind = "renamed"
+)
+
+// FileChange is one file-level entry in a diff, carried independently of the
+// hunks. Two common change kinds carry no usable hunk at all — a deleted file
+// (new side is /dev/null) and a 100%-similar rename (no @@ header is emitted) —
+// so a hunk-only view of a diff reports them as no change whatsoever.
+// Path is the file's post-change path, or its pre-change path when the change
+// removed it; PreviousPath is set only for a rename.
+type FileChange struct {
+	Path         string         `json:"path"`
+	PreviousPath string         `json:"previous_path,omitempty"`
+	Kind         FileChangeKind `json:"change_kind"`
 }
 
 // ChangedSymbol is a symbol affected by a git diff hunk.
@@ -30,10 +59,16 @@ type ChangedSymbol struct {
 }
 
 // DiffResult is the output of git diff → symbol mapping.
+//
+// FileChanges is the file-granular view and is authoritative for *what* the
+// diff touched: ChangedSymbols is empty for any file the graph does not index
+// (docs, manifests, fixtures) and for deletes/renames the graph still indexes
+// under the old path, so an empty ChangedSymbols never means "nothing changed".
 type DiffResult struct {
 	Hunks          []DiffHunk      `json:"hunks"`
 	ChangedSymbols []ChangedSymbol `json:"changed_symbols"`
 	ChangedFiles   []string        `json:"changed_files"`
+	FileChanges    []FileChange    `json:"file_changes"`
 }
 
 // MapGitDiff parses git diff output and maps changed lines to symbols in the graph.
@@ -55,15 +90,15 @@ func MapGitDiff(g graph.Store, repoRoot, repoPrefix, scope, baseRef string) (*Di
 	// trim) so the parsed diff stays byte-identical to the pre-gitcmd output.
 	output, err := gitcmd.Run(ctx, repoRoot, args...)
 	if err != nil {
-		// If git diff returns empty, that's fine
-		if len(output) == 0 {
-			return &DiffResult{}, nil
-		}
+		// A failed `git diff` is not an empty diff. Swallowing the error
+		// whenever stdout happened to be empty is how an unknown base ref, a
+		// repo root that is not a work tree, or a git that never ran at all
+		// became a confident "no changes" answer.
 		return nil, fmt.Errorf("git diff failed: %w", err)
 	}
 
-	hunks := parseDiffHunks(string(output))
-	return joinHunksToSymbols(g, repoPrefix, hunks), nil
+	hunks, files := parseDiffFiles(string(output))
+	return joinHunksToSymbols(g, repoPrefix, hunks, files), nil
 }
 
 // JoinFileNodes maps one repo-relative changed-file path to the graph nodes
@@ -103,39 +138,64 @@ func JoinFilePath(g graph.Store, repoPrefix, path string) string {
 // hunk in its file, deduped, plus the changed-file set. ChangedFiles keeps
 // the diff-relative paths (callers re-join them with git pathspecs); only
 // the node lookup is prefix-aware.
-func joinHunksToSymbols(g graph.Store, repoPrefix string, hunks []DiffHunk) *DiffResult {
-	result := &DiffResult{Hunks: hunks}
+func joinHunksToSymbols(g graph.Store, repoPrefix string, hunks []DiffHunk, files []FileChange) *DiffResult {
+	result := &DiffResult{Hunks: hunks, FileChanges: files}
 
 	fileSet := make(map[string]bool)
 	symbolSeen := make(map[string]bool)
+
+	addSymbol := func(n *graph.Node) {
+		if n.Kind == graph.KindFile || symbolSeen[n.ID] {
+			return
+		}
+		symbolSeen[n.ID] = true
+		result.ChangedSymbols = append(result.ChangedSymbols, ChangedSymbol{
+			ID:       n.ID,
+			Name:     n.Name,
+			Kind:     string(n.Kind),
+			FilePath: n.FilePath,
+			Line:     n.StartLine,
+		})
+	}
 
 	for _, hunk := range hunks {
 		fileSet[hunk.FilePath] = true
 
 		// Find symbols whose line range overlaps the hunk
 		for _, n := range JoinFileNodes(g, repoPrefix, hunk.FilePath) {
-			if n.Kind == graph.KindFile {
-				continue
-			}
 			// Check if symbol's line range overlaps with the hunk
 			if n.StartLine <= hunk.EndLine && n.EndLine >= hunk.StartLine {
-				if !symbolSeen[n.ID] {
-					symbolSeen[n.ID] = true
-					result.ChangedSymbols = append(result.ChangedSymbols, ChangedSymbol{
-						ID:       n.ID,
-						Name:     n.Name,
-						Kind:     string(n.Kind),
-						FilePath: n.FilePath,
-						Line:     n.StartLine,
-					})
-				}
+				addSymbol(n)
 			}
+		}
+	}
+
+	// A file record reaches ChangedFiles even when it carried no hunk, which
+	// is how a delete of an empty file or a 100%-similar rename stays visible.
+	// Removing or moving a file affects every symbol the graph still indexes
+	// under its old path, and no line range in the diff describes that — so
+	// those symbols are taken whole rather than by overlap.
+	for _, fc := range files {
+		if fc.Path != "" {
+			fileSet[fc.Path] = true
+		}
+		vanished := fc.PreviousPath
+		if fc.Kind == FileDeleted {
+			vanished = fc.Path
+		}
+		if vanished == "" {
+			continue
+		}
+		fileSet[vanished] = true
+		for _, n := range JoinFileNodes(g, repoPrefix, vanished) {
+			addSymbol(n)
 		}
 	}
 
 	for f := range fileSet {
 		result.ChangedFiles = append(result.ChangedFiles, f)
 	}
+	sort.Strings(result.ChangedFiles)
 
 	return result
 }
@@ -320,50 +380,196 @@ func MapGitDiffWithLines(g graph.Store, repoRoot, repoPrefix, scope, baseRef str
 	// never dropped; gitcmd injects `-C repoRoot` for us.
 	output, err := gitcmd.Run(ctx, repoRoot, args...)
 	if err != nil {
-		if len(output) == 0 {
-			return &DiffResult{}, map[string][]HunkLine{}, nil
-		}
+		// See MapGitDiff: an error here means the diff was never observed,
+		// which is not the same answer as "the diff was empty".
 		return nil, nil, fmt.Errorf("git diff failed: %w", err)
 	}
 
 	text := string(output)
-	hunks := parseDiffHunks(text)
+	hunks, files := parseDiffFiles(text)
 	lines := parseDiffLines(text)
 
-	return joinHunksToSymbols(g, repoPrefix, hunks), lines, nil
+	return joinHunksToSymbols(g, repoPrefix, hunks, files), lines, nil
 }
 
+// parseDiffHunks returns only the changed line ranges. Callers that need to
+// know a file changed at all — including the deletes and renames that carry no
+// hunk — want parseDiffFiles instead.
 func parseDiffHunks(output string) []DiffHunk {
-	var hunks []DiffHunk
-	var currentFile string
-
-	scanner := bufio.NewScanner(strings.NewReader(output))
-	for scanner.Scan() {
-		line := scanner.Text()
-
-		// Detect file path from diff header
-		if strings.HasPrefix(line, "+++ b/") {
-			currentFile = strings.TrimPrefix(line, "+++ b/")
-			continue
-		}
-		if strings.HasPrefix(line, "+++ /dev/null") {
-			currentFile = ""
-			continue
-		}
-
-		// Parse @@ hunk header for the new file's line range
-		if strings.HasPrefix(line, "@@") && currentFile != "" {
-			hunk := parseHunkHeader(line, currentFile)
-			if hunk != nil {
-				hunks = append(hunks, *hunk)
-			}
-		}
-	}
-
+	hunks, _ := parseDiffFiles(output)
 	return hunks
 }
 
-func parseHunkHeader(line, filePath string) *DiffHunk {
+// fileDiffState accumulates the header facts parseDiffFiles has seen for the
+// diff entry it is currently inside.
+type fileDiffState struct {
+	oldPath string
+	newPath string
+	added   bool
+	deleted bool
+	renamed bool
+}
+
+// change projects the accumulated header facts onto a FileChange. Rename is
+// checked first: a rename carries both an old and a new path, and describing
+// it as a delete of one plus an add of the other loses the link between them.
+func (s fileDiffState) change() FileChange {
+	switch {
+	case s.renamed:
+		return FileChange{Path: s.newPath, PreviousPath: s.oldPath, Kind: FileRenamed}
+	case s.deleted:
+		return FileChange{Path: s.oldPath, Kind: FileDeleted}
+	case s.added:
+		return FileChange{Path: s.newPath, Kind: FileAdded}
+	default:
+		return FileChange{Path: s.newPath, Kind: FileModified}
+	}
+}
+
+// parseDiffFiles walks unified diff output and returns the changed line ranges
+// together with a file-level record for every entry in the diff — including
+// the entries that carry no hunk at all.
+//
+// Anchoring only on "+++ b/" and "@@" — the pre-fix parser — silently drops
+// two change kinds that are squarely inside every scope this package serves:
+//
+//   - a deleted file, whose new side is "+++ /dev/null", so clearing the
+//     current path there also skips the "@@" that follows it;
+//   - a 100%-similar rename, which git reports with "rename from"/"rename to"
+//     headers and no "@@" header whatsoever.
+//
+// Both produced zero hunks, so the file never reached ChangedFiles and its
+// symbols never reached ChangedSymbols: a delete-only or rename-only change
+// read as an empty diff. Deletes are therefore parsed off the old side and
+// renames off their rename headers.
+func parseDiffFiles(output string) ([]DiffHunk, []FileChange) {
+	var (
+		hunks   []DiffHunk
+		changes []FileChange
+		cur     fileDiffState
+		inEntry bool
+	)
+
+	flush := func() {
+		if !inEntry {
+			return
+		}
+		if change := cur.change(); change.Path != "" {
+			changes = append(changes, change)
+		}
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		switch {
+		case strings.HasPrefix(line, "diff --git "):
+			flush()
+			cur = fileDiffState{}
+			inEntry = true
+			// Only a same-path header parses unambiguously (see
+			// parseDiffGitPaths). Every other entry shape carries an
+			// explicit ---/+++ or rename header below, which overrides this.
+			cur.oldPath = parseDiffGitPaths(line)
+			cur.newPath = cur.oldPath
+			continue
+		case strings.HasPrefix(line, "deleted file mode "):
+			cur.deleted = true
+			continue
+		case strings.HasPrefix(line, "new file mode "):
+			cur.added = true
+			continue
+		case strings.HasPrefix(line, "rename from "):
+			cur.renamed = true
+			cur.oldPath = cleanDiffPath(strings.TrimPrefix(line, "rename from "))
+			continue
+		case strings.HasPrefix(line, "rename to "):
+			cur.renamed = true
+			cur.newPath = cleanDiffPath(strings.TrimPrefix(line, "rename to "))
+			continue
+		case strings.HasPrefix(line, "--- a/"):
+			cur.oldPath = cleanDiffPath(strings.TrimPrefix(line, "--- a/"))
+			continue
+		case strings.HasPrefix(line, "--- /dev/null"):
+			cur.added = true
+			continue
+		case strings.HasPrefix(line, "+++ b/"):
+			cur.newPath = cleanDiffPath(strings.TrimPrefix(line, "+++ b/"))
+			continue
+		case strings.HasPrefix(line, "+++ /dev/null"):
+			cur.deleted = true
+			continue
+		case !strings.HasPrefix(line, "@@"):
+			continue
+		}
+
+		// A deleted file has no new side, so its only line numbers are
+		// old-side — and they span exactly the lines the file used to hold,
+		// which is what joins the symbols the graph still indexes for it.
+		if cur.deleted && !cur.renamed {
+			if hunk := parseHunkHeader(line, cur.oldPath, "-"); hunk != nil {
+				hunk.Deleted = true
+				hunks = append(hunks, *hunk)
+			}
+			continue
+		}
+		if hunk := parseHunkHeader(line, cur.newPath, "+"); hunk != nil {
+			hunks = append(hunks, *hunk)
+		}
+	}
+	flush()
+
+	return hunks, changes
+}
+
+// cleanDiffPath normalizes a path lifted out of a diff header the same way
+// DiffHunk.FilePath and parseDiffLines do, so a hunk and its file record join.
+func cleanDiffPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	return filepath.Clean(path)
+}
+
+// parseDiffGitPaths recovers the path from a "diff --git a/P b/P" header. It is
+// the only path source for an entry that carries no ---/+++ and no rename
+// header — a mode-only change (chmod) is the common case.
+//
+// The header is ambiguous in general: git separates the two paths with a bare
+// space, which a path may itself contain. When both sides name the same file
+// the line is exactly "a/P b/P", so P is recoverable by length regardless of
+// its spaces. When they differ, the entry is a rename or a copy and carries
+// explicit rename headers, so this returns "" and lets those win.
+func parseDiffGitPaths(line string) string {
+	rest := strings.TrimPrefix(line, "diff --git ")
+	// Git quotes paths containing control or non-ASCII bytes; decoding that
+	// quoting here would be guesswork, and every quoted entry that matters
+	// also carries an explicit header below.
+	if !strings.HasPrefix(rest, "a/") || strings.Contains(rest, `"`) {
+		return ""
+	}
+	// len("a/") + len(P) + len(" ") + len("b/") + len(P)
+	pathLen := (len(rest) - 5) / 2
+	if pathLen <= 0 || len(rest) != 2*pathLen+5 {
+		return ""
+	}
+	old, next := rest[2:2+pathLen], rest[2+pathLen:]
+	if !strings.HasPrefix(next, " b/") || next[3:] != old {
+		return ""
+	}
+	return cleanDiffPath(old)
+}
+
+// parseHunkHeader reads one "@@ -old,count +new,count @@" header and returns
+// the range on the requested side ("+" for the new side, "-" for the old side
+// of a deleted file), attributed to filePath.
+func parseHunkHeader(line, filePath, side string) *DiffHunk {
+	if filePath == "" {
+		return nil
+	}
 	// Format: @@ -old,count +new,count @@
 	parts := strings.SplitN(line, "@@", 3)
 	if len(parts) < 2 {
@@ -373,8 +579,8 @@ func parseHunkHeader(line, filePath string) *DiffHunk {
 	fields := strings.Fields(ranges)
 
 	for _, f := range fields {
-		if strings.HasPrefix(f, "+") {
-			f = strings.TrimPrefix(f, "+")
+		if strings.HasPrefix(f, side) {
+			f = strings.TrimPrefix(f, side)
 			rangeP := strings.SplitN(f, ",", 2)
 			start, err := strconv.Atoi(rangeP[0])
 			if err != nil {

--- a/internal/analysis/diffmap_test.go
+++ b/internal/analysis/diffmap_test.go
@@ -5,6 +5,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -372,5 +374,358 @@ func TestMapGitDiffUnchanged(t *testing.T) {
 	}
 	if !sawFoo {
 		t.Fatalf("expected Foo among changed symbols: %#v", res.ChangedSymbols)
+	}
+}
+
+// --- file-level change detection (issue #546) ---------------------------------
+
+// newDeleteRepo commits gone.go (two symbols) plus a non-symbol README so the
+// delete/rename cases have both an indexed and an unindexed file to move.
+func newDeleteRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init")
+	run("config", "user.email", "t@t")
+	run("config", "user.name", "t")
+	run("config", "diff.mnemonicPrefix", "false")
+	run("config", "diff.noprefix", "false")
+
+	src := "package foo\n\nfunc Gone() int {\n\treturn 2\n}\n\nfunc AlsoGone() int {\n\treturn 3\n}\n"
+	if err := os.WriteFile(filepath.Join(dir, "gone.go"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# doc\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("commit", "-m", "base")
+	return dir
+}
+
+// deleteRepoGraph indexes the two symbols gone.go holds before the change.
+func deleteRepoGraph() *graph.Graph {
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID: "gone.go::Gone", Kind: graph.KindFunction, Name: "Gone",
+		FilePath: "gone.go", StartLine: 3, EndLine: 5, Language: "go",
+	})
+	g.AddNode(&graph.Node{
+		ID: "gone.go::AlsoGone", Kind: graph.KindFunction, Name: "AlsoGone",
+		FilePath: "gone.go", StartLine: 7, EndLine: 9, Language: "go",
+	})
+	return g
+}
+
+func gitIn(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func hasFile(files []string, want string) bool {
+	for _, f := range files {
+		if f == want {
+			return true
+		}
+	}
+	return false
+}
+
+func symbolIDs(syms []ChangedSymbol) []string {
+	out := make([]string, 0, len(syms))
+	for _, s := range syms {
+		out = append(out, s.ID)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func findFileChange(changes []FileChange, path string) (FileChange, bool) {
+	for _, c := range changes {
+		if c.Path == path {
+			return c, true
+		}
+	}
+	return FileChange{}, false
+}
+
+// TestMapGitDiffDeletedFile pins the headline defect of issue #546: a deleted
+// file's new side is /dev/null, so the pre-fix parser cleared the current path
+// and skipped the @@ header that followed. The delete produced no hunk, no
+// changed file and no changed symbol — a delete-only change was reported as a
+// clean tree in every scope.
+func TestMapGitDiffDeletedFile(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		stage  bool
+		scopes []string
+	}{
+		{name: "worktree", scopes: []string{"unstaged", "all"}},
+		{name: "staged", stage: true, scopes: []string{"staged", "all"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := newDeleteRepo(t)
+			if tc.stage {
+				gitIn(t, dir, "rm", "-q", "gone.go")
+			} else if err := os.Remove(filepath.Join(dir, "gone.go")); err != nil {
+				t.Fatal(err)
+			}
+
+			for _, scope := range tc.scopes {
+				res, err := MapGitDiff(deleteRepoGraph(), dir, "", scope, "main")
+				if err != nil {
+					t.Fatalf("MapGitDiff(%s): %v", scope, err)
+				}
+				if !hasFile(res.ChangedFiles, "gone.go") {
+					t.Fatalf("scope %s: deleted file missing from ChangedFiles: %#v", scope, res.ChangedFiles)
+				}
+				fc, ok := findFileChange(res.FileChanges, "gone.go")
+				if !ok || fc.Kind != FileDeleted {
+					t.Fatalf("scope %s: want a deleted FileChange for gone.go, got %#v", scope, res.FileChanges)
+				}
+				// Every symbol the graph still holds for the file is gone with it.
+				if got := symbolIDs(res.ChangedSymbols); len(got) != 2 ||
+					got[0] != "gone.go::AlsoGone" || got[1] != "gone.go::Gone" {
+					t.Fatalf("scope %s: want both deleted symbols, got %#v", scope, got)
+				}
+			}
+		})
+	}
+}
+
+// TestMapGitDiffDeletedFileHunkIsOldSide pins the line numbers a deleted file
+// reports. There is no new side to number, so the range must be the old-side
+// span the file occupied — that is what overlaps the still-indexed symbols —
+// and it must be flagged so a consumer never anchors it as a new-side line.
+func TestMapGitDiffDeletedFileHunkIsOldSide(t *testing.T) {
+	dir := newDeleteRepo(t)
+	if err := os.Remove(filepath.Join(dir, "gone.go")); err != nil {
+		t.Fatal(err)
+	}
+	res, err := MapGitDiff(deleteRepoGraph(), dir, "", "all", "main")
+	if err != nil {
+		t.Fatalf("MapGitDiff: %v", err)
+	}
+	var found bool
+	for _, h := range res.Hunks {
+		if h.FilePath != "gone.go" {
+			continue
+		}
+		found = true
+		if !h.Deleted {
+			t.Fatalf("deleted-file hunk must be flagged Deleted: %#v", h)
+		}
+		if h.StartLine != 1 || h.EndLine != 9 {
+			t.Fatalf("want the old-side span 1..9 the file occupied, got %d..%d", h.StartLine, h.EndLine)
+		}
+	}
+	if !found {
+		t.Fatalf("no hunk for the deleted file: %#v", res.Hunks)
+	}
+}
+
+// TestMapGitDiffDeletedEmptyFile covers the delete that carries no @@ header at
+// all: git emits only the "deleted file mode" header for an empty file. The
+// file-level record is the only thing that can keep it visible.
+func TestMapGitDiffDeletedEmptyFile(t *testing.T) {
+	dir := newDeleteRepo(t)
+	if err := os.WriteFile(filepath.Join(dir, "empty.txt"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitIn(t, dir, "add", ".")
+	gitIn(t, dir, "commit", "-m", "empty")
+	gitIn(t, dir, "rm", "-q", "empty.txt")
+
+	res, err := MapGitDiff(deleteRepoGraph(), dir, "", "all", "main")
+	if err != nil {
+		t.Fatalf("MapGitDiff: %v", err)
+	}
+	if !hasFile(res.ChangedFiles, "empty.txt") {
+		t.Fatalf("deleted empty file missing from ChangedFiles: %#v", res.ChangedFiles)
+	}
+	if fc, ok := findFileChange(res.FileChanges, "empty.txt"); !ok || fc.Kind != FileDeleted {
+		t.Fatalf("want a deleted FileChange for empty.txt, got %#v", res.FileChanges)
+	}
+}
+
+// TestMapGitDiffRename pins the second half of issue #546: a 100%-similar
+// rename carries rename from/to headers and no @@ header whatsoever, so a
+// hunk-driven parser reported a pure `git mv` as an empty diff. Both paths must
+// surface, linked, and the symbols indexed under the old path must come with it.
+func TestMapGitDiffRename(t *testing.T) {
+	for _, tc := range []struct{ name, edit string }{
+		{name: "pure"},
+		{name: "with_edits", edit: "package foo\n\nfunc Gone() int {\n\treturn 99\n}\n\nfunc AlsoGone() int {\n\treturn 3\n}\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := newDeleteRepo(t)
+			gitIn(t, dir, "mv", "gone.go", "moved.go")
+			if tc.edit != "" {
+				if err := os.WriteFile(filepath.Join(dir, "moved.go"), []byte(tc.edit), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			res, err := MapGitDiff(deleteRepoGraph(), dir, "", "all", "main")
+			if err != nil {
+				t.Fatalf("MapGitDiff: %v", err)
+			}
+			if !hasFile(res.ChangedFiles, "gone.go") || !hasFile(res.ChangedFiles, "moved.go") {
+				t.Fatalf("a rename changes both paths, got ChangedFiles %#v", res.ChangedFiles)
+			}
+			fc, ok := findFileChange(res.FileChanges, "moved.go")
+			if !ok || fc.Kind != FileRenamed || fc.PreviousPath != "gone.go" {
+				t.Fatalf("want moved.go renamed from gone.go, got %#v", res.FileChanges)
+			}
+			// The graph still indexes the symbols under the old path; moving
+			// the file affects every one of them, and no line range says so.
+			if got := symbolIDs(res.ChangedSymbols); len(got) != 2 ||
+				got[0] != "gone.go::AlsoGone" || got[1] != "gone.go::Gone" {
+				t.Fatalf("want both moved symbols, got %#v", got)
+			}
+		})
+	}
+}
+
+// TestMapGitDiffFileChangeKinds pins the remaining kinds, including the
+// non-symbol files issue #546 calls out: a changed manifest or doc has no
+// indexed symbol, so the file-level record is the only evidence it changed.
+func TestMapGitDiffFileChangeKinds(t *testing.T) {
+	dir := newDeleteRepo(t)
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# doc\nmore\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "added.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitIn(t, dir, "add", ".")
+
+	res, err := MapGitDiff(deleteRepoGraph(), dir, "", "all", "main")
+	if err != nil {
+		t.Fatalf("MapGitDiff: %v", err)
+	}
+	for path, want := range map[string]FileChangeKind{
+		"README.md":  FileModified,
+		"added.json": FileAdded,
+	} {
+		fc, ok := findFileChange(res.FileChanges, path)
+		if !ok || fc.Kind != want {
+			t.Fatalf("want %s classified %q, got %#v", path, want, res.FileChanges)
+		}
+		if !hasFile(res.ChangedFiles, path) {
+			t.Fatalf("%s missing from ChangedFiles: %#v", path, res.ChangedFiles)
+		}
+	}
+	if len(res.ChangedSymbols) != 0 {
+		t.Fatalf("neither file holds an indexed symbol, got %#v", res.ChangedSymbols)
+	}
+}
+
+// TestMapGitDiffModeOnlyChange covers the entry that carries no ---/+++ and no
+// rename header: chmod. The "diff --git a/P b/P" line is its only path source.
+func TestMapGitDiffModeOnlyChange(t *testing.T) {
+	dir := newDeleteRepo(t)
+	if err := os.Chmod(filepath.Join(dir, "README.md"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Skip on a filesystem git cannot see the mode bit through — but decide
+	// that from git itself, so the skip can never stand in for a real miss.
+	cmd := exec.Command("git", "diff", "--name-only", "HEAD")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git diff --name-only: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "README.md") {
+		t.Skipf("git does not report the mode change on this filesystem: %q", out)
+	}
+
+	res, err := MapGitDiff(deleteRepoGraph(), dir, "", "all", "main")
+	if err != nil {
+		t.Fatalf("MapGitDiff: %v", err)
+	}
+	if !hasFile(res.ChangedFiles, "README.md") {
+		t.Fatalf("mode-only change missing from ChangedFiles: %#v", res.ChangedFiles)
+	}
+	if fc, ok := findFileChange(res.FileChanges, "README.md"); !ok || fc.Kind != FileModified {
+		t.Fatalf("want README.md modified, got %#v", res.FileChanges)
+	}
+}
+
+// TestParseDiffGitPaths pins the same-path recovery, including a path with a
+// space, and the deliberate refusal to guess when the two sides differ.
+func TestParseDiffGitPaths(t *testing.T) {
+	for _, tc := range []struct{ line, want string }{
+		{"diff --git a/pkg/foo.go b/pkg/foo.go", "pkg/foo.go"},
+		{"diff --git a/my dir/foo.go b/my dir/foo.go", "my dir/foo.go"},
+		// Differing sides are a rename or a copy; the rename headers below
+		// carry the truth, so guessing a split here would only be wrong.
+		{"diff --git a/old.go b/new.go", ""},
+		{`diff --git "a/od\td.go" "b/od\td.go"`, ""},
+		{"diff --git nonsense", ""},
+	} {
+		if got := parseDiffGitPaths(tc.line); got != tc.want {
+			t.Fatalf("parseDiffGitPaths(%q) = %q, want %q", tc.line, got, tc.want)
+		}
+	}
+}
+
+// TestMapGitDiffSurfacesGitFailure pins the third defect: MapGitDiff used to
+// discard the error whenever stdout happened to be empty, so an unknown base
+// ref or a root that is not a work tree returned a clean, confident "no
+// changes" result. Both must now fail loudly.
+func TestMapGitDiffSurfacesGitFailure(t *testing.T) {
+	t.Run("unknown_base_ref", func(t *testing.T) {
+		dir := newDeleteRepo(t)
+		if _, err := MapGitDiff(deleteRepoGraph(), dir, "", "compare", "no-such-branch"); err == nil {
+			t.Fatal("an unknown base ref must not be reported as an empty diff")
+		}
+	})
+	t.Run("not_a_work_tree", func(t *testing.T) {
+		if _, err := MapGitDiff(deleteRepoGraph(), t.TempDir(), "", "unstaged", "main"); err == nil {
+			t.Fatal("a root that is not a git work tree must not be reported as an empty diff")
+		}
+	})
+	t.Run("with_lines", func(t *testing.T) {
+		if _, _, err := MapGitDiffWithLines(deleteRepoGraph(), t.TempDir(), "", "unstaged", "main"); err == nil {
+			t.Fatal("MapGitDiffWithLines must surface the same failure")
+		}
+	})
+}
+
+// TestMapGitDiffUntrackedStaysUnobserved pins the documented limitation rather
+// than a defect: `git diff` never lists untracked files, so no scope can see
+// them. detect_changes says so in its response note; this keeps the two honest
+// with each other, and keeps the fix above from silently growing an
+// ignored-tree walk (issue #324).
+func TestMapGitDiffUntrackedStaysUnobserved(t *testing.T) {
+	dir := newDeleteRepo(t)
+	if err := os.WriteFile(filepath.Join(dir, "new.go"), []byte("package foo\n\nfunc New() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res, err := MapGitDiff(deleteRepoGraph(), dir, "", "all", "main")
+	if err != nil {
+		t.Fatalf("MapGitDiff: %v", err)
+	}
+	if hasFile(res.ChangedFiles, "new.go") {
+		t.Fatalf("git diff cannot observe untracked files; ChangedFiles = %#v", res.ChangedFiles)
 	}
 }

--- a/internal/mcp/overlay_e2e_test.go
+++ b/internal/mcp/overlay_e2e_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -45,6 +46,11 @@ func Caller() {
 	Target()
 }
 `), 0o644))
+	// A committed, clean work tree. These tests only ever want an empty diff
+	// from the fixture, and before MapGitDiff stopped swallowing failures they
+	// got one by accident: git refused to diff a directory that was not a repo
+	// at all, and the error was returned as "no changes".
+	initCleanGitRepo(t, dir)
 
 	g := graph.New()
 	reg := testRegistry()
@@ -59,6 +65,30 @@ func Caller() {
 	srv.SetOverlayManager(daemon.NewOverlayManager(time.Minute))
 	srv.RunAnalysis()
 	return srv, dir, targetFile, callerFile
+}
+
+// initCleanGitRepo turns dir into a git work tree whose HEAD holds everything
+// already written there, so every diff scope reports a genuinely empty diff.
+func initCleanGitRepo(t *testing.T, dir string) {
+	t.Helper()
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-b", "main")
+	run("config", "user.email", "t@t")
+	run("config", "user.name", "t")
+	run("config", "diff.mnemonicPrefix", "false")
+	run("config", "diff.noprefix", "false")
+	run("add", ".")
+	run("commit", "-m", "base")
 }
 
 func callToolByName(t *testing.T, srv *Server, ctx context.Context, name string, args map[string]any) *mcplib.CallToolResult {

--- a/internal/mcp/tools_analysis.go
+++ b/internal/mcp/tools_analysis.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -40,7 +41,7 @@ func (s *Server) registerAnalysisTools() {
 
 	s.addTool(
 		mcp.NewTool("detect_changes",
-			mcp.WithDescription("Maps uncommitted git changes to symbols in the graph and runs blast radius analysis. The key pre-commit review tool."),
+			mcp.WithDescription("Maps uncommitted git changes to symbols in the graph and runs blast radius analysis. The key pre-commit review tool. changed_files and file_changes are the file-granular view (added/modified/deleted/renamed) and stay populated for changes that carry no indexed symbol, so an empty changed_symbols never means 'nothing changed'. Untracked and ignored files are not observed — every scope reads `git diff`."),
 			mcp.WithString("scope", mcp.Description("unstaged (default), staged, all, or compare")),
 			mcp.WithString("base_ref", mcp.Description("Branch/commit for compare scope (default: main)")),
 			mcp.WithString("repo", mcp.Description("Repository prefix or path (multi-repo mode); defaults to the lone tracked repo or the session's cwd-bound repo")),
@@ -303,6 +304,22 @@ func uniqueRepoPrefixesFromSteps(steps []analysis.Step) []string {
 	return out
 }
 
+// detectUnobservedNote names what `git diff` cannot see, so a caller reading an
+// empty or short result knows which changes this tool never had a chance to
+// report rather than concluding the working tree is clean.
+const detectUnobservedNote = "untracked and ignored files are not observed: every scope reads `git diff`, which lists tracked files only"
+
+// detectEmptySymbolSummary distinguishes the two causes of an empty symbol set.
+// Files that carry no indexed symbol — docs, manifests, fixtures — and files
+// deleted or moved wholesale are real changes with a real blast radius, and
+// reporting them with the same sentence as a clean tree hides them.
+func detectEmptySymbolSummary(changedFiles int) string {
+	if changedFiles == 0 {
+		return "no changes detected in tracked files"
+	}
+	return fmt.Sprintf("%d changed file(s), none mapping to indexed symbols — see changed_files and file_changes", changedFiles)
+}
+
 func (s *Server) handleDetectChanges(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	scope := req.GetString("scope", "unstaged")
 	baseRef := req.GetString("base_ref", "main")
@@ -323,12 +340,29 @@ func (s *Server) handleDetectChanges(ctx context.Context, req mcp.CallToolReques
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
+	changedFiles := diff.ChangedFiles
+	if changedFiles == nil {
+		// Never answer with a null file list: a caller cannot tell a null
+		// apart from "the field was omitted", and this branch is exactly
+		// where that reads as "nothing changed".
+		changedFiles = []string{}
+	}
+	fileChanges := diff.FileChanges
+	if fileChanges == nil {
+		fileChanges = []analysis.FileChange{}
+	}
+
 	if len(diff.ChangedSymbols) == 0 {
 		return s.respondJSONOrTOON(ctx, req, map[string]any{
 			"changed_symbols": []any{},
-			"changed_files":   diff.ChangedFiles,
+			"changed_files":   changedFiles,
+			"file_changes":    fileChanges,
 			"risk":            "NONE",
-			"summary":         "no indexed symbols affected by current changes",
+			// An empty symbol set has two very different causes, and calling
+			// both of them "no changes" is what makes a delete-only or
+			// docs-only change look like a clean tree.
+			"summary": detectEmptySymbolSummary(len(changedFiles)),
+			"note":    detectUnobservedNote,
 			// Echo the resolved scope so a caller can name the tree it got
 			// answered about. diffRepoScope prefers an explicit selector, then
 			// the lone tracked repo, then the session cwd — so the caller
@@ -349,7 +383,8 @@ func (s *Server) handleDetectChanges(ctx context.Context, req mcp.CallToolReques
 
 	detectResult := map[string]any{
 		"changed_symbols":      diff.ChangedSymbols,
-		"changed_files":        diff.ChangedFiles,
+		"changed_files":        changedFiles,
+		"file_changes":         fileChanges,
 		"risk":                 impact.Risk,
 		"summary":              impact.Summary,
 		"by_depth":             impact.ByDepth,


### PR DESCRIPTION
Closes #546.

Issue #546 asks for a path-scoped `detect`. Investigating it surfaced three defects in the diff path that already exists, all reproduced against real `git` output. This PR fixes those; the `scope: "paths"` / `include_ignored` API the issue requests is separate work and is **not** included.

## 1. Deleted files were invisible

`parseDiffHunks` anchored on `+++ b/` and `@@`. Git writes `+++ /dev/null` for a deleted file, and the parser cleared the current path there — which also skipped the `@@` header that follows. The file produced no hunk, so it reached neither `changed_files` nor `changed_symbols`, in every scope.

| Action | hunks | changed_files | changed_symbols |
|---|---|---|---|
| `rm gone.go` | 0 | `nil` | `nil` |
| `git rm gone.go` | 0 | `nil` | `nil` |

Deleting a tracked file is an uncommitted change to a tracked file — squarely inside what these scopes advertise.

## 2. Renames were invisible

A 100%-similar `git mv` carries `rename from` / `rename to` headers and no `@@` header at all, so a hunk-driven parser saw nothing. A rename *with* edits reported only the new path and silently dropped the old path and its symbols.

## 3. Git failures were reported as "no changes"

```go
if err != nil {
    if len(output) == 0 {
        return &DiffResult{}, nil   // error discarded
    }
    ...
}
```

An unknown base ref under `scope=compare`, and a root that is not a work tree, both returned `err == nil` with an empty result.

## Why it matters beyond `detect`

`MapGitDiff` has 14 non-test call sites — `change_contract`, `review`, `pr_risk`, `suggest_reviewers`, `pr_review_context`, `critique_review`, `review_post`, `review_questions`, `prompts`, `review/flow.go`. A PR that only deletes or renames files reviewed as an empty diff, so guards, tests and contract checks all passed on an empty input set.

## What changed

- Deletes are parsed off the old side — the only line numbers such an entry carries, and the span that joins the symbols the graph still indexes. `DiffHunk.Deleted` flags the range as old-side so nothing anchors it as a new-side line.
- Renames are parsed off their rename headers; both paths surface, linked.
- `DiffResult.FileChanges` is a file-granular view (`added` / `modified` / `deleted` / `renamed`, with `previous_path`). It keeps files that carry no indexed symbol — docs, manifests, fixtures — visible, and covers entries with no hunk at all (a deleted empty file, a pure rename, a mode-only `chmod`).
- Removing or moving a file marks every symbol the graph still holds under its old path; no line range in a diff expresses that.
- A failed `git diff` is reported instead of discarded.
- `detect_changes` never answers with a null `changed_files`; the summary distinguishes a clean tree from files that carry no indexed symbol, and the response names what `git diff` structurally cannot see.

## Deliberately unchanged

Untracked and ignored files stay unobserved — `git diff` never lists them. That limitation is now pinned by a test and stated in the response, so it cannot be misread as a clean tree. **Nothing here walks an ignored tree**, so #324 does not regress.

## Verification

Every new test was run against the literal pre-fix parser and fails there:

```
--- FAIL: TestMapGitDiffDeletedFile/worktree
--- FAIL: TestMapGitDiffDeletedFile/staged
--- FAIL: TestMapGitDiffDeletedFileHunkIsOldSide
--- FAIL: TestMapGitDiffDeletedEmptyFile
--- FAIL: TestMapGitDiffRename/pure
--- FAIL: TestMapGitDiffRename/with_edits
--- FAIL: TestMapGitDiffFileChangeKinds
--- FAIL: TestMapGitDiffSurfacesGitFailure/{unknown_base_ref,not_a_work_tree,with_lines}
--- FAIL: TestDetectChanges_EmptyResultIsUnambiguous
```

`go build ./...`, `go test ./...` (145 packages), and `golangci-lint run` on the touched packages are clean. One unrelated `internal/graph` failure in the shared checkout came from a stale `.claude/worktrees/` copy and does not reproduce here.

One existing test needed a real fixture: the overlay server's temp dir was never a git repo, so its "empty diff" was the swallowed error. It is now a committed, clean work tree.
