### PR TITLE
fix(release): re-sign checksums.txt after the windows job appends to it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -672,6 +672,88 @@ jobs:
             echo "published scoop manifest ${VER} -> $dest"
           fi
 
+  # Release-wide signature gate. checksums.txt is assembled across three
+  # jobs (goreleaser, then darwin, then windows) and signed along the way,
+  # so any step that rewrites a file after it was signed silently ships a
+  # release whose signature verifies against nothing — which is exactly
+  # what v0.35.3 through v0.63.5 did (issue #625). Neither the signing
+  # steps nor a unit test can catch that; only re-downloading the release
+  # and verifying the PUBLISHED bytes, after every job that can touch them,
+  # can. Runs last and fails the release rather than shipping a bad pair.
+  verify-signatures:
+    needs: [release, release-windows]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v2.4.1
+
+      - name: Verify every published signature against its published artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF#refs/tags/}"
+          mkdir -p verify
+          cd verify
+          gh release download "$TAG" --clobber
+
+          shopt -s nullglob
+          # Keyless certs live ~10 minutes, so verify-blob resolves the
+          # signing time from the Rekor transparency log. That is a network
+          # call against a shared service — retry it a couple of times so a
+          # transient Rekor hiccup can't fail an otherwise good release,
+          # while a genuine mismatch (which fails deterministically) still
+          # stops it.
+          verify_blob() {
+            for attempt in 1 2 3; do
+              if cosign verify-blob \
+                   --certificate "$2" \
+                   --signature "$3" \
+                   --certificate-identity "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release.yml@${GITHUB_REF}" \
+                   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+                   "$1" >/dev/null 2>&1; then
+                return 0
+              fi
+              if [ "$attempt" -lt 3 ]; then sleep 10; fi
+            done
+            return 1
+          }
+
+          failed=0
+          checked=0
+          for sig in *.sig; do
+            checked=$((checked + 1))
+            artifact="${sig%.sig}"
+            cert="${artifact}.pem"
+            if [ ! -f "$artifact" ]; then
+              echo "FAIL: $sig has no matching artifact ($artifact)"; failed=1; continue
+            fi
+            if [ ! -f "$cert" ]; then
+              echo "FAIL: $artifact has no matching certificate ($cert)"; failed=1; continue
+            fi
+            if verify_blob "$artifact" "$cert" "$sig"; then
+              echo "ok: $artifact"
+            else
+              echo "FAIL: $sig does not verify against the published $artifact"; failed=1
+            fi
+          done
+
+          [ "$checked" -gt 0 ] || { echo "FATAL: release $TAG published no signatures"; exit 1; }
+
+          # Every primary artifact must be signed AND listed in checksums.txt —
+          # the two verification paths consumers actually use. A tarball that
+          # slipped past one of them is as broken as a bad signature.
+          for artifact in *.tar.gz *.zip *.deb *.rpm *.apk; do
+            [ -f "${artifact}.sig" ] || { echo "FAIL: $artifact has no signature"; failed=1; }
+            grep -q " ${artifact}$" checksums.txt || { echo "FAIL: $artifact is missing from checksums.txt"; failed=1; }
+          done
+
+          [ "$failed" -eq 0 ] || { echo "release $TAG has unverifiable assets"; exit 1; }
+          echo "all $checked published signatures verify against their artifacts"
+
   # SLSA-3 provenance via the OpenSSF reusable workflow. This runs in a
   # separate, isolated job that the `release` job can't tamper with —
   # that isolation is what elevates us from SLSA-2 to SLSA-3. Output is

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,9 +308,10 @@ jobs:
 
       # goreleaser's checksums.txt only hashed its own (linux + nfpm)
       # artifacts. Append the darwin tarballs so install.sh — which verifies
-      # every download against checksums.txt — and the cask both resolve. Done
-      # before cosign so the signature covers the final checksums.txt. (The
-      # release-windows job appends the windows zip the same way.)
+      # every download against checksums.txt — and the cask both resolve.
+      # Done before cosign, but the signature produced there is NOT the final
+      # one: release-windows appends the windows zip afterwards and re-signs.
+      # Whichever job writes checksums.txt last owns its signature.
       - name: Append darwin checksums
         run: |
           set -euo pipefail
@@ -576,13 +577,39 @@ jobs:
           # the one-line installer (scripts/install.ps1, which verifies
           # against checksums.txt) covers windows too — the unix goreleaser
           # run only hashed its own artifacts. needs:release guarantees
-          # checksums.txt already exists.
+          # checksums.txt already exists, so a failed download is a real
+          # error and must stop the job: falling back to an empty file would
+          # make the --clobber below replace the release's checksums.txt with
+          # a windows-only one, breaking sha256 verification on every other
+          # platform.
           sha="$(sha256sum gortex_windows_amd64.zip | awk '{print $1}')"
-          gh release download "$TAG" --pattern checksums.txt --clobber 2>/dev/null || : > checksums.txt
-          if ! grep -q "gortex_windows_amd64.zip" checksums.txt; then
-            printf '%s  gortex_windows_amd64.zip\n' "$sha" >> checksums.txt
-            gh release upload "$TAG" checksums.txt --clobber
-          fi
+          gh release download "$TAG" --pattern checksums.txt --clobber \
+            || { echo "FATAL: could not download checksums.txt from $TAG"; exit 1; }
+          [ -s checksums.txt ] || { echo "FATAL: downloaded checksums.txt is empty"; exit 1; }
+          grep -q " gortex_windows_amd64.zip$" checksums.txt \
+            || printf '%s  gortex_windows_amd64.zip\n' "$sha" >> checksums.txt
+          sort -o checksums.txt checksums.txt
+
+          # This job is the LAST writer of checksums.txt, so it must also be
+          # the one that signs it. The `release` job signed the file it knew
+          # about (linux + darwin); appending the windows line above
+          # invalidates that signature, so re-sign the final content and
+          # clobber all three assets together. Skipping this shipped a
+          # checksums.txt.sig that verified against nothing on every release
+          # from v0.35.3 to v0.63.5 (issue #625). Keyless signing here yields
+          # the same certificate identity as the `release` job — same
+          # workflow ref, same tag — so the documented verification command
+          # is unchanged.
+          cosign sign-blob \
+            --output-signature checksums.txt.sig \
+            --output-certificate checksums.txt.pem \
+            checksums.txt
+          gh release upload "$TAG" \
+            checksums.txt \
+            checksums.txt.sig \
+            checksums.txt.pem \
+            --clobber
+          cat checksums.txt
 
       - name: Publish Scoop manifest
         # Push a refreshed `gortex` manifest to gortexhq/scoop-bucket so


### PR DESCRIPTION
Closes #625.

## The bug

`checksums.txt.sig` has never verified against `checksums.txt` on any release since **v0.35.3**. The per-artifact signatures are fine — only the checksums file is affected.

The `release` job builds the checksums file and signs it:

| step | effect |
|---|---|
| Append darwin checksums | adds the darwin tarball hashes, then `sort` |
| Sign release artifacts with cosign | produces `checksums.txt.sig` / `.pem` |
| Upload … | publishes the file and its signature |

At that point the pair is consistent. Then `release-windows` (`needs: release`) runs and mutates the already-signed file:

```
gh release download "$TAG" --pattern checksums.txt ...   # pull the signed file back
printf '%s  gortex_windows_amd64.zip\n' "$sha" >> checksums.txt
gh release upload "$TAG" checksums.txt --clobber          # overwrite the release asset
```

It never re-runs `cosign sign-blob`, so the published `.sig` still covers the pre-windows content.

### Evidence

The published v0.63.4 file has a visible tell — lines 1–10 are sorted, and the windows line sits out of sort order at the end, i.e. appended after `sort` ran. Verifying with the published certificate:

```
published checksums.txt            -> Verification failure
same file minus the windows line   -> Verified OK
```

Confirmed on v0.63.5 (latest), v0.63.4 (reported) and v0.35.3 (first affected). v0.35.2, which predates the change, verifies OK as published. Introduced by 39e9e43d.

### Impact

Not a security exposure. Per-artifact signatures are genuine, and `scripts/install.sh` cosign-verifies the **artifact's own** `.sig`/`.pem`, never the checksums signature — so installs were unaffected. What breaks is the conventional "verify `checksums.txt`, then check everything against it" gate, which fails closed on a good release.

## The fix

**1. The last writer of `checksums.txt` also signs it.** `release-windows` now appends, sorts, re-signs, and clobbers the file together with its `.sig` and `.pem`. Keyless signing there yields the same certificate identity as the `release` job — same workflow ref, same tag — so the documented verification command is unchanged.

**2. The append no longer fails open.** This line turned a transient download failure into an empty file:

```
gh release download "$TAG" --pattern checksums.txt --clobber 2>/dev/null || : > checksums.txt
```

The `grep` guard then found no windows entry, and the `--clobber` upload would publish a **one-line, windows-only** `checksums.txt`, breaking sha256 verification for every other platform. `set -euo pipefail` could not catch it because of the `||`, and `2>/dev/null` hid the cause. `needs: release` guarantees the file exists, so a failed download is now fatal.

**3. A release-wide signature gate.** A new `verify-signatures` job runs after every job that can touch a release asset, re-downloads the release, and verifies each published `.sig` against the published artifact using the same cosign invocation consumers are given. It also asserts that every primary artifact is both signed and listed in `checksums.txt`. Rekor lookups are a network call against a shared service, so a failure is retried twice before the release is failed; a genuine mismatch fails deterministically and still stops the release.

This is the part that would have caught the bug on its first release — no signing step or unit test can, because the defect only exists in the *published* bytes after three jobs have taken turns writing them.

## Verification

The workflow can only be exercised end-to-end by cutting a tag, so both shell blocks were extracted verbatim from the YAML and rehearsed offline against the real v0.63.4 assets, with `gh` and `cosign` stood in by local equivalents.

The windows block, starting from the exact 10-line `checksums.txt` that the published `checksums.txt.sig` is proven to cover:

```
== CASE 1: normal run
  PASS  exit 0
  PASS  published sig verifies
  PASS  11 checksum lines
  PASS  one windows entry
  PASS  sorted
== CASE 2: re-run against an already-updated release (idempotent)
  PASS  exit 0
  PASS  published sig verifies
  PASS  still 11 lines, no dupe
== CASE 3: gh release download fails (was: silent clobber)
  PASS  job fails loudly
  PASS  release file untouched
  PASS  still 10 lines
== CASE 4: regression control — the OLD code on the same inputs
  PASS  old code ships a BROKEN sig
== CASE 5: regression control — old code + failed download
  PASS  old code exits 0 on failure
  PASS  old code CLOBBERS to 1 line
```

Cases 4 and 5 run the pre-fix code through the same harness, so the passing cases above are not no-ops.

The gate job:

```
== healthy release                                   PASS  gate passes
== checksums.txt mutated after signing (#625)        PASS  gate fails, names checksums.txt
== an artifact missing from checksums.txt            PASS  gate fails, names the artifact
== an artifact shipped unsigned                      PASS  gate fails, names the artifact
== release with no signatures at all                 PASS  gate fails
```

`actionlint` reports the same 7 pre-existing SC2035 info findings as `main` — none added.

## Note on already-published releases

This fixes releases going forward. The ~28 existing releases still carry a mismatched `checksums.txt.sig`. Re-signing them is possible but would mint certificates whose identity no longer matches the original tag's workflow run, so it is left out of this PR — worth a separate decision. Until then the workaround stands: verify against each artifact's own `.sig`/`.pem`, which is the stronger check anyway.
