### PR TITLE
Fix silent empty index: gitignore patterns leaked regexp operators, and a zero-file repo reported success

### DIFF
--- a/cmd/gortex/daemon.go
+++ b/cmd/gortex/daemon.go
@@ -1465,11 +1465,12 @@ func renderDaemonRepos(w io.Writer, st daemon.StatusResponse) {
 	}
 
 	// The state column appears only once a repo is in trouble — its
-	// directory is gone, or the daemon holds no index for it. On a
-	// healthy workspace every row would read "ok", so it stays hidden.
+	// directory is gone, the daemon holds no index for it, or it indexed
+	// nothing at all. On a healthy workspace every row would read "ok",
+	// so it stays hidden.
 	showState := false
 	for _, r := range rows {
-		if r.Missing || r.Unloaded {
+		if r.Missing || r.Unloaded || repoIndexIsEmpty(r) {
 			showState = true
 			break
 		}
@@ -1539,6 +1540,7 @@ func renderDaemonRepos(w io.Writer, st daemon.StatusResponse) {
 
 	t.Render()
 	renderMissingRepoWarning(w, rows)
+	renderEmptyIndexWarning(w, rows)
 }
 
 // repoStateLabel names a tracked repo's inventory state for the status
@@ -1551,9 +1553,48 @@ func repoStateLabel(r daemon.TrackedRepoStatus) string {
 		return "MISSING"
 	case r.Unloaded:
 		return "not indexed"
+	case repoIndexIsEmpty(r):
+		return "EMPTY"
 	default:
 		return "ok"
 	}
+}
+
+// repoIndexIsEmpty reports whether a repo finished indexing and came back
+// with no files at all. That state used to render as an ordinary
+// zero-count row, which is how a repo of 1,519 Python files could report
+// as healthy while holding nothing (#624) — and why every query against
+// it answered "no callers" with full confidence. A repo still waiting for
+// its first index (LastIndex unset) is not yet empty, only pending.
+func repoIndexIsEmpty(r daemon.TrackedRepoStatus) bool {
+	return !r.Missing && !r.Unloaded && r.Files == 0 && r.LastIndex > 0
+}
+
+// renderEmptyIndexWarning prints the remediation block for every tracked
+// repo that indexed zero files. The daemon log names the exact ignore
+// pattern responsible; this points the operator at it.
+func renderEmptyIndexWarning(w io.Writer, rows []daemon.TrackedRepoStatus) {
+	var empty []daemon.TrackedRepoStatus
+	for _, r := range rows {
+		if repoIndexIsEmpty(r) {
+			empty = append(empty, r)
+		}
+	}
+	if len(empty) == 0 {
+		return
+	}
+	subject := "repo indexed no files"
+	if len(empty) > 1 {
+		subject = "repos indexed no files"
+	}
+	fmt.Fprintf(w, "\n!! %d tracked %s — queries against them return empty answers, not missing ones:\n",
+		len(empty), subject)
+	for _, r := range empty {
+		fmt.Fprintf(w, "     %-24s %s\n", r.Prefix, r.Path)
+	}
+	fmt.Fprintln(w, "   Either the path holds no source Gortex can parse, or an ignore rule excluded all of it.")
+	fmt.Fprintln(w, "   The daemon log names the pattern:")
+	fmt.Fprintln(w, "     gortex daemon logs | grep 'no source files were indexed'")
 }
 
 // renderMissingRepoWarning prints the remediation block below the repos

--- a/cmd/gortex/daemon_status_tui.go
+++ b/cmd/gortex/daemon_status_tui.go
@@ -119,6 +119,8 @@ func repoItemState(r daemon.TrackedRepoStatus) string {
 		return "MISSING — path deleted"
 	case r.Unloaded:
 		return "not indexed"
+	case repoIndexIsEmpty(r):
+		return "EMPTY — 0 files indexed"
 	default:
 		return ""
 	}

--- a/cmd/gortex/repo_inventory_empty_test.go
+++ b/cmd/gortex/repo_inventory_empty_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zzet/gortex/internal/daemon"
+)
+
+// Issue #624: a repo that finished indexing with zero files rendered as
+// an ordinary zero-count row. That is the one state an operator has to
+// act on and the one state every view stayed quiet about — so a repo of
+// 1,519 Python files reported as tracked and healthy while holding
+// nothing, and every query against it answered "not found" with full
+// confidence.
+
+func TestRepoIndexIsEmpty(t *testing.T) {
+	assert.True(t, repoIndexIsEmpty(daemon.TrackedRepoStatus{LastIndex: 1700000000}),
+		"indexed, present, zero files — the reported state")
+	assert.False(t, repoIndexIsEmpty(daemon.TrackedRepoStatus{Files: 12, LastIndex: 1700000000}))
+	assert.False(t, repoIndexIsEmpty(daemon.TrackedRepoStatus{}),
+		"a repo that has never finished an index pass is pending, not empty")
+	assert.False(t, repoIndexIsEmpty(daemon.TrackedRepoStatus{Missing: true, LastIndex: 1700000000}),
+		"a deleted path is the actionable fact; it outranks an empty index")
+	assert.False(t, repoIndexIsEmpty(daemon.TrackedRepoStatus{Unloaded: true, LastIndex: 1700000000}))
+}
+
+func TestRepoStateLabel_EmptyIndex(t *testing.T) {
+	assert.Equal(t, "EMPTY", repoStateLabel(daemon.TrackedRepoStatus{LastIndex: 1700000000}))
+	assert.Equal(t, "MISSING", repoStateLabel(daemon.TrackedRepoStatus{Missing: true, LastIndex: 1700000000}))
+	assert.Equal(t, "ok", repoStateLabel(daemon.TrackedRepoStatus{Files: 1, LastIndex: 1700000000}))
+}
+
+func TestRepoItemState_EmptyIndex(t *testing.T) {
+	assert.Equal(t, "EMPTY — 0 files indexed", repoItemState(daemon.TrackedRepoStatus{LastIndex: 1700000000}))
+	assert.Empty(t, repoItemState(daemon.TrackedRepoStatus{Files: 3, LastIndex: 1700000000}))
+}
+
+func TestRenderEmptyIndexWarning_PluralisesAndListsEach(t *testing.T) {
+	var buf bytes.Buffer
+	renderEmptyIndexWarning(&buf, []daemon.TrackedRepoStatus{
+		{Prefix: "pandas", Path: "/srv/pandas", LastIndex: 1700000000},
+		{Prefix: "django", Path: "/srv/django", Files: 2600, LastIndex: 1700000000},
+		{Prefix: "numpy", Path: "/srv/numpy", LastIndex: 1700000000},
+	})
+	out := buf.String()
+
+	assert.Contains(t, out, "2 tracked repos indexed no files")
+	assert.NotContains(t, out, "repos indexed no file\n")
+	assert.Contains(t, out, "/srv/pandas")
+	assert.Contains(t, out, "/srv/numpy")
+	assert.NotContains(t, out, "/srv/django")
+	assert.Contains(t, out, "no source files were indexed",
+		"the block must point at the daemon log line that names the pattern")
+}
+
+func TestRenderEmptyIndexWarning_QuietWhenEveryRepoHasFiles(t *testing.T) {
+	var buf bytes.Buffer
+	renderEmptyIndexWarning(&buf, []daemon.TrackedRepoStatus{
+		{Prefix: "django", Path: "/srv/django", Files: 2600, LastIndex: 1700000000},
+		{Prefix: "pending", Path: "/srv/pending"},
+	})
+	assert.Empty(t, buf.String())
+}

--- a/cmd/gortex/status.go
+++ b/cmd/gortex/status.go
@@ -124,6 +124,8 @@ func runStatusViaDaemon(cmd *cobra.Command) error {
 			suffix = "MISSING — path no longer exists on disk"
 		case r.Unloaded:
 			suffix = "(not indexed — tracked in config, no index held)"
+		case repoIndexIsEmpty(r):
+			suffix = "EMPTY — indexed 0 files; no parsable source, or an ignore rule excluded all of it"
 		}
 		if showWS {
 			ws := r.Workspace
@@ -136,6 +138,7 @@ func runStatusViaDaemon(cmd *cobra.Command) error {
 		}
 	}
 	renderMissingRepoWarning(w, st.TrackedRepos)
+	renderEmptyIndexWarning(w, st.TrackedRepos)
 	return nil
 }
 

--- a/docs/multi-repo.md
+++ b/docs/multi-repo.md
@@ -180,6 +180,28 @@ it: `daemon status` reconciles the live indexer registry against
 `not indexed` rather than dropping out of one view while the other keeps
 listing it.
 
+### Empty indexes
+
+A repo that finished indexing with no files at all is reported as
+`EMPTY`, not as an ordinary zero-count row. It is the one failure that
+otherwise reads as success everywhere: the repo is tracked, loaded, and
+answering — with an empty graph, so `find_usages` returns "no callers"
+and `analyze` returns "likely unused" with full confidence.
+
+`gortex status` and `gortex daemon status` mark the row `EMPTY` and print
+the affected paths below the table; `index_health` reports
+`repos_hold_files_ok: false` with the prefixes under `empty_repos`. The
+daemon log names the exact cause, including the ignore pattern
+responsible and one file it excluded:
+
+```
+gortex daemon logs | grep 'no source files were indexed'
+```
+
+The usual cause is an ignore rule that matches more than intended — a
+`.gitignore`, `.gortexignore`, or `.gortex.yaml` `excludes` entry. A repo
+that genuinely holds no source Gortex can parse is not flagged.
+
 ## MCP tools
 
 Agents can manage repos at runtime without CLI access:

--- a/internal/codeowners/parser.go
+++ b/internal/codeowners/parser.go
@@ -16,7 +16,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	gitignore "github.com/sabhiram/go-gitignore"
+	"github.com/zzet/gortex/internal/excludes"
 	"github.com/zzet/gortex/internal/graph"
 )
 
@@ -25,7 +25,7 @@ import (
 type Rule struct {
 	Pattern string
 	Owners  []string
-	matcher *gitignore.GitIgnore
+	matcher *excludes.Matcher
 }
 
 // matchPattern returns the rule's gitignore matcher. Parse precompiles
@@ -35,11 +35,17 @@ type Rule struct {
 // list). For a Rule hand-constructed outside Parse the field is nil;
 // compile a throwaway matcher rather than caching into r.matcher, so
 // concurrent callers still can't race on the field.
-func (r *Rule) matchPattern() *gitignore.GitIgnore {
+//
+// Compilation goes through excludes.New rather than go-gitignore
+// directly: the raw library splices pattern text into a regexp with
+// almost nothing escaped, so an owner rule as ordinary as "*$" would
+// claim every file in the repository (the same defect that emptied a
+// whole index in #624).
+func (r *Rule) matchPattern() *excludes.Matcher {
 	if r.matcher != nil {
 		return r.matcher
 	}
-	return gitignore.CompileIgnoreLines(r.Pattern)
+	return excludes.New([]string{r.Pattern})
 }
 
 // Parse reads a CODEOWNERS file's bytes and returns the rule list in
@@ -73,7 +79,7 @@ func Parse(source []byte) []Rule {
 		rule := Rule{Pattern: fields[0]}
 		// Precompile the matcher in this single-goroutine parse so the
 		// concurrent MatchFile hot path only reads rule.matcher.
-		rule.matcher = gitignore.CompileIgnoreLines(rule.Pattern)
+		rule.matcher = excludes.New([]string{rule.Pattern})
 		if len(fields) > 1 {
 			rule.Owners = append(rule.Owners, fields[1:]...)
 		}
@@ -90,7 +96,7 @@ func MatchFile(path string, rules []Rule) []string {
 	path = filepath.ToSlash(path)
 	for i := len(rules) - 1; i >= 0; i-- {
 		r := &rules[i]
-		if r.matchPattern().MatchesPath(path) {
+		if r.matchPattern().MatchRel(path) {
 			if len(r.Owners) == 0 {
 				return nil
 			}

--- a/internal/codeowners/pattern_metachar_test.go
+++ b/internal/codeowners/pattern_metachar_test.go
@@ -1,0 +1,37 @@
+package codeowners
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// CODEOWNERS globs were compiled by go-gitignore directly, which splices
+// pattern text into a regexp with almost nothing escaped. A rule path
+// carrying a regexp metacharacter therefore claimed files it never named
+// — the same defect that emptied a whole index in #624, applied to
+// ownership instead of indexing.
+func TestMatchFile_RegexMetacharactersInPatternAreLiteral(t *testing.T) {
+	rules := Parse([]byte("*$ @backup-team\n"))
+
+	assert.Nil(t, MatchFile("src/app.go", rules),
+		`"*$" must not own every file in the repository`)
+	assert.Nil(t, MatchFile("README.md", rules))
+	assert.Equal(t, []string{"@backup-team"}, MatchFile("notes.txt$", rules),
+		`"*$" still owns the files it actually names`)
+}
+
+func TestMatchFile_AlternationIsLiteral(t *testing.T) {
+	rules := Parse([]byte("api|web @platform\n"))
+
+	assert.Nil(t, MatchFile("api", rules))
+	assert.Nil(t, MatchFile("web", rules))
+	assert.Equal(t, []string{"@platform"}, MatchFile("api|web", rules))
+}
+
+// A hand-constructed Rule takes the uncached compile path; it must get
+// the same treatment.
+func TestMatchFile_UncachedRuleUsesSameCompiler(t *testing.T) {
+	rules := []Rule{{Pattern: "*$", Owners: []string{"@backup-team"}}}
+	assert.Nil(t, MatchFile("src/app.go", rules))
+}

--- a/internal/config/gitignore_effective_test.go
+++ b/internal/config/gitignore_effective_test.go
@@ -1,0 +1,97 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/excludes"
+)
+
+// pandasIgnoreExcerpt is the head of pandas-dev/pandas' .gitignore,
+// verbatim. Line 7, "*$", is an Emacs autosave pattern; go-gitignore used
+// to compile it into a regexp whose "$" was an end-of-text anchor, so it
+// matched every path in the repository. `gortex track` then reported
+// success on a repo holding 1,519 .py files and produced an index with
+// zero source files in it, with no error or warning anywhere (#624).
+const pandasIgnoreExcerpt = `#########################################
+# Editor temporary/working/backup files #
+.#*
+*\#*\#
+[#]*#
+*~
+*$
+*.bak
+*.log
+
+# Compiled source #
+###################
+*.pxi
+*.o
+*.py[ocd]
+*.so
+MANIFEST
+
+# Python files #
+################
+build
+doc/_build
+dist
+*.egg-info
+__pycache__
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+`
+
+// A repo's own .gitignore must never be able to exclude the whole repo by
+// accident. This walks the same layering `gortex track` uses: the file on
+// disk, through the ConfigManager's exclude chain, into the matcher the
+// index walk consults.
+func TestEffectiveExclude_PandasGitignoreKeepsSourceFiles(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "pandas", "core"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".git"), 0o755))
+	write := func(rel, body string) {
+		require.NoError(t, os.WriteFile(filepath.Join(root, rel), []byte(body), 0o644))
+	}
+	write(".gitignore", pandasIgnoreExcerpt)
+	write("pyproject.toml", "[project]\nname = \"pandas\"\n")
+	write("setup.py", "print(1)\n")
+	write(filepath.Join("pandas", "__init__.py"), "x = 1\n")
+	write(filepath.Join("pandas", "core", "frame.py"), "class DataFrame: pass\n")
+
+	cm, err := NewConfigManager(filepath.Join(t.TempDir(), "config.yaml"))
+	require.NoError(t, err)
+	cm.LoadWorkspaceConfig("pandas", root)
+	m := excludes.New(cm.EffectiveExclude("pandas"))
+
+	for _, rel := range []string{
+		"pyproject.toml",
+		"setup.py",
+		"pandas/__init__.py",
+		"pandas/core/frame.py",
+		"pandas/core/",
+		"pandas/",
+	} {
+		excluded, pattern := m.Explain(rel)
+		require.Falsef(t, excluded, "%s must be indexable; excluded by pattern %q", rel, pattern)
+	}
+
+	// The ignore file still does its actual job.
+	for _, rel := range []string{
+		"pandas/core/frame.pyc",
+		"pandas/_libs/algos.so",
+		"build/lib/x.py",
+		"pandas/core/.frame.py~",
+		"#frame.py#",
+		"pandas.egg-info/PKG-INFO",
+		"__pycache__/frame.cpython-312.pyc",
+	} {
+		require.Truef(t, m.MatchRel(rel), "%s should still be excluded", rel)
+	}
+}

--- a/internal/excludes/hierarchical.go
+++ b/internal/excludes/hierarchical.go
@@ -48,17 +48,26 @@ func NewHierarchical(root string, filenames ...string) *Hierarchical {
 // slash patterns prune the whole subtree. A path outside the root is
 // never excluded.
 func (h *Hierarchical) Match(absPath string, isDir bool) bool {
+	matched, _, _ := h.Explain(absPath, isDir)
+	return matched
+}
+
+// Explain is Match plus attribution: the absolute directory whose ignore
+// file excluded the path, and the pattern that did it. Both are "" when
+// nothing matched. Used to name the culprit when an over-broad ignore
+// leaves a repo with nothing to index.
+func (h *Hierarchical) Explain(absPath string, isDir bool) (bool, string, string) {
 	if h == nil || len(h.filenames) == 0 {
-		return false
+		return false, "", ""
 	}
 	absPath = filepath.Clean(absPath)
 	rel, err := filepath.Rel(h.root, absPath)
 	if err != nil {
-		return false
+		return false, "", ""
 	}
 	rel = filepath.ToSlash(rel)
 	if rel == "." || rel == "" || rel == ".." || strings.HasPrefix(rel, "../") {
-		return false
+		return false, "", ""
 	}
 
 	// Test the path against the root's ignore matcher and that of every
@@ -66,17 +75,17 @@ func (h *Hierarchical) Match(absPath string, isDir bool) bool {
 	// level that excludes the path wins; a file's own directory cannot
 	// exclude the file from itself.
 	dir := h.root
-	if h.dirMatcher(dir).MatchAbsDir(absPath, dir, isDir) {
-		return true
+	if matched, pat := h.dirMatcher(dir).ExplainAbsDir(absPath, dir, isDir); matched {
+		return true, dir, pat
 	}
 	segs := strings.Split(rel, "/")
 	for _, seg := range segs[:len(segs)-1] {
 		dir = filepath.Join(dir, seg)
-		if h.dirMatcher(dir).MatchAbsDir(absPath, dir, isDir) {
-			return true
+		if matched, pat := h.dirMatcher(dir).ExplainAbsDir(absPath, dir, isDir); matched {
+			return true, dir, pat
 		}
 	}
-	return false
+	return false, "", ""
 }
 
 // HasNegatedDescendant reports whether any per-directory ignore file

--- a/internal/excludes/matcher.go
+++ b/internal/excludes/matcher.go
@@ -23,17 +23,28 @@ type Matcher struct {
 // directory matches paths regardless of which Unicode form the
 // filesystem walk produced — MatchRel folds the candidate path to the
 // same form before testing it.
+//
+// Each pattern is also run through literalizePattern before it reaches
+// go-gitignore, whose compiler splices pattern text straight into a Go
+// regexp and escapes only "." and "?". Without that step a line as
+// ordinary as "*$" compiles to a regexp that matches every path and
+// excludes the entire repository (#624). The Matcher keeps the original
+// text in patterns — the rewrite is a compiler detail and must never
+// reach a user-visible surface.
 func New(patterns []string) *Matcher {
 	cleaned := make([]string, 0, len(patterns))
+	compiled := make([]string, 0, len(patterns))
 	for _, p := range patterns {
 		p = strings.TrimSpace(p)
 		if p == "" || strings.HasPrefix(p, "#") {
 			continue
 		}
-		cleaned = append(cleaned, pathkey.Normalize(p))
+		p = pathkey.Normalize(p)
+		cleaned = append(cleaned, p)
+		compiled = append(compiled, literalizePattern(p))
 	}
 	return &Matcher{
-		ign:      ignore.CompileIgnoreLines(cleaned...),
+		ign:      ignore.CompileIgnoreLines(compiled...),
 		patterns: cleaned,
 	}
 }
@@ -66,6 +77,34 @@ func (m *Matcher) MatchRel(relPath string) bool {
 	return m.ign.MatchesPath(rel)
 }
 
+// Explain reports whether a repo-root-relative path is excluded and, when
+// it is, which pattern excluded it — in the caller's original wording, not
+// the rewritten form New compiles.
+//
+// This is what makes an over-broad ignore self-diagnosing: a repo that
+// indexes zero files can name the one line responsible instead of leaving
+// the operator to bisect a .gitignore by hand.
+func (m *Matcher) Explain(relPath string) (bool, string) {
+	if m == nil || m.ign == nil {
+		return false, ""
+	}
+	rel := pathkey.Normalize(filepath.ToSlash(relPath))
+	rel = strings.TrimPrefix(rel, "./")
+	if rel == "" || rel == "." {
+		return false, ""
+	}
+	matched, ip := m.ign.MatchesPathHow(rel)
+	if !matched || ip == nil {
+		return matched, ""
+	}
+	// LineNo is 1-based into the slice New handed the compiler, which is
+	// index-aligned with m.patterns.
+	if ip.LineNo >= 1 && ip.LineNo <= len(m.patterns) {
+		return true, m.patterns[ip.LineNo-1]
+	}
+	return true, ip.Line
+}
+
 // MatchAbs reports whether an absolute path under root is excluded.
 // Returns false if path is not under root.
 func (m *Matcher) MatchAbs(absPath, root string) bool {
@@ -79,17 +118,25 @@ func (m *Matcher) MatchAbs(absPath, root string) bool {
 // descending it and re-testing every file. Returns false if path is
 // not under root.
 func (m *Matcher) MatchAbsDir(absPath, root string, isDir bool) bool {
+	matched, _ := m.ExplainAbsDir(absPath, root, isDir)
+	return matched
+}
+
+// ExplainAbsDir is MatchAbsDir plus the pattern that excluded the path,
+// in the caller's original wording. The pattern is "" when nothing
+// matched.
+func (m *Matcher) ExplainAbsDir(absPath, root string, isDir bool) (bool, string) {
 	if m == nil || m.ign == nil {
-		return false
+		return false, ""
 	}
 	rel, err := filepath.Rel(root, absPath)
 	if err != nil {
-		return false
+		return false, ""
 	}
 	if isDir {
 		rel += "/"
 	}
-	return m.MatchRel(rel)
+	return m.Explain(rel)
 }
 
 // HasNegatedDescendant reports whether any re-include ("!") pattern in

--- a/internal/excludes/pattern.go
+++ b/internal/excludes/pattern.go
@@ -1,0 +1,176 @@
+package excludes
+
+import (
+	"regexp"
+	"strings"
+)
+
+// go-gitignore compiles a pattern by string-substituting it into a Go
+// regular expression, and it escapes exactly two characters on the way:
+// "." and "?". Every other regexp metacharacter in the pattern text
+// reaches the engine as an operator, even though gitignore reads it as
+// ordinary text. The results range from wrong to catastrophic:
+//
+//   - "*$" (an Emacs autosave pattern that appears verbatim in pandas'
+//     .gitignore) compiles to `^(|.*/)([^/]*)$(|/.*)$`. The "$" is an
+//     end-of-text anchor, so the pattern matches every path in the repo
+//     and the whole tree is excluded from indexing — silently (#624).
+//   - "^*" matches everything for the same reason.
+//   - "a|b" also matches "b"; "foo+" also matches "foo".
+//   - An unbalanced "[" or "(" makes regexp.Compile fail. go-gitignore
+//     discards the error and drops the line, so the ignore stops
+//     applying at all — the mirror-image failure.
+//
+// literalizePattern rewrites a gitignore pattern so none of that can
+// happen: characters git treats as literal text are escaped before the
+// library ever sees them, and the two glob constructs the library gets
+// wrong ("?" and bracket expressions) are lowered here instead.
+//
+// "*" and "." are deliberately left alone — go-gitignore's own handling
+// of those (including "**" across path separators) is correct, and
+// pre-escaping "." would collide with its `\.` substitution pass.
+
+// regexOnlyMeta are the regexp metacharacters that carry no meaning in a
+// gitignore pattern. Each is escaped so it matches itself.
+const regexOnlyMeta = `$^+(){}|]`
+
+// literalizePattern returns pattern with every regexp-only metacharacter
+// escaped and every glob construct lowered to the equivalent the
+// underlying regexp engine understands. The result is intended for
+// go-gitignore's compiler, not for display: callers keep the original
+// text for anything user-visible.
+func literalizePattern(pattern string) string {
+	if pattern == "" {
+		return pattern
+	}
+	// A leading "!" is go-gitignore's negation marker, not pattern text.
+	// Keep it outside the rewrite so the line still reads as a negation.
+	neg := ""
+	body := pattern
+	if strings.HasPrefix(body, "!") {
+		neg, body = "!", body[1:]
+	}
+
+	var b strings.Builder
+	b.Grow(len(body) + 8)
+	for i := 0; i < len(body); {
+		c := body[i]
+		switch {
+		case c == '\\':
+			// A gitignore backslash escape. Copy the pair through
+			// untouched: go-gitignore maps `\*` back to a literal star,
+			// and every other `\X` already reaches the regexp as a
+			// literal X.
+			if i+1 < len(body) {
+				b.WriteByte('\\')
+				b.WriteByte(body[i+1])
+				i += 2
+				continue
+			}
+			// A trailing lone backslash would be a dangling escape and
+			// the pattern would not compile at all. Make it literal.
+			b.WriteString(`\\`)
+			i++
+		case c == '[':
+			if class, n, ok := scanBracketExpr(body[i:]); ok {
+				b.WriteString(class)
+				i += n
+				continue
+			}
+			// An unterminated "[" is ordinary text to fnmatch, and so to
+			// git. Left alone it would fail to compile and take the whole
+			// pattern down with it.
+			b.WriteString(`\[`)
+			i++
+		case c == '?':
+			// gitignore: any single character except "/". go-gitignore
+			// escapes it into a literal "?" instead, which under-matches.
+			b.WriteString(`[^/]`)
+			i++
+		case strings.IndexByte(regexOnlyMeta, c) >= 0:
+			b.WriteByte('\\')
+			b.WriteByte(c)
+			i++
+		default:
+			b.WriteByte(c)
+			i++
+		}
+	}
+	return neg + b.String()
+}
+
+// scanBracketExpr reads a bracket expression at the start of s (which
+// must begin with "["). It returns the rewritten expression, how many
+// bytes of s it consumed, and whether s opens a usable one at all.
+//
+// Two shapes need rewriting for the regexp engine: git's negation marker
+// is "!" where regexp wants "^", and a "*" or "$" inside the brackets is
+// literal text that go-gitignore's later substitution passes would
+// otherwise rewrite (its "*" expansion, and its "#$~" sentinel). Anything
+// that still fails to compile is reported as "not a bracket expression"
+// so the caller falls back to treating the "[" as literal text.
+func scanBracketExpr(s string) (string, int, bool) {
+	j := 1 // s[0] == '['
+	negated := false
+	if j < len(s) && (s[j] == '!' || s[j] == '^') {
+		negated = true
+		j++
+	}
+	// A "]" in the first position is literal, per POSIX bracket rules.
+	if j < len(s) && s[j] == ']' {
+		j++
+	}
+	for j < len(s) {
+		switch s[j] {
+		case '\\':
+			j += 2
+			continue
+		case '/':
+			// gitignore wildcards never cross a path separator, so a "["
+			// that only closes past one was never a bracket expression.
+			return "", 0, false
+		case ']':
+			inner := s[1:j]
+			if negated {
+				inner = "^" + inner[1:]
+			}
+			out := "[" + escapeInBracketExpr(inner) + "]"
+			if _, err := regexp.Compile(out); err != nil {
+				return "", 0, false
+			}
+			return out, j + 1, true
+		}
+		j++
+	}
+	return "", 0, false
+}
+
+// escapeInBracketExpr escapes the two characters that are literal inside
+// a bracket expression but that go-gitignore's post-processing would
+// still rewrite: "*" (expanded to a capture group) and "$" (half of its
+// "#$~" placeholder). Escaping them here survives that pass — the
+// library maps `\*` back to a literal star, and `\$` never forms the
+// placeholder.
+func escapeInBracketExpr(inner string) string {
+	if !strings.ContainsAny(inner, `*$`) {
+		return inner
+	}
+	var b strings.Builder
+	b.Grow(len(inner) + 4)
+	for i := 0; i < len(inner); i++ {
+		switch c := inner[i]; c {
+		case '\\':
+			b.WriteByte(c)
+			if i+1 < len(inner) {
+				i++
+				b.WriteByte(inner[i])
+			}
+		case '*', '$':
+			b.WriteByte('\\')
+			b.WriteByte(c)
+		default:
+			b.WriteByte(c)
+		}
+	}
+	return b.String()
+}

--- a/internal/excludes/pattern_test.go
+++ b/internal/excludes/pattern_test.go
@@ -1,0 +1,185 @@
+package excludes
+
+import "testing"
+
+// The regression this whole file exists for: pandas' .gitignore carries
+// "*$" on line 7 as an Emacs autosave pattern. go-gitignore used to
+// compile it into `^(|.*/)([^/]*)$(|/.*)$` — the "$" read as a regexp
+// anchor — so every path in the repository matched and `gortex track`
+// produced an index holding zero source files, with no error anywhere
+// (#624).
+func TestMatcher_RegexAnchorIsLiteralText(t *testing.T) {
+	for _, pattern := range []string{"*$", "^*"} {
+		m := New([]string{pattern})
+		for _, p := range []string{
+			"pandas/core/frame.py",
+			"pandas/core/",
+			"pyproject.toml",
+			"README.md",
+		} {
+			if m.MatchRel(p) {
+				t.Errorf("pattern %q must not exclude %q", pattern, p)
+			}
+		}
+	}
+	// The patterns still do their actual job.
+	if !New([]string{"*$"}).MatchRel("core.py$") {
+		t.Error(`"*$" should still exclude a file whose name ends in "$"`)
+	}
+	if !New([]string{"^*"}).MatchRel("^scratch") {
+		t.Error(`"^*" should still exclude a file whose name starts with "^"`)
+	}
+}
+
+// Every regexp-only metacharacter is ordinary text to git. Before the
+// fix each one leaked an operator into the compiled pattern.
+func TestMatcher_RegexOnlyMetacharactersAreLiteral(t *testing.T) {
+	cases := []struct {
+		pattern  string
+		excluded string   // the file the pattern actually names
+		admitted []string // files a leaked regexp operator would have caught
+	}{
+		{"a|b", "a|b", []string{"a", "b"}},
+		{"foo+", "foo+", []string{"foo", "fooo"}},
+		{"(tmp)", "(tmp)", []string{"tmp"}},
+		{"a{1,2}", "a{1,2}", []string{"a", "aa"}},
+		{"gen.d", "gen.d", []string{"genxd"}},
+		{"cache]", "cache]", []string{"cache"}},
+	}
+	for _, tc := range cases {
+		m := New([]string{tc.pattern})
+		if !m.MatchRel(tc.excluded) {
+			t.Errorf("pattern %q should exclude %q", tc.pattern, tc.excluded)
+		}
+		for _, p := range tc.admitted {
+			if m.MatchRel(p) {
+				t.Errorf("pattern %q must not exclude %q", tc.pattern, p)
+			}
+		}
+	}
+}
+
+// An unbalanced bracket or paren used to make regexp.Compile fail;
+// go-gitignore discarded the error and dropped the line, so the ignore
+// silently stopped applying. Both must now be honoured as literal text.
+func TestMatcher_UncompilablePatternsStillApply(t *testing.T) {
+	cases := []struct{ pattern, excluded string }{
+		{"lib[", "lib["},
+		{"build(", "build("},
+		{"a)b", "a)b"},
+		{"weird\\", "weird\\"},
+	}
+	for _, tc := range cases {
+		if !New([]string{tc.pattern}).MatchRel(tc.excluded) {
+			t.Errorf("pattern %q should exclude %q", tc.pattern, tc.excluded)
+		}
+	}
+}
+
+// "?" is a single-character wildcard in gitignore. go-gitignore escaped
+// it into a literal "?", which under-matched: pandas' "Icon?" never
+// caught the macOS "Icon\r" file it was written for.
+func TestMatcher_QuestionMarkIsSingleCharWildcard(t *testing.T) {
+	m := New([]string{"Icon?"})
+	for _, p := range []string{"Icon1", "IconX", "sub/IconZ"} {
+		if !m.MatchRel(p) {
+			t.Errorf(`"Icon?" should exclude %q`, p)
+		}
+	}
+	// A wildcard never crosses a path separator, and never matches the
+	// empty string.
+	for _, p := range []string{"Icon", "Icon/x"} {
+		if m.MatchRel(p) {
+			t.Errorf(`"Icon?" must not exclude %q`, p)
+		}
+	}
+}
+
+func TestMatcher_BracketExpressions(t *testing.T) {
+	cases := []struct {
+		pattern  string
+		excluded []string
+		admitted []string
+	}{
+		// pandas' compiled-Python pattern: .pyc / .pyo / .pyd, never .py.
+		{"*.py[ocd]", []string{"a.pyc", "a.pyo", "pkg/a.pyd"}, []string{"a.py", "a.pyx"}},
+		// git spells class negation with "!"; the regexp engine wants "^".
+		{"[!a-z]*", []string{"Build", "9lives"}, []string{"alpha", "zeta"}},
+		{"[^a-z]*", []string{"Build"}, []string{"alpha"}},
+		// A "*" inside brackets is literal text on both sides.
+		{"x[*?]y", []string{"x*y", "x?y"}, []string{"xay", "xy"}},
+		// pandas' Emacs lock pattern.
+		{"[#]*#", []string{"#frame.py#"}, []string{"frame.py"}},
+	}
+	for _, tc := range cases {
+		m := New([]string{tc.pattern})
+		for _, p := range tc.excluded {
+			if !m.MatchRel(p) {
+				t.Errorf("pattern %q should exclude %q", tc.pattern, p)
+			}
+		}
+		for _, p := range tc.admitted {
+			if m.MatchRel(p) {
+				t.Errorf("pattern %q must not exclude %q", tc.pattern, p)
+			}
+		}
+	}
+}
+
+// Escapes and the "**" forms are go-gitignore's own business; the
+// rewrite must leave them working.
+func TestMatcher_EscapesAndGlobstarSurvive(t *testing.T) {
+	if m := New([]string{`\*.log`}); !m.MatchRel("*.log") || m.MatchRel("app.log") {
+		t.Error(`"\*.log" should name the literal file "*.log" only`)
+	}
+	m := New([]string{"docs/**/build"})
+	if !m.MatchRel("docs/a/b/build") {
+		t.Error(`"docs/**/build" should exclude "docs/a/b/build"`)
+	}
+	if m.MatchRel("other/a/build") {
+		t.Error(`"docs/**/build" must not exclude "other/a/build"`)
+	}
+	if n := New([]string{"!keep$"}); !n.HasNegatedDescendant("build") {
+		t.Error("a negation must still register after the rewrite")
+	}
+}
+
+// Explain reports the pattern in the caller's wording, not the rewritten
+// form New hands the compiler.
+func TestMatcher_ExplainNamesOriginalPattern(t *testing.T) {
+	m := New([]string{"node_modules/", "*$", "dist/"})
+	matched, pattern := m.Explain("pandas/core/frame.py")
+	if matched {
+		t.Fatalf("nothing should match after the fix, got pattern %q", pattern)
+	}
+	matched, pattern = m.Explain("node_modules/x/index.js")
+	if !matched || pattern != "node_modules/" {
+		t.Fatalf("Explain = (%v, %q), want (true, \"node_modules/\")", matched, pattern)
+	}
+	var nilm *Matcher
+	if matched, pattern = nilm.Explain("a"); matched || pattern != "" {
+		t.Error("nil matcher should explain nothing")
+	}
+}
+
+func TestLiteralizePattern(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", ""},
+		{"src/main.go", "src/main.go"},
+		{"*$", `*\$`},
+		{"!keep$", `!keep\$`},
+		{"a|b", `a\|b`},
+		{"?", "[^/]"},
+		{"[!a-z]", "[^a-z]"},
+		{"[abc]", "[abc]"},
+		{"lib[", `lib\[`},
+		{`\*`, `\*`},
+		{`trail\`, `trail\\`},
+		{"x[*]y", `x[\*]y`},
+	}
+	for _, tc := range cases {
+		if got := literalizePattern(tc.in); got != tc.want {
+			t.Errorf("literalizePattern(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/indexer/empty_walk_diagnostic_test.go
+++ b/internal/indexer/empty_walk_diagnostic_test.go
@@ -1,0 +1,118 @@
+package indexer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func newObservedLogger() (*zap.Logger, *observer.ObservedLogs) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	return zap.New(core), logs
+}
+
+func writeTree(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+	for rel, body := range files {
+		abs := filepath.Join(root, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(abs), 0o755))
+		require.NoError(t, os.WriteFile(abs, []byte(body), 0o644))
+	}
+}
+
+// A repo whose ignore rules swallowed every file used to index silently:
+// zero files, no error, no warning, and every downstream query answering
+// "not found" with full confidence (#624). The walk must now say so, and
+// name the pattern that did it.
+func TestIndex_WarnsWhenEveryCandidateFileIsExcluded(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"pkg/frame.go": "package pkg\n\nfunc DataFrame() {}\n",
+		"main.go":      "package main\n\nfunc main() {}\n",
+	})
+
+	logger, logs := newObservedLogger()
+	idx := New(graph.New(), newTestRegistry(), config.IndexConfig{
+		Workers: 1,
+		Exclude: []string{"node_modules/", "everything-eater/"},
+	}, logger)
+	idx.SetRootPath(dir)
+	// An exclude that swallows the whole tree, in the shape that caused
+	// the report: one pattern, no negation, applied at the root.
+	idx.SetExcludePatterns([]string{"*"})
+
+	res, err := idx.Index(dir)
+	require.NoError(t, err)
+	require.Equal(t, 0, res.FileCount, "precondition: the walk admits nothing")
+
+	entries := logs.FilterMessageSnippet("no source files were indexed").All()
+	require.Len(t, entries, 1, "an empty index must warn exactly once")
+	fields := entries[0].ContextMap()
+	require.Equal(t, "*", fields["pattern"], "the warning must name the responsible pattern")
+	require.Contains(t, fields, "example_file")
+	require.Contains(t, fields["excluded_by"], "exclude list")
+}
+
+// A per-directory ignore file is the other door into the same failure, so
+// it has to be attributed too — naming the directory, since the pattern
+// alone would not say which file it came from.
+func TestIndex_WarnsAndNamesPerDirectoryIgnoreFile(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{
+		"pkg/frame.go":  "package pkg\n\nfunc DataFrame() {}\n",
+		".gortexignore": "*.go\n",
+	})
+
+	logger, logs := newObservedLogger()
+	idx := New(graph.New(), newTestRegistry(), config.IndexConfig{Workers: 1}, logger)
+	idx.SetRootPath(dir)
+
+	res, err := idx.Index(dir)
+	require.NoError(t, err)
+	require.Equal(t, 0, res.FileCount)
+
+	entries := logs.FilterMessageSnippet("no source files were indexed").All()
+	require.Len(t, entries, 1)
+	fields := entries[0].ContextMap()
+	require.Equal(t, "*.go", fields["pattern"])
+	require.Contains(t, fields["excluded_by"], "per-directory ignore file")
+}
+
+// A repo that genuinely holds no source is not a failure, and must not
+// cry wolf — otherwise the warning stops meaning anything.
+func TestIndex_DoesNotWarnWhenRepoHasNoSource(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{"notes.unknownext": "nothing to parse\n"})
+
+	logger, logs := newObservedLogger()
+	idx := New(graph.New(), newTestRegistry(), config.IndexConfig{Workers: 1}, logger)
+	idx.SetRootPath(dir)
+
+	res, err := idx.Index(dir)
+	require.NoError(t, err)
+	require.Equal(t, 0, res.FileCount)
+	require.Empty(t, logs.FilterMessageSnippet("no source files were indexed").All())
+}
+
+// The happy path pays nothing and says nothing.
+func TestIndex_DoesNotWarnWhenFilesAreIndexed(t *testing.T) {
+	dir := t.TempDir()
+	writeTree(t, dir, map[string]string{"main.go": "package main\n\nfunc main() {}\n"})
+
+	logger, logs := newObservedLogger()
+	idx := New(graph.New(), newTestRegistry(), config.IndexConfig{Workers: 1}, logger)
+	idx.SetRootPath(dir)
+
+	res, err := idx.Index(dir)
+	require.NoError(t, err)
+	require.Positive(t, res.FileCount)
+	require.Empty(t, logs.FilterMessageSnippet("no source files were indexed").All())
+}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -2443,6 +2443,7 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 			zap.Int("count", len(skippedByContent)),
 			zap.Int64("total_bytes", skippedContentBytes))
 	}
+	idx.warnIfWalkAdmittedNothing(absRoot, len(files))
 	reporter.Report("walking files", len(files), len(files))
 	// Capture raw content identities while the parser already owns each source
 	// buffer. A nil collector keeps the disabled path allocation-free.
@@ -5334,6 +5335,115 @@ func (idx *Indexer) shouldExclude(path, root string, isDir bool) bool {
 		return true
 	}
 	return idx.dirIgnoreMatcher(root).Match(path, isDir)
+}
+
+// emptyWalkProbeCap bounds the diagnostic re-walk below. It only ever
+// runs on a repo that indexed nothing, and it stops at the first file it
+// can explain, so the cap is a backstop against a pathological tree, not
+// a budget anyone should hit.
+const emptyWalkProbeCap = 200000
+
+// emptyWalkCause names one file the walk could have indexed and the
+// reason it did not.
+type emptyWalkCause struct {
+	// RelPath is the repo-relative path of the first file whose language
+	// the indexer recognises.
+	RelPath string
+	// Source is where the responsible pattern came from, in words an
+	// operator can act on. Empty when nothing excluded the file.
+	Source string
+	// Pattern is the ignore pattern that excluded RelPath, in its
+	// original wording. Empty when nothing excluded the file.
+	Pattern string
+}
+
+// diagnoseEmptyWalk explains why an index walk admitted no files at all.
+//
+// A repo that indexes zero files is indistinguishable, from every
+// downstream surface, from a repo that genuinely has no code: queries
+// return "no callers" and "likely unused" with full confidence (#624).
+// The walk cannot tell the difference either — an over-broad ignore
+// prunes whole directories, so the excluded files are never even
+// enumerated. So when the walk comes back empty, re-walk without pruning
+// until the first file whose language is registered, and report what
+// excluded it. This runs only on the failure path; a healthy index never
+// pays for it.
+//
+// Returns a zero cause when the tree really does hold no indexable file.
+func (idx *Indexer) diagnoseEmptyWalk(absRoot string) emptyWalkCause {
+	var cause emptyWalkCause
+	visited := 0
+	_ = filepath.WalkDir(absRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if visited++; visited > emptyWalkProbeCap {
+			return filepath.SkipAll
+		}
+		if d.IsDir() {
+			// .git is excluded on every repo and is often the biggest
+			// directory in the tree; descending it would only slow the
+			// probe down and could never explain anything.
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if _, ok := idx.effectiveLanguage(path, nil); !ok {
+			return nil
+		}
+		rel, relErr := filepath.Rel(absRoot, path)
+		if relErr != nil {
+			return nil
+		}
+		cause.RelPath = filepath.ToSlash(rel)
+		if m := idx.excludeMatcher(); m != nil {
+			if matched, pattern := m.ExplainAbsDir(path, absRoot, false); matched {
+				cause.Source = "exclude list (.gitignore, .gortex.yaml, or global config)"
+				cause.Pattern = pattern
+				return filepath.SkipAll
+			}
+		}
+		if matched, dir, pattern := idx.dirIgnoreMatcher(absRoot).Explain(path, false); matched {
+			cause.Source = "per-directory ignore file in " + dir
+			cause.Pattern = pattern
+			return filepath.SkipAll
+		}
+		// Recognised and not excluded: the size cap or the content
+		// admission gate dropped it, and both already report themselves.
+		return filepath.SkipAll
+	})
+	return cause
+}
+
+// warnIfWalkAdmittedNothing logs a warning when an index walk produced no
+// files but the tree holds at least one file the indexer knows how to
+// parse. Silence is the failure mode being fixed here: without this, a
+// repo whose ignore rules swallowed everything reports success at every
+// layer and agents read the empty graph as an authoritative answer.
+func (idx *Indexer) warnIfWalkAdmittedNothing(absRoot string, admitted int) {
+	if admitted > 0 || idx.logger == nil {
+		return
+	}
+	cause := idx.diagnoseEmptyWalk(absRoot)
+	if cause.RelPath == "" {
+		// No registered language anywhere under the root — an empty index
+		// is the correct answer, not a failure.
+		return
+	}
+	if cause.Pattern == "" {
+		idx.logger.Warn("indexer: no source files were indexed, though the repo contains some",
+			zap.String("repo", idx.repoPrefix),
+			zap.String("root", absRoot),
+			zap.String("example_file", cause.RelPath))
+		return
+	}
+	idx.logger.Warn("indexer: no source files were indexed — an ignore pattern excludes the whole repo",
+		zap.String("repo", idx.repoPrefix),
+		zap.String("root", absRoot),
+		zap.String("example_file", cause.RelPath),
+		zap.String("excluded_by", cause.Source),
+		zap.String("pattern", cause.Pattern))
 }
 
 // shouldPruneDir reports whether the index walk may skip a directory

--- a/internal/indexer/pandas_gitignore_regression_test.go
+++ b/internal/indexer/pandas_gitignore_regression_test.go
@@ -1,0 +1,97 @@
+package indexer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// pandasIgnoreExcerpt is the head of pandas-dev/pandas' .gitignore,
+// verbatim. Line 7 is "*$" — an Emacs autosave pattern that used to
+// compile into a regexp matching every path in the repository, so
+// `gortex track` on pandas reported success while indexing none of its
+// 1,519 Python files (#624).
+const pandasIgnoreExcerpt = `#########################################
+# Editor temporary/working/backup files #
+.#*
+*\#*\#
+[#]*#
+*~
+*$
+*.bak
+*.log
+
+# Compiled source #
+###################
+*.pxi
+*.o
+*.py[ocd]
+*.so
+MANIFEST
+
+# Python files #
+################
+build
+dist
+*.egg-info
+__pycache__
+
+# OS generated files #
+######################
+.DS_Store
+Icon?
+`
+
+// The whole pipeline the report exercised: a .gitignore on disk, through
+// the config manager's exclude layering, into a real index pass.
+func TestMultiIndexer_PandasGitignoreDoesNotEmptyTheRepo(t *testing.T) {
+	root := t.TempDir()
+	files := map[string]string{
+		".gitignore":     pandasIgnoreExcerpt,
+		"main.go":        "package main\n\nfunc main() {}\n",
+		"core/frame.go":  "package core\n\nfunc DataFrame() {}\n",
+		"core/series.go": "package core\n\nfunc Series() {}\n",
+		// Still ignored, by patterns that were never the problem.
+		"build/gen.go":      "package build\n",
+		"core/.frame.go~":   "package core\n",
+		"dist/bundled.go":   "package dist\n",
+		"pkg.egg-info/x.go": "package egg\n",
+	}
+	for rel, body := range files {
+		abs := filepath.Join(root, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(abs), 0o755))
+		require.NoError(t, os.WriteFile(abs, []byte(body), 0o644))
+	}
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	gc := &config.GlobalConfig{Repos: []config.RepoEntry{{Path: root, Name: "pandas"}}}
+	gc.SetConfigPath(cfgPath)
+	require.NoError(t, gc.Save())
+	cm, err := config.NewConfigManager(cfgPath)
+	require.NoError(t, err)
+
+	reg := parser.NewRegistry()
+	reg.Register(languages.NewGoExtractor())
+	g := graph.New()
+	mi := NewMultiIndexer(g, reg, search.NewNull(), cm, zap.NewNop())
+
+	results, err := mi.IndexAll()
+	require.NoError(t, err)
+	require.Contains(t, results, "pandas")
+	assert.Equal(t, 3, results["pandas"].FileCount,
+		"the three source files must be indexed; the ignore file's other patterns still apply")
+
+	require.NotEmpty(t, g.FindNodesByName("DataFrame"),
+		"a symbol from a source file the ignore rules never named must reach the graph")
+	assert.Empty(t, g.FindNodesByName("Series0"))
+}

--- a/internal/mcp/index_health_empty_repo_test.go
+++ b/internal/mcp/index_health_empty_repo_test.go
@@ -1,0 +1,115 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// Issue #624: a repo whose ignore rules matched every path indexed zero
+// files and reported success. index_health is the call an agent makes
+// before trusting a whole-workspace answer, and nothing in it could see
+// that state — every other signal describes what IS in the graph, so an
+// index holding nothing looks exactly like a repo that has no code.
+
+// healthServerWithIndexedRepos indexes each supplied directory through a
+// real MultiIndexer and returns a server wired to the result.
+func healthServerWithIndexedRepos(t *testing.T, named map[string]string) *Server {
+	t.Helper()
+	srv, _ := setupTestServer(t)
+
+	entries := make([]config.RepoEntry, 0, len(named))
+	for name, path := range named {
+		entries = append(entries, config.RepoEntry{Path: path, Name: name})
+	}
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	gc := &config.GlobalConfig{Repos: entries}
+	gc.SetConfigPath(cfgPath)
+	require.NoError(t, gc.Save())
+	cm, err := config.NewConfigManager(cfgPath)
+	require.NoError(t, err)
+
+	reg := parser.NewRegistry()
+	reg.Register(languages.NewGoExtractor())
+	mi := indexer.NewMultiIndexer(graph.New(), reg, search.NewNull(), cm, zap.NewNop())
+	_, err = mi.IndexAll()
+	require.NoError(t, err)
+
+	srv.configManager = cm
+	srv.multiIndexer = mi
+	return srv
+}
+
+func writeRepo(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for rel, body := range files {
+		abs := filepath.Join(root, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(abs), 0o755))
+		require.NoError(t, os.WriteFile(abs, []byte(body), 0o644))
+	}
+	return root
+}
+
+func TestIndexHealth_FlagsRepoThatIndexedNoFiles(t *testing.T) {
+	healthy := writeRepo(t, map[string]string{"main.go": "package main\n\nfunc main() {}\n"})
+	// An ignore rule that swallows the whole tree — the shape the report
+	// hit, reached here through a per-directory ignore file so the test
+	// needs no daemon config.
+	swallowed := writeRepo(t, map[string]string{
+		"pkg/frame.go":  "package pkg\n\nfunc DataFrame() {}\n",
+		".gortexignore": "*\n",
+	})
+
+	srv := healthServerWithIndexedRepos(t, map[string]string{
+		"healthy":   healthy,
+		"swallowed": swallowed,
+	})
+
+	payload := srv.buildIndexHealthPayload()
+	require.NotNil(t, payload)
+
+	assert.Equal(t, false, payload["repos_hold_files_ok"])
+	assert.Equal(t, []string{"swallowed"}, payload["empty_repos"],
+		"only the repo that indexed nothing is reported")
+
+	rec, _ := payload["recommendation"].(string)
+	assert.Contains(t, rec, "swallowed")
+	assert.Contains(t, rec, "ignore rule",
+		"health must point at the cause an operator can act on")
+}
+
+func TestIndexHealth_EveryRepoHoldsFilesStaysGreen(t *testing.T) {
+	srv := healthServerWithIndexedRepos(t, map[string]string{
+		"a": writeRepo(t, map[string]string{"a.go": "package a\n"}),
+		"b": writeRepo(t, map[string]string{"b.go": "package b\n"}),
+	})
+
+	payload := srv.buildIndexHealthPayload()
+	require.NotNil(t, payload)
+
+	assert.Equal(t, true, payload["repos_hold_files_ok"])
+	assert.NotContains(t, payload, "empty_repos")
+}
+
+// A server with no multi-repo registry (an embedded single-repo server)
+// must report no empty repos rather than panicking.
+func TestIndexHealth_NoMultiIndexerReportsNoEmptyRepos(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	assert.Empty(t, srv.emptyTrackedRepos())
+
+	payload := srv.buildIndexHealthPayload()
+	require.NotNil(t, payload)
+	assert.Equal(t, true, payload["repos_hold_files_ok"])
+}

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -3456,6 +3456,31 @@ func (s *Server) buildIndexHealthPayloadCtx(ctx context.Context) (map[string]any
 		result["tracked_repo_paths_ok"] = true
 	}
 
+	// A tracked repo holding zero indexed files is the one failure that
+	// looks identical to success from every query: find_usages answers
+	// "no callers", analyze answers "likely unused", and nothing marks the
+	// answer as coming from an empty index (#624). Like a dead
+	// registration, it can only be seen from here.
+	if emptyRepos := s.emptyTrackedRepos(); len(emptyRepos) > 0 {
+		result["empty_repos"] = emptyRepos
+		result["repos_hold_files_ok"] = false
+		subject := "Tracked repository"
+		if len(emptyRepos) > 1 {
+			subject = "Tracked repositories"
+		}
+		msg := subject + " holding no indexed files: " + strings.Join(emptyRepos, ", ") +
+			". Every query scoped to them returns an empty answer that reads like a real one. Either the path holds no " +
+			"source Gortex can parse, or an ignore rule (.gitignore, .gortexignore, .gortex.yaml excludes) excluded all of " +
+			"it — the daemon log names the pattern. Re-index with index_repository path \".\" once it is fixed."
+		if recommendation == "" {
+			recommendation = msg
+		} else {
+			recommendation = msg + " " + recommendation
+		}
+	} else {
+		result["repos_hold_files_ok"] = true
+	}
+
 	if recommendation != "" {
 		result["recommendation"] = recommendation
 	}
@@ -3594,6 +3619,42 @@ func (s *Server) buildIndexHealthFileRollup(repoPrefixes map[string]struct{}) (f
 		}
 	}
 	return filesWithErrors, indexedFileCount
+}
+
+// emptyTrackedRepos names every tracked repository whose last index pass
+// admitted no source file at all.
+//
+// This is the failure behind #624, and it is invisible from everywhere
+// else in the payload: an ignore rule that matches every path leaves a
+// repo tracked, loaded, and answering — with an empty graph. find_usages
+// says "no callers", analyze says "likely unused", and nothing marks the
+// answer as coming from a repo that indexed nothing.
+//
+// The per-repo file count is the authoritative measure, not the graph's
+// file nodes: a repo that indexed zero files can still hold a synthetic
+// file node minted from a root manifest (go.mod, package.json,
+// pyproject.toml), which is exactly what made the pandas report read as
+// a one-file index. A repo that has never finished an index pass is
+// pending, not empty, and is skipped.
+func (s *Server) emptyTrackedRepos() []string {
+	if s.multiIndexer == nil {
+		return nil
+	}
+	var empty []string
+	for _, meta := range s.multiIndexer.AllMetadata() {
+		if meta == nil || meta.LastIndexTime.IsZero() || meta.FileCount > 0 {
+			continue
+		}
+		name := meta.RepoPrefix
+		if name == "" {
+			name = meta.RootPath
+		}
+		if name != "" {
+			empty = append(empty, name)
+		}
+	}
+	sort.Strings(empty)
+	return empty
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/review/rules.go
+++ b/internal/review/rules.go
@@ -4,10 +4,10 @@ import (
 	"os"
 	"path/filepath"
 
-	gitignore "github.com/sabhiram/go-gitignore"
 	"gopkg.in/yaml.v3"
 
 	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/excludes"
 	"github.com/zzet/gortex/internal/platform"
 )
 
@@ -27,9 +27,14 @@ type RuleResolver struct {
 // compiledRule pairs a config rule with its precompiled gitignore
 // matcher so RuleFor never recompiles. The matcher is read-only after
 // construction, so RuleFor is safe to call concurrently.
+//
+// Compilation goes through excludes.New, which neutralises the regexp
+// metacharacters go-gitignore would otherwise splice into its pattern
+// verbatim — a rule path holding "$", "^" or "|" would otherwise govern
+// files it never named (#624).
 type compiledRule struct {
 	rule    config.ReviewRule
-	matcher *gitignore.GitIgnore
+	matcher *excludes.Matcher
 }
 
 // NewRuleResolver merges the four rule layers in precedence order,
@@ -93,7 +98,7 @@ func NewRuleResolver(customPath, repoRoot string) (*RuleResolver, error) {
 		}
 		compiled = append(compiled, compiledRule{
 			rule:    r,
-			matcher: gitignore.CompileIgnoreLines(r.Path),
+			matcher: excludes.New([]string{r.Path}),
 		})
 	}
 
@@ -108,7 +113,7 @@ func NewRuleResolver(customPath, repoRoot string) (*RuleResolver, error) {
 // callers should still check it.
 func (r *RuleResolver) RuleFor(filePath string) (config.ReviewRule, bool) {
 	for _, cr := range r.rules {
-		if cr.matcher.MatchesPath(filePath) {
+		if cr.matcher.MatchRel(filePath) {
 			return cr.rule, true
 		}
 	}

--- a/internal/review/rules_metachar_test.go
+++ b/internal/review/rules_metachar_test.go
@@ -1,0 +1,42 @@
+package review
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Review rule globs were compiled by go-gitignore directly, which
+// splices pattern text into a regexp with almost nothing escaped. A rule
+// path holding a regexp metacharacter therefore governed files it never
+// named — the ownership-side twin of the indexing failure in #624.
+func TestRuleFor_RegexMetacharactersInRulePathAreLiteral(t *testing.T) {
+	dir := t.TempDir()
+	rulesPath := filepath.Join(dir, "review.yaml")
+	require.NoError(t, os.WriteFile(rulesPath, []byte(`rules:
+  - name: backups
+    path: "*$"
+    severity: critical
+  - name: services
+    path: "api|web"
+    severity: critical
+`), 0o644))
+
+	r, err := NewRuleResolver(rulesPath, "")
+	require.NoError(t, err)
+
+	for _, f := range []string{"internal/app.go", "README.md", "api", "web"} {
+		rule, ok := r.RuleFor(f)
+		require.True(t, ok, "the embedded catch-all always matches")
+		assert.NotEqual(t, "critical", rule.Severity,
+			"%s must not be governed by a rule whose path never named it", f)
+	}
+
+	rule, ok := r.RuleFor("dump.sql$")
+	require.True(t, ok)
+	assert.Equal(t, "critical", rule.Severity,
+		`"*$" still governs the files it actually names`)
+}


### PR DESCRIPTION
Closes #624.

## What happened

`gortex track` on pandas reported success and produced an index holding **zero** of its 1,519 Python files — no error, no warning, no non-zero exit. Every query against that repo then answered "no callers" and "likely unused" with full confidence, which from the MCP surface is indistinguishable from a real result.

Two independent defects, both fixed here.

## Bug 1 — one `.gitignore` line excluded the whole repository

pandas' `.gitignore` line 7 is an Emacs autosave pattern:

```
*$
```

To git that means "names ending in a dollar sign". `github.com/sabhiram/go-gitignore` compiles a pattern by **string-substituting it into a Go regular expression**, escaping exactly two characters on the way — `.` and `?`. Everything else reaches the engine as an operator. So `*$` became:

```
^(|.*/)([^/]*)$(|/.*)$
```

whose `$` is an end-of-text anchor. It matches **every path in the repository**. The index walk pruned every top-level directory and admitted nothing.

The `pyproject.toml` that appeared in the graph was not evidence the walk ran: `Indexer.extractOneModuleManifest` reads root manifests with a plain `os.ReadFile`, bypassing the exclude matcher. pandas' manifest parses to 42 unique module nodes plus one synthetic file node — exactly the 43 nodes in the report.

### The defect is general, and it cuts both ways

| Pattern | git means | gortex did |
|---|---|---|
| `*$`, `^*` | names ending / starting with that char | **matched everything** |
| `a\|b` | a file named `a\|b` | also matched `b` |
| `foo+` | a file named `foo+` | also matched `foo` |
| `[!a-z]` | negated class | inverted wrongly — git spells negation `!`, regexp wants `^` |
| `?` | any single char except `/` | escaped to a **literal** `?`, so pandas' `Icon?` never caught the macOS `Icon\r` file |
| `lib[`, `build(` | literal text | `regexp.Compile` failed; `pattern, _ := regexp.Compile(expr)` **discarded the error** and dropped the line, so the ignore silently stopped applying |

Over-matching empties an index. Under-matching lets an ignored tree in. Both are silent.

### The fix

Rewrite each pattern before the library sees it (`internal/excludes/pattern.go`):

- escape the metacharacters that carry no meaning in a gitignore pattern — `$ ^ + ( ) { } | ]`
- lower `?` to `[^/]`, the wildcard git actually defines
- translate bracket expressions: `[!…]` → `[^…]`, and escape a literal `*` or `$` inside the brackets (the library's later substitution passes would otherwise rewrite them — `$` is half of its `#$~` placeholder)
- an unterminated `[` becomes literal text, as fnmatch and git read it
- a bracket expression that still refuses to compile falls back to literal text rather than taking the whole pattern down with it

`*` and `.` are deliberately left alone — the library handles those correctly (including `**` across separators), and pre-escaping `.` would collide with its own `\.` pass.

`Matcher` keeps the **original** pattern text; the rewrite is a compiler detail and never reaches a user-visible surface. New `Explain` / `ExplainAbsDir` / `Hierarchical.Explain` report which pattern excluded a path, in the caller's wording.

### Measured against real `git check-ignore`

Fifteen upstream `github/gitignore` templates plus pandas' own file — ~470 patterns × 50 candidate paths:

| | divergences |
|---|---|
| before | **27** |
| after | **2** |

Both survivors are outside this issue: one is macOS `core.ignorecase`, which git honours and this matcher does not; one is an artifact of passing a bare CR through `git check-ignore --stdin`. Every stock template was already clean — the defect only bites on hand-written lines, which is why it survived this long.

### Same library, two other callers

CODEOWNERS rules (`internal/codeowners`) and review path rules (`internal/review`) compiled their globs with go-gitignore **directly**, so an owner or review rule as ordinary as `*$` claimed every file in the repository. Both now go through `excludes.New`. There is now exactly one door onto go-gitignore in the tree.

## Bug 2 — the silence

> The silence is the bug more than the skip.

Agreed, and it is the more general half: the pattern bug is fixed, but any exclude, `.gortexignore`, or hand-written `.gitignore` can still empty a repo, and nothing in any view said so.

There was **no zero-source-file check anywhere in the codebase**. `gortex status` already special-cases `MISSING` and `not indexed` (from #312), but a repo that indexed successfully and produced 0 files rendered as an ordinary count row. `IndexResult.SkippedFiles` could not help either — an over-broad ignore prunes whole directories, so the excluded files are never enumerated and every skip counter stays at zero alongside everything else.

So when the walk comes back empty, re-walk without pruning until the first file whose language is registered, and report what excluded it. **This runs only on the failure path** — a healthy index never pays for it, and a repo that genuinely holds no parsable source is not flagged.

Surfaced in the three places the state can be acted on:

```
WARN  indexer: no source files were indexed — an ignore pattern excludes the whole repo
      repo=pandas root=/srv/pandas example_file=pandas/core/frame.py
      excluded_by="exclude list (.gitignore, .gortex.yaml, or global config)" pattern="*$"
```

```
tracked repos:
  pandas   /srv/pandas   EMPTY — indexed 0 files; no parsable source, or an ignore rule excluded all of it

!! 1 tracked repo indexed no files — queries against them return empty answers, not missing ones:
     pandas   /srv/pandas
   Either the path holds no source Gortex can parse, or an ignore rule excluded all of it.
   The daemon log names the pattern:
     gortex daemon logs | grep 'no source files were indexed'
```

and `index_health` gains `repos_hold_files_ok: false` with the prefixes under `empty_repos`, plus a recommendation naming the likely cause — the call an agent makes before trusting a whole-workspace answer.

The per-repo file count is the authoritative measure, not the graph's file nodes: a repo that indexed nothing can still hold that synthetic manifest file node, which is what made the original report read as a one-file index. A repo that has never finished an index pass is pending, not empty, and stays unflagged.

## Tests

Every test below was verified to **fail** with the fix neutered, not merely to pass with it.

- `internal/excludes/pattern_test.go` — the anchor case, every regexp-only metacharacter, uncompilable patterns still applying, `?` as a wildcard, bracket expressions, escapes and `**` surviving, `Explain` reporting original wording
- `internal/config/gitignore_effective_test.go` — pandas' verbatim ignore block through `ConfigManager.EffectiveExclude`, asserting both directions: source files indexable, `*.pyc` / `build/` / `*~` / `*.egg-info` still excluded
- `internal/indexer/pandas_gitignore_regression_test.go` — the reported repro end to end: `.gitignore` on disk → config layering → a real `MultiIndexer` pass. Reproduces `FileCount == 0` without the fix.
- `internal/indexer/empty_walk_diagnostic_test.go` — warns and names the pattern for both exclude-list and per-directory ignore files; stays quiet for a repo with no source and for a healthy index
- `cmd/gortex/repo_inventory_empty_test.go`, `internal/mcp/index_health_empty_repo_test.go` — the reporting surfaces, including the pending-vs-empty distinction and a server with no multi-repo registry
- `internal/codeowners/pattern_metachar_test.go`, `internal/review/rules_metachar_test.go` — the two sibling callers

Full suite green; `golangci-lint run ./...` reports 0 issues.

## Known, out of scope

- **`core.ignorecase`** — on macOS and Windows git matches ignore patterns case-insensitively; this matcher is always case-sensitive. It causes under-exclusion (gortex indexes *more*), never an empty index. Not touched here.
- **Root manifests bypass excludes** — `extractOneModuleManifest` reads `go.mod` / `package.json` / `pyproject.toml` from the repo root without consulting the exclude matcher. That is what made an empty index look like a one-file index. Making it honour excludes would risk losing dependency extraction for repos that gitignore their manifests, so it is left alone; the empty-repo signal above uses the per-repo file count precisely so it is not fooled by that node.
