### PR TITLE
fix(doctor): PostToolUse zero-injection is expected under the deny posture

### DIFF
--- a/cmd/gortex/doctor_runtime.go
+++ b/cmd/gortex/doctor_runtime.go
@@ -183,7 +183,11 @@ func doctorAgentProbes(home string) []agentProbe {
 					MCPServer: state.MCPServer, Hooks: state.Hooks,
 					InstructionsPath: state.InstructionsPath, InstructionsWired: state.InstructionsWired,
 				},
-				adoption: doctor.ScanClaudeSessions(doctor.ClaudeHome(), since, 10),
+				// Deny-posture installs never expect PostToolUse context
+				// injections (its matcher only watches Gortex tools); the
+				// flag keeps Diagnose from warning on that steady state.
+				postToolUseDeny: state.PostToolUseDenyPosture,
+				adoption:        doctor.ScanClaudeSessions(doctor.ClaudeHome(), since, 10),
 			}, activity, now)
 		}},
 		{agent: copilotcli.Name, run: func(since time.Time, activity hooks.EffectivenessSummary, now time.Time) doctorAgentRuntime {
@@ -287,6 +291,7 @@ type agentRuntimeInput struct {
 	agent               string
 	hookEvents          []string
 	install             doctorAgentInstall
+	postToolUseDeny     bool
 	requiresTrust       bool
 	trustRemedy         string
 	hooksDisabledRemedy string
@@ -311,13 +316,14 @@ func buildAgentRuntime(in agentRuntimeInput, activity hooks.EffectivenessSummary
 	}
 	duplicateEvents, duplicateFiles := duplicateHookDeclarations(in.install.HookSources)
 	out.Findings = doctor.Diagnose(doctor.AgentHooks{
-		Agent:               in.agent,
-		Configured:          in.install.Hooks,
-		RequiresTrust:       in.requiresTrust,
-		TrustRemedy:         in.trustRemedy,
-		HooksDisabled:       in.install.HooksDisabled,
-		HooksDisabledRemedy: in.hooksDisabledRemedy,
-		DuplicateHookEvents: duplicateEvents,
+		Agent:                  in.agent,
+		Configured:             in.install.Hooks,
+		PostToolUseDenyPosture: in.postToolUseDeny,
+		RequiresTrust:          in.requiresTrust,
+		TrustRemedy:            in.trustRemedy,
+		HooksDisabled:          in.install.HooksDisabled,
+		HooksDisabledRemedy:    in.hooksDisabledRemedy,
+		DuplicateHookEvents:    duplicateEvents,
 		// ConfigPath is the file the adapter's installer rewrites, so it is
 		// the one a duplicate must NOT be cleaned out of.
 		DuplicateHookSources: duplicateFiles,

--- a/internal/agents/claudecode/inspect.go
+++ b/internal/agents/claudecode/inspect.go
@@ -15,12 +15,13 @@ import (
 
 // InstallState is the observed state of the Claude Code integration.
 type InstallState struct {
-	ConfigPath        string         `json:"config_path"`
-	ConfigPresent     bool           `json:"config_present"`
-	MCPServer         bool           `json:"mcp_server"`
-	Hooks             map[string]int `json:"hooks"`
-	InstructionsPath  string         `json:"instructions_path,omitempty"`
-	InstructionsWired bool           `json:"instructions_wired"`
+	ConfigPath             string         `json:"config_path"`
+	ConfigPresent          bool           `json:"config_present"`
+	MCPServer              bool           `json:"mcp_server"`
+	Hooks                  map[string]int `json:"hooks"`
+	PostToolUseDenyPosture bool           `json:"post_tool_use_deny_posture"`
+	InstructionsPath       string         `json:"instructions_path,omitempty"`
+	InstructionsWired      bool           `json:"instructions_wired"`
 }
 
 // HookEvents are the lifecycle events this adapter installs. SessionStart
@@ -48,7 +49,8 @@ func Inspect(home string) InstallState {
 		state.ConfigPresent = true
 		var settings struct {
 			Hooks map[string][]struct {
-				Hooks []struct {
+				Matcher string `json:"matcher"`
+				Hooks   []struct {
 					Command string `json:"command"`
 				} `json:"hooks"`
 			} `json:"hooks"`
@@ -59,14 +61,26 @@ func Inspect(home string) InstallState {
 					continue
 				}
 				for _, entry := range entries {
+					gortexOwned := false
 					for _, h := range entry.Hooks {
 						// Same recogniser the installer's idempotency check
 						// uses: a gortex-invoking command, however it is
 						// spelled or pathed.
 						if strings.Contains(h.Command, "gortex") {
 							state.Hooks[event]++
+							gortexOwned = true
 							break
 						}
+					}
+					// The PostToolUse matcher is the posture tell: enrich
+					// mode joins the native read-shaped tools into it;
+					// deny mode leaves it watching Gortex tool calls only.
+					// An empty matcher matches every tool (native reads
+					// included), so it is treated as enrichment-capable
+					// rather than deny.
+					if gortexOwned && event == "PostToolUse" && entry.Matcher != "" &&
+						!postToolUseMatcherWatchesNativeTools(entry.Matcher) {
+						state.PostToolUseDenyPosture = true
 					}
 				}
 			}
@@ -89,4 +103,16 @@ func Inspect(home string) InstallState {
 			strings.Contains(text, agents.InstructionsSentinel)
 	}
 	return state
+}
+
+// postToolUseMatcherWatchesNativeTools reports whether a PostToolUse matcher
+// includes the native read-shaped tools — the enrich posture, where
+// InstallHookWithMode joins CurrentPostToolUseMatcher into the localization
+// matcher. Under the deny posture the matcher names only the Gortex MCP
+// tools. The alternatives are matched case-sensitively so the lowercase
+// mcp__gortex__read alternative of the deny-posture matcher can never match.
+func postToolUseMatcherWatchesNativeTools(matcher string) bool {
+	return strings.Contains(matcher, "Read") ||
+		strings.Contains(matcher, "Grep") ||
+		strings.Contains(matcher, "Glob")
 }

--- a/internal/agents/claudecode/inspect_test.go
+++ b/internal/agents/claudecode/inspect_test.go
@@ -3,6 +3,7 @@ package claudecode
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/zzet/gortex/internal/agents"
@@ -90,5 +91,54 @@ func TestInspectSurvivesBrokenConfig(t *testing.T) {
 
 	if got := Inspect(""); got.ConfigPresent {
 		t.Errorf("empty home should report nothing, got %+v", got)
+	}
+}
+
+// TestInspectDetectsPostToolUsePosture — the PostToolUse matcher is the
+// deny/enrich tell: InstallHookWithMode joins the native read-shaped tools
+// into it only under enrich, leaving deny watching Gortex tool calls alone.
+// doctor keys its "ran but never injected" severity off this flag (#630), so
+// a misread posture either hides real enrich-mode breakage or warns forever
+// on a healthy deny install.
+func TestInspectDetectsPostToolUsePosture(t *testing.T) {
+	hookWithMatcher := func(matcher string) string {
+		return `{"hooks":{"PostToolUse":[{"matcher":` + strconv.Quote(matcher) +
+			`,"hooks":[{"type":"command","command":"/opt/homebrew/bin/gortex hook"}]}]}}`
+	}
+
+	cases := []struct {
+		name    string
+		matcher string
+		want    bool
+	}{
+		// The deny posture: only Gortex MCP tools. The lowercase
+		// mcp__gortex__read alternative must never read as native Read.
+		{"deny matcher watches only gortex tools",
+			"mcp__gortex__explore|mcp__gortex__search|mcp__gortex__read", true},
+		// Enrich joins CurrentPostToolUseMatcher into the localization set.
+		{"enrich matcher includes native tools",
+			"Read|Grep|Glob|mcp__gortex__explore|mcp__gortex__read", false},
+		// An empty matcher matches every tool, so enrichment is possible.
+		{"empty matcher is not deny", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env, _ := agentstest.NewEnv(t)
+			path := userSettingsLocalPath(env.Home)
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte(hookWithMatcher(tc.matcher)), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			state := Inspect(env.Home)
+			if state.Hooks["PostToolUse"] != 1 {
+				t.Fatalf("fixture not recognised as a gortex hook: %+v", state.Hooks)
+			}
+			if state.PostToolUseDenyPosture != tc.want {
+				t.Errorf("PostToolUseDenyPosture=%v want %v (matcher %q)",
+					state.PostToolUseDenyPosture, tc.want, tc.matcher)
+			}
+		})
 	}
 }

--- a/internal/doctor/findings.go
+++ b/internal/doctor/findings.go
@@ -69,6 +69,15 @@ type AgentHooks struct {
 	// InstructionsShadowed is set when the agent will read a different file
 	// instead, making the block above dead text.
 	InstructionsShadowed string
+	// PostToolUseDenyPosture is set when the installed PostToolUse hook runs
+	// under the deny posture — its matcher names only the Gortex MCP tools,
+	// never the native read-shaped tools the enrichment path keys on. There
+	// the hook exists to watch localization receipts and is never expected
+	// to inject context (PreToolUse already redirects native reads), so
+	// "ran but never emitted" is the designed steady state, not a
+	// degradation. Agents without a posture concept leave it false and keep
+	// the original warning semantics.
+	PostToolUseDenyPosture bool
 	// HooksDisabled marks a harness whose configuration switches hook
 	// execution off wholesale. It explains an idle install completely, so it
 	// must pre-empt the trust and PATH remedies — both of which would send
@@ -197,6 +206,20 @@ func Diagnose(agent AgentHooks, summary hooks.EffectivenessSummary, adoption Ado
 			continue
 		}
 		if stats.Emitted == 0 {
+			// Under the deny posture the PostToolUse hook only watches
+			// Gortex tool calls for localization receipts — its matcher
+			// never names the native read-shaped tools the enrichment
+			// path keys on, so zero injections is the designed steady
+			// state, and warning on it would fire permanently on every
+			// healthy deny-mode install (#630). Enrich-mode installs
+			// keep the warning: there, silence genuinely means the
+			// enrichment path broke.
+			if event == "PostToolUse" && agent.PostToolUseDenyPosture {
+				add(SeverityInfo, "",
+					"%s ran %d time(s) and injected context 0 times — expected under the deny posture: PreToolUse already redirects native reads, and this hook only watches Gortex tool calls.",
+					event, stats.Runs)
+				continue
+			}
 			add(SeverityWarn, "",
 				"%s ran %d time(s) and injected context 0 times — it fires but has nothing to say.", event, stats.Runs)
 		}

--- a/internal/doctor/findings_test.go
+++ b/internal/doctor/findings_test.go
@@ -493,3 +493,50 @@ func TestHooksTurnedOffSuppressesThePerEventTrustRemedy(t *testing.T) {
 		}
 	}
 }
+
+// TestPostToolUseSilenceUnderDenyPostureIsExpected is #630: the deny posture
+// narrows the PostToolUse matcher to the Gortex MCP tools, so the enrichment
+// path can never fire and zero injections is the designed steady state.
+// Warning on it permanently accuses every healthy deny-mode install.
+func TestPostToolUseSilenceUnderDenyPostureIsExpected(t *testing.T) {
+	agent := codexAgent()
+	agent.Agent = "claude-code"
+	agent.PostToolUseDenyPosture = true
+
+	findings := Diagnose(agent, activity(map[string]hooks.EventActivity{
+		"SessionStart":     {Runs: 4, Emitted: 4, DaemonKnown: 4, DaemonUp: 4},
+		"UserPromptSubmit": {Runs: 9, Emitted: 3, DaemonKnown: 9, DaemonUp: 9},
+		"PreToolUse":       {Runs: 9, Emitted: 3, DaemonKnown: 9, DaemonUp: 9},
+		"PostToolUse":      {Runs: 9, Emitted: 0, DaemonKnown: 9, DaemonUp: 9},
+	}), Adoption{GortexCalls: 20, ShellCalls: 2}, time.Now())
+
+	got := findingWith(t, findings, "PostToolUse ran 9 time(s) and injected context 0 times")
+	if got.Severity != SeverityInfo {
+		t.Errorf("severity=%s want INFO — deny-posture silence is expected, not a fault", got.Severity)
+	}
+	if !strings.Contains(got.Summary, "deny posture") {
+		t.Errorf("summary should name the posture so the reader learns why: %q", got.Summary)
+	}
+	assertNoFindingWith(t, findings, "nothing to say")
+}
+
+// TestPostToolUseSilenceStillWarnsUnderEnrich is the guard the downgrade
+// must not swallow: under enrich the matcher names the native read-shaped
+// tools, so zero emissions genuinely means the enrichment path broke.
+func TestPostToolUseSilenceStillWarnsUnderEnrich(t *testing.T) {
+	agent := codexAgent()
+	agent.Agent = "claude-code"
+	agent.PostToolUseDenyPosture = false
+
+	findings := Diagnose(agent, activity(map[string]hooks.EventActivity{
+		"SessionStart":     {Runs: 4, Emitted: 4, DaemonKnown: 4, DaemonUp: 4},
+		"UserPromptSubmit": {Runs: 9, Emitted: 3, DaemonKnown: 9, DaemonUp: 9},
+		"PreToolUse":       {Runs: 9, Emitted: 3, DaemonKnown: 9, DaemonUp: 9},
+		"PostToolUse":      {Runs: 9, Emitted: 0, DaemonKnown: 9, DaemonUp: 9},
+	}), Adoption{GortexCalls: 20, ShellCalls: 2}, time.Now())
+
+	got := findingWith(t, findings, "nothing to say")
+	if got.Severity != SeverityWarn {
+		t.Errorf("severity=%s want WARN — enrich-mode silence is real breakage", got.Severity)
+	}
+}


### PR DESCRIPTION
Fixes #630.

## Summary

Under the deny posture, `gortex doctor` permanently warns:

```
! WARN    [claude-code] PostToolUse ran 482 time(s) and injected context 0 times — it fires but has nothing to say.
```

This is the designed steady state, not a fault. `InstallHookWithMode` narrows the deny-mode PostToolUse matcher to the Gortex MCP tools only (localization watching); `postToolUse`'s enrichment path keys on the native tool names `Grep`/`Glob`/`Read`, which that matcher can never produce. So `emitted=0` is structural on every deny-mode machine — the hook's daemon reachability (482/482 in the issue's evidence) proves it is alive and doing its real job. The WARN that exists to catch #241-class silent breakage instead fires forever on healthy installs, training users to ignore it.

## Changes

- `internal/agents/claudecode/inspect.go` — `InstallState.PostToolUseDenyPosture`, derived from the installed Gortex-owned PostToolUse matcher: names native read-shaped tools ⇒ enrich (false); Gortex-only ⇒ deny (true). An **empty matcher stays enrichment-capable** (it matches every tool, so silence there is still worth warning about). Detection is case-sensitive so the deny matcher's lowercase `mcp__gortex__read` alternative never reads as native `Read`.
- `internal/doctor/findings.go` — `AgentHooks.PostToolUseDenyPosture`; when it is set, the zero-injection finding for PostToolUse downgrades WARN → INFO with the posture explanation. Enrich-mode installs (flag false — also the default for agents without a posture concept: codex, copilot-cli, opencode) keep the original WARN.
- `cmd/gortex/doctor_runtime.go` — the claude-code probe threads `state.PostToolUseDenyPosture` through `agentRuntimeInput` into `Diagnose`. No other probe changes: their semantics are unchanged by construction.

## Testing

- [x] `go build ./...` + `go vet` clean; `gofmt` clean on all touched files.
- [x] `go test ./internal/doctor/ ./internal/agents/claudecode/ -count=1` — green.
- [x] New tests:
  - `TestPostToolUseSilenceUnderDenyPostureIsExpected` — deny posture: severity INFO, summary names the posture, the old WARN text is absent.
  - `TestPostToolUseSilenceStillWarnsUnderEnrich` — the guard the downgrade must not swallow: enrich-mode silence stays WARN.
  - `TestInspectDetectsPostToolUsePosture` — matcher table: deny matcher ⇒ true, enrich matcher ⇒ false, empty matcher ⇒ false, plus the fixture is recognised as a Gortex hook in every case.
- [x] E2E on the repro machine from #630 (branch binary against the live `~/.gortex` + `~/.claude`):

```
before: ! WARN    [claude-code] PostToolUse ran 482 time(s) and injected context 0 times — it fires but has nothing to say.
after:  · INFO    [claude-code] PostToolUse ran 482 time(s) and injected context 0 times — expected under the deny posture: PreToolUse already redirects native reads, and this hook only watches Gortex tool calls.
```

## Notes

- The INFO finding is kept (not dropped) so the number stays visible for anyone comparing hook activity across postures.
- Out of scope, observed while diagnosing: `SubagentStart`/`SubagentStop`/`PreCompact` also log `emitted=0` rows but do not appear in claude-code's `Configured` set, so they never reach this rule today. If that set ever widens, the same posture question applies to them.