### PR TITLE
fix(release): give the signature gate an explicit repo to query

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -698,7 +698,11 @@ jobs:
           TAG="${GITHUB_REF#refs/tags/}"
           mkdir -p verify
           cd verify
-          gh release download "$TAG" --clobber
+          # --repo is required: this job deliberately skips actions/checkout
+          # (it verifies published bytes, not the source tree), so there is no
+          # git remote for gh to infer the repository from and the command
+          # would abort with "not a git repository".
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --clobber
 
           shopt -s nullglob
           # Keyless certs live ~10 minutes, so verify-blob resolves the


### PR DESCRIPTION
Follow-up to #628. The signature fix itself works — **v0.63.6 ships a `checksums.txt.sig` that verifies** — but the new `verify-signatures` gate failed the run.

## What broke

[The job](https://github.com/zzet/gortex/actions/runs/32310936931/job/96259244964) died in 7 seconds on its first command:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

`verify-signatures` skips `actions/checkout` on purpose — it verifies published bytes, not the source tree — so there is no git remote for `gh` to infer the repository from, and `gh release download` aborts before downloading anything.

Fix: pass `--repo "$GITHUB_REPOSITORY"`.

## Why the original rehearsal missed it

The gate was tested against a **stubbed** `gh`, which by construction could not surface a repository-resolution failure. Stubbing the thing under test hid the only bug that was actually there.

## The release itself was fine

Confirmed independently against the published v0.63.6 assets — the fix from #628 works:

```
published checksums.txt          -> Verified OK
windows entry                    -> present, in correct sorted position
all 12 published signatures      -> verify against their artifacts
every primary artifact           -> signed and listed in checksums.txt
```

So the gate failed a good release. That is the right direction to fail in, but it still needs to run.

## Verification

This time the gate block was extracted verbatim from the YAML and run end to end with the **real** `gh` and the **real** `cosign` (real Rekor lookups) against the real published v0.63.6 release:

```
ok: checksums.txt
ok: gortex_darwin_amd64.tar.gz
... (12 total)
all 12 published signatures verify against their artifacts
EXIT=0
```

Negative control — re-appending a line to the already-signed `checksums.txt`, i.e. reproducing #625 exactly:

```
FAIL: checksums.txt.sig does not verify against the published checksums.txt
ok: gortex_darwin_amd64.tar.gz
... (the other 11 still ok)
release v0.63.6 has unverifiable assets
EXIT=1
```

The gate names the offending file and fails, so it is not a no-op.

Run under bash 3.2 locally; the runner has 5.x, so the stricter direction is covered. `actionlint` reports the same 7 pre-existing SC2035 info findings as `main` — none added.
