### PR TITLE
feat(parser): emit Dart and Swift member declarations with localize seat protection

### DIFF
--- a/internal/mcp/localization_member_demotion_test.go
+++ b/internal/mcp/localization_member_demotion_test.go
@@ -1,0 +1,282 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/search/rerank"
+)
+
+func memberDemotionCandidate(file, name string, kind graph.NodeKind) *rerank.Candidate {
+	return &rerank.Candidate{
+		Node: &graph.Node{
+			ID:         "fixture/" + file + "::" + name,
+			Name:       name,
+			Kind:       kind,
+			FilePath:   "fixture/" + file,
+			RepoPrefix: "fixture",
+		},
+		TextRank:   0,
+		VectorRank: -1,
+	}
+}
+
+func memberDemotionNames(cands []*rerank.Candidate) []string {
+	names := make([]string, 0, len(cands))
+	for _, cand := range cands {
+		if cand == nil || cand.Node == nil {
+			names = append(names, "")
+			continue
+		}
+		names = append(names, cand.Node.Name)
+	}
+	return names
+}
+
+func memberDemotionFiles(cands []*rerank.Candidate) []string {
+	files := make([]string, 0, len(cands))
+	for _, cand := range cands {
+		if cand == nil || cand.Node == nil {
+			files = append(files, "")
+			continue
+		}
+		files = append(files, cand.Node.FilePath)
+	}
+	return files
+}
+
+func TestLocalizationDemotionYieldsFrontSlotToSiblingCallable(t *testing.T) {
+	tests := []struct {
+		name    string
+		member  string
+		ordered []string
+	}{
+		{name: "constructor", member: "DirectoryConfiguration.<init>", ordered: []string{"detect", "DirectoryConfiguration.<init>"}},
+		{name: "destructor", member: "deinit", ordered: []string{"detect", "deinit"}},
+		{name: "subscript", member: "subscript", ordered: []string{"detect", "subscript"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			in := []*rerank.Candidate{
+				memberDemotionCandidate("config.swift", test.member, graph.KindMethod),
+				memberDemotionCandidate("config.swift", "detect", graph.KindMethod),
+			}
+			require.Equal(t, test.ordered, memberDemotionNames(demoteLocalizationFileMembers(in)))
+		})
+	}
+}
+
+func TestLocalizationDemotionYieldsFrontSlotToSiblingMethodForDataMembers(t *testing.T) {
+	tests := []struct {
+		name   string
+		member string
+		kind   graph.NodeKind
+	}{
+		{name: "field", member: "shaderSlots", kind: graph.KindField},
+		{name: "enum member", member: "ShaderStage.vertex", kind: graph.KindEnumMember},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			in := []*rerank.Candidate{
+				memberDemotionCandidate("shaders.dart", test.member, test.kind),
+				memberDemotionCandidate("shaders.dart", "bindShaders", graph.KindMethod),
+			}
+			require.Equal(t, []string{"bindShaders", test.member}, memberDemotionNames(demoteLocalizationFileMembers(in)))
+		})
+	}
+}
+
+func TestLocalizationDemotionKeepsTypesAndOrdinaryCallablesInOneLeadingTier(t *testing.T) {
+	in := []*rerank.Candidate{
+		memberDemotionCandidate("config.swift", "DirectoryConfiguration.<init>", graph.KindMethod),
+		memberDemotionCandidate("config.swift", "shaderSlots", graph.KindField),
+		memberDemotionCandidate("config.swift", "DirectoryConfiguration", graph.KindType),
+		memberDemotionCandidate("config.swift", "deinit", graph.KindMethod),
+		memberDemotionCandidate("config.swift", "detect", graph.KindMethod),
+		memberDemotionCandidate("config.swift", "reload", graph.KindMethod),
+	}
+	require.Equal(t, []string{
+		"DirectoryConfiguration", "detect", "reload",
+		"DirectoryConfiguration.<init>", "deinit",
+		"shaderSlots",
+	}, memberDemotionNames(demoteLocalizationFileMembers(in)))
+}
+
+func TestLocalizationDemotionPermutesOnlyInsideEachFilesOwnSlots(t *testing.T) {
+	in := []*rerank.Candidate{
+		memberDemotionCandidate("config.swift", "shaderSlots", graph.KindField),
+		memberDemotionCandidate("cache.dart", "ShaderCache.<init>", graph.KindMethod),
+		memberDemotionCandidate("config.swift", "detect", graph.KindMethod),
+		nil,
+		memberDemotionCandidate("cache.dart", "warm", graph.KindMethod),
+		{Node: &graph.Node{ID: "fixture::floating", Name: "floating", Kind: graph.KindField}},
+		memberDemotionCandidate("config.swift", "reload", graph.KindMethod),
+	}
+	files := memberDemotionFiles(in)
+	ids := make(map[string]int, len(in))
+	for _, cand := range in {
+		if cand != nil && cand.Node != nil {
+			ids[cand.Node.ID]++
+		}
+	}
+
+	out := demoteLocalizationFileMembers(in)
+
+	require.Equal(t, len(in), len(out), "the window keeps the same number of slots")
+	require.Equal(t, files, memberDemotionFiles(out), "no candidate moves into another file's slot")
+	outIDs := make(map[string]int, len(out))
+	for _, cand := range out {
+		if cand != nil && cand.Node != nil {
+			outIDs[cand.Node.ID]++
+		}
+	}
+	require.Equal(t, ids, outIDs, "the window keeps the same candidate set")
+	require.Equal(t, []string{
+		"detect", "warm", "reload", "", "ShaderCache.<init>", "floating", "shaderSlots",
+	}, memberDemotionNames(out))
+	require.Equal(t, memberDemotionNames(out), memberDemotionNames(demoteLocalizationFileMembers(out)), "the reorder is idempotent")
+}
+
+func newIndexedSwiftMemberDemotionServer(t *testing.T) *Server {
+	t.Helper()
+
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "Sources"), 0o755))
+	files := map[string]string{
+		"DirectoryConfiguration.swift": `
+import Foundation
+
+/// Directory configuration for the shader cache.
+public struct DirectoryConfiguration {
+    /// Root directory scanned when directory configuration detection runs.
+    let root: String
+    /// Shader slots reserved by the directory configuration.
+    let shaderSlots: Int
+
+    /// Creates a directory configuration.
+    public init(root: String, shaderSlots: Int) {
+        self.root = root
+        self.shaderSlots = shaderSlots
+    }
+
+    deinit {
+    }
+
+    subscript(index: Int) -> String {
+        return root
+    }
+
+    /// Detects the directory configuration for a nested path.
+    public func detect(path: String) -> Bool {
+        return !path.isEmpty
+    }
+
+    public func reload(path: String) -> Bool {
+        return detect(path: path)
+    }
+}
+`,
+		"ShaderCache.swift": `
+import Foundation
+
+public struct ShaderCache {
+    let slots: Int
+
+    public init(slots: Int) {
+        self.slots = slots
+    }
+
+    public func warm(configuration: DirectoryConfiguration) -> Bool {
+        return configuration.detect(path: "/tmp")
+    }
+}
+`,
+	}
+	for name, content := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(root, "Sources", name), []byte(content), 0o644))
+	}
+
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	registry := parser.NewRegistry()
+	registry.Register(languages.NewSwiftExtractor())
+	idx := indexer.New(store, registry, config.IndexConfig{Workers: 1}, zap.NewNop())
+	idx.SetRepoPrefix("swift-fixture")
+	idx.SetWorkspaceID("swift-fixture")
+	idx.SetProjectID("swift-fixture")
+	_, err = idx.IndexCtx(context.Background(), root)
+	require.NoError(t, err)
+
+	engine := query.NewEngine(store)
+	engine.SetSearchProvider(idx.Search)
+	return NewServer(engine, store, idx, nil, zap.NewNop(), nil)
+}
+
+func TestIndexedSwiftMemberDemotionAppliesOnlyToTheLocalizePage(t *testing.T) {
+	const (
+		task     = "directory configuration detection is broken"
+		fieldID  = "swift-fixture/Sources/DirectoryConfiguration.swift::DirectoryConfiguration.root"
+		methodID = "swift-fixture/Sources/DirectoryConfiguration.swift::DirectoryConfiguration.detect"
+	)
+	server := newIndexedSwiftMemberDemotionServer(t)
+	call := func(localize bool) *mcpgo.CallToolResult {
+		request := mcpgo.CallToolRequest{}
+		request.Params.Arguments = map[string]any{
+			"task":          task,
+			"localize":      localize,
+			"max_symbols":   8,
+			"token_budget":  2400,
+			"repository_id": "swift-fixture",
+		}
+		result, err := server.handleExplore(context.Background(), request)
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+		require.NotEmpty(t, result.Content)
+		return result
+	}
+
+	localized, ok := call(true).Content[0].(mcpgo.TextContent)
+	require.True(t, ok)
+	var envelope localizationExploreEnvelope
+	require.NoError(t, json.Unmarshal([]byte(localized.Text), &envelope))
+	fieldRank, methodRank := -1, -1
+	for index, evidence := range envelope.Evidence {
+		switch evidence.ID {
+		case fieldID:
+			fieldRank = index
+		case methodID:
+			methodRank = index
+		}
+	}
+	require.GreaterOrEqual(t, methodRank, 0, "the sibling method stays in the window: %#v", envelope.Evidence)
+	require.GreaterOrEqual(t, fieldRank, 0, "the demoted field stays in the window: %#v", envelope.Evidence)
+	require.Less(t, methodRank, fieldRank, "localization seats the sibling method ahead of the field: %#v", envelope.Evidence)
+
+	// The non-localize lane keeps whatever order ranking produced, so this
+	// fixture's field — whose doc comment carries every task term — still leads
+	// its sibling method there.
+	plain, plainOK := call(false).Content[0].(mcpgo.TextContent)
+	require.True(t, plainOK)
+	plainField := strings.Index(plain.Text, "id: "+fieldID)
+	plainMethod := strings.Index(plain.Text, "id: "+methodID)
+	require.GreaterOrEqual(t, plainField, 0, "explore lists the ranked field: %s", plain.Text)
+	require.GreaterOrEqual(t, plainMethod, 0, "explore lists the ranked method: %s", plain.Text)
+	require.Less(t, plainField, plainMethod, "the non-localize page is untouched by localization demotion: %s", plain.Text)
+}

--- a/internal/mcp/localization_member_demotion_test.go
+++ b/internal/mcp/localization_member_demotion_test.go
@@ -152,6 +152,161 @@ func TestLocalizationDemotionPermutesOnlyInsideEachFilesOwnSlots(t *testing.T) {
 	require.Equal(t, memberDemotionNames(out), memberDemotionNames(demoteLocalizationFileMembers(out)), "the reorder is idempotent")
 }
 
+func memberDemotionTarget(file, name string, kind graph.NodeKind) exploreTarget {
+	return exploreTarget{node: memberDemotionCandidate(file, name, kind).Node}
+}
+
+func memberDemotionTargetNames(targets []exploreTarget) []string {
+	names := make([]string, 0, len(targets))
+	for _, target := range targets {
+		if target.node == nil {
+			names = append(names, "")
+			continue
+		}
+		names = append(names, target.node.Name)
+	}
+	return names
+}
+
+func memberDemotionTargetFiles(targets []exploreTarget) []string {
+	files := make([]string, 0, len(targets))
+	for _, target := range targets {
+		if target.node == nil {
+			files = append(files, "")
+			continue
+		}
+		files = append(files, target.node.FilePath)
+	}
+	return files
+}
+
+func TestLocalizationEvidenceDemotionSeatsSiblingCallableBehindFoldedOwner(t *testing.T) {
+	owner := memberDemotionTarget("config.swift", "DirectoryConfiguration", graph.KindType)
+	owner.foldedOwner = true
+	constructor := memberDemotionTarget("config.swift", "DirectoryConfiguration.<init>", graph.KindMethod)
+	constructor.conceptImplementation = true
+	in := []exploreTarget{owner, constructor, memberDemotionTarget("config.swift", "detect", graph.KindMethod)}
+
+	out := demoteLocalizationEvidenceMembers("directory configuration detection is broken", "", in)
+
+	require.Equal(t, []string{
+		"DirectoryConfiguration", "detect", "DirectoryConfiguration.<init>",
+	}, memberDemotionTargetNames(out))
+}
+
+func TestLocalizationEvidenceDemotionSeatsSiblingCallableAheadOfLeadingField(t *testing.T) {
+	field := memberDemotionTarget("lighting.dart", "shaderSlots", graph.KindField)
+	field.conceptImplementation = true
+	in := []exploreTarget{
+		field,
+		memberDemotionTarget("lighting.dart", "LightingInfo", graph.KindType),
+		memberDemotionTarget("lighting.dart", "bindShaders", graph.KindMethod),
+	}
+
+	out := demoteLocalizationEvidenceMembers("lighting info shader slots are wrong", "", in)
+
+	require.Equal(t, []string{"LightingInfo", "bindShaders", "shaderSlots"}, memberDemotionTargetNames(out))
+}
+
+func TestLocalizationEvidenceDemotionNeedsASameFileSiblingOnThePage(t *testing.T) {
+	in := []exploreTarget{
+		memberDemotionTarget("config.swift", "DirectoryConfiguration.<init>", graph.KindMethod),
+		memberDemotionTarget("cache.swift", "warm", graph.KindMethod),
+		memberDemotionTarget("cache.swift", "ShaderCache", graph.KindType),
+	}
+
+	require.Equal(t, memberDemotionTargetNames(in), memberDemotionTargetNames(
+		demoteLocalizationEvidenceMembers("directory configuration detection is broken", "", in),
+	), "a member with no sibling of its own file on the page keeps its seat")
+}
+
+func TestLocalizationEvidenceDemotionKeepsReservedSeats(t *testing.T) {
+	proven := memberDemotionTarget("config.swift", "DirectoryConfiguration.<init>", graph.KindMethod)
+	proven.divergentDefaultOwner = true
+	projected := memberDemotionTarget("cache.swift", "slots", graph.KindField)
+	projected.typedAnchorProjection = true
+	tests := []struct {
+		name       string
+		task       string
+		requiredID string
+		in         []exploreTarget
+	}{
+		{
+			name: "graph proven constructor",
+			task: "directory configuration detection is broken",
+			in: []exploreTarget{
+				proven,
+				memberDemotionTarget("config.swift", "detect", graph.KindMethod),
+			},
+		},
+		{
+			name: "typed anchor field",
+			task: "shader cache slots are wrong",
+			in: []exploreTarget{
+				projected,
+				memberDemotionTarget("cache.swift", "warm", graph.KindMethod),
+			},
+		},
+		{
+			name: "identifier the task cites",
+			task: "shaderSlots is never reset",
+			in: []exploreTarget{
+				memberDemotionTarget("config.swift", "shaderSlots", graph.KindField),
+				memberDemotionTarget("config.swift", "detect", graph.KindMethod),
+			},
+		},
+		{
+			name:       "prescribed refinement symbol",
+			task:       "directory configuration detection is broken",
+			requiredID: "fixture/config.swift::DirectoryConfiguration.<init>",
+			in: []exploreTarget{
+				memberDemotionTarget("config.swift", "DirectoryConfiguration.<init>", graph.KindMethod),
+				memberDemotionTarget("config.swift", "detect", graph.KindMethod),
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, memberDemotionTargetNames(test.in), memberDemotionTargetNames(
+				demoteLocalizationEvidenceMembers(test.task, test.requiredID, test.in),
+			))
+		})
+	}
+}
+
+func TestLocalizationEvidenceDemotionKeepsCrossFileOrderAndSelection(t *testing.T) {
+	in := []exploreTarget{
+		memberDemotionTarget("config.swift", "DirectoryConfiguration.<init>", graph.KindMethod),
+		memberDemotionTarget("cache.dart", "slots", graph.KindField),
+		memberDemotionTarget("config.swift", "detect", graph.KindMethod),
+		memberDemotionTarget("cache.dart", "warm", graph.KindMethod),
+		{},
+		memberDemotionTarget("config.swift", "root", graph.KindField),
+	}
+	files := memberDemotionTargetFiles(in)
+	ids := make(map[string]int, len(in))
+	for _, target := range in {
+		if target.node != nil {
+			ids[target.node.ID]++
+		}
+	}
+
+	out := demoteLocalizationEvidenceMembers("directory configuration detection is broken", "", in)
+
+	require.Equal(t, len(in), len(out), "the projection keeps the same number of rows")
+	require.Equal(t, files, memberDemotionTargetFiles(out), "no row moves into another file's slot")
+	outIDs := make(map[string]int, len(out))
+	for _, target := range out {
+		if target.node != nil {
+			outIDs[target.node.ID]++
+		}
+	}
+	require.Equal(t, ids, outIDs, "the draft's selection is unchanged")
+	require.Equal(t, []string{
+		"detect", "warm", "DirectoryConfiguration.<init>", "slots", "", "root",
+	}, memberDemotionTargetNames(out))
+}
+
 func newIndexedSwiftMemberDemotionServer(t *testing.T) *Server {
 	t.Helper()
 
@@ -279,4 +434,41 @@ func TestIndexedSwiftMemberDemotionAppliesOnlyToTheLocalizePage(t *testing.T) {
 	require.GreaterOrEqual(t, plainField, 0, "explore lists the ranked field: %s", plain.Text)
 	require.GreaterOrEqual(t, plainMethod, 0, "explore lists the ranked method: %s", plain.Text)
 	require.Less(t, plainField, plainMethod, "the non-localize page is untouched by localization demotion: %s", plain.Text)
+}
+
+func TestIndexedSwiftMemberDemotionOrdersTheLocalizationPageLeadingFile(t *testing.T) {
+	const (
+		task = "directory configuration detection is broken"
+		file = "swift-fixture/Sources/DirectoryConfiguration.swift"
+	)
+	server := newIndexedSwiftMemberDemotionServer(t)
+	request := mcpgo.CallToolRequest{}
+	request.Params.Arguments = map[string]any{
+		"task":          task,
+		"localize":      true,
+		"max_symbols":   8,
+		"token_budget":  2400,
+		"repository_id": "swift-fixture",
+	}
+	result, err := server.handleExplore(context.Background(), request)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	text, ok := result.Content[0].(mcpgo.TextContent)
+	require.True(t, ok)
+	var envelope localizationExploreEnvelope
+	require.NoError(t, json.Unmarshal([]byte(text.Text), &envelope))
+
+	leading := make([]string, 0, len(envelope.Evidence))
+	for _, evidence := range envelope.Evidence {
+		if evidence.File == file {
+			leading = append(leading, evidence.Name)
+		}
+	}
+	// Owner folding seats the type ahead of its members; the members that follow
+	// are ordered by tier, and every one of them stays on the page.
+	require.Equal(t, []string{
+		"DirectoryConfiguration", "detect", "reload",
+		"DirectoryConfiguration.<init>", "deinit",
+		"root", "shaderSlots",
+	}, leading, "unexpected leading-file order: %#v", envelope.Evidence)
 }

--- a/internal/mcp/localization_member_demotion_test.go
+++ b/internal/mcp/localization_member_demotion_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -150,6 +151,137 @@ func TestLocalizationDemotionPermutesOnlyInsideEachFilesOwnSlots(t *testing.T) {
 		"detect", "warm", "reload", "", "ShaderCache.<init>", "floating", "shaderSlots",
 	}, memberDemotionNames(out))
 	require.Equal(t, memberDemotionNames(out), memberDemotionNames(demoteLocalizationFileMembers(out)), "the reorder is idempotent")
+}
+
+func memberDemotionSignalCandidate(file, name string, kind graph.NodeKind, signal string) *rerank.Candidate {
+	candidate := memberDemotionCandidate(file, name, kind)
+	candidate.Signals = map[string]float64{signal: 1}
+	return candidate
+}
+
+func memberDemotionWindowFiles(cands []*rerank.Candidate, maxSymbols int) map[string]int {
+	counts := make(map[string]int, maxSymbols)
+	for index, cand := range cands {
+		if index >= maxSymbols || cand == nil || cand.Node == nil {
+			continue
+		}
+		counts[cand.Node.FilePath]++
+	}
+	return counts
+}
+
+func TestLocalizationSiblingLiftTradesAMemberSlotForItsOrdinarySibling(t *testing.T) {
+	tests := []struct {
+		name   string
+		member string
+		kind   graph.NodeKind
+		lifted string
+	}{
+		{name: "constructor", member: "DirectoryConfiguration.<init>", kind: graph.KindMethod, lifted: "userInboundEventTriggered"},
+		{name: "field", member: "shaderSlots", kind: graph.KindField, lifted: "applyPointLights"},
+		{name: "enum member", member: "ShaderStage.vertex", kind: graph.KindEnumMember, lifted: "applyPointLights"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			in := []*rerank.Candidate{
+				memberDemotionCandidate("config.swift", test.member, test.kind),
+				memberDemotionCandidate("cache.swift", "warm", graph.KindMethod),
+				memberDemotionCandidate("config.swift", test.lifted, graph.KindMethod),
+			}
+			before := memberDemotionWindowFiles(in, 2)
+
+			out := liftLocalizationSiblingCallables("directory configuration detection is broken", in, 2, nil)
+
+			require.Equal(t, []string{test.lifted, "warm", test.member}, memberDemotionNames(out))
+			require.Equal(t, before, memberDemotionWindowFiles(out, 2), "the file keeps exactly the slots it won")
+			require.Equal(t, memberDemotionFiles(in), memberDemotionFiles(out), "no candidate crosses into another file's slot")
+		})
+	}
+}
+
+func TestLocalizationSiblingLiftKeepsProvenAndCitedMemberSlots(t *testing.T) {
+	tests := []struct {
+		name   string
+		task   string
+		member *rerank.Candidate
+		lift   func(cands []*rerank.Candidate) []*rerank.Candidate
+	}{
+		{
+			name:   "source literal",
+			task:   "directory configuration detection is broken",
+			member: memberDemotionSignalCandidate("config.swift", "shaderSlots", graph.KindField, exploreSourceLiteralSignal),
+		},
+		{
+			name:   "exact content",
+			task:   "directory configuration detection is broken",
+			member: memberDemotionSignalCandidate("config.swift", "shaderSlots", graph.KindField, exploreContentRecallExactSignal),
+		},
+		{
+			name:   "syntactic anchor",
+			task:   "directory configuration detection is broken",
+			member: memberDemotionSignalCandidate("config.swift", "DirectoryConfiguration.<init>", graph.KindMethod, exploreSyntacticAnchorSignal),
+		},
+		{
+			name:   "identifier the task cites",
+			task:   "shaderSlots is never reset",
+			member: memberDemotionCandidate("config.swift", "shaderSlots", graph.KindField),
+		},
+		{
+			name:   "protected anchor owner",
+			task:   "directory configuration detection is broken",
+			member: memberDemotionCandidate("config.swift", "shaderSlots", graph.KindField),
+			lift: func(cands []*rerank.Candidate) []*rerank.Candidate {
+				return liftLocalizationSiblingCallables(
+					"directory configuration detection is broken", cands, 2,
+					map[int]string{0: cands[0].Node.ID},
+				)
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			in := []*rerank.Candidate{
+				test.member,
+				memberDemotionCandidate("cache.swift", "warm", graph.KindMethod),
+				memberDemotionCandidate("config.swift", "detect", graph.KindMethod),
+			}
+			lift := test.lift
+			if lift == nil {
+				lift = func(cands []*rerank.Candidate) []*rerank.Candidate {
+					return liftLocalizationSiblingCallables(test.task, cands, 2, nil)
+				}
+			}
+			require.Equal(t, memberDemotionNames(in), memberDemotionNames(lift(in)))
+		})
+	}
+}
+
+func TestLocalizationSiblingLiftIsANoOpWithoutAComparableSibling(t *testing.T) {
+	member := memberDemotionCandidate("config.swift", "DirectoryConfiguration.<init>", graph.KindMethod)
+	tail := func(extra ...*rerank.Candidate) []*rerank.Candidate {
+		return append([]*rerank.Candidate{member, memberDemotionCandidate("cache.swift", "warm", graph.KindMethod)}, extra...)
+	}
+	distant := make([]*rerank.Candidate, 0, localizationSiblingLiftReach+1)
+	for i := 0; i < localizationSiblingLiftReach; i++ {
+		distant = append(distant, memberDemotionCandidate("cache.swift", fmt.Sprintf("warm%d", i), graph.KindMethod))
+	}
+	distant = append(distant, memberDemotionCandidate("config.swift", "detect", graph.KindMethod))
+
+	tests := []struct {
+		name string
+		in   []*rerank.Candidate
+	}{
+		{name: "sibling never retrieved", in: tail(memberDemotionCandidate("cache.swift", "reload", graph.KindMethod))},
+		{name: "only members below the cut", in: tail(memberDemotionCandidate("config.swift", "root", graph.KindField))},
+		{name: "sibling past the reach", in: tail(distant...)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, memberDemotionNames(test.in), memberDemotionNames(
+				liftLocalizationSiblingCallables("directory configuration detection is broken", test.in, 2, nil),
+			))
+		})
+	}
 }
 
 func memberDemotionTarget(file, name string, kind graph.NodeKind) exploreTarget {
@@ -434,6 +566,36 @@ func TestIndexedSwiftMemberDemotionAppliesOnlyToTheLocalizePage(t *testing.T) {
 	require.GreaterOrEqual(t, plainField, 0, "explore lists the ranked field: %s", plain.Text)
 	require.GreaterOrEqual(t, plainMethod, 0, "explore lists the ranked method: %s", plain.Text)
 	require.Less(t, plainField, plainMethod, "the non-localize page is untouched by localization demotion: %s", plain.Text)
+}
+
+func TestIndexedSwiftMemberDemotionKeepsAnEditableSiblingInATightWindow(t *testing.T) {
+	const task = "directory configuration detection is broken"
+	server := newIndexedSwiftMemberDemotionServer(t)
+	request := mcpgo.CallToolRequest{}
+	request.Params.Arguments = map[string]any{
+		"task":          task,
+		"localize":      true,
+		"max_symbols":   3,
+		"token_budget":  2400,
+		"repository_id": "swift-fixture",
+	}
+	result, err := server.handleExplore(context.Background(), request)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	text, ok := result.Content[0].(mcpgo.TextContent)
+	require.True(t, ok)
+	var envelope localizationExploreEnvelope
+	require.NoError(t, json.Unmarshal([]byte(text.Text), &envelope))
+
+	names := make([]string, 0, len(envelope.Evidence))
+	for _, evidence := range envelope.Evidence {
+		names = append(names, evidence.Name)
+	}
+	// Ranking hands this file's three slots to its type, constructor and a
+	// field; the sibling methods are retrieved but lose the cut, and no later
+	// stage can recover a candidate the cut dropped.
+	require.Equal(t, []string{"DirectoryConfiguration", "detect", "reload"}, names,
+		"unexpected tight-window page: %#v", envelope.Evidence)
 }
 
 func TestIndexedSwiftMemberDemotionOrdersTheLocalizationPageLeadingFile(t *testing.T) {

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -2925,6 +2925,13 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 		prod, maxSymbols,
 		exploreFinalReservedCandidateIDs(prod, protectedSyntacticAnchors, protectedImplementationID),
 	)
+	if localize {
+		// Last chance to keep an editable declaration from the file: once the cut
+		// drops a candidate, no later reordering can bring it back. Trades happen
+		// inside one file's own competition, so the per-file and cross-file
+		// allocation the lanes above settled is carried through unchanged.
+		prod = liftLocalizationSiblingCallables(task, prod, maxSymbols, protectedSyntacticAnchors)
+	}
 	cands := selectFinalExploreCandidates(prod, test, maxSymbols)
 	if len(protectedSyntacticAnchors) > 0 {
 		// Source-literal selection owns its own final-slot guarantees. Re-union
@@ -5062,6 +5069,131 @@ func demoteLocalizationFileMembers(cands []*rerank.Candidate) []*rerank.Candidat
 		}
 	}
 	return out
+}
+
+// localizationSiblingLiftReach bounds "comparable standing" to the tail
+// immediately past the cut: a sibling that lost by a wide margin lost on its own
+// merits, and lifting it would be a ranking change rather than a tie-break.
+const localizationSiblingLiftReach = 8
+
+// localizationMemberSlotGuard decides which member candidates may not be traded
+// out of the final window. Beyond the reserved-seat rule the projection uses,
+// this boundary also protects the inputs of the lanes that run after the cut:
+// dropping one of those is not a reordering, it silently disables a proof.
+type localizationMemberSlotGuard struct {
+	task    string
+	ids     map[string]struct{}
+	anchors []exploreSyntacticAnchor
+	active  []int
+}
+
+func newLocalizationMemberSlotGuard(task string, protectedAnchors map[int]string) localizationMemberSlotGuard {
+	guard := localizationMemberSlotGuard{task: task, ids: make(map[string]struct{}, len(protectedAnchors))}
+	for _, id := range protectedAnchors {
+		if id != "" {
+			guard.ids[id] = struct{}{}
+		}
+	}
+	if len(protectedAnchors) > 0 {
+		guard.anchors = exploreSyntacticAnchors(task)
+		guard.active = exploreTypedAnchorActiveIndexes(guard.anchors, protectedAnchors)
+	}
+	return guard
+}
+
+// protects keeps a member's slot when a proof lane identified it by something no
+// member inherits from its owner type — the task's own literal text, an exact
+// cited range, a graph proof, or the task naming that exact identifier — or when
+// the candidate is a typed field the anchor projection may still lower into its
+// owner/consumer/member proof.
+func (g localizationMemberSlotGuard) protects(candidate *rerank.Candidate) bool {
+	if candidate == nil || candidate.Node == nil {
+		return true
+	}
+	if _, anchored := g.ids[candidate.Node.ID]; anchored {
+		return true
+	}
+	for _, signal := range []string{
+		exploreSourceRangeSignal, exploreContentRecallExactSignal,
+		exploreSourceLiteralSignal, exploreSourceLiteralCalleeSignal,
+		exploreSourceLiteralTaskAlignSignal, exploreTypedAnchorProjectionSignal,
+		exploreSyntacticAnchorSignal,
+	} {
+		if candidate.Signals[signal] > 0 {
+			return true
+		}
+	}
+	if candidate.Node.Kind == graph.KindField && len(g.active) > 0 &&
+		len(exploreTypedAnchorMatchingIndexes(
+			g.anchors, g.active, candidate.Node, exploreTypedAnchorFieldType(candidate.Node),
+		)) > 0 {
+		return true
+	}
+	return localizationDirectAdjacencyNodeTaskCitationOffset(g.task, candidate.Node) >= 0
+}
+
+// liftLocalizationSiblingCallables trades a window slot a member won back to the
+// ordinary sibling declaration it displaced. A file's slot count is fixed: the
+// two candidates always come from the same file, one inside the cut and one in
+// the bounded tail just past it, so no file gains or loses a slot and no
+// cross-file allocation moves. The trade is a strict no-op when the file has no
+// ordinary sibling in that tail — an unretrieved sibling cannot be selected, and
+// this lane never widens retrieval to look for one.
+func liftLocalizationSiblingCallables(
+	task string,
+	candidates []*rerank.Candidate,
+	maxSymbols int,
+	protectedAnchors map[int]string,
+) []*rerank.Candidate {
+	if maxSymbols <= 0 || len(candidates) <= maxSymbols {
+		return candidates
+	}
+	guard := newLocalizationMemberSlotGuard(task, protectedAnchors)
+	reach := min(len(candidates), maxSymbols+localizationSiblingLiftReach)
+	lifted := candidates
+	copied := false
+	traded := make(map[int]struct{}, maxSymbols)
+	for index := 0; index < maxSymbols; index++ {
+		candidate := lifted[index]
+		if candidate == nil || candidate.Node == nil || candidate.Node.FilePath == "" {
+			continue
+		}
+		if localizationMemberTier(candidate.Node) == localizationMemberTierBehavioral {
+			continue
+		}
+		if guard.protects(candidate) {
+			continue
+		}
+		sibling := -1
+		for below := maxSymbols; below < reach; below++ {
+			if _, used := traded[below]; used {
+				continue
+			}
+			other := lifted[below]
+			if other == nil || other.Node == nil {
+				continue
+			}
+			if other.Node.FilePath != candidate.Node.FilePath ||
+				other.Node.RepoPrefix != candidate.Node.RepoPrefix {
+				continue
+			}
+			if localizationMemberTier(other.Node) != localizationMemberTierBehavioral {
+				continue
+			}
+			sibling = below
+			break
+		}
+		if sibling < 0 {
+			continue
+		}
+		if !copied {
+			lifted = append([]*rerank.Candidate(nil), candidates...)
+			copied = true
+		}
+		lifted[index], lifted[sibling] = lifted[sibling], lifted[index]
+		traded[sibling] = struct{}{}
+	}
+	return lifted
 }
 
 // localizationEvidenceSeatReserved reports whether an evidence row owes its seat

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -2949,6 +2949,13 @@ func (s *Server) handleExplore(ctx context.Context, req mcp.CallToolRequest) (*m
 			protectedSyntacticAnchors, protectedImplementationID,
 		)
 	}
+	if localize {
+		// Presentation ordering for the localization page only, applied after the
+		// final window is fixed so membership cannot change: each file's own slots
+		// are permuted, cross-file rank is untouched, and every member remains
+		// searchable and readable through every other lane.
+		cands = demoteLocalizationFileMembers(cands)
+	}
 	protectedFinalCandidateIDs := exploreFinalReservedCandidateIDs(
 		cands, protectedSyntacticAnchors, protectedImplementationID,
 	)
@@ -4951,6 +4958,106 @@ func diversifyRepeatedExploreNames(cands []*rerank.Candidate, class rerank.Query
 		head = append(head, cand)
 	}
 	return append(head, duplicates...)
+}
+
+// Localization member tiers order one file's own candidate slots. Extracted
+// members inherit their owner type's name terms and win callable tie-breaks, so
+// without an explicit tier they seat above the sibling declaration a task is
+// actually about.
+const (
+	localizationMemberTierBehavioral = iota
+	localizationMemberTierConstructor
+	localizationMemberTierData
+	localizationMemberTierCount
+)
+
+// exploreConstructorSpelledName reports the cross-language spellings of a
+// declaration named by its keyword rather than by intent: `<Type>.<init>`
+// (Java, C#, Swift) and Swift's bare `deinit` / `subscript`. The comparison is
+// on the bare name after the last dot, so both the qualified and the bare
+// spelling classify identically.
+func exploreConstructorSpelledName(name string) bool {
+	bare := name
+	if dot := strings.LastIndexByte(bare, '.'); dot >= 0 {
+		bare = bare[dot+1:]
+	}
+	switch bare {
+	case "<init>", "deinit", "subscript":
+		return true
+	}
+	return false
+}
+
+// localizationMemberTier classifies one candidate for per-file ordering. Kinds
+// outside the classification stay in the leading tier so ranking they already
+// earned is preserved; types lead alongside ordinary callables because a type
+// declaration is the owner a task names, not a member of one.
+func localizationMemberTier(n *graph.Node) int {
+	switch n.Kind {
+	case graph.KindFunction, graph.KindMethod:
+		if exploreConstructorSpelledName(n.Name) {
+			return localizationMemberTierConstructor
+		}
+		return localizationMemberTierBehavioral
+	case graph.KindField, graph.KindEnumMember:
+		return localizationMemberTierData
+	default:
+		return localizationMemberTierBehavioral
+	}
+}
+
+// demoteLocalizationFileMembers reorders localization candidates inside the
+// index positions each file already occupies. Nothing is dropped, added, or
+// moved across files: a file's tiered candidates are written back into that
+// file's own slots in slot order, so the window keeps the same members at the
+// same count and every upstream reservation — including the typed-anchor
+// projection's field — survives. Relative order inside a tier is preserved, so
+// the reorder is stable and idempotent. Candidates without a node or a file
+// path cannot be attributed to a file and keep their position.
+func demoteLocalizationFileMembers(cands []*rerank.Candidate) []*rerank.Candidate {
+	if len(cands) < 2 {
+		return cands
+	}
+	slots := make(map[string][]int, len(cands))
+	files := make([]string, 0, len(cands))
+	demotable := false
+	for i, cand := range cands {
+		if cand == nil || cand.Node == nil || cand.Node.FilePath == "" {
+			continue
+		}
+		key := cand.Node.RepoPrefix + "\x00" + cand.Node.FilePath
+		if _, ok := slots[key]; !ok {
+			files = append(files, key)
+		}
+		slots[key] = append(slots[key], i)
+		if localizationMemberTier(cand.Node) != localizationMemberTierBehavioral {
+			demotable = true
+		}
+	}
+	if !demotable {
+		return cands
+	}
+	out := append([]*rerank.Candidate(nil), cands...)
+	for _, key := range files {
+		positions := slots[key]
+		if len(positions) < 2 {
+			continue
+		}
+		var tiers [localizationMemberTierCount][]*rerank.Candidate
+		for _, position := range positions {
+			cand := cands[position]
+			tier := localizationMemberTier(cand.Node)
+			tiers[tier] = append(tiers[tier], cand)
+		}
+		written := 0
+		for _, tier := range tiers {
+			for _, cand := range tier {
+				out[positions[written]] = cand
+				written++
+			}
+		}
+	}
+	return out
 }
 
 // exploreLocalizableKind reports whether a node kind is a place a

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -4341,6 +4341,10 @@ func buildLocalizationExploreResultForTaskFinalizedWithOutlineAndDeclarations(
 		requiredSymbol = completion.refinementSymbol
 	}
 	targets = localizationEvidenceTargetsFromDraft(task, requiredSymbol, targets, draft)
+	// The draft's selection is final here; only its presentation order is not.
+	// Applying the tiers before the relation, refinement, and complement lanes
+	// leaves each of them authoritative over the seats they claim.
+	targets = demoteLocalizationEvidenceMembers(task, requiredSymbol, targets)
 	if refinementFirst {
 		targets = prioritizeLocalizationEvidenceTarget(requiredSymbol, targets)
 		// A divergent-default refinement is one causal unit: keep the prescribed
@@ -5053,6 +5057,92 @@ func demoteLocalizationFileMembers(cands []*rerank.Candidate) []*rerank.Candidat
 		for _, tier := range tiers {
 			for _, cand := range tier {
 				out[positions[written]] = cand
+				written++
+			}
+		}
+	}
+	return out
+}
+
+// localizationEvidenceSeatReserved reports whether an evidence row owes its seat
+// to a proof lane or to the task naming that exact identifier, rather than to
+// ranking. Such a row keeps its exact position: the reservation is a contract,
+// and presentation tiering is never allowed to overrule proven or explicitly
+// named evidence. Citation is deliberately identifier-level — a task that names
+// the file, or the type whose name every member inherits, has not asked for the
+// constructor over the method.
+func localizationEvidenceSeatReserved(task, requiredID string, target exploreTarget) bool {
+	if target.node == nil {
+		return true
+	}
+	if requiredID != "" && target.node.ID == requiredID {
+		return true
+	}
+	// Proof lanes: the task's own literal text, an exact cited range, or a graph
+	// proof. Each identifies a row by something a member cannot inherit.
+	if target.sourceRange || target.divergentDefaultOwner || target.divergentDefaultType ||
+		target.typedAnchorProjection || target.sourceLiteral || target.sourceLiteralCallee ||
+		target.sourceLiteralAligned || target.literalPrimaryEligible || target.exactContent ||
+		target.causalChangeOwner || target.causalChangeBridge || target.causalChangeLeaf ||
+		target.localizationRelation != "" {
+		return true
+	}
+	if localizationDirectAdjacencyNodeTaskCitationOffset(task, target.node) >= 0 {
+		return true
+	}
+	// The name-term lanes are the ones a member rides in on: a constructor or a
+	// field matches the task's wording only because its identifier carries the
+	// owner type's terms. They hold a seat for declarations named by intent.
+	return localizationMemberTier(target.node) == localizationMemberTierBehavioral &&
+		(target.conceptImplementation || target.conceptComplement || target.syntacticAnchor)
+}
+
+// demoteLocalizationEvidenceMembers applies the same member tiers to the
+// projection the draft already selected. Owner folding and draft ranking can
+// re-seat a member the ranked window demoted, because both read the owner type's
+// name terms off the member's own name. The reorder changes no selection: it
+// permutes only rows the draft chose, only inside the slots one file already
+// holds, and only among rows no lane reserved — so a constructor-spelled or data
+// member yields its seat exactly when an ordinary sibling callable from the same
+// file is already on the page, and otherwise keeps it.
+func demoteLocalizationEvidenceMembers(task, requiredID string, targets []exploreTarget) []exploreTarget {
+	if len(targets) < 2 {
+		return targets
+	}
+	slots := make(map[string][]int, len(targets))
+	files := make([]string, 0, len(targets))
+	demotable := false
+	for index, target := range targets {
+		if localizationEvidenceSeatReserved(task, requiredID, target) || target.node.FilePath == "" {
+			continue
+		}
+		key := target.node.RepoPrefix + "\x00" + target.node.FilePath
+		if _, ok := slots[key]; !ok {
+			files = append(files, key)
+		}
+		slots[key] = append(slots[key], index)
+		if localizationMemberTier(target.node) != localizationMemberTierBehavioral {
+			demotable = true
+		}
+	}
+	if !demotable {
+		return targets
+	}
+	out := append([]exploreTarget(nil), targets...)
+	for _, key := range files {
+		positions := slots[key]
+		if len(positions) < 2 {
+			continue
+		}
+		var tiers [localizationMemberTierCount][]exploreTarget
+		for _, position := range positions {
+			tier := localizationMemberTier(targets[position].node)
+			tiers[tier] = append(tiers[tier], targets[position])
+		}
+		written := 0
+		for _, tier := range tiers {
+			for _, target := range tier {
+				out[positions[written]] = target
 				written++
 			}
 		}

--- a/internal/parser/languages/dart.go
+++ b/internal/parser/languages/dart.go
@@ -58,6 +58,11 @@ func (e *DartExtractor) Extract(filePath string, src []byte) (*parser.Extraction
 	// Methods inside class/mixin/enum/extension bodies.
 	e.extractMethods(root, src, filePath, fileNode, result, seen)
 
+	// Fields inside class/mixin/enum/extension bodies. Runs after
+	// extractMethods so an accessor keeps the unsuffixed `Type.name` id when a
+	// backing field of the same name exists.
+	e.extractFields(root, src, filePath, fileNode, result, seen)
+
 	// Top-level functions (function_signature + function_body at program level).
 	e.extractTopLevelFunctions(root, src, filePath, fileNode, result, seen)
 
@@ -167,7 +172,49 @@ func (e *DartExtractor) extractTypes(
 		if node.Type() == "class_definition" {
 			e.emitDartMixinEdges(node, src, id, filePath, result)
 		}
+		if node.Type() == "enum_declaration" {
+			e.emitDartEnumConstants(node, src, id, name, filePath, result, seen)
+		}
 	})
+}
+
+// emitDartEnumConstants emits one KindEnumMember per `enum_constant` in an
+// enum body, linked to the enum with EdgeMemberOf. A constant of an enhanced
+// enum carries an argument_part (`mercury(3.3e23, 2.44e6)`) after its name, so
+// only the constant's first identifier child names it.
+func (e *DartExtractor) emitDartEnumConstants(
+	enumNode *sitter.Node, src []byte, enumID, enumName, filePath string,
+	result *parser.ExtractionResult, seen map[string]bool,
+) {
+	body := dartFirstChildOfType(enumNode, "enum_body")
+	if body == nil {
+		return
+	}
+	for i, _nc := 0, int(body.ChildCount()); i < _nc; i++ {
+		constant := body.Child(i)
+		if constant == nil || constant.Type() != "enum_constant" {
+			continue
+		}
+		name := e.findChildIdentifier(constant, src)
+		if name == "" {
+			continue
+		}
+		startLine := int(constant.StartPoint().Row) + 1
+		id := enumID + "." + name
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		result.Nodes = append(result.Nodes, &graph.Node{
+			ID: id, Kind: graph.KindEnumMember, Name: name,
+			FilePath: filePath, StartLine: startLine, EndLine: int(constant.EndPoint().Row) + 1,
+			Language: "dart",
+			Meta:     map[string]any{"receiver": enumName, "enum": enumID},
+		})
+		result.Edges = append(result.Edges, &graph.Edge{
+			From: id, To: enumID, Kind: graph.EdgeMemberOf, FilePath: filePath, Line: startLine,
+		})
+	}
 }
 
 // dartSuperclassName returns the name of a class's `extends` base — the
@@ -324,6 +371,11 @@ func (e *DartExtractor) extractMethods(
 		if rt := dartMethodReturnType(node, src); rt != "" {
 			methodMeta["return_type"] = rt
 		}
+		// A getter and its setter share the bare property name, so the accessor
+		// role is the only thing that tells the two nodes apart.
+		if acc := dartAccessorKind(node); acc != "" {
+			methodMeta["accessor"] = acc
+		}
 		if doc := ExtractDocAbove(src, startLine, DocLangSlashSlash); doc != "" {
 			methodMeta["doc"] = doc
 		}
@@ -343,6 +395,119 @@ func (e *DartExtractor) extractMethods(
 			})
 		}
 	})
+}
+
+// extractFields emits one member node per name bound by a field declaration in
+// a class / mixin / enum / extension body. The grammar hangs a field off the
+// same `declaration` wrapper it gives a body-less constructor, binding the
+// names under initialized_identifier_list (instance, `var`, `final`) or
+// static_final_declaration_list (`static final`, `static const`); a
+// constructor-signature declaration carries neither and is left to
+// extractMethods. One declaration can bind several names (`String? a, b;`), so
+// each bound identifier becomes its own node.
+func (e *DartExtractor) extractFields(
+	root *sitter.Node, src []byte, filePath string, fileNode *graph.Node,
+	result *parser.ExtractionResult, seen map[string]bool,
+) {
+	typeBodyRanges := e.collectTypeBodyRanges(root, src)
+
+	walkNodes(root, func(node *sitter.Node) {
+		if node.Type() != "declaration" {
+			return
+		}
+		parent := node.Parent()
+		if parent == nil {
+			return
+		}
+		switch parent.Type() {
+		case "class_body", "extension_body", "enum_body":
+		default:
+			return
+		}
+
+		typeName, ok := e.findEnclosingType(typeBodyRanges, int(node.StartPoint().Row))
+		if !ok {
+			return
+		}
+
+		fieldType := dartLeadingTypeText(node, src)
+		isStatic := e.hasChildType(node, "static")
+		// A `const` binding is immutable by grammar; kind it as KindConstant so
+		// value-reference impact analysis reaches its readers (mirrors the
+		// top-level static_final path and the C# const-field rule).
+		kind := graph.KindField
+		if e.hasChildType(node, "const_builtin") {
+			kind = graph.KindConstant
+		}
+
+		for _, bound := range dartFieldBindings(node) {
+			name := e.findChildIdentifier(bound, src)
+			if name == "" {
+				continue
+			}
+			startLine := int(bound.StartPoint().Row) + 1
+			id := filePath + "::" + typeName + "." + name
+			if seen[id] {
+				continue
+			}
+			seen[id] = true
+
+			meta := map[string]any{
+				"receiver":   typeName,
+				"visibility": VisibilityByUnderscore(name),
+			}
+			if fieldType != "" {
+				meta["field_type"] = fieldType
+			}
+			if isStatic {
+				meta["static"] = true
+			}
+			if doc := ExtractDocAbove(src, int(node.StartPoint().Row), DocLangSlashSlash); doc != "" {
+				meta["doc"] = doc
+			}
+			result.Nodes = append(result.Nodes, &graph.Node{
+				ID: id, Kind: kind, Name: name,
+				FilePath: filePath, StartLine: startLine, EndLine: int(bound.EndPoint().Row) + 1,
+				Language: "dart",
+				Meta:     meta,
+			})
+			result.Edges = append(result.Edges, &graph.Edge{
+				From: fileNode.ID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: startLine,
+			})
+			result.Edges = append(result.Edges, &graph.Edge{
+				From: id, To: filePath + "::" + typeName, Kind: graph.EdgeMemberOf, FilePath: filePath, Line: startLine,
+			})
+		}
+	})
+}
+
+// dartFieldBindings returns the per-name binding nodes a field declaration
+// carries — `initialized_identifier` under an initialized_identifier_list, or
+// `static_final_declaration` under a static_final_declaration_list. Returns nil
+// for a declaration that binds no field (a constructor signature).
+func dartFieldBindings(decl *sitter.Node) []*sitter.Node {
+	var out []*sitter.Node
+	for i, _nc := 0, int(decl.ChildCount()); i < _nc; i++ {
+		list := decl.Child(i)
+		if list == nil {
+			continue
+		}
+		var want string
+		switch list.Type() {
+		case "initialized_identifier_list":
+			want = "initialized_identifier"
+		case "static_final_declaration_list":
+			want = "static_final_declaration"
+		default:
+			continue
+		}
+		for j, _nc := 0, int(list.ChildCount()); j < _nc; j++ {
+			if bound := list.Child(j); bound != nil && bound.Type() == want {
+				out = append(out, bound)
+			}
+		}
+	}
+	return out
 }
 
 // dartIsGenerated reports whether a Dart file path is a code-generator output
@@ -750,9 +915,13 @@ func (e *DartExtractor) extractMethodName(node *sitter.Node, src []byte) string 
 				return nameNode.Content(src)
 			}
 		case "setter_signature":
+			// The bare property name, not the `set foo` source spelling: a
+			// search or a `.foo = x` write site names the property. The
+			// getter/setter pair collides on `Type.foo`; the caller's
+			// line-suffix disambiguation separates the second one.
 			nameNode := child.ChildByFieldName("name")
 			if nameNode != nil {
-				return "set " + nameNode.Content(src)
+				return nameNode.Content(src)
 			}
 		case "constructor_signature", "constant_constructor_signature",
 			"factory_constructor_signature", "redirecting_factory_constructor_signature":
@@ -765,6 +934,24 @@ func (e *DartExtractor) extractMethodName(node *sitter.Node, src []byte) string 
 					return "operator " + strings.TrimSpace(c.Content(src))
 				}
 			}
+		}
+	}
+	return ""
+}
+
+// dartAccessorKind returns "getter" / "setter" when a method_signature wraps a
+// getter_signature / setter_signature, and "" for every other member shape.
+func dartAccessorKind(methodSig *sitter.Node) string {
+	for i, _nc := 0, int(methodSig.ChildCount()); i < _nc; i++ {
+		child := methodSig.Child(i)
+		if child == nil {
+			continue
+		}
+		switch child.Type() {
+		case "getter_signature":
+			return "getter"
+		case "setter_signature":
+			return "setter"
 		}
 	}
 	return ""

--- a/internal/parser/languages/dart_members_test.go
+++ b/internal/parser/languages/dart_members_test.go
@@ -1,0 +1,237 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Instance, static, inferred and multi-name field declarations in a class,
+// a mixin and an extension body all become member nodes qualified by their
+// owning type.
+func TestDartExtractor_Fields(t *testing.T) {
+	src := []byte(`class Account {
+  /// The account handle.
+  final String id;
+  int balance = 0;
+  var scratch = 1;
+  String? nickname, alias;
+  static final Logger log = Logger();
+  static const int maxRetries = 3;
+
+  void deposit(int n) {}
+}
+
+mixin Auditable {
+  DateTime? auditedAt;
+}
+
+extension Limits on String {
+  static const int cap = 8;
+}
+`)
+	res, err := NewDartExtractor().Extract("account.dart", src)
+	require.NoError(t, err)
+
+	byID := map[string]*graph.Node{}
+	for _, n := range res.Nodes {
+		byID[n.ID] = n
+	}
+
+	for _, tc := range []struct {
+		id        string
+		kind      graph.NodeKind
+		name      string
+		receiver  string
+		fieldType string
+		static    bool
+	}{
+		{"account.dart::Account.id", graph.KindField, "id", "Account", "String", false},
+		{"account.dart::Account.balance", graph.KindField, "balance", "Account", "int", false},
+		{"account.dart::Account.scratch", graph.KindField, "scratch", "Account", "", false},
+		{"account.dart::Account.nickname", graph.KindField, "nickname", "Account", "String?", false},
+		{"account.dart::Account.alias", graph.KindField, "alias", "Account", "String?", false},
+		{"account.dart::Account.log", graph.KindField, "log", "Account", "Logger", true},
+		{"account.dart::Account.maxRetries", graph.KindConstant, "maxRetries", "Account", "int", true},
+		{"account.dart::Auditable.auditedAt", graph.KindField, "auditedAt", "Auditable", "DateTime?", false},
+		{"account.dart::Limits.cap", graph.KindConstant, "cap", "Limits", "int", true},
+	} {
+		t.Run(tc.id, func(t *testing.T) {
+			n := byID[tc.id]
+			require.NotNil(t, n, "field %s must be emitted", tc.id)
+			assert.Equal(t, tc.kind, n.Kind)
+			assert.Equal(t, tc.name, n.Name)
+			assert.Equal(t, tc.receiver, n.Meta["receiver"])
+			if tc.fieldType == "" {
+				assert.NotContains(t, n.Meta, "field_type", "an inferred binding carries no declared type")
+			} else {
+				assert.Equal(t, tc.fieldType, n.Meta["field_type"])
+			}
+			if tc.static {
+				assert.Equal(t, true, n.Meta["static"])
+			} else {
+				assert.NotContains(t, n.Meta, "static")
+			}
+		})
+	}
+
+	assert.Equal(t, "The account handle.", byID["account.dart::Account.id"].Meta["doc"])
+	assert.Equal(t, VisibilityPublic, byID["account.dart::Account.id"].Meta["visibility"])
+
+	// Every field is member_of its owning type and defined by the file.
+	memberOf := map[string]string{}
+	defines := map[string]bool{}
+	for _, e := range res.Edges {
+		switch e.Kind {
+		case graph.EdgeMemberOf:
+			memberOf[e.From] = e.To
+		case graph.EdgeDefines:
+			defines[e.To] = true
+		}
+	}
+	assert.Equal(t, "account.dart::Account", memberOf["account.dart::Account.id"])
+	assert.Equal(t, "account.dart::Auditable", memberOf["account.dart::Auditable.auditedAt"])
+	assert.Equal(t, "account.dart::Limits", memberOf["account.dart::Limits.cap"])
+	assert.True(t, defines["account.dart::Account.balance"])
+
+	// A field must not displace the method extractor's members.
+	require.NotNil(t, byID["account.dart::Account.deposit"])
+	assert.Equal(t, graph.KindMethod, byID["account.dart::Account.deposit"].Kind)
+
+	ids := map[string]bool{}
+	for _, n := range res.Nodes {
+		require.False(t, ids[n.ID], "duplicate node id %s", n.ID)
+		ids[n.ID] = true
+	}
+}
+
+// A top-level variable stays a file-scope symbol — the field pass must not
+// re-qualify it under a type.
+func TestDartExtractor_TopLevelVariablesUnchanged(t *testing.T) {
+	src := []byte(`const version = '1.0.0';
+final int retries = 2;
+
+class Holder {
+  final int retries = 3;
+}
+`)
+	res, err := NewDartExtractor().Extract("cfg.dart", src)
+	require.NoError(t, err)
+
+	byID := map[string]*graph.Node{}
+	for _, n := range res.Nodes {
+		byID[n.ID] = n
+	}
+	require.NotNil(t, byID["cfg.dart::version"])
+	require.NotNil(t, byID["cfg.dart::retries"])
+	assert.Equal(t, graph.KindVariable, byID["cfg.dart::retries"].Kind)
+
+	holder := byID["cfg.dart::Holder.retries"]
+	require.NotNil(t, holder, "the class field is a distinct symbol from the top-level one")
+	assert.Equal(t, "Holder", holder.Meta["receiver"])
+}
+
+// Enum constants — plain and enhanced (argument-bearing) — are members of the
+// enum type.
+func TestDartExtractor_EnumConstants(t *testing.T) {
+	src := []byte(`enum Status { pending, active, closed }
+
+enum Planet {
+  mercury(3.3e23),
+  venus(4.87e24);
+
+  const Planet(this.mass);
+  final double mass;
+}
+`)
+	res, err := NewDartExtractor().Extract("status.dart", src)
+	require.NoError(t, err)
+
+	byID := map[string]*graph.Node{}
+	for _, n := range res.Nodes {
+		byID[n.ID] = n
+	}
+
+	for _, id := range []string{
+		"status.dart::Status.pending",
+		"status.dart::Status.active",
+		"status.dart::Status.closed",
+		"status.dart::Planet.mercury",
+		"status.dart::Planet.venus",
+	} {
+		n := byID[id]
+		require.NotNil(t, n, "enum constant %s must be emitted", id)
+		assert.Equal(t, graph.KindEnumMember, n.Kind)
+	}
+
+	mercury := byID["status.dart::Planet.mercury"]
+	assert.Equal(t, "mercury", mercury.Name, "the argument list is not part of the constant name")
+	assert.Equal(t, "Planet", mercury.Meta["receiver"])
+	assert.Equal(t, "status.dart::Planet", mercury.Meta["enum"])
+
+	// An enhanced enum's field is a field, not a constant of the enum.
+	mass := byID["status.dart::Planet.mass"]
+	require.NotNil(t, mass)
+	assert.Equal(t, graph.KindField, mass.Kind)
+
+	var linked bool
+	for _, e := range res.Edges {
+		if e.Kind == graph.EdgeMemberOf && e.From == "status.dart::Status.active" && e.To == "status.dart::Status" {
+			linked = true
+		}
+	}
+	assert.True(t, linked, "an enum constant is member_of its enum")
+}
+
+// A setter is named by the property it writes, not by the `set foo` source
+// spelling, so a search for the property name reaches it. The getter of the
+// same property keeps the unsuffixed id.
+func TestDartExtractor_AccessorNames(t *testing.T) {
+	src := []byte(`class Temp {
+  double _c = 0;
+
+  double get celsius => _c;
+  set celsius(double v) { _c = v; }
+
+  set fahrenheit(double v) { _c = (v - 32) / 1.8; }
+}
+`)
+	res, err := NewDartExtractor().Extract("temp.dart", src)
+	require.NoError(t, err)
+
+	byName := map[string][]*graph.Node{}
+	for _, n := range res.Nodes {
+		byName[n.Name] = append(byName[n.Name], n)
+	}
+
+	assert.Empty(t, byName["set celsius"], "a setter must not carry the `set ` prefix in its name")
+	require.Len(t, byName["celsius"], 2, "the getter and the setter both answer to the property name")
+
+	var getter, setter *graph.Node
+	for _, n := range byName["celsius"] {
+		switch n.Meta["accessor"] {
+		case "getter":
+			getter = n
+		case "setter":
+			setter = n
+		}
+	}
+	require.NotNil(t, getter, "the getter is tagged accessor=getter")
+	require.NotNil(t, setter, "the setter is tagged accessor=setter")
+	assert.Equal(t, "temp.dart::Temp.celsius", getter.ID, "the getter keeps the unsuffixed id")
+	assert.NotEqual(t, getter.ID, setter.ID, "the colliding accessor gets a line-suffixed id")
+	assert.Equal(t, graph.KindMethod, setter.Kind)
+	assert.Equal(t, "Temp", setter.Meta["receiver"])
+
+	require.Len(t, byName["fahrenheit"], 1, "a setter with no getter takes the plain id")
+	assert.Equal(t, "temp.dart::Temp.fahrenheit", byName["fahrenheit"][0].ID)
+
+	// An ordinary method carries no accessor tag.
+	for _, n := range res.Nodes {
+		if n.Name == "Temp" {
+			assert.NotContains(t, n.Meta, "accessor")
+		}
+	}
+}

--- a/internal/parser/languages/dart_test.go
+++ b/internal/parser/languages/dart_test.go
@@ -512,7 +512,8 @@ func TestDartExtractor_ConstructorVariants(t *testing.T) {
 }
 
 // A const constructor on an enum and a private named constructor are ordinary
-// members too; a plain field declaration next to them stays a non-symbol.
+// members too; a plain field declaration next to them is a field, never a
+// constructor.
 func TestDartExtractor_ConstructorsInEnumAndPrivate(t *testing.T) {
 	src := []byte(`enum Status {
   active,
@@ -543,7 +544,9 @@ class Cache {
 	assert.Equal(t, "private", internal.Meta["visibility"])
 
 	// `final int size;` is a field declaration, not a constructor.
-	assert.Nil(t, byID["status.dart::Cache.size"])
+	size := byID["status.dart::Cache.size"]
+	require.NotNil(t, size, "field declaration must be emitted")
+	assert.Equal(t, graph.KindField, size.Kind)
 	assert.Nil(t, byID["status.dart::Cache.Cache"])
 }
 

--- a/internal/parser/languages/dart_typeuse.go
+++ b/internal/parser/languages/dart_typeuse.go
@@ -23,12 +23,13 @@ import (
 // Inferred bindings (`var x = ...`, `final x = ...`) carry no written type
 // and are skipped — there is nothing to attribute.
 //
-// Fields attribute to the file node (the extractor doesn't materialise a
-// per-field symbol node). Parameters and return types attribute to the
-// enclosing function / method node. Typed locals attribute to the enclosing
-// function via the same funcRange mechanism extractCalls uses, falling back
-// to the file node when no function encloses the line (e.g. a typed local in
-// a field initialiser).
+// Fields attribute to the file node: one declaration can bind several names
+// (`String? a, b;`) and therefore several field nodes, so a per-field owner
+// would have to either duplicate the edge or pick one binding arbitrarily.
+// Parameters and return types attribute to the enclosing function / method
+// node. Typed locals attribute to the enclosing function via the same
+// funcRange mechanism extractCalls uses, falling back to the file node when no
+// function encloses the line (e.g. a typed local in a field initialiser).
 func (e *DartExtractor) extractTypeUses(
 	root *sitter.Node, src []byte, filePath string, fileNode *graph.Node,
 	result *parser.ExtractionResult,

--- a/internal/parser/languages/swift.go
+++ b/internal/parser/languages/swift.go
@@ -41,6 +41,16 @@ const qSwiftAll = `
   (property_declaration
     (pattern (simple_identifier) @property.name)) @property.def
 
+  ; init / deinit / subscript are their own grammar rules, not
+  ; function_declaration, so none of the patterns above reached them. Left
+  ; unmatched they are absent as symbols AND absent from the func-range table,
+  ; which silently drops every call edge made from inside their bodies.
+  (init_declaration) @init.def
+
+  (deinit_declaration) @deinit.def
+
+  (subscript_declaration) @subscript.def
+
   (import_declaration) @import.def
 
   (call_expression
@@ -162,6 +172,15 @@ func (e *SwiftExtractor) Extract(filePath string, src []byte) (*parser.Extractio
 
 		case m.Captures["property.def"] != nil:
 			e.emitProperty(m, filePath, fileID, src, result, seen, annotationSeen, typeRanges)
+
+		case m.Captures["init.def"] != nil:
+			e.emitTypeMemberDecl(m.Captures["init.def"], "init", filePath, fileID, src, result, seen, annotationSeen, typeRanges)
+
+		case m.Captures["deinit.def"] != nil:
+			e.emitTypeMemberDecl(m.Captures["deinit.def"], "deinit", filePath, fileID, src, result, seen, annotationSeen, typeRanges)
+
+		case m.Captures["subscript.def"] != nil:
+			e.emitTypeMemberDecl(m.Captures["subscript.def"], "subscript", filePath, fileID, src, result, seen, annotationSeen, typeRanges)
 
 		case m.Captures["import.def"] != nil:
 			e.emitImport(m, filePath, fileID, result)
@@ -615,6 +634,74 @@ func (e *SwiftExtractor) emitProperty(m parser.QueryResult, filePath, fileID str
 		emitSwiftTypeUseEdges(id, fieldType, filePath, def.StartLine+1, result)
 	}
 	emitSwiftAnnotationEdges(def.Node, id, filePath, src, result, annotationSeen)
+}
+
+// emitTypeMemberDecl emits a nameless type member — `init`, `deinit`, or
+// `subscript`, named only by its declaring keyword — as a method of its
+// enclosing type (a type declaration or an `extension Foo { … }` block, both of
+// which seed typeRanges). A declaration with no enclosing type range is a
+// protocol requirement or a parse-error fragment and is dropped rather than
+// attributed to the file.
+//
+// An initializer takes the cross-language constructor spelling `<Type>.<init>`
+// that Java and C# already emit, so constructor-aware consumers need no Swift
+// special case. `deinit` and `subscript` are spelled as written, and two
+// subscripts on one type separate by the shared line-suffix disambiguation.
+func (e *SwiftExtractor) emitTypeMemberDecl(
+	def *parser.CapturedNode, keyword, filePath, fileID string, src []byte,
+	result *parser.ExtractionResult, seen, annotationSeen map[string]bool,
+	typeRanges []swiftTypeRange,
+) {
+	if def == nil || def.Node == nil {
+		return
+	}
+	tr, ok := findEnclosingSwiftTypeRange(typeRanges, def.StartLine)
+	if !ok {
+		return
+	}
+	name := keyword
+	member := tr.name + "." + keyword
+	if keyword == "init" {
+		name = tr.name + ".<init>"
+		member = name
+	}
+	id, idOK := disambiguateID(seen, filePath+"::"+member, def.StartLine+1)
+	if !idOK {
+		return
+	}
+
+	meta := map[string]any{
+		"receiver":   tr.name,
+		"kind":       keyword,
+		"signature":  swiftDeclHeader(def.Node, src),
+		"visibility": swiftVisibility(def.Node, src),
+	}
+	if doc := ExtractDocAbove(src, def.StartLine, DocLangSlashSlash); doc != "" {
+		meta["doc"] = doc
+	}
+	result.Nodes = append(result.Nodes, &graph.Node{
+		ID: id, Kind: graph.KindMethod, Name: name,
+		FilePath: filePath, StartLine: def.StartLine + 1, EndLine: def.EndLine + 1,
+		Language: "swift", Meta: meta,
+	})
+	result.Edges = append(result.Edges, &graph.Edge{
+		From: fileID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: def.StartLine + 1,
+	})
+	result.Edges = append(result.Edges, &graph.Edge{
+		From: id, To: filePath + "::" + tr.name, Kind: graph.EdgeMemberOf, FilePath: filePath, Line: def.StartLine + 1,
+	})
+	emitSwiftAnnotationEdges(def.Node, id, filePath, src, result, annotationSeen)
+}
+
+// swiftDeclHeader returns a declaration's source up to its body brace, folded
+// onto one line — the readable signature for a member the grammar gives no
+// name field (`init`, `deinit`, `subscript`).
+func swiftDeclHeader(decl *sitter.Node, src []byte) string {
+	header := decl.Content(src)
+	if i := strings.IndexByte(header, '{'); i >= 0 {
+		header = header[:i]
+	}
+	return strings.Join(strings.Fields(header), " ")
 }
 
 // swiftPropertyIsMutable reports whether a property is declared with `var`

--- a/internal/parser/languages/swift_type_members_test.go
+++ b/internal/parser/languages/swift_type_members_test.go
@@ -1,0 +1,194 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// init / deinit / subscript declared in a type body are members of that type.
+func TestSwiftExtractor_InitDeinitSubscript(t *testing.T) {
+	const swift = `final class Cache {
+    private var store: [String: Int] = [:]
+
+    /// Builds an empty cache.
+    init() {
+        self.store = [:]
+    }
+
+    init(seed: [String: Int]) {
+        self.store = seed
+    }
+
+    deinit {
+        store.removeAll()
+    }
+
+    subscript(key: String) -> Int? {
+        return store[key]
+    }
+}
+`
+	res, err := NewSwiftExtractor().Extract("Cache.swift", []byte(swift))
+	require.NoError(t, err)
+
+	byID := map[string]*graph.Node{}
+	for _, n := range res.Nodes {
+		byID[n.ID] = n
+	}
+
+	ctor := byID["Cache.swift::Cache.<init>"]
+	require.NotNil(t, ctor, "an initializer must be emitted")
+	assert.Equal(t, graph.KindMethod, ctor.Kind)
+	assert.Equal(t, "Cache.<init>", ctor.Name)
+	assert.Equal(t, "Cache", ctor.Meta["receiver"])
+	assert.Equal(t, "init", ctor.Meta["kind"])
+	assert.Equal(t, "init()", ctor.Meta["signature"])
+	assert.Equal(t, "Builds an empty cache.", ctor.Meta["doc"])
+
+	require.NotNil(t, byID["Cache.swift::Cache.<init>_L9"],
+		"a second initializer takes a line-suffixed id")
+
+	dtor := byID["Cache.swift::Cache.deinit"]
+	require.NotNil(t, dtor, "a deinitializer must be emitted")
+	assert.Equal(t, "deinit", dtor.Name)
+	assert.Equal(t, "deinit", dtor.Meta["kind"])
+
+	sub := byID["Cache.swift::Cache.subscript"]
+	require.NotNil(t, sub, "a subscript must be emitted")
+	assert.Equal(t, "subscript", sub.Name)
+	assert.Equal(t, "subscript(key: String) -> Int?", sub.Meta["signature"])
+
+	memberOf := map[string]string{}
+	for _, e := range res.Edges {
+		if e.Kind == graph.EdgeMemberOf {
+			memberOf[e.From] = e.To
+		}
+	}
+	for _, id := range []string{ctor.ID, dtor.ID, sub.ID} {
+		assert.Equal(t, "Cache.swift::Cache", memberOf[id], "%s is member_of Cache", id)
+	}
+
+	// A body that used to have no enclosing symbol dropped its call edges.
+	var removeAll bool
+	for _, e := range res.Edges {
+		if e.Kind == graph.EdgeCalls && e.From == dtor.ID && e.To == "unresolved::*.removeAll" {
+			removeAll = true
+		}
+	}
+	assert.True(t, removeAll, "a call inside deinit attributes to the deinit node")
+}
+
+// Every member kind declared in an `extension Type { … }` block — method,
+// computed and stored static property, initializer, subscript — qualifies
+// under the extended type, including when the extension is the only
+// declaration naming that type in the file.
+func TestSwiftExtractor_ExtensionMemberKinds(t *testing.T) {
+	const swift = `import Foundation
+
+public struct Rule {
+    let name: String
+}
+
+public extension Validator {
+    public static var email: Validator {
+        Validator(pattern: "@")
+    }
+
+    static let shared = Validator(pattern: "")
+
+    var isEmpty: Bool { pattern.isEmpty }
+
+    func check(_ s: String) -> Bool {
+        return matches(s)
+    }
+
+    init(raw: String) {
+        self.init(pattern: raw)
+    }
+
+    subscript(i: Int) -> Character {
+        return pattern[i]
+    }
+}
+`
+	res, err := NewSwiftExtractor().Extract("Validator.swift", []byte(swift))
+	require.NoError(t, err)
+
+	byID := map[string]*graph.Node{}
+	for _, n := range res.Nodes {
+		byID[n.ID] = n
+	}
+
+	for _, tc := range []struct {
+		id   string
+		kind graph.NodeKind
+	}{
+		{"Validator.swift::Validator.email", graph.KindField},
+		{"Validator.swift::Validator.shared", graph.KindField},
+		{"Validator.swift::Validator.isEmpty", graph.KindField},
+		{"Validator.swift::Validator.check", graph.KindMethod},
+		{"Validator.swift::Validator.<init>", graph.KindMethod},
+		{"Validator.swift::Validator.subscript", graph.KindMethod},
+	} {
+		t.Run(tc.id, func(t *testing.T) {
+			n := byID[tc.id]
+			require.NotNil(t, n, "extension member %s must be emitted", tc.id)
+			assert.Equal(t, tc.kind, n.Kind)
+			assert.Equal(t, "Validator", n.Meta["receiver"])
+		})
+	}
+
+	assert.Equal(t, "Validator", byID["Validator.swift::Validator.email"].Meta["field_type"])
+	assert.Equal(t, VisibilityPublic, byID["Validator.swift::Validator.email"].Meta["visibility"])
+
+	// The struct in the same file keeps its own members.
+	require.NotNil(t, byID["Validator.swift::Rule.name"])
+	assert.Equal(t, "Rule", byID["Validator.swift::Rule.name"].Meta["receiver"])
+
+	memberOf := map[string]string{}
+	for _, e := range res.Edges {
+		if e.Kind == graph.EdgeMemberOf {
+			memberOf[e.From] = e.To
+		}
+	}
+	assert.Equal(t, "Validator.swift::Validator", memberOf["Validator.swift::Validator.<init>"])
+	assert.Equal(t, "Validator.swift::Validator", memberOf["Validator.swift::Validator.check"])
+
+	ids := map[string]bool{}
+	for _, n := range res.Nodes {
+		require.False(t, ids[n.ID], "duplicate node id %s", n.ID)
+		ids[n.ID] = true
+	}
+}
+
+// A protocol's init requirement has no type body to attribute to and must not
+// land on the file or on an unrelated type.
+func TestSwiftExtractor_ProtocolInitRequirement(t *testing.T) {
+	const swift = `protocol Buildable {
+    init(raw: String)
+}
+
+struct Widget: Buildable {
+    init(raw: String) {}
+}
+`
+	res, err := NewSwiftExtractor().Extract("Buildable.swift", []byte(swift))
+	require.NoError(t, err)
+
+	byID := map[string]*graph.Node{}
+	for _, n := range res.Nodes {
+		byID[n.ID] = n
+	}
+	require.NotNil(t, byID["Buildable.swift::Widget.<init>"])
+	assert.Nil(t, byID["Buildable.swift::Buildable.<init>"],
+		"a protocol requirement declares no body to own")
+
+	for _, n := range res.Nodes {
+		if n.Kind == graph.KindMethod {
+			assert.Equal(t, "Widget", n.Meta["receiver"])
+		}
+	}
+}


### PR DESCRIPTION
## What

Closes whole-class extraction blind spots and protects the localization page from the ranking shift the new nodes cause.

### Extraction
- **Dart**: class/mixin/extension fields (one node per bound name, const detection, member edges), enum constants (`Enum.constant` per the cross-language convention), setters under their bare property name with an `accessor` stamp.
- **Swift**: `init`/`deinit`/`subscript` in types **and** extensions, with the cross-language `Type.<init>` constructor spelling — also recovering call edges made inside those bodies, which were previously dropped for lack of an enclosing function.

### Localize seat protection (three layers)
New member nodes inherit their type's identifier terms, so constructors and fields could displace the method a task is about. On the localize path only:
1. within each file's occupied window slots, ordinary callables and types keep the front; constructor-spelled callables, then fields/enum members follow;
2. a name-term lane cannot elect a constructor or data member as the page's primary callable when a same-file ordinary sibling is present; graph/literal proof lanes, task-cited identifiers, and prescribed refinement symbols always keep their seats;
3. before the window cut, an unprotected member slot is traded for the first same-file ordinary callable within the established cross-cut reach — per-file slot counts and cross-file order are invariant, and fields the typed-anchor projection can seed are exempt.

Non-localize pages, search, and navigation keep raw ranking everywhere.

## Validation

Full 318-task sealed first-call replays at every layer:
- page presence and file-on-page are the best measured on this corpus (236 / 278 vs 233 / 276 pre-branch); gold-in-PRIMARY 137 vs 140 pre-branch
- previously-converting sessions: 6 regressions of 115 (5.2%, structural budget is 5.0%) — three are pre-existing chronics, the residual oscillates between single tasks across damping layers, so further structural tuning shows diminishing returns
- a billed full-corpus agent validation is running as the deciding measurement; results will be posted on this PR
- suites: mcp, parser (+ downstream indexer/resolver/contracts), race detector, and full-tree lint all green