### PR TITLE
fix(connectivity): stop the note promising dead_code rows are safe to remove

### DIFF
--- a/internal/analysis/connectivity.go
+++ b/internal/analysis/connectivity.go
@@ -13,10 +13,13 @@ import (
 // This is deliberately DISTINCT from dead-code analysis (FindDeadCode):
 //
 //   - Dead-code analysis reports symbols with zero *incoming usage*
-//     edges — genuinely unreachable code. Such a symbol is still a
-//     normally extracted node: its file `defines` it, a method is
-//     `member_of` its type. The finding is actionable — the code is
-//     unused and can be removed.
+//     edges. Such a symbol is still a normally extracted node: its file
+//     `defines` it, a method is `member_of` its type. That is a narrower
+//     signal than "unreachable", and it is not a removal verdict: a call
+//     site the resolver left unresolved — an ambiguous member call, a
+//     name-only match — leaves exactly the same zero-incoming shape as
+//     genuinely unused code. Confirm a dead-code row against the source
+//     before deleting anything.
 //
 //   - This analyzer reports *isolated* nodes — nodes with zero edges of
 //     *any* kind, structural edges included. A normally extracted
@@ -98,8 +101,11 @@ const connectivityNote = "Connectivity health is a graph-EXTRACTION diagnostic, 
 	"symbol always has at least a structural edge, so an isolated node " +
 	"signals the indexer mis-extracted the symbol, NOT that the code is " +
 	"unused. This is distinct from dead code (analyze kind=dead_code), " +
-	"which reports symbols with zero INCOMING usage edges — genuinely " +
-	"unreachable code that is safe to remove."
+	"which reports symbols with zero INCOMING usage edges. That is a " +
+	"narrower signal, not a removal verdict: a call site the resolver " +
+	"left unresolved — an ambiguous member call, a name-only match — " +
+	"leaves the same zero-incoming shape as genuinely unused code, so " +
+	"confirm a dead_code row against the source before removing anything."
 
 // GraphConnectivity computes the connectivity-health report over the
 // supplied nodes. The caller passes the node slice (e.g. a

--- a/internal/analysis/connectivity_test.go
+++ b/internal/analysis/connectivity_test.go
@@ -2,6 +2,7 @@ package analysis
 
 import (
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -245,6 +246,47 @@ func TestGraphConnectivity_IsolatedIsNotDeadCode(t *testing.T) {
 	assert.NotEqual(t, graph.ZeroEdgePossibleExtractionGap,
 		graph.ClassifyZeroEdge(g, "a.go::Unused"),
 		"the structurally-linked dead-code node is NOT an extraction gap")
+}
+
+// TestConnectivityNote_MatchesSharedZeroEdgeStance pins the standing note
+// against the per-symbol caveat vocabulary this analyzer says it stays in
+// lockstep with. graph.ClassifyZeroEdge — reused here for the
+// isolated/leaf split — deliberately refuses to call a zero-incoming
+// symbol proof of anything, because an unresolved or name-only call site
+// leaves the same shape. The note describing kind=dead_code must not
+// contradict that by promising the row is safe to delete.
+func TestConnectivityNote_MatchesSharedZeroEdgeStance(t *testing.T) {
+	nodes := []connNode{
+		{"a.go", graph.KindFile, "a.go"},
+		// Zero incoming *usage* edges, one structural edge — exactly the
+		// shape kind=dead_code reports on.
+		{"a.go::Unused", graph.KindFunction, "a.go"},
+	}
+	g, allNodes := buildConnGraph(nodes, []connEdge{{"a.go", "a.go::Unused"}})
+
+	// Control: the shared classifier sees this very shape and still hedges.
+	caveat := graph.CaveatForZeroEdge(g, "a.go::Unused")
+	require.NotNil(t, caveat, "the dead-code shape carries a zero-edge caveat")
+	require.Equal(t, graph.ZeroEdgeLikelyUnused, caveat.Class)
+	require.Contains(t, caveat.Message, "not proof",
+		"the shared caveat refuses to call zero incoming usage edges proof")
+
+	report := GraphConnectivity(g, allNodes, 0)
+	require.Equal(t, connectivityNote, report.Note, "the report carries the standing note")
+
+	// The distinction the note exists to draw must survive any rewording.
+	assert.Contains(t, report.Note, "dead_code", "the note still names the analyzer it contrasts with")
+	assert.Contains(t, report.Note, "INCOMING", "the note still states the dead_code signal")
+
+	// What must never come back: a removal verdict the classifier withholds.
+	lowered := strings.ToLower(report.Note)
+	for _, verdict := range []string{
+		"safe to remove", "safe to delete",
+		"can be removed", "can be deleted",
+	} {
+		assert.NotContains(t, lowered, verdict,
+			"the note must not promise removal safety the shared classifier withholds")
+	}
 }
 
 // TestGraphConnectivity_NilGraph asserts a nil graph yields a zero

--- a/internal/mcp/tools_analyze_connectivity.go
+++ b/internal/mcp/tools_analyze_connectivity.go
@@ -7,10 +7,11 @@
 // leaf nodes.
 //
 // It is deliberately DISTINCT from kind=dead_code. dead_code reports
-// symbols with zero *incoming usage* edges — genuinely unreachable
-// code, a real finding to act on (delete it). This analyzer reports
-// isolated nodes — zero edges of *any* kind, structural edges
-// included — which a normally extracted symbol never has. An isolated
+// symbols with zero *incoming usage* edges — a narrower signal than
+// "unreachable", and not a removal verdict, since an unresolved or
+// name-only call site leaves the same zero-incoming shape. This
+// analyzer reports isolated nodes — zero edges of *any* kind, structural
+// edges included — which a normally extracted symbol never has. An isolated
 // node signals the indexer mis-extracted the symbol or its file, not
 // that the code is unused; the response carries a `note` spelling out
 // the distinction so a reader does not delete live code.


### PR DESCRIPTION
## Problem

Every `connectivity_health` response ships a `note` that ends:

> This is distinct from dead code (analyze kind=dead_code), which reports symbols with zero INCOMING usage edges — **genuinely unreachable code that is safe to remove.**

The two doc-comments feeding it agree — `internal/analysis/connectivity.go` says "the code is unused and can be removed", `internal/mcp/tools_analyze_connectivity.go` says "a real finding to act on (delete it)".

That contradicts the vocabulary this analyzer explicitly says it stays in lockstep with. `ClassifyZeroEdge` reaches the **opposite** conclusion from the same zero-incoming shape:

- `likely_unused` → *"this is evidence of no callers, not proof: confirm with a text search for the symbol name before removing it"* (`extraction_gap.go:296`)
- `coverage_incomplete` → *"not as proof the symbol is unused or safe to remove"* (`extraction_gap.go:310`)

And `FindDeadCode`'s own contract claims no more than *"all symbols with zero incoming calls or references, excluding entry points, test functions, exported symbols, and user-excluded patterns"* (`deadcode.go:233`). The removal verdict is layered on top of that, and only in these three places.

## Why the hedge is load-bearing

Two ordinary situations leave a **live** symbol with exactly the zero-incoming shape `dead_code` reports on:

1. **Ambiguous member calls.** `resolveMethodCall` deliberately declines to bind rather than misattribute to a same-name candidate — *"ambiguous stays unresolved rather than misattributing to a same-name"*. Every losing candidate keeps zero incoming edges.
2. **Name-only matches**, which never earn a trustworthy usage edge.

Measured on a 2,475-file Go repository (`gortex v0.63.7+0988412`): `analyze dead_code` returned 4 rows and `git grep` refuted 3 of them. Two were methods reached through a nested field selector (`p.provider.recordSubmit(...)`, called 16 lines below their own definition); one was a method value (`var cryptorandRead = randReader`). A reader who trusted the note would have deleted three working symbols.

Note the `callers` caveat next door is already correctly hedged — this is the one surface that still isn't.

## Change

Reword all three sites to state the signal and withhold the verdict. The isolated-vs-dead-code distinction the note exists to draw is unchanged; only the removal promise goes.

## Test

`TestConnectivityNote_MatchesSharedZeroEdgeStance` pins the **property**, not the prose, so a future rewording is free but a re-promotion is not:

1. builds the dead-code shape (one structural `defines` edge, zero incoming usage),
2. asserts as a positive control that `CaveatForZeroEdge` for that same symbol is `likely_unused` and still says `"not proof"`,
3. asserts the report actually carries `connectivityNote`,
4. asserts the note keeps naming `dead_code` and its `INCOMING` signal,
5. asserts it contains no removal verdict (`safe to remove` / `safe to delete` / `can be removed` / `can be deleted`).

**Sabotage-verified:** restoring the old sentence fails the test on assertion 5 — `should not contain "safe to remove"`. Reverting makes it green again.

### Limitations I'd rather declare than have found

- The forbidden-phrase list is a **closed** set of four. A future note could promise removal in wording the list does not cover; the test would not catch that. I chose an explicit list over a fuzzier check because a false positive here would block unrelated rewordings.
- Assertions 3–5 bind the note only through `GraphConnectivity`'s return value. The MCP handler's own doc-comment is changed for coherence but is not test-bound (it is a comment).
- The measurement above is evidence for *why* the hedge matters; it is not exercised by the test, which uses a synthetic fixture.

## Verification

- `go test ./internal/analysis/ -run 'TestConnectivityNote|TestGraphConnectivity' -count=1` — 6/6 pass, plus the sabotage run above.
- `go build ./internal/mcp/ ./internal/analysis/` — clean.
- `golangci-lint run --timeout=10m ./internal/analysis/... ./internal/mcp/...` — **0 issues**.
- `git diff --check` clean; diff carries no CR bytes. (`gofmt -l` flags all 83 files in `internal/analysis` on my Windows clone, untouched files included — a local `core.autocrlf` artifact, not this change.)
- No `.md` / `.json` / `.yaml` mirrors the old wording; no test referenced the note before this one.

Windows 11, go1.26.6, branched from `main` at `a71cbedb`.