### PR TITLE
test(store_sqlite): close the plan-lock fixture store so TempDir cleanup works on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,18 @@ jobs:
       - name: Test sidecar handle release
         run: go test -timeout=5m -count=1 -run TestCloseSidecar ./internal/persistence
 
+      # Same asymmetry, different holder: the plan-lock fixture opens an
+      # on-disk Store, so a missing Close pins plan_lock.sqlite and fails
+      # its t.TempDir() cleanup here while passing everywhere else. Every
+      # assertion in these tests is platform-neutral — only the cleanup
+      # distinguishes the runners — so nothing but this step can protect
+      # the fixture's Close from being dropped again.
+      - name: Test plan-lock fixture handle release
+        run: >
+          go test -timeout=10m -count=1
+          -run 'PlanLock|PlansLocked|PlansNeverScan'
+          ./internal/graph/store_sqlite
+
       # os.UserHomeDir reads %USERPROFILE% here and $HOME everywhere else, so
       # a test that isolates itself with HOME alone keeps resolving the real
       # profile on Windows — and writes to it. That is invisible to the

--- a/internal/graph/store_sqlite/plan_lock_test.go
+++ b/internal/graph/store_sqlite/plan_lock_test.go
@@ -142,6 +142,11 @@ func newPlanLockFixture(t *testing.T) *Store {
 	if err != nil {
 		t.Fatalf("open fixture store: %v", err)
 	}
+	// Registered after t.TempDir() so LIFO cleanup closes the database
+	// before the directory is removed. Without it the sqlite handle
+	// outlives the test and TempDir's RemoveAll fails on Windows, where
+	// an open file cannot be unlinked.
+	t.Cleanup(func() { _ = s.Close() })
 	kinds := []graph.NodeKind{
 		graph.KindLocal, graph.KindLocal, graph.KindLocal, graph.KindLocal,
 		graph.KindParam, graph.KindParam, graph.KindVariable,


### PR DESCRIPTION
## Problem

`newPlanLockFixture` (`plan_lock_test.go:139`) opens an on-disk `Store` and never closes it. Windows refuses to unlink an open file, so `plan_lock.sqlite` survives the test and the enclosing `t.TempDir()` cleanup fails.

Whole package on windows/amd64, go1.26.6, at `main`:

```
--- FAIL: TestSweepPlanLocks (1.75s)
--- FAIL: TestAdjacencyPlanLocksDuringBulkLoad (1.93s)
--- FAIL: TestSweepPlanLockReceiverRebindBatch (1.97s)
--- FAIL: TestPreparedStatementPlansNeverScanBigTables (2.04s)
--- FAIL: TestSweepWarnPlanLocks (1.69s)
    testing.go:1464: TempDir RemoveAll cleanup: unlinkat
    …\plan_lock.sqlite: The process cannot access the file because it is
    being used by another process.
FAIL	github.com/zzet/gortex/internal/graph/store_sqlite	120.141s
```

Five failures, one cause, and **zero failing assertions** — every plan lock passes; only cleanup dies. The fixture is the only holder: nothing else in the package fails, and a scan of the package's tests finds `newPlanLockFixture` among just 5 `Open()` sites without a `Close`, the other four being benchmarks or an error-path test that never gets a live store.

After the change: `ok github.com/zzet/gortex/internal/graph/store_sqlite 147.360s`, no failures.

## Change

Two things.

**1. Close the fixture** — `t.Cleanup(func() { _ = s.Close() })`, registered *after* `t.TempDir()` so LIFO ordering closes the database before the directory is removed. This is already the convention at 160 of the 165 `Open()` sites in this package's tests.

**2. Guard it on the windows runner.** Every assertion in these tests is platform-neutral: on linux/macos an unlinked-but-open file is removed normally, so the whole set passes with or without the `Close`, and the matrix cannot notice if the cleanup is dropped again. That is the same asymmetry — and the same fix shape — as the sidecar-handle step from #415, so the new step sits directly below it with the reasoning spelled out in a comment.

The `-run` selector is verified to match the fixture's users and nothing else:

```
$ go test ./internal/graph/store_sqlite/ -list 'PlanLock|PlansLocked|PlansNeverScan'
TestHotQueryPlansLocked
TestSweepPlanLocks
TestAdjacencyPlanLocksDuringBulkLoad
TestSweepPlanLockReceiverRebindBatch
TestPreparedStatementPlansNeverScanBigTables
TestSweepWarnPlanLocks
```

## Verification

- Before / after on windows, whole package: **5 failures → 0**.
- **Sabotage-verified:** with the `t.Cleanup` line removed, the exact new CI command reproduces all 5 failures; restoring it returns `ok`. The step provably binds.
- New step wall time locally: **21.7s** total, of which the test run is 1.8s — on the runner the package is already compiled by the preceding `go build ./...`.
- `.github/workflows/ci.yml` indentation matches the neighbouring `run: >` step; `git diff --check` clean, no CR bytes in the diff.

### Declared, so you don't have to find them

- `TestHotQueryPlansLocked` already had its own `defer s.Close()` (line 39), which is why it was the one fixture user that never failed. That defer is now redundant. I left it rather than widen the diff — both call sites discard the error, and the full package is green — but say the word and I'll drop it.
- `golangci-lint run ./internal/graph/store_sqlite/...` reports 6 `staticcheck` SA5011 findings in `meta_promoted_test.go`. They are **pre-existing**: identical output with this change stashed. Untouched here.
- This is a test-side leak only. `Store.Close()` itself is thorough and there is no global handle cache, so no production path is affected — the value is unblocking the windows runner, not fixing user-visible behaviour.

Branched from `main` at `e8d60b80`. Windows 11, go1.26.6.