### PR TITLE
release: stop running `go mod tidy` at release time, assert tidiness in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,21 @@ jobs:
           version: v2.11.4
           args: --timeout=10m
 
+      # goreleaser used to run `go mod tidy` as a release before-hook, which
+      # meant an untidy go.mod was silently rewritten inside the release
+      # container — the shipped binaries could be built against a module set
+      # no CI job had ever compiled. That hook is gone; tidiness is asserted
+      # here instead, on the PR that introduces the drift, and it FAILS rather
+      # than rewrites.
+      - name: go.mod is tidy
+        run: |
+          set -euo pipefail
+          go mod tidy
+          if ! git diff --exit-code --stat go.mod go.sum; then
+            echo "FATAL: go.mod/go.sum are not tidy — run \`go mod tidy\` and commit the result" >&2
+            exit 1
+          fi
+
   build-onnx:
     runs-on: ubuntu-latest
     steps:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,11 +13,22 @@ version: 2
 #     release.yml once the darwin hashes exist — it is NOT generated here.
 #   - windows: the CGo tree-sitter bindings need a real mingw C/C++ toolchain.
 before:
-  hooks:
-    - go mod tidy
-    # Tests run in CI on every push. Re-running ./... inside
-    # goreleaser-cross slows the tag-to-artifact loop without catching
-    # anything new — the tag is already on a green commit.
+  hooks: []
+    # No before hooks, for the same reason in both cases: the tag is already
+    # on a green commit, so re-running work here costs tag-to-artifact time
+    # without catching anything new.
+    #
+    # Tests run in CI on every push, so `go test ./...` inside
+    # goreleaser-cross adds nothing.
+    #
+    # `go mod tidy` was worse than redundant. It walks the full module graph
+    # including the test dependencies of dependencies, so it spent ~5 minutes
+    # on the network and took v0.63.8 down when proxy.golang.org returned
+    # HTTP/2 INTERNAL_ERROR on six unrelated fetches. And because it MUTATES
+    # go.mod/go.sum in the container, a drifted module set would be silently
+    # rewritten at release time and the shipped binaries built against
+    # something no CI job had ever compiled. Tidiness is now asserted in the
+    # `lint` job of ci.yml, where drift fails the PR instead.
 
 builds:
   - id: main


### PR DESCRIPTION
## What broke

The v0.63.8 release failed in goreleaser's `before` hook:

```
• running before hooks
  • running                                        hook=go mod tidy
    • took: 4m49s
⨯ release failed after 4m53s   error=exit status 1 message=hook failed: command failed cmd=go
```

Six unrelated module fetches got HTTP/2 `INTERNAL_ERROR` from `proxy.golang.org` — `gomlx`, four `go-sitter-forest` grammars, `tree-sitter-protobuf`. A transient proxy flake, but it took the release down after ~5 minutes, and nothing had been published yet.

## Why the hook has to go, not just get a retry

`go mod tidy` resolves the *test dependencies of the dependencies* — that's why the failure log is full of `... tested by ... .test imports ...` chains. It touches far more of the network than building the release needs, on the one path where a flake costs a release.

It is also unsound in a quieter way: **it mutates `go.mod`/`go.sum` inside the release container.** A drifted module set would have been silently rewritten at tag time and the published binaries built against something no CI job had ever compiled. A rewrite is not a check.

The config already skips tests in this hook on the reasoning that "the tag is already on a green commit". The same argument applies here.

## Correction to what I said when I proposed this

I claimed CI already verified tidiness. **It does not** — there is no `go mod tidy` check in any workflow or in the Makefile. This release-time hook was the only thing exercising it, and it did so by rewriting rather than failing. So dropping it alone would have removed the last (bad) tidy pass.

This PR therefore does both halves:

- removes the `go mod tidy` before-hook from `.goreleaser.yml`
- adds a **`go.mod is tidy`** step to the `lint` job: `go mod tidy` then `git diff --exit-code go.mod go.sum`, which fails the PR that introduces drift

`main` is already tidy, so the new gate is green on landing.

## Verification (real toolchain, not by reading it)

- `goreleaser build --snapshot` with a deliberately failing before-hook aborts at `running before hooks` in 0s — proving hooks do execute in that mode.
- With `hooks: []`, that stage **never appears**; the run goes straight from `snapshotting` to `building binaries`. No default hook silently takes its place.
- `goreleaser check` validates the config.
- The new CI gate passes on `main` unchanged, and **exits 1 naming `go.mod`** when run against a commit carrying a deliberately untidy `require` line.

## Not included

Re-running the failed v0.63.8 release — that's yours to trigger. State is clean for it: no v0.63.8 GitHub release was created, and the tap is untouched.
