### PR TITLE
telemetry: fix the flaky consent-cache TTL test that broke CI on main

### DIFF
--- a/internal/telemetry/consent_store.go
+++ b/internal/telemetry/consent_store.go
@@ -89,6 +89,13 @@ func clearBuffer(dir string) {
 // within ttl without an os.ReadFile per event. It is the live resolver a
 // long-lived process hands to NewRecorderFunc. Safe for concurrent use.
 func CachedConsentResolver(dir string, ttl time.Duration) func() bool {
+	return cachedConsentResolver(dir, ttl, time.Now)
+}
+
+// cachedConsentResolver is CachedConsentResolver with an injectable clock, so a
+// test can step across the TTL boundary instead of racing a real deadline
+// against a loaded machine's scheduler and disk.
+func cachedConsentResolver(dir string, ttl time.Duration, clock func() time.Time) func() bool {
 	var (
 		mu        sync.Mutex
 		enabled   bool
@@ -98,7 +105,7 @@ func CachedConsentResolver(dir string, ttl time.Duration) func() bool {
 	return func() bool {
 		mu.Lock()
 		defer mu.Unlock()
-		now := time.Now()
+		now := clock()
 		if !valid || now.Sub(checkedAt) >= ttl {
 			enabled = ResolveConsent(LoadConsentConfig(dir), os.Getenv).Enabled
 			checkedAt = now

--- a/internal/telemetry/recorder_test.go
+++ b/internal/telemetry/recorder_test.go
@@ -147,7 +147,13 @@ func TestCachedConsentResolver(t *testing.T) {
 	if err := SaveConsent(dir, true, "test", nil); err != nil {
 		t.Fatal(err)
 	}
-	resolve := CachedConsentResolver(dir, 20*time.Millisecond)
+	// A stepped clock, not wall time: the TTL boundary is the thing under test,
+	// so the test must not lose a race between SaveConsent's disk write and a
+	// real deadline on a loaded machine.
+	const ttl = 20 * time.Millisecond
+	base, _ := time.Parse("2006-01-02", "2026-06-18")
+	clock := base
+	resolve := cachedConsentResolver(dir, ttl, func() time.Time { return clock })
 	if !resolve() {
 		t.Fatal("resolver should reflect persisted enabled=true")
 	}
@@ -155,12 +161,27 @@ func TestCachedConsentResolver(t *testing.T) {
 	if err := SaveConsent(dir, false, "test", nil); err != nil {
 		t.Fatal(err)
 	}
+	clock = base.Add(ttl - 1)
 	if !resolve() {
 		t.Error("within TTL the cached value should persist")
 	}
-	// After the TTL elapses it re-reads → false.
-	time.Sleep(30 * time.Millisecond)
+	// Once the TTL has elapsed it re-reads → false.
+	clock = base.Add(ttl)
 	if resolve() {
 		t.Error("after TTL the resolver should re-read and return false")
+	}
+}
+
+func TestCachedConsentResolverUsesRealClock(t *testing.T) {
+	t.Setenv("GORTEX_TELEMETRY", "")
+	t.Setenv("DO_NOT_TRACK", "")
+	dir := t.TempDir()
+	if err := SaveConsent(dir, true, "test", nil); err != nil {
+		t.Fatal(err)
+	}
+	// The exported constructor is the one production wires up; a long TTL keeps
+	// this to the wiring (dir + real clock) with no timing assumption.
+	if !CachedConsentResolver(dir, time.Hour)() {
+		t.Error("exported resolver should reflect persisted enabled=true")
 	}
 }


### PR DESCRIPTION
## What broke

The `test (ubuntu-latest, 1.26)` leg of CI failed on `main`:

```
--- FAIL: TestCachedConsentResolver (0.07s)
    recorder_test.go:159: within TTL the cached value should persist
FAIL	github.com/zzet/gortex/internal/telemetry	0.115s
```

Nothing in the merged change touched telemetry — the test is timing-dependent.

## Root cause

`TestCachedConsentResolver` built a resolver with a **20 ms** TTL against the real
clock, then:

1. `resolve()` → primes the cache with `enabled=true` and stamps `checkedAt`
2. `SaveConsent(dir, false, …)` → a **file write to disk**
3. `resolve()` → asserts the cached `true` is still served

Step 2 is the problem. `CachedConsentResolver` re-reads whenever
`now.Sub(checkedAt) >= ttl`, so the assertion in step 3 only holds if the disk
write plus scheduler latency finishes inside 20 ms. On a loaded runner — the
ubuntu leg runs `go test ./...` with coverage across packages that take 90–145 s
apiece — it doesn't, the cache expires legitimately, and the test reports a bug
that isn't there. macOS passed on both attempts, which is the signature of a
margin that is too thin rather than broken logic.

## Fix

Add an unexported `cachedConsentResolver(dir, ttl, clock)`; the exported
`CachedConsentResolver` is now a one-line wrapper passing `time.Now` and keeps
its signature (no caller changes — 4 direct dependents, all untouched).

The test steps that clock across the boundary instead of racing it:

- `base + (ttl-1)` → still cached, must return the stale `true`
- `base + ttl` → expired, must re-read and return `false`

That asserts the boundary *exactly* rather than approximately, and drops a
30 ms `time.Sleep` from the suite. A new `TestCachedConsentResolverUsesRealClock`
keeps the exported constructor's wiring (dir + real clock) covered.

## Verification

The rewritten test still catches a broken cache — checked by neutering the
implementation three ways and confirming each is caught:

| Injected defect | Result |
| --- | --- |
| never cache (`>= 0`) | ✅ fails on `within TTL the cached value should persist` |
| never expire (`if !valid`) | ✅ fails on `after TTL the resolver should re-read` |
| off-by-one (`> ttl` for `>= ttl`) | ✅ fails on the boundary assertion |
| unmodified | ✅ passes |

`go test -race -count=3 ./internal/telemetry/...` green; `golangci-lint run
internal/telemetry/...` reports 0 issues; `cmd/gortex` and `internal/serverstack`
still build.
