### PR TITLE
test: stop three assertions assuming POSIX separators on native paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,12 +102,18 @@ jobs:
       - name: Test store path separator handling
         run: go test -timeout=5m -count=1 ./internal/graphpath
 
+      # The same asymmetry reaches the other direction too: a test that spells
+      # an expected path with '/' passes on POSIX whatever the code does, and
+      # only this runner can tell whether the value under test is a native
+      # filesystem path (filepath.Join / filepath.Clean) or a '/'-keyed store
+      # path. ParseDiffGitPaths, ParseDiffLinesNewSide and FeedbackDir all
+      # assert on native paths, so they belong here rather than nowhere.
       - name: Test native-separator store path comparisons
         run: >
           go test -timeout=10m -count=1
-          -run 'NativeSeparator|MixedSeparator|ImportAdjacency'
+          -run 'NativeSeparator|MixedSeparator|ImportAdjacency|ParseDiffGitPaths|ParseDiffLinesNewSide|FeedbackDir'
           ./internal/analysis ./internal/graph/store_sqlite
-          ./internal/mcp ./internal/resolver
+          ./internal/mcp ./internal/resolver ./internal/persistence
 
   build-linux-static:
     # The linux release ships a statically linked binary so it runs on any

--- a/internal/analysis/diffmap_test.go
+++ b/internal/analysis/diffmap_test.go
@@ -55,10 +55,16 @@ func TestParseDiffHunksEqualsInternal(t *testing.T) {
 	}
 }
 
+// diffKey spells a repo-relative path the way parseDiffLines keys its map and
+// DiffHunk.FilePath is cleaned: filepath.Clean, so the key carries the running
+// platform's separators. Writing the '/' form directly reads fine on POSIX and
+// misses on Windows, where the map key is `pkg\foo.go`.
+func diffKey(p string) string { return filepath.Clean(p) }
+
 func TestParseDiffLinesNewSide(t *testing.T) {
 	lines := parseDiffLines(sampleDiff)
 
-	foo := lines["pkg/foo.go"]
+	foo := lines[diffKey("pkg/foo.go")]
 	if len(foo) == 0 {
 		t.Fatalf("expected new-side lines for pkg/foo.go")
 	}
@@ -86,7 +92,7 @@ func TestParseDiffLinesNewSide(t *testing.T) {
 	}
 
 	// New-file lines all carry "+", numbered 1..3.
-	baz := lines["pkg/baz.go"]
+	baz := lines[diffKey("pkg/baz.go")]
 	if len(baz) != 3 {
 		t.Fatalf("expected 3 new-side lines for pkg/baz.go, got %d (%#v)", len(baz), baz)
 	}
@@ -682,8 +688,14 @@ func TestParseDiffGitPaths(t *testing.T) {
 		{`diff --git "a/od\td.go" "b/od\td.go"`, ""},
 		{"diff --git nonsense", ""},
 	} {
-		if got := parseDiffGitPaths(tc.line); got != tc.want {
-			t.Fatalf("parseDiffGitPaths(%q) = %q, want %q", tc.line, got, tc.want)
+		// The recovered path is cleaned, so it carries native separators;
+		// the '/' spelling above is the diff's, not the result's.
+		want := tc.want
+		if want != "" {
+			want = filepath.Clean(want)
+		}
+		if got := parseDiffGitPaths(tc.line); got != want {
+			t.Fatalf("parseDiffGitPaths(%q) = %q, want %q", tc.line, got, want)
 		}
 	}
 }

--- a/internal/persistence/feedback_test.go
+++ b/internal/persistence/feedback_test.go
@@ -1,6 +1,7 @@
 package persistence
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -102,5 +103,8 @@ func TestRepoCacheKey_DifferentRepos(t *testing.T) {
 func TestFeedbackDir(t *testing.T) {
 	dir := FeedbackDir("/home/user/.cache/gortex", "/tmp/my-repo")
 	assert.Contains(t, dir, "_latest")
-	assert.Contains(t, dir, ".cache/gortex")
+	// FeedbackDir filepath.Joins, so the result carries native separators and
+	// feeds os.Open directly. The '/' spelling is the caller's input, not the
+	// result's: on Windows this reads `\home\user\.cache\gortex\<key>`.
+	assert.Contains(t, dir, filepath.Join(".cache", "gortex"))
 }


### PR DESCRIPTION
## Problem

Three tests compare against a `/`-spelled path while the value under test is a **native filesystem path**. On POSIX the two spellings coincide, so the linux/macos matrix has never been able to see it. On windows/amd64, go1.26.6, all three fail at `main`:

```
--- FAIL: TestFeedbackDir
    "\home\user\.cache\gortex\5887dcec1741_latest"
      does not contain ".cache/gortex"

--- FAIL: TestParseDiffGitPaths
    parseDiffGitPaths("diff --git a/pkg/foo.go b/pkg/foo.go")
      = "pkg\foo.go", want "pkg/foo.go"

--- FAIL: TestParseDiffLinesNewSide
    diffmap_test.go:63: expected new-side lines for pkg/foo.go
```

## The production values are correct — I checked before touching them

This looked at first like a separator bug in `cleanDiffPath`. It is not, and the tests are what needs to change:

- **`FeedbackDir`** is `filepath.Join(cacheDir, RepoCacheKey(repoPath))` and its result feeds `os.Open` through `LoadFeedback`. It *must* carry native separators.
- **`cleanDiffPath`** is `filepath.Clean`, and `JoinFileNodes` looks a diff path up as `repoPrefix + "/" + path`. Per `internal/graphpath`'s package doc, indexed paths are `repoPrefix + '/' + the repo-relative path in native separators` — on Windows `repo/dir\file`. So the cleaned **native** form is exactly the shape the join needs. Making diff paths slash-canonical would produce `repo/pkg/foo.go` and **break** the lookup on Windows.

So the fix is on the assertion side: build the expectation with `filepath.Join` / `filepath.Clean` instead of a literal. On POSIX both are the identity for these inputs, so the assertions keep exactly the strength they have today on the matrix that already runs them.

## Guarding it

Folded into the **existing** `Test native-separator store path comparisons` step rather than adding a new one — `internal/analysis`, `internal/mcp`, `internal/resolver` and `internal/graph/store_sqlite` are already in that step's package list, and `internal/persistence` is already compiled by the sidecar step directly above it. The regex gains exactly the three tests and nothing else:

```
$ go test -list 'NativeSeparator|MixedSeparator|ImportAdjacency|ParseDiffGitPaths|ParseDiffLinesNewSide|FeedbackDir' <pkgs>
… existing 12 …
TestParseDiffLinesNewSide
TestParseDiffGitPaths
TestFeedbackDir
```

## Verification

- The exact extended CI command, on windows: `ok` for all five packages.
- **Sabotage-verified:** with only the two test files reverted (`ci.yml` kept), that same command reports `--- FAIL` for all three. The step provably binds.
- `golangci-lint run ./internal/persistence/...` — 0 issues.
- Committed blobs add CR exactly in step with the added lines (`+6/+12/+4` against numstat `8-2 / 16-4 / 5-1`), so no line-ending noise rides along.

### Declared

- `internal/analysis/grounding.go`'s `cleanFile` says it "normalizes a path the same way DiffHunk.FilePath / parseDiffLines do" but only does `TrimPrefix(p, "./")` — no `Clean`. That is a real inconsistency, and on Windows it would miss the `parseDiffLines` map key. I did **not** touch it: its only production caller (`internal/review/anchor.go:277`) builds the map and looks it up with the same variable, so the mismatch is not reachable today. Happy to send it separately if you want the comment and the code reconciled.
- Two further Windows failures in `internal/analysis` (`TestMapGitDiffRepoPrefixJoin`, `TestMapGitDiffFileChangeKinds`, both `TempDir RemoveAll cleanup: …\.git: The directory is not empty`) are **not** included: I traced them to a non-stock `git` on my machine that writes `.git/ai/logs` on every `git init`. Reproduced with a bare `git init` outside this repo, so they are my environment, not gortex.

Branched from `main` at `b8b13ca7`. Windows 11, go1.26.6.