### PR TITLE
fix(mcp): keep path anchoring when the server has no multiIndexer

### DIFF
--- a/internal/mcp/id_resolve.go
+++ b/internal/mcp/id_resolve.go
@@ -91,14 +91,21 @@ func (s *Server) resolveSymbolID(ctx context.Context, id string) string {
 	if id == "" || s.graph == nil || s.graph.GetNode(id) != nil {
 		return id
 	}
-	if s.multiIndexer == nil {
-		return id
-	}
-	cwd := SessionCWDFromContext(ctx)
-	if cwd != "" {
-		if _, _, prefix, ok := s.multiIndexer.ScopeForCWD(cwd); ok && prefix != "" {
-			if cand := prefix + "/" + id; s.graph.GetNode(cand) != nil {
-				return cand
+	// The cwd rung needs the multi-repo index to map a directory to a repo
+	// prefix; the graphRelID rung below does not. Returning early on a nil
+	// multiIndexer skipped both, which cost a server built without
+	// MultiRepoOptions (cmd/gortex eval_recall.go, eval_server.go) the
+	// separator normalization graphPathSpelling exists to provide: on Windows
+	// the stored id is `pkga\a.go::Foo` while every agent writes
+	// `pkga/a.go::Foo`, and the tool answered "symbol not found" for an
+	// indexed symbol.
+	if s.multiIndexer != nil {
+		cwd := SessionCWDFromContext(ctx)
+		if cwd != "" {
+			if _, _, prefix, ok := s.multiIndexer.ScopeForCWD(cwd); ok && prefix != "" {
+				if cand := prefix + "/" + id; s.graph.GetNode(cand) != nil {
+					return cand
+				}
 			}
 		}
 	}

--- a/internal/mcp/id_resolve_test.go
+++ b/internal/mcp/id_resolve_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,6 +21,40 @@ func nameResolveServer(t *testing.T) *Server {
 	s.graph.AddNode(&graph.Node{ID: "pkg/foo.go::Bar#local", Name: "Bar", Kind: graph.KindLocal, FilePath: "pkg/foo.go"})
 	s.engine = query.NewEngine(s.graph)
 	return s
+}
+
+// TestResolveSymbolID_WithoutMultiIndexer_StillAnchorsThePath pins the rung
+// order inside resolveSymbolID: the cwd rung needs the multi-repo index to map
+// a directory to a repo prefix, the graphRelID rung does not. Returning early
+// on a nil multiIndexer skipped both, so a server built without
+// MultiRepoOptions — cmd/gortex's eval_recall.go and eval_server.go — lost path
+// anchoring entirely.
+//
+// The absolute-path spelling is deliberate: it exercises the rung on every
+// platform, so the linux/macos matrix protects this. On Windows the same rung
+// additionally reconciles the separator, which is what graphPathSpelling exists
+// for — the store holds `pkga\a.go::Foo` while every agent writes
+// `pkga/a.go::Foo`, and move_symbol answered "symbol not found" for an indexed
+// symbol.
+func TestResolveSymbolID_WithoutMultiIndexer_StillAnchorsThePath(t *testing.T) {
+	srv, dir := setupMoveInlineRepo(t, map[string]string{
+		"pkga/a.go": "package pkga\n\nfunc Foo() int { return 42 }\n",
+	})
+	require.Nil(t, srv.multiIndexer, "fixture must exercise the nil-multiIndexer path")
+
+	var stored string
+	for _, n := range srv.graph.FindNodesByName("Foo") {
+		if n != nil && n.Kind == graph.KindFunction {
+			stored = n.ID
+		}
+	}
+	require.NotEmpty(t, stored, "fixture must index Foo")
+
+	absID := filepath.Join(dir, "pkga", "a.go") + "::Foo"
+	require.Nil(t, srv.graph.GetNode(absID), "the absolute spelling must not be a stored id")
+
+	assert.Equal(t, stored, srv.resolveSymbolID(context.Background(), absID),
+		"an absolute-path id must anchor back to the stored id without a multiIndexer")
 }
 
 func TestResolveNameToIDs(t *testing.T) {


### PR DESCRIPTION
## Root cause

`resolveSymbolID` has three rungs: exact hit, cwd-prefix, then `graphRelID`. The `multiIndexer == nil` early return sits **above** the last two — but only the cwd rung actually needs the multi-repo index (it maps a directory to a repo prefix). `graphRelID` does not, and it was being skipped for free.

Probed on windows/amd64 with the move/inline fixture, which builds its `Server` through `NewServer(...)` with no `MultiRepoOptions`:

```
multiIndexer == nil:               true
GetNode("pkga/a.go::Foo"):         false
resolveSymbolID("pkga/a.go::Foo")  "pkga/a.go::Foo"   <- returned unchanged
graphRelID("pkga/a.go::Foo")       "pkga\a.go::Foo"
GetNode(graphRelID):               true                <- resolves
graphRelPath("pkga/a.go")          "pkga\a.go"         <- needs no multiIndexer
```

The machinery was already there and already deliberate — `graphPathSpelling`'s doc-comment names this exact failure:

> a forward-slash path — **the spelling every agent writes** — missed every node below the repo root on Windows and the read tools answered `file_not_indexed` for an indexed file

The rung was simply unreachable for a server built without `MultiRepoOptions`.

## Change

Scope the guard to the cwd rung. Additive by construction: the `graphRelID` result stays gated on `GetNode(rel) != nil`, so it can only turn a miss into a hit — it can never redirect an id that already resolves, and rung 1 still short-circuits an exact match before anything else runs.

## Effect

Whole `internal/mcp` package on windows/amd64, go1.26.6, `-count=1`:

| | failures |
|---|---|
| `main` (`b8b13ca7`) | **40** |
| with this change | **27** |

Diffing the failing test *names* rather than the counts: exactly 13 flip, and the newly-broken set is **empty**.

```
FIXED:  TestMoveSymbol_{SamePackage_FunctionRelocated, TargetFileMissing_CreatesIt,
        DryRun_NoOnDiskChanges, CrossPackage_RewritesThirdPartyCaller,
        CrossPackage_CallerInTarget_BecomesBare, CrossPackage_CallerInSource_GainsImport}
        TestInlineSymbol_{TrivialAccessor, TwoCallsites_BothRewritten,
        ArgumentSubstitution, SideEffectArgRefuses, DeleteAfterFalse_KeepsCallee,
        RefusesDefer, RefusesMultipleReturns}
NEWLY BROKEN: (none)
```

## Test

`TestResolveSymbolID_WithoutMultiIndexer_StillAnchorsThePath` uses an **absolute-path** id rather than the Windows separator. That exercises the same rung on every platform, so the linux/macos matrix protects this fix and no new windows CI step is needed.

**Sabotage-verified:** restoring the early return fails both the new unit test (on the anchoring assertion) and `TestMoveSymbol_SamePackage_FunctionRelocated`; reverting the sabotage returns both to green.

## Scope of the user-visible impact — stated narrowly on purpose

The real daemon is not affected: `internal/serverstack/shared_server.go:620` passes `multiOpts...`. The production call sites that build a `Server` **without** `MultiRepoOptions` are `cmd/gortex/eval_recall.go:247` and `cmd/gortex/eval_server.go:71`. So on Windows this cost the `eval` surfaces their path anchoring, and it cost the test suite 13 tests. I would rather say that plainly than sell it as a broken daemon.

## Verification

- `golangci-lint run ./internal/mcp/...` reports 6 `staticcheck` SA5011 findings — **pre-existing**, byte-identical with this change stashed. Untouched here.
- `git diff --check` clean.

Branched from `main` at `b8b13ca7`. Windows 11, go1.26.6.

Related, not included: the remaining 27 windows failures in this package split into symlink-privilege cases (needs `SeCreateSymbolicLinkPrivilege`, environment rather than code) and further POSIX-spelled assertions, e.g. `TestPathToFileURI_Absolute` expecting `file:///work/main.go` where Windows resolves `file:///D:/work/main.go`. Happy to take those separately if they are worth having.