### PR TITLE
find_usages: honor declared limit/compact; close the exclude_tests node-kind leak

### DIFF
--- a/internal/daemon/federation.go
+++ b/internal/daemon/federation.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/respbudget"
 )
 
 // federationReadTools is the allowlist of read traversal tools eligible
@@ -133,6 +134,16 @@ func (f *Federator) Augment(ctx context.Context, tool string, body, localResult 
 
 	localTool, wrapped := unwrapToolJSON(localResult)
 
+	// Renderings that cannot round-trip as JSON (compact, gcx, toon,
+	// mermaid, dot) have no merge adapter: fanning out would silently
+	// discard every remote row behind a local-only body. Skip the
+	// fan-out entirely and make the partiality explicit instead —
+	// merging the canonical graph before rendering is the deeper fix,
+	// but until then a labeled local answer beats an unlabeled one.
+	if !json.Valid(localTool) || len(localTool) == 0 || (localTool[0] != '{' && localTool[0] != '[') {
+		return annotateLocalOnlyFormat(localResult, wrapped, len(remotes))
+	}
+
 	results, meta := f.fanOut(ctx, tool, body, remotes)
 
 	merged, origins := f.merge(tool, body, localTool, results)
@@ -157,11 +168,123 @@ func (f *Federator) Augment(ctx context.Context, tool string, body, localResult 
 			len(meta.RemotesFailed), remoteOnlyOrPartial(meta))
 	}
 
+	// The caller's byte/token budget binds the FINAL representation:
+	// each daemon budgeted only its own page, so a multi-peer merge can
+	// overshoot every source's cap combined. Same arithmetic and
+	// truncation meta as the per-daemon budget layer (respbudget), so
+	// a trimmed merge is legible the same way a trimmed page is.
 	mergedWithMeta := attachFederation(merged, meta)
+	mergedWithMeta = budgetMergedJSON(mergedWithMeta, respbudget.EffectiveFromArgs(argsMapFromBody(body)))
 	if !wrapped {
 		return mergedWithMeta
 	}
 	return rewrapToolJSON(localResult, mergedWithMeta)
+}
+
+// budgetMergedJSON applies the caller's effective budget to the merged
+// representation with the same structural trim (and truncation meta)
+// the per-daemon budget layer uses. The generic trim bounds the
+// top-level lists; the federation origins map scales with the node set
+// — a coupling the shape-agnostic trim cannot know — so origins are
+// re-pruned to the surviving nodes and the trim re-run until the
+// result fits or nothing further can shrink.
+func budgetMergedJSON(raw []byte, budget int) []byte {
+	if budget <= 0 || len(raw) <= budget {
+		return raw
+	}
+	var generic map[string]any
+	if err := json.Unmarshal(raw, &generic); err != nil {
+		return raw // non-JSON body: some other layer's contract
+	}
+	for pass := 0; pass < 3; pass++ {
+		trimmed, _ := respbudget.Apply(generic, budget)
+		m, ok := trimmed.(map[string]any)
+		if !ok {
+			break
+		}
+		generic = m
+		pruneOriginsToNodes(generic)
+		out, err := json.Marshal(generic)
+		if err != nil {
+			return raw
+		}
+		if len(out) <= budget {
+			return out
+		}
+	}
+	out, err := json.Marshal(generic)
+	if err != nil {
+		return raw
+	}
+	return out
+}
+
+// pruneOriginsToNodes drops origins entries whose node the budget trim
+// removed — an origin annotates a returned row (attachFederation puts
+// the map at top level, beside the rows), so one keyed to a trimmed
+// node is dead weight against the budget.
+func pruneOriginsToNodes(m map[string]any) {
+	origins, ok := m["origins"].(map[string]any)
+	if !ok {
+		return
+	}
+	keep := make(map[string]bool)
+	if nodes, ok := m["nodes"].([]any); ok {
+		for _, n := range nodes {
+			if nm, ok := n.(map[string]any); ok {
+				if id, ok := nm["id"].(string); ok {
+					keep[id] = true
+				}
+			}
+		}
+	}
+	for id := range origins {
+		if !keep[id] {
+			delete(origins, id)
+		}
+	}
+}
+
+// argsMapFromBody extracts the tool arguments map from the routed
+// request body's production envelope ({"arguments":{...}}, the shape
+// subGraphArgsFromBody and bareNameFromBody parse). Nil when absent.
+func argsMapFromBody(body []byte) map[string]any {
+	var env struct {
+		Arguments map[string]any `json:"arguments"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		return nil
+	}
+	return env.Arguments
+}
+
+// annotateLocalOnlyFormat appends an explicit local-only note to a
+// non-mergeable-format response as a second content item, leaving the
+// primary rendering byte-for-byte intact. Error results and unwrapped
+// bodies pass through unchanged — an error is already explicit, and a
+// bare body has no envelope to carry the note.
+func annotateLocalOnlyFormat(localResult []byte, wrapped bool, peerCount int) []byte {
+	if !wrapped {
+		return localResult
+	}
+	var m map[string]any
+	if err := json.Unmarshal(localResult, &m); err != nil {
+		return localResult
+	}
+	if m["isError"] == true || m["is_error"] == true {
+		return localResult
+	}
+	content, ok := m["content"].([]any)
+	if !ok {
+		return localResult
+	}
+	note := fmt.Sprintf("note: local results only — %d enabled federation peer(s) were not queried because this response format cannot be merged; use the JSON format for federated results.", peerCount)
+	m["content"] = append(content, map[string]any{"type": "text", "text": note})
+	out, err := json.Marshal(m)
+	if err != nil {
+		return localResult
+	}
+	return out
 }
 
 func remoteOnlyOrPartial(meta FederationMeta) string {
@@ -278,6 +401,12 @@ func (f *Federator) merge(tool string, body, local []byte, remotes []remoteResul
 	sort.Slice(remotes, func(i, j int) bool { return remotes[i].slug < remotes[j].slug })
 	switch tool {
 	case "find_usages", "get_callers", "get_call_chain", "get_dependents":
+		// group_by:"file" renders a grouped shape, not a SubGraph —
+		// round-tripping it through the flat merge would discard every
+		// grouped field and answer with an empty subgraph.
+		if tool == "find_usages" && groupByFileRequested(body) {
+			return mergeGroupedUsages(body, local, remotes)
+		}
 		return mergeSubGraph(tool, body, local, remotes)
 	case "search_symbols":
 		return mergeKeyedList(local, remotes, "results")
@@ -311,6 +440,165 @@ func subGraphArgsFromBody(body []byte) subGraphMergeArgs {
 	return subGraphMergeArgs{}
 }
 
+// groupByFileRequested mirrors the handler's group_by:"file" gate on
+// the routed body, so the merge dispatch and the render agree on when
+// the grouped shape is in play.
+func groupByFileRequested(body []byte) bool {
+	gb, _ := argsMapFromBody(body)["group_by"].(string)
+	return strings.EqualFold(strings.TrimSpace(gb), "file")
+}
+
+// The wire shape of a group_by:"file" find_usages response, as
+// groupUsagesByFile serializes it on every daemon.
+type groupedUsagesWire struct {
+	GroupedBy  string            `json:"grouped_by"`
+	FileCount  int               `json:"file_count"`
+	TotalUses  int               `json:"total_uses"`
+	Groups     []*usageGroupWire `json:"groups"`
+	Truncated  bool              `json:"truncated"`
+	TotalEdges int               `json:"total_edges,omitempty"`
+}
+
+type usageGroupWire struct {
+	File  string         `json:"file"`
+	Count int            `json:"count"`
+	Uses  []usageRowWire `json:"uses"`
+}
+
+type usageRowWire struct {
+	Line        int    `json:"line"`
+	EdgeKind    string `json:"edge_kind"`
+	Context     string `json:"context,omitempty"`
+	ReturnUsage string `json:"return_usage,omitempty"`
+	SymbolID    string `json:"symbol_id,omitempty"`
+	SymbolName  string `json:"symbol_name,omitempty"`
+}
+
+// mergeGroupedUsages merges group_by:"file" find_usages responses
+// group-wise: rows dedupe on (file, line, kind, symbol), counts and
+// totals are recomputed over the union, and the caller's limit is
+// reapplied once, globally, mirroring the flat merge's contract.
+func mergeGroupedUsages(body, local []byte, remotes []remoteResult) ([]byte, map[string]string) {
+	origins := map[string]string{}
+	var lg groupedUsagesWire
+	if err := json.Unmarshal(local, &lg); err != nil || lg.GroupedBy == "" {
+		return local, origins
+	}
+	byFile := make(map[string]*usageGroupWire, len(lg.Groups))
+	order := make([]string, 0, len(lg.Groups))
+	rowSeen := map[string]bool{}
+	rowKey := func(file string, u usageRowWire) string {
+		return file + "\x00" + strconv.Itoa(u.Line) + "\x00" + u.EdgeKind + "\x00" + u.SymbolID
+	}
+	addRows := func(g *usageGroupWire) {
+		dst := byFile[g.File]
+		if dst == nil {
+			dst = &usageGroupWire{File: g.File}
+			byFile[g.File] = dst
+			order = append(order, g.File)
+		}
+		for _, u := range g.Uses {
+			k := rowKey(g.File, u)
+			if rowSeen[k] {
+				continue
+			}
+			rowSeen[k] = true
+			dst.Uses = append(dst.Uses, u)
+		}
+	}
+	for _, g := range lg.Groups {
+		if g != nil {
+			addRows(g)
+		}
+	}
+	// A source that already capped or trimmed its page makes the merged
+	// totals a floor; total_edges falls back to total_uses for sources
+	// that answered complete (they omit the explicit floor).
+	anyTruncated := lg.Truncated || budgetTrimmed(local)
+	totalEdgesFloor := max(lg.TotalEdges, lg.TotalUses)
+	for _, rr := range remotes {
+		var rg groupedUsagesWire
+		if err := json.Unmarshal(rr.toolJSON, &rg); err != nil || rg.GroupedBy == "" {
+			continue
+		}
+		anyTruncated = anyTruncated || rg.Truncated || budgetTrimmed(rr.toolJSON)
+		totalEdgesFloor = max(totalEdgesFloor, max(rg.TotalEdges, rg.TotalUses))
+		for _, g := range rg.Groups {
+			if g != nil {
+				addRows(g)
+			}
+		}
+	}
+	// One deterministic global order before any cut: rows within a
+	// group by (line, kind, symbol), groups by count desc then path —
+	// the same order the local renderer emits.
+	groups := make([]*usageGroupWire, 0, len(order))
+	mergedRows := 0
+	for _, file := range order {
+		g := byFile[file]
+		sort.Slice(g.Uses, func(i, j int) bool {
+			a, b := g.Uses[i], g.Uses[j]
+			if a.Line != b.Line {
+				return a.Line < b.Line
+			}
+			if a.EdgeKind != b.EdgeKind {
+				return a.EdgeKind < b.EdgeKind
+			}
+			return a.SymbolID < b.SymbolID
+		})
+		g.Count = len(g.Uses)
+		mergedRows += g.Count
+		groups = append(groups, g)
+	}
+	sort.Slice(groups, func(i, j int) bool {
+		if groups[i].Count != groups[j].Count {
+			return groups[i].Count > groups[j].Count
+		}
+		return groups[i].File < groups[j].File
+	})
+	totalEdgesFloor = max(totalEdgesFloor, mergedRows)
+
+	args := subGraphArgsFromBody(body)
+	limit := 50
+	if args.Limit != nil {
+		limit = *args.Limit
+	}
+	if limit > 0 && mergedRows > limit {
+		remaining := limit
+		kept := groups[:0]
+		for _, g := range groups {
+			if remaining == 0 {
+				break
+			}
+			if len(g.Uses) > remaining {
+				g.Uses = g.Uses[:remaining]
+				g.Count = remaining
+			}
+			remaining -= g.Count
+			kept = append(kept, g)
+		}
+		groups = kept
+		anyTruncated = true
+		mergedRows = limit
+	}
+
+	out := groupedUsagesWire{
+		GroupedBy: "file",
+		FileCount: len(groups),
+		TotalUses: mergedRows,
+		Groups:    groups,
+		Truncated: anyTruncated,
+	}
+	if anyTruncated {
+		out.TotalEdges = totalEdgesFloor
+	}
+	b, err := json.Marshal(out)
+	if err != nil {
+		return local, origins
+	}
+	return b, origins
+}
+
 // mergeSubGraph merges query.SubGraph responses: nodes deduped by string
 // ID (local wins), edges by (From,To,Kind,FilePath,Line) so distinct
 // call sites of the same pair stay distinct rows. Origins keys each
@@ -328,13 +616,19 @@ func mergeSubGraph(tool string, body, local []byte, remotes []remoteResult) ([]b
 	if err := json.Unmarshal(local, &sg); err != nil {
 		return local, origins
 	}
-	anySourceTruncated := sg.Truncated
+	// A source page the budget layer structurally trimmed is incomplete
+	// even when its own `truncated` flag is false: the trim's
+	// `_truncated_by_budget` marker is a map key, not a SubGraph field,
+	// so it must be read off the raw source bytes before the typed
+	// round trip discards it.
+	anySourceTruncated := sg.Truncated || budgetTrimmed(local)
 	totalEdgesFloor := sg.TotalEdges
 	totalNodesFloor := sg.TotalNodes
 	var sourceSummaries []*query.UsageSummary
 	if sg.UsageSummary != nil {
 		sourceSummaries = append(sourceSummaries, sg.UsageSummary)
 	}
+	var remoteCaveats []*graph.ZeroEdgeCaveat
 	seen := make(map[string]bool, len(sg.Nodes))
 	for _, n := range sg.Nodes {
 		if n != nil {
@@ -353,7 +647,7 @@ func mergeSubGraph(tool string, body, local []byte, remotes []remoteResult) ([]b
 		if err := json.Unmarshal(rr.toolJSON, &rsg); err != nil {
 			continue
 		}
-		if rsg.Truncated {
+		if rsg.Truncated || budgetTrimmed(rr.toolJSON) {
 			anySourceTruncated = true
 		}
 		totalEdgesFloor = max(totalEdgesFloor, rsg.TotalEdges)
@@ -367,6 +661,19 @@ func mergeSubGraph(tool string, body, local []byte, remotes []remoteResult) ([]b
 		if rsg.UsageSummary != nil {
 			sourceSummaries = append(sourceSummaries, rsg.UsageSummary)
 		}
+		// Uncertainty metadata: a peer's caveat, suppression counters,
+		// and tier_filtered marker make the merged answer exactly as
+		// uncertain as that peer's own answer was. Counts floor at the
+		// largest single source — the deduplicated union is unknowable.
+		if rsg.Caveat != nil {
+			remoteCaveats = append(remoteCaveats, rsg.Caveat)
+		}
+		sg.TextMatchedSuppressed = max(sg.TextMatchedSuppressed, rsg.TextMatchedSuppressed)
+		sg.NameOnlyCandidates = max(sg.NameOnlyCandidates, rsg.NameOnlyCandidates)
+		if sg.SuppressionCaveat == "" {
+			sg.SuppressionCaveat = rsg.SuppressionCaveat
+		}
+		sg.TierFiltered = mergeTierFiltered(sg.TierFiltered, rsg.TierFiltered)
 		if len(rsg.CallerNotes) > 0 {
 			if sg.CallerNotes == nil {
 				sg.CallerNotes = make(map[string]*graph.ConcurrencyAnnotation, len(rsg.CallerNotes))
@@ -407,11 +714,20 @@ func mergeSubGraph(tool string, body, local []byte, remotes []remoteResult) ([]b
 	// Merged rows can invalidate the local zero-edge caveat: a symbol
 	// unused locally but used on a peer must not answer "appears unused"
 	// above rows that prove otherwise. Re-judge from the merged edges.
+	// With zero merged rows every source answered empty, and the most
+	// conservative source caveat survives — a local "likely_unused"
+	// must not out-rank a peer's "coverage_incomplete".
 	if len(sg.Edges) > 0 {
 		if graph.WeakUsageEvidenceOnly(sg.Edges) {
 			sg.Caveat = graph.CaveatForWeakUsageEvidence()
 		} else {
 			sg.Caveat = nil
+		}
+	} else {
+		for _, c := range remoteCaveats {
+			if sg.Caveat == nil || graph.ZeroEdgeClassConservatism(c.Class) > graph.ZeroEdgeClassConservatism(sg.Caveat.Class) {
+				sg.Caveat = c
+			}
 		}
 	}
 	// The summary is a whole-set rollup. Recompute it over the merged
@@ -486,6 +802,35 @@ func mergeSubGraph(tool string, body, local []byte, remotes []remoteResult) ([]b
 		return local, origins
 	}
 	return out, origins
+}
+
+// mergeTierFiltered floors the tier_filtered marker across sources:
+// the counter keeps the largest single source's floor and the
+// available tier keeps the strongest tier any source still holds, so
+// a min_tier-emptied peer stays legible as "filtered", never as "no
+// usages on that peer".
+func mergeTierFiltered(local, remote *graph.TierFilteredCaveat) *graph.TierFilteredCaveat {
+	if remote == nil {
+		return local
+	}
+	if local == nil {
+		c := *remote
+		return &c
+	}
+	local.EdgesBelowMinTier = max(local.EdgesBelowMinTier, remote.EdgesBelowMinTier)
+	if graph.OriginRank(remote.MaxAvailableTier) > graph.OriginRank(local.MaxAvailableTier) {
+		local.MaxAvailableTier = remote.MaxAvailableTier
+	}
+	return local
+}
+
+// budgetTrimmed reports whether a source's raw tool JSON carries the
+// budget layer's structural-trim marker (respbudget.TruncatedKey).
+func budgetTrimmed(toolJSON []byte) bool {
+	var probe struct {
+		TruncatedByBudget bool `json:"_truncated_by_budget"`
+	}
+	return json.Unmarshal(toolJSON, &probe) == nil && probe.TruncatedByBudget
 }
 
 // mapNodeGetter serves graph.NodeGetter lookups from the merged node

--- a/internal/daemon/federation.go
+++ b/internal/daemon/federation.go
@@ -297,6 +297,23 @@ type subGraphMergeArgs struct {
 	Limit *int   `json:"limit"`
 }
 
+// subGraphArgsFromBody extracts the tool args from the routed request
+// body. Production stdio and streamable MCP dispatch nest them under
+// "arguments" (the same envelope bareNameFromBody reads); a flat body
+// is accepted as a fallback so an internal caller that skips the
+// envelope cannot silently lose its limit.
+func subGraphArgsFromBody(body []byte) subGraphMergeArgs {
+	var env struct {
+		Arguments *subGraphMergeArgs `json:"arguments"`
+	}
+	if err := json.Unmarshal(body, &env); err == nil && env.Arguments != nil {
+		return *env.Arguments
+	}
+	var flat subGraphMergeArgs
+	_ = json.Unmarshal(body, &flat)
+	return flat
+}
+
 // mergeSubGraph merges query.SubGraph responses: nodes deduped by string
 // ID (local wins), edges by (From,To,Kind,FilePath,Line) so distinct
 // call sites of the same pair stay distinct rows. Origins keys each
@@ -340,6 +357,22 @@ func mergeSubGraph(tool string, body, local []byte, remotes []remoteResult) ([]b
 		}
 		totalEdgesFloor = max(totalEdgesFloor, rsg.TotalEdges)
 		totalNodesFloor = max(totalNodesFloor, rsg.TotalNodes)
+		// Remote completeness metadata: a peer's floor makes the merged
+		// result a floor; its epistemic boundaries and caller notes are
+		// evidence about rows now in the merged set.
+		sg.LowerBound = sg.LowerBound || rsg.LowerBound
+		sg.Boundaries = appendBoundaries(sg.Boundaries, rsg.Boundaries)
+		sg.DynamicBoundaries = append(sg.DynamicBoundaries, rsg.DynamicBoundaries...)
+		if len(rsg.CallerNotes) > 0 {
+			if sg.CallerNotes == nil {
+				sg.CallerNotes = make(map[string]*graph.ConcurrencyAnnotation, len(rsg.CallerNotes))
+			}
+			for id, note := range rsg.CallerNotes {
+				if _, exists := sg.CallerNotes[id]; !exists { // local wins
+					sg.CallerNotes[id] = note
+				}
+			}
+		}
 		for _, n := range rsg.Nodes {
 			if n == nil || seen[n.ID] {
 				continue // local wins on collision
@@ -367,9 +400,15 @@ func mergeSubGraph(tool string, body, local []byte, remotes []remoteResult) ([]b
 	sg.TotalNodes = max(totalNodesFloor, len(sg.Nodes))
 	sg.Truncated = anySourceTruncated
 	sg.LowerBound = sg.LowerBound || anySourceTruncated
+	// The summary is a whole-set rollup, so recompute it over the merged
+	// deduplicated rows before any recap — exact when every source was
+	// complete, a floor (with lower_bound set) otherwise. Only attached
+	// where the local response carried one (find_usages).
+	if sg.UsageSummary != nil {
+		sg.UsageSummary = mergedUsageSummary(&sg)
+	}
 
-	var args subGraphMergeArgs
-	_ = json.Unmarshal(body, &args)
+	args := subGraphArgsFromBody(body)
 	limit := 50
 	if args.Limit != nil {
 		limit = *args.Limit
@@ -416,6 +455,64 @@ func mergeSubGraph(tool string, body, local []byte, remotes []remoteResult) ([]b
 		return local, origins
 	}
 	return out, origins
+}
+
+// appendBoundaries appends remote epistemic boundaries, deduplicated by
+// (seed, target, edge kind) and capped at the same 50 the BFS walk
+// applies, so a many-peer merge cannot grow the section without bound.
+func appendBoundaries(dst, src []graph.EpistemicBoundary) []graph.EpistemicBoundary {
+	const boundaryCap = 50
+	seen := make(map[string]bool, len(dst))
+	for _, b := range dst {
+		seen[b.SeedID+"\x00"+b.Target+"\x00"+b.EdgeKind] = true
+	}
+	for _, b := range src {
+		if len(dst) >= boundaryCap {
+			break
+		}
+		k := b.SeedID + "\x00" + b.Target + "\x00" + b.EdgeKind
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		dst = append(dst, b)
+	}
+	return dst
+}
+
+// mergedUsageSummary recomputes the find_usages completeness rollup
+// over the merged rows, mirroring the local usageSummaryOf shape:
+// per-edge file resolution with a from-node fallback, and the shared
+// test classifier on the serialized node stamps (no owner hop — the
+// remote graph is not reachable here, and its stamped rows carry the
+// flag in meta).
+func mergedUsageSummary(sg *query.SubGraph) *query.UsageSummary {
+	if len(sg.Edges) == 0 {
+		return nil
+	}
+	nodeByID := make(map[string]*graph.Node, len(sg.Nodes))
+	for _, n := range sg.Nodes {
+		if n != nil {
+			nodeByID[n.ID] = n
+		}
+	}
+	files := make(map[string]struct{}, len(sg.Edges))
+	testRefs := 0
+	for _, e := range sg.Edges {
+		from := nodeByID[e.From]
+		file := e.FilePath
+		if file == "" && from != nil {
+			file = from.FilePath
+		}
+		if file == "" {
+			file = "(unknown)"
+		}
+		files[file] = struct{}{}
+		if graph.NodeIsTest(nil, from) {
+			testRefs++
+		}
+	}
+	return &query.UsageSummary{NRefs: len(sg.Edges), NFiles: len(files), NTestRefs: testRefs}
 }
 
 // pruneMergedNodes drops nodes (and their origins entries) that the

--- a/internal/daemon/federation.go
+++ b/internal/daemon/federation.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -133,7 +135,7 @@ func (f *Federator) Augment(ctx context.Context, tool string, body, localResult 
 
 	results, meta := f.fanOut(ctx, tool, body, remotes)
 
-	merged, origins := f.merge(tool, localTool, results)
+	merged, origins := f.merge(tool, body, localTool, results)
 	meta.Origins = origins
 
 	// Opt-in name-keyed fallback (OFF by default): a bare-name
@@ -269,10 +271,14 @@ func (f *Federator) fanOut(ctx context.Context, tool string, body []byte, remote
 
 // merge dispatches to the per-tool adapter and returns the merged tool
 // JSON plus the origins map.
-func (f *Federator) merge(tool string, local []byte, remotes []remoteResult) ([]byte, map[string]string) {
+func (f *Federator) merge(tool string, body, local []byte, remotes []remoteResult) ([]byte, map[string]string) {
+	// Fan-out results arrive in goroutine completion order; sort by slug
+	// so the merged result — and any post-merge cap cut from it — is
+	// deterministic across runs.
+	sort.Slice(remotes, func(i, j int) bool { return remotes[i].slug < remotes[j].slug })
 	switch tool {
 	case "find_usages", "get_callers", "get_call_chain", "get_dependents":
-		return mergeSubGraph(local, remotes)
+		return mergeSubGraph(tool, body, local, remotes)
 	case "search_symbols":
 		return mergeKeyedList(local, remotes, "results")
 	case "find_implementations":
@@ -284,15 +290,33 @@ func (f *Federator) merge(tool string, local []byte, remotes []remoteResult) ([]
 	}
 }
 
+// subGraphMergeArgs are the request args the post-merge recap needs:
+// the queried node (kept through node pruning) and the caller's limit.
+type subGraphMergeArgs struct {
+	ID    string `json:"id"`
+	Limit *int   `json:"limit"`
+}
+
 // mergeSubGraph merges query.SubGraph responses: nodes deduped by string
-// ID (local wins), edges by (From,To,Kind). Origins keys each node ID to
-// "local" or "remote:<slug>".
-func mergeSubGraph(local []byte, remotes []remoteResult) ([]byte, map[string]string) {
+// ID (local wins), edges by (From,To,Kind,FilePath,Line) so distinct
+// call sites of the same pair stay distinct rows. Origins keys each
+// node ID to "local" or "remote:<slug>".
+//
+// Each daemon applied the caller's limit to its own page, so the merged
+// row set must honor the contract once, globally: the limit is
+// reapplied after a deterministic merge, truncation from any source
+// propagates, and — because a source that discarded its tail makes the
+// exact deduplicated total unknowable — the merged totals are an
+// explicit floor (lower_bound) in that case.
+func mergeSubGraph(tool string, body, local []byte, remotes []remoteResult) ([]byte, map[string]string) {
 	origins := map[string]string{}
 	var sg query.SubGraph
 	if err := json.Unmarshal(local, &sg); err != nil {
 		return local, origins
 	}
+	anySourceTruncated := sg.Truncated
+	totalEdgesFloor := sg.TotalEdges
+	totalNodesFloor := sg.TotalNodes
 	seen := make(map[string]bool, len(sg.Nodes))
 	for _, n := range sg.Nodes {
 		if n != nil {
@@ -311,6 +335,11 @@ func mergeSubGraph(local []byte, remotes []remoteResult) ([]byte, map[string]str
 		if err := json.Unmarshal(rr.toolJSON, &rsg); err != nil {
 			continue
 		}
+		if rsg.Truncated {
+			anySourceTruncated = true
+		}
+		totalEdgesFloor = max(totalEdgesFloor, rsg.TotalEdges)
+		totalNodesFloor = max(totalNodesFloor, rsg.TotalNodes)
 		for _, n := range rsg.Nodes {
 			if n == nil || seen[n.ID] {
 				continue // local wins on collision
@@ -331,8 +360,57 @@ func mergeSubGraph(local []byte, remotes []remoteResult) ([]byte, map[string]str
 			sg.Edges = append(sg.Edges, e)
 		}
 	}
-	sg.TotalNodes = len(sg.Nodes)
-	sg.TotalEdges = len(sg.Edges)
+	// Totals: exact deduplicated counts when every source was complete;
+	// otherwise the best available floor — never smaller than any single
+	// source's own full count or the merged set itself.
+	sg.TotalEdges = max(totalEdgesFloor, len(sg.Edges))
+	sg.TotalNodes = max(totalNodesFloor, len(sg.Nodes))
+	sg.Truncated = anySourceTruncated
+	sg.LowerBound = sg.LowerBound || anySourceTruncated
+
+	var args subGraphMergeArgs
+	_ = json.Unmarshal(body, &args)
+	limit := 50
+	if args.Limit != nil {
+		limit = *args.Limit
+	}
+	if limit > 0 {
+		switch tool {
+		case "find_usages":
+			// Usage rows page by edges: one stable global order (the
+			// same the local row cap consumes), then the cap, once.
+			query.SortEdgesForPage(sg.Edges)
+			if len(sg.Edges) > limit {
+				sg.Edges = sg.Edges[:limit]
+				sg.Truncated = true
+				keep := map[string]bool{args.ID: true}
+				for _, e := range sg.Edges {
+					keep[e.From] = true
+					keep[e.To] = true
+				}
+				pruneMergedNodes(&sg, origins, keep)
+			}
+		default:
+			// BFS-shaped tools cap nodes; the merge order (local first,
+			// then slug-sorted remotes) is the deterministic page order.
+			if len(sg.Nodes) > limit {
+				keep := make(map[string]bool, limit)
+				sg.Nodes = sg.Nodes[:limit]
+				for _, n := range sg.Nodes {
+					keep[n.ID] = true
+				}
+				kept := sg.Edges[:0]
+				for _, e := range sg.Edges {
+					if keep[e.From] && keep[e.To] {
+						kept = append(kept, e)
+					}
+				}
+				sg.Edges = kept
+				sg.Truncated = true
+				pruneMergedNodes(&sg, origins, keep)
+			}
+		}
+	}
 	out, err := json.Marshal(sg)
 	if err != nil {
 		return local, origins
@@ -340,8 +418,26 @@ func mergeSubGraph(local []byte, remotes []remoteResult) ([]byte, map[string]str
 	return out, origins
 }
 
+// pruneMergedNodes drops nodes (and their origins entries) that the
+// post-merge cap removed from the response.
+func pruneMergedNodes(sg *query.SubGraph, origins map[string]string, keep map[string]bool) {
+	nodes := sg.Nodes[:0]
+	for _, n := range sg.Nodes {
+		if n != nil && keep[n.ID] {
+			nodes = append(nodes, n)
+		}
+	}
+	sg.Nodes = nodes
+	for id := range origins {
+		if !keep[id] {
+			delete(origins, id)
+		}
+	}
+}
+
 func edgeKey(e *graph.Edge) string {
-	return e.From + "\x00" + e.To + "\x00" + string(e.Kind)
+	return e.From + "\x00" + e.To + "\x00" + string(e.Kind) +
+		"\x00" + e.FilePath + "\x00" + strconv.Itoa(e.Line)
 }
 
 // idKeyedTools are the SubGraph traversals whose primary query keys on a

--- a/internal/daemon/federation.go
+++ b/internal/daemon/federation.go
@@ -143,7 +143,8 @@ func (f *Federator) Augment(ctx context.Context, tool string, body, localResult 
 	// but until then a labeled local answer beats an unlabeled one.
 	probe := bytes.TrimLeft(localTool, " \t\r\n")
 	if len(probe) == 0 || (probe[0] != '{' && probe[0] != '[') || !json.Valid(probe) {
-		return annotateLocalOnlyFormat(localResult, wrapped, len(remotes))
+		return annotateLocalOnlyFormat(localResult, wrapped, len(remotes),
+			respbudget.EffectiveFromArgs(argsMapFromBody(body)))
 	}
 
 	results, meta := f.fanOut(ctx, tool, body, remotes)
@@ -278,12 +279,83 @@ func argsMapFromBody(body []byte) map[string]any {
 	return env.Arguments
 }
 
+// localOnlyNote is the visible signal that a non-mergeable-format
+// response is local-only. One definition, because its byte length is
+// load-bearing twice: ReserveLocalNoteBudget subtracts it from the
+// budget forwarded to the local handler, and annotateLocalOnlyFormat
+// fits it into what that handler left.
+func localOnlyNote(peerCount int) string {
+	return fmt.Sprintf("note: local results only — %d enabled federation peer(s) were not queried because this response format cannot be merged; use the JSON format for federated results.", peerCount)
+}
+
+// nonMergeableFormatRequested mirrors the format routing the local
+// handler will take, from the request args alone: these renderings
+// cannot round-trip as JSON, so their federation path is the local-only
+// note. A session-DEFAULT toon/gcx rendering is invisible here — that
+// request gets no reservation and falls back to the fit-or-drop rule
+// in annotateLocalOnlyFormat.
+func nonMergeableFormatRequested(args map[string]any) bool {
+	if compact, _ := args["compact"].(bool); compact {
+		return true
+	}
+	switch f, _ := args["format"].(string); strings.ToLower(strings.TrimSpace(f)) {
+	case "compact", "gcx", "toon", "mermaid", "dot":
+		return true
+	}
+	return false
+}
+
+// ReserveLocalNoteBudget rewrites a to-be-dispatched local request so
+// the local handler leaves headroom for the local-only note: the
+// caller's effective cap minus the note's size, injected as max_bytes
+// (min-merged by the handler with any caller axis, so it binds on
+// both). Reserve-first is the token-budget decoration's rule — the
+// note must never be the bytes that break the cap, and dropping it
+// instead would silence the only "peers were not queried" signal on
+// exactly the saturating responses. Requests that keep the JSON merge
+// path, opt out of budgeting, or cap below the note's own size pass
+// through untouched.
+func (f *Federator) ReserveLocalNoteBudget(tool string, body []byte, peerCount int) []byte {
+	if !federationReadTools[tool] || IsEffectful(tool) || peerCount == 0 {
+		return body
+	}
+	var env map[string]any
+	if err := json.Unmarshal(body, &env); err != nil {
+		return body
+	}
+	args, _ := env["arguments"].(map[string]any)
+	if !nonMergeableFormatRequested(args) {
+		return body
+	}
+	budget := respbudget.EffectiveFromArgs(args)
+	reserve := len(localOnlyNote(peerCount))
+	if budget <= 0 || budget <= reserve {
+		return body
+	}
+	// The reserved cap min-merges below any caller token axis, so it
+	// binds regardless of which axis was the tighter one.
+	args["max_bytes"] = budget - reserve
+	env["arguments"] = args
+	out, err := json.Marshal(env)
+	if err != nil {
+		return body
+	}
+	return out
+}
+
 // annotateLocalOnlyFormat appends an explicit local-only note to a
 // non-mergeable-format response as a second content item, leaving the
 // primary rendering byte-for-byte intact. Error results and unwrapped
 // bodies pass through unchanged — an error is already explicit, and a
 // bare body has no envelope to carry the note.
-func annotateLocalOnlyFormat(localResult []byte, wrapped bool, peerCount int) []byte {
+//
+// The caller's byte/token budget binds the COMPLETE response.
+// ReserveLocalNoteBudget normally pre-shrank the local rendering so
+// the note has room by construction; when it could not (session-
+// default formats, caps below the note's own size), a note that
+// does not fit the remaining headroom is dropped — never the bytes
+// that push the response past the cap it was budgeted to.
+func annotateLocalOnlyFormat(localResult []byte, wrapped bool, peerCount, budget int) []byte {
 	if !wrapped {
 		return localResult
 	}
@@ -298,7 +370,20 @@ func annotateLocalOnlyFormat(localResult []byte, wrapped bool, peerCount int) []
 	if !ok {
 		return localResult
 	}
-	note := fmt.Sprintf("note: local results only — %d enabled federation peer(s) were not queried because this response format cannot be merged; use the JSON format for federated results.", peerCount)
+	note := localOnlyNote(peerCount)
+	if budget > 0 {
+		spent := 0
+		for _, c := range content {
+			if cm, ok := c.(map[string]any); ok {
+				if text, ok := cm["text"].(string); ok {
+					spent += len(text)
+				}
+			}
+		}
+		if spent+len(note) > budget {
+			return localResult
+		}
+	}
 	m["content"] = append(content, map[string]any{"type": "text", "text": note})
 	out, err := json.Marshal(m)
 	if err != nil {
@@ -551,6 +636,10 @@ func mergeGroupedUsages(body, local []byte, remotes []remoteResult) ([]byte, map
 	groups := make([]*query.UsageFileGroup, 0, len(byFile))
 	mergedRows := 0
 	for _, g := range byFile {
+		// The comparator is a total order over every field of the dedup
+		// identity (line, kind, symbol, name, context): two rows the
+		// dedup keeps apart must never compare equal, or the limit cut
+		// below picks its survivor by source arrival order.
 		sort.Slice(g.Uses, func(i, j int) bool {
 			a, b := g.Uses[i], g.Uses[j]
 			if a.Line != b.Line {
@@ -562,7 +651,10 @@ func mergeGroupedUsages(body, local []byte, remotes []remoteResult) ([]byte, map
 			if a.SymbolID != b.SymbolID {
 				return a.SymbolID < b.SymbolID
 			}
-			return a.SymbolName < b.SymbolName
+			if a.SymbolName != b.SymbolName {
+				return a.SymbolName < b.SymbolName
+			}
+			return a.Context < b.Context
 		})
 		g.Count = len(g.Uses)
 		mergedRows += g.Count
@@ -671,7 +763,22 @@ func mergeSubGraph(tool string, body, local []byte, remotes []remoteResult) ([]b
 	if sg.UsageSummary != nil {
 		sourceSummaries = append(sourceSummaries, sg.UsageSummary)
 	}
-	var remoteCaveats []*graph.ZeroEdgeCaveat
+	// Zero-edge caveats are judged per SOURCE, each tagged with whether
+	// that source resolved the queried node — the gate below needs the
+	// distinction in both orientations, local and remote alike.
+	type sourceCaveat struct {
+		caveat   *graph.ZeroEdgeCaveat
+		resolved bool
+	}
+	// Read the local orientation BEFORE the merge loop: sg.Nodes gains
+	// remote rows below, after which this containment check would read
+	// "anyone resolved".
+	localResolved := nodeListContains(sg.Nodes, args.ID)
+	depthUnknown := false
+	var caveats []sourceCaveat
+	if sg.Caveat != nil {
+		caveats = append(caveats, sourceCaveat{sg.Caveat, localResolved})
+	}
 	seen := make(map[string]bool, len(sg.Nodes))
 	for _, n := range sg.Nodes {
 		if n != nil {
@@ -701,6 +808,21 @@ func mergeSubGraph(tool string, body, local []byte, remotes []remoteResult) ([]b
 		sg.LowerBound = sg.LowerBound || rsg.LowerBound
 		sg.Boundaries = appendBoundaries(sg.Boundaries, rsg.Boundaries)
 		sg.DynamicBoundaries = appendDynamicBoundaries(sg.DynamicBoundaries, rsg.DynamicBoundaries)
+		// Budgeted-walk and freshness metadata: any source's early stop
+		// makes the merged result at least as incomplete, the merged
+		// depth guarantee is the weakest source's — unknowable when a
+		// source stopped on budget without reporting how deep it got —
+		// and the merged freshness is the stalest source's.
+		sg.BudgetHit = sg.BudgetHit || rsg.BudgetHit
+		if rsg.BudgetHit && rsg.StoppedAtDepth == 0 {
+			depthUnknown = true
+		}
+		if rsg.StoppedAtDepth > 0 && (sg.StoppedAtDepth == 0 || rsg.StoppedAtDepth < sg.StoppedAtDepth) {
+			sg.StoppedAtDepth = rsg.StoppedAtDepth
+		}
+		if rsg.LastSynced != nil && (sg.LastSynced == nil || rsg.LastSynced.Before(*sg.LastSynced)) {
+			sg.LastSynced = rsg.LastSynced
+		}
 		if rsg.UsageSummary != nil {
 			sourceSummaries = append(sourceSummaries, rsg.UsageSummary)
 		}
@@ -709,14 +831,7 @@ func mergeSubGraph(tool string, body, local []byte, remotes []remoteResult) ([]b
 		// uncertain as that peer's own answer was. Counts floor at the
 		// largest single source — the deduplicated union is unknowable.
 		if rsg.Caveat != nil {
-			// A peer that resolved nothing has no evidence about the
-			// symbol: its extraction-gap caveat describes its own graph,
-			// not the union, and must not displace a classification from
-			// a daemon that resolved the node.
-			gap := rsg.Caveat.Class == graph.ZeroEdgePossibleExtractionGap
-			if !gap || nodeListContains(rsg.Nodes, args.ID) {
-				remoteCaveats = append(remoteCaveats, rsg.Caveat)
-			}
+			caveats = append(caveats, sourceCaveat{rsg.Caveat, nodeListContains(rsg.Nodes, args.ID)})
 		}
 		sg.TextMatchedSuppressed = max(sg.TextMatchedSuppressed, rsg.TextMatchedSuppressed)
 		sg.NameOnlyCandidates = max(sg.NameOnlyCandidates, rsg.NameOnlyCandidates)
@@ -754,6 +869,9 @@ func mergeSubGraph(tool string, body, local []byte, remotes []remoteResult) ([]b
 			sg.Edges = append(sg.Edges, e)
 		}
 	}
+	if depthUnknown {
+		sg.StoppedAtDepth = 0
+	}
 	// Totals: exact deduplicated counts when every source was complete;
 	// otherwise the best available floor — never smaller than any single
 	// source's own full count or the merged set itself.
@@ -766,23 +884,46 @@ func mergeSubGraph(tool string, body, local []byte, remotes []remoteResult) ([]b
 	// above rows that prove otherwise. Re-judge from the merged edges.
 	// With zero merged rows every source answered empty, and the most
 	// conservative source caveat survives — a local "likely_unused"
-	// must not out-rank a peer's "coverage_incomplete".
+	// must not out-rank a peer's "coverage_incomplete". Two gates,
+	// applied to local and remote sources alike, with the class
+	// semantics owned by the graph package beside the class producer:
+	//
+	//   - A source that resolved nothing answers an own-graph-only
+	//     caveat about its own graph, not the union: it cannot
+	//     displace a CLASSIFICATION from a source that resolved the
+	//     node. A resolving source that carried no caveat classified
+	//     nothing, so it displaces nothing — without a resolving
+	//     classification the gap caveat is the honest answer and
+	//     survives, never a bare, confident "0 usages".
+	//   - A tier_filtered marker suppresses only the classes it
+	//     refutes: it names edges that exist below the requested tier.
+	//     A different source's coverage UNCERTAINTY rides alongside
+	//     the merged filter marker. (Within one response the handler
+	//     keeps the markers exclusive; cross-source they are
+	//     independent.)
 	if len(sg.Edges) > 0 {
 		if graph.WeakUsageEvidenceOnly(sg.Edges) {
 			sg.Caveat = graph.CaveatForWeakUsageEvidence()
 		} else {
 			sg.Caveat = nil
 		}
-	} else if sg.TierFiltered != nil {
-		// A tier_filtered emptiness already explains itself — the
-		// handler contract keeps the two markers exclusive, and a
-		// zero-edge caveat on top would assert a second, contradictory
-		// reason for the same empty page.
-		sg.Caveat = nil
 	} else {
-		for _, c := range remoteCaveats {
-			if sg.Caveat == nil || graph.ZeroEdgeClassConservatism(c.Class) > graph.ZeroEdgeClassConservatism(sg.Caveat.Class) {
-				sg.Caveat = c
+		resolvedClassified := false
+		for _, sc := range caveats {
+			if sc.resolved {
+				resolvedClassified = true
+			}
+		}
+		sg.Caveat = nil
+		for _, sc := range caveats {
+			if graph.ZeroEdgeClassDescribesOwnGraphOnly(sc.caveat.Class) && !sc.resolved && resolvedClassified {
+				continue
+			}
+			if sg.TierFiltered != nil && graph.ZeroEdgeClassRefutedByTierFilter(sc.caveat.Class) {
+				continue
+			}
+			if sg.Caveat == nil || graph.ZeroEdgeClassConservatism(sc.caveat.Class) > graph.ZeroEdgeClassConservatism(sg.Caveat.Class) {
+				sg.Caveat = sc.caveat
 			}
 		}
 	}

--- a/internal/daemon/federation.go
+++ b/internal/daemon/federation.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -140,7 +141,8 @@ func (f *Federator) Augment(ctx context.Context, tool string, body, localResult 
 	// fan-out entirely and make the partiality explicit instead —
 	// merging the canonical graph before rendering is the deeper fix,
 	// but until then a labeled local answer beats an unlabeled one.
-	if !json.Valid(localTool) || len(localTool) == 0 || (localTool[0] != '{' && localTool[0] != '[') {
+	probe := bytes.TrimLeft(localTool, " \t\r\n")
+	if len(probe) == 0 || (probe[0] != '{' && probe[0] != '[') || !json.Valid(probe) {
 		return annotateLocalOnlyFormat(localResult, wrapped, len(remotes))
 	}
 
@@ -184,10 +186,9 @@ func (f *Federator) Augment(ctx context.Context, tool string, body, localResult 
 // budgetMergedJSON applies the caller's effective budget to the merged
 // representation with the same structural trim (and truncation meta)
 // the per-daemon budget layer uses. The generic trim bounds the
-// top-level lists; the federation origins map scales with the node set
-// — a coupling the shape-agnostic trim cannot know — so origins are
-// re-pruned to the surviving nodes and the trim re-run until the
-// result fits or nothing further can shrink.
+// top-level lists; the origins map scales with the rows — a coupling
+// the shape-agnostic trim cannot know — so origins are re-pruned to
+// the rows that survived.
 func budgetMergedJSON(raw []byte, budget int) []byte {
 	if budget <= 0 || len(raw) <= budget {
 		return raw
@@ -196,47 +197,66 @@ func budgetMergedJSON(raw []byte, budget int) []byte {
 	if err := json.Unmarshal(raw, &generic); err != nil {
 		return raw // non-JSON body: some other layer's contract
 	}
-	for pass := 0; pass < 3; pass++ {
-		trimmed, _ := respbudget.Apply(generic, budget)
-		m, ok := trimmed.(map[string]any)
-		if !ok {
-			break
-		}
-		generic = m
-		pruneOriginsToNodes(generic)
-		out, err := json.Marshal(generic)
-		if err != nil {
-			return raw
-		}
-		if len(out) <= budget {
-			return out
-		}
+	// One trim, one prune: a non-fitting Apply empties every top-level
+	// list, so re-running it after the prune could never cut further —
+	// pruning the row-keyed annotations is the only shrink left.
+	trimmed, _ := respbudget.Apply(generic, budget)
+	m, ok := trimmed.(map[string]any)
+	if !ok {
+		return raw
 	}
-	out, err := json.Marshal(generic)
+	pruneOriginsToRows(m)
+	out, err := json.Marshal(m)
 	if err != nil {
 		return raw
 	}
 	return out
 }
 
-// pruneOriginsToNodes drops origins entries whose node the budget trim
-// removed — an origin annotates a returned row (attachFederation puts
-// the map at top level, beside the rows), so one keyed to a trimmed
-// node is dead weight against the budget.
-func pruneOriginsToNodes(m map[string]any) {
+// pruneOriginsToRows drops origins entries whose row the budget trim
+// removed. An origin annotates a returned row, and each merge shape
+// keys rows differently — SubGraph nodes and keyed lists by "id",
+// grouped usages by the nested rows' "symbol_id" — so the keep-set is
+// the union of ids across every top-level list the payload actually
+// carries (one nesting level down included, for the grouped shape).
+func pruneOriginsToRows(m map[string]any) {
 	origins, ok := m["origins"].(map[string]any)
 	if !ok {
 		return
 	}
 	keep := make(map[string]bool)
-	if nodes, ok := m["nodes"].([]any); ok {
-		for _, n := range nodes {
-			if nm, ok := n.(map[string]any); ok {
-				if id, ok := nm["id"].(string); ok {
+	sawList := false
+	var collect func(items []any, depth int)
+	collect = func(items []any, depth int) {
+		for _, it := range items {
+			im, ok := it.(map[string]any)
+			if !ok {
+				continue
+			}
+			for _, key := range []string{"id", "symbol_id"} {
+				if id, ok := im[key].(string); ok && id != "" {
 					keep[id] = true
 				}
 			}
+			if depth == 0 {
+				for _, v := range im {
+					if nested, ok := v.([]any); ok {
+						collect(nested, 1)
+					}
+				}
+			}
 		}
+	}
+	for k, v := range m {
+		arr, ok := v.([]any)
+		if !ok || k == "origins" {
+			continue
+		}
+		sawList = true
+		collect(arr, 0)
+	}
+	if !sawList {
+		return
 	}
 	for id := range origins {
 		if !keep[id] {
@@ -448,54 +468,44 @@ func groupByFileRequested(body []byte) bool {
 	return strings.EqualFold(strings.TrimSpace(gb), "file")
 }
 
-// The wire shape of a group_by:"file" find_usages response, as
-// groupUsagesByFile serializes it on every daemon.
+// The wire envelope of a group_by:"file" find_usages response. The
+// group and row shapes are the shared query types the renderer
+// serializes, so the merge round trip can never strip a field the
+// renderer added.
 type groupedUsagesWire struct {
-	GroupedBy  string            `json:"grouped_by"`
-	FileCount  int               `json:"file_count"`
-	TotalUses  int               `json:"total_uses"`
-	Groups     []*usageGroupWire `json:"groups"`
-	Truncated  bool              `json:"truncated"`
-	TotalEdges int               `json:"total_edges,omitempty"`
-}
-
-type usageGroupWire struct {
-	File  string         `json:"file"`
-	Count int            `json:"count"`
-	Uses  []usageRowWire `json:"uses"`
-}
-
-type usageRowWire struct {
-	Line        int    `json:"line"`
-	EdgeKind    string `json:"edge_kind"`
-	Context     string `json:"context,omitempty"`
-	ReturnUsage string `json:"return_usage,omitempty"`
-	SymbolID    string `json:"symbol_id,omitempty"`
-	SymbolName  string `json:"symbol_name,omitempty"`
+	GroupedBy  string                  `json:"grouped_by"`
+	FileCount  int                     `json:"file_count"`
+	TotalUses  int                     `json:"total_uses"`
+	Groups     []*query.UsageFileGroup `json:"groups"`
+	Truncated  bool                    `json:"truncated"`
+	TotalEdges int                     `json:"total_edges,omitempty"`
 }
 
 // mergeGroupedUsages merges group_by:"file" find_usages responses
 // group-wise: rows dedupe on (file, line, kind, symbol), counts and
-// totals are recomputed over the union, and the caller's limit is
-// reapplied once, globally, mirroring the flat merge's contract.
+// totals are recomputed over the union, the caller's limit is
+// reapplied once, globally, and every surviving row is attributed to
+// the daemon that contributed it — mirroring the flat merge's
+// contract.
 func mergeGroupedUsages(body, local []byte, remotes []remoteResult) ([]byte, map[string]string) {
 	origins := map[string]string{}
 	var lg groupedUsagesWire
 	if err := json.Unmarshal(local, &lg); err != nil || lg.GroupedBy == "" {
 		return local, origins
 	}
-	byFile := make(map[string]*usageGroupWire, len(lg.Groups))
-	order := make([]string, 0, len(lg.Groups))
+	byFile := make(map[string]*query.UsageFileGroup, len(lg.Groups))
 	rowSeen := map[string]bool{}
-	rowKey := func(file string, u usageRowWire) string {
-		return file + "\x00" + strconv.Itoa(u.Line) + "\x00" + u.EdgeKind + "\x00" + u.SymbolID
+	// The key carries the name and context columns too: a row whose
+	// enclosing symbol was pruned (empty symbol_id) must not collapse
+	// into a different peer's row at the same site.
+	rowKey := func(file string, u query.UsageGroupItem) string {
+		return file + "\x00" + strconv.Itoa(u.Line) + "\x00" + u.EdgeKind + "\x00" + u.SymbolID + "\x00" + u.SymbolName + "\x00" + u.Context
 	}
-	addRows := func(g *usageGroupWire) {
+	addRows := func(g *query.UsageFileGroup, source string) {
 		dst := byFile[g.File]
 		if dst == nil {
-			dst = &usageGroupWire{File: g.File}
+			dst = &query.UsageFileGroup{File: g.File}
 			byFile[g.File] = dst
-			order = append(order, g.File)
 		}
 		for _, u := range g.Uses {
 			k := rowKey(g.File, u)
@@ -504,38 +514,43 @@ func mergeGroupedUsages(body, local []byte, remotes []remoteResult) ([]byte, map
 			}
 			rowSeen[k] = true
 			dst.Uses = append(dst.Uses, u)
+			if u.SymbolID != "" {
+				if _, exists := origins[u.SymbolID]; !exists { // local wins
+					origins[u.SymbolID] = source
+				}
+			}
 		}
 	}
 	for _, g := range lg.Groups {
 		if g != nil {
-			addRows(g)
+			addRows(g, "local")
 		}
 	}
 	// A source that already capped or trimmed its page makes the merged
 	// totals a floor; total_edges falls back to total_uses for sources
 	// that answered complete (they omit the explicit floor).
-	anyTruncated := lg.Truncated || budgetTrimmed(local)
+	anyTruncated := lg.Truncated || respbudget.Trimmed(local)
 	totalEdgesFloor := max(lg.TotalEdges, lg.TotalUses)
 	for _, rr := range remotes {
 		var rg groupedUsagesWire
 		if err := json.Unmarshal(rr.toolJSON, &rg); err != nil || rg.GroupedBy == "" {
 			continue
 		}
-		anyTruncated = anyTruncated || rg.Truncated || budgetTrimmed(rr.toolJSON)
+		anyTruncated = anyTruncated || rg.Truncated || respbudget.Trimmed(rr.toolJSON)
 		totalEdgesFloor = max(totalEdgesFloor, max(rg.TotalEdges, rg.TotalUses))
 		for _, g := range rg.Groups {
 			if g != nil {
-				addRows(g)
+				addRows(g, "remote:"+rr.slug)
 			}
 		}
 	}
 	// One deterministic global order before any cut: rows within a
 	// group by (line, kind, symbol), groups by count desc then path —
-	// the same order the local renderer emits.
-	groups := make([]*usageGroupWire, 0, len(order))
+	// the same order the local renderer emits. (Map iteration order
+	// upstream cannot leak through: both sorts are total orders.)
+	groups := make([]*query.UsageFileGroup, 0, len(byFile))
 	mergedRows := 0
-	for _, file := range order {
-		g := byFile[file]
+	for _, g := range byFile {
 		sort.Slice(g.Uses, func(i, j int) bool {
 			a, b := g.Uses[i], g.Uses[j]
 			if a.Line != b.Line {
@@ -544,7 +559,10 @@ func mergeGroupedUsages(body, local []byte, remotes []remoteResult) ([]byte, map
 			if a.EdgeKind != b.EdgeKind {
 				return a.EdgeKind < b.EdgeKind
 			}
-			return a.SymbolID < b.SymbolID
+			if a.SymbolID != b.SymbolID {
+				return a.SymbolID < b.SymbolID
+			}
+			return a.SymbolName < b.SymbolName
 		})
 		g.Count = len(g.Uses)
 		mergedRows += g.Count
@@ -580,6 +598,20 @@ func mergeGroupedUsages(body, local []byte, remotes []remoteResult) ([]byte, map
 		groups = kept
 		anyTruncated = true
 		mergedRows = limit
+		// Origins annotate returned rows; re-derive from the cut page.
+		keep := map[string]bool{}
+		for _, g := range groups {
+			for _, u := range g.Uses {
+				if u.SymbolID != "" {
+					keep[u.SymbolID] = true
+				}
+			}
+		}
+		for id := range origins {
+			if !keep[id] {
+				delete(origins, id)
+			}
+		}
 	}
 
 	out := groupedUsagesWire{
@@ -612,6 +644,17 @@ func mergeGroupedUsages(body, local []byte, remotes []remoteResult) ([]byte, map
 // explicit floor (lower_bound) in that case.
 func mergeSubGraph(tool string, body, local []byte, remotes []remoteResult) ([]byte, map[string]string) {
 	origins := map[string]string{}
+	// A JSON body outside the flat nodes/edges contract (a grouped
+	// variant this dispatch does not yet route) must pass through
+	// local-only: unmarshaling an unknown shape into a zero-valued
+	// SubGraph would replace a correct local answer with an empty one.
+	var shape struct {
+		GroupedBy string `json:"grouped_by"`
+	}
+	if json.Unmarshal(local, &shape) == nil && shape.GroupedBy != "" {
+		return local, origins
+	}
+	args := subGraphArgsFromBody(body)
 	var sg query.SubGraph
 	if err := json.Unmarshal(local, &sg); err != nil {
 		return local, origins
@@ -621,7 +664,7 @@ func mergeSubGraph(tool string, body, local []byte, remotes []remoteResult) ([]b
 	// `_truncated_by_budget` marker is a map key, not a SubGraph field,
 	// so it must be read off the raw source bytes before the typed
 	// round trip discards it.
-	anySourceTruncated := sg.Truncated || budgetTrimmed(local)
+	anySourceTruncated := sg.Truncated || respbudget.Trimmed(local)
 	totalEdgesFloor := sg.TotalEdges
 	totalNodesFloor := sg.TotalNodes
 	var sourceSummaries []*query.UsageSummary
@@ -647,7 +690,7 @@ func mergeSubGraph(tool string, body, local []byte, remotes []remoteResult) ([]b
 		if err := json.Unmarshal(rr.toolJSON, &rsg); err != nil {
 			continue
 		}
-		if rsg.Truncated || budgetTrimmed(rr.toolJSON) {
+		if rsg.Truncated || respbudget.Trimmed(rr.toolJSON) {
 			anySourceTruncated = true
 		}
 		totalEdgesFloor = max(totalEdgesFloor, rsg.TotalEdges)
@@ -666,7 +709,14 @@ func mergeSubGraph(tool string, body, local []byte, remotes []remoteResult) ([]b
 		// uncertain as that peer's own answer was. Counts floor at the
 		// largest single source — the deduplicated union is unknowable.
 		if rsg.Caveat != nil {
-			remoteCaveats = append(remoteCaveats, rsg.Caveat)
+			// A peer that resolved nothing has no evidence about the
+			// symbol: its extraction-gap caveat describes its own graph,
+			// not the union, and must not displace a classification from
+			// a daemon that resolved the node.
+			gap := rsg.Caveat.Class == graph.ZeroEdgePossibleExtractionGap
+			if !gap || nodeListContains(rsg.Nodes, args.ID) {
+				remoteCaveats = append(remoteCaveats, rsg.Caveat)
+			}
 		}
 		sg.TextMatchedSuppressed = max(sg.TextMatchedSuppressed, rsg.TextMatchedSuppressed)
 		sg.NameOnlyCandidates = max(sg.NameOnlyCandidates, rsg.NameOnlyCandidates)
@@ -723,6 +773,12 @@ func mergeSubGraph(tool string, body, local []byte, remotes []remoteResult) ([]b
 		} else {
 			sg.Caveat = nil
 		}
+	} else if sg.TierFiltered != nil {
+		// A tier_filtered emptiness already explains itself — the
+		// handler contract keeps the two markers exclusive, and a
+		// zero-edge caveat on top would assert a second, contradictory
+		// reason for the same empty page.
+		sg.Caveat = nil
 	} else {
 		for _, c := range remoteCaveats {
 			if sg.Caveat == nil || graph.ZeroEdgeClassConservatism(c.Class) > graph.ZeroEdgeClassConservatism(sg.Caveat.Class) {
@@ -755,7 +811,6 @@ func mergeSubGraph(tool string, body, local []byte, remotes []remoteResult) ([]b
 		sg.UsageSummary = merged
 	}
 
-	args := subGraphArgsFromBody(body)
 	limit := 50
 	if args.Limit != nil {
 		limit = *args.Limit
@@ -824,13 +879,17 @@ func mergeTierFiltered(local, remote *graph.TierFilteredCaveat) *graph.TierFilte
 	return local
 }
 
-// budgetTrimmed reports whether a source's raw tool JSON carries the
-// budget layer's structural-trim marker (respbudget.TruncatedKey).
-func budgetTrimmed(toolJSON []byte) bool {
-	var probe struct {
-		TruncatedByBudget bool `json:"_truncated_by_budget"`
+// nodeListContains reports whether the queried id is among nodes.
+func nodeListContains(nodes []*graph.Node, id string) bool {
+	if id == "" {
+		return false
 	}
-	return json.Unmarshal(toolJSON, &probe) == nil && probe.TruncatedByBudget
+	for _, n := range nodes {
+		if n != nil && n.ID == id {
+			return true
+		}
+	}
+	return false
 }
 
 // mapNodeGetter serves graph.NodeGetter lookups from the merged node

--- a/internal/daemon/federation.go
+++ b/internal/daemon/federation.go
@@ -298,10 +298,9 @@ type subGraphMergeArgs struct {
 }
 
 // subGraphArgsFromBody extracts the tool args from the routed request
-// body. Production stdio and streamable MCP dispatch nest them under
-// "arguments" (the same envelope bareNameFromBody reads); a flat body
-// is accepted as a fallback so an internal caller that skips the
-// envelope cannot silently lose its limit.
+// body: production stdio and streamable MCP dispatch nest them under
+// "arguments", the one envelope every federation body reader parses
+// (bareNameFromBody reads the same shape).
 func subGraphArgsFromBody(body []byte) subGraphMergeArgs {
 	var env struct {
 		Arguments *subGraphMergeArgs `json:"arguments"`
@@ -309,9 +308,7 @@ func subGraphArgsFromBody(body []byte) subGraphMergeArgs {
 	if err := json.Unmarshal(body, &env); err == nil && env.Arguments != nil {
 		return *env.Arguments
 	}
-	var flat subGraphMergeArgs
-	_ = json.Unmarshal(body, &flat)
-	return flat
+	return subGraphMergeArgs{}
 }
 
 // mergeSubGraph merges query.SubGraph responses: nodes deduped by string
@@ -334,6 +331,10 @@ func mergeSubGraph(tool string, body, local []byte, remotes []remoteResult) ([]b
 	anySourceTruncated := sg.Truncated
 	totalEdgesFloor := sg.TotalEdges
 	totalNodesFloor := sg.TotalNodes
+	var sourceSummaries []*query.UsageSummary
+	if sg.UsageSummary != nil {
+		sourceSummaries = append(sourceSummaries, sg.UsageSummary)
+	}
 	seen := make(map[string]bool, len(sg.Nodes))
 	for _, n := range sg.Nodes {
 		if n != nil {
@@ -362,7 +363,10 @@ func mergeSubGraph(tool string, body, local []byte, remotes []remoteResult) ([]b
 		// evidence about rows now in the merged set.
 		sg.LowerBound = sg.LowerBound || rsg.LowerBound
 		sg.Boundaries = appendBoundaries(sg.Boundaries, rsg.Boundaries)
-		sg.DynamicBoundaries = append(sg.DynamicBoundaries, rsg.DynamicBoundaries...)
+		sg.DynamicBoundaries = appendDynamicBoundaries(sg.DynamicBoundaries, rsg.DynamicBoundaries)
+		if rsg.UsageSummary != nil {
+			sourceSummaries = append(sourceSummaries, rsg.UsageSummary)
+		}
 		if len(rsg.CallerNotes) > 0 {
 			if sg.CallerNotes == nil {
 				sg.CallerNotes = make(map[string]*graph.ConcurrencyAnnotation, len(rsg.CallerNotes))
@@ -400,12 +404,39 @@ func mergeSubGraph(tool string, body, local []byte, remotes []remoteResult) ([]b
 	sg.TotalNodes = max(totalNodesFloor, len(sg.Nodes))
 	sg.Truncated = anySourceTruncated
 	sg.LowerBound = sg.LowerBound || anySourceTruncated
-	// The summary is a whole-set rollup, so recompute it over the merged
-	// deduplicated rows before any recap — exact when every source was
-	// complete, a floor (with lower_bound set) otherwise. Only attached
-	// where the local response carried one (find_usages).
-	if sg.UsageSummary != nil {
-		sg.UsageSummary = mergedUsageSummary(&sg)
+	// Merged rows can invalidate the local zero-edge caveat: a symbol
+	// unused locally but used on a peer must not answer "appears unused"
+	// above rows that prove otherwise. Re-judge from the merged edges.
+	if len(sg.Edges) > 0 {
+		if graph.WeakUsageEvidenceOnly(sg.Edges) {
+			sg.Caveat = graph.CaveatForWeakUsageEvidence()
+		} else {
+			sg.Caveat = nil
+		}
+	}
+	// The summary is a whole-set rollup. Recompute it over the merged
+	// deduplicated rows with a merged-node getter (the owner hop for
+	// child nodes resolves against nodes the merge carried), then floor
+	// element-wise against every source's own rollup — a source's counts
+	// describe its full set even when only its capped page reached the
+	// merge. Attached only when a source carried one (find_usages).
+	if len(sourceSummaries) > 0 {
+		nodeByID := make(mapNodeGetter, len(sg.Nodes))
+		for _, n := range sg.Nodes {
+			if n != nil {
+				nodeByID[n.ID] = n
+			}
+		}
+		merged := query.UsageSummaryOf(&sg, nodeByID)
+		if merged == nil {
+			merged = &query.UsageSummary{}
+		}
+		for _, src := range sourceSummaries {
+			merged.NRefs = max(merged.NRefs, src.NRefs)
+			merged.NFiles = max(merged.NFiles, src.NFiles)
+			merged.NTestRefs = max(merged.NTestRefs, src.NTestRefs)
+		}
+		sg.UsageSummary = merged
 	}
 
 	args := subGraphArgsFromBody(body)
@@ -457,20 +488,30 @@ func mergeSubGraph(tool string, body, local []byte, remotes []remoteResult) ([]b
 	return out, origins
 }
 
+// mapNodeGetter serves graph.NodeGetter lookups from the merged node
+// set, so the summary's owner-hop classification resolves against the
+// nodes the merge actually carried.
+type mapNodeGetter map[string]*graph.Node
+
+func (m mapNodeGetter) GetNode(id string) *graph.Node { return m[id] }
+
+// mergedBoundaryCap bounds each merged boundary section, matching the
+// 50-row cap the BFS walk applies to its own boundary recording.
+const mergedBoundaryCap = 50
+
 // appendBoundaries appends remote epistemic boundaries, deduplicated by
-// (seed, target, edge kind) and capped at the same 50 the BFS walk
-// applies, so a many-peer merge cannot grow the section without bound.
+// (seed, target) — the same key the BFS walk dedups on — and capped so
+// a many-peer merge cannot grow the section without bound.
 func appendBoundaries(dst, src []graph.EpistemicBoundary) []graph.EpistemicBoundary {
-	const boundaryCap = 50
 	seen := make(map[string]bool, len(dst))
 	for _, b := range dst {
-		seen[b.SeedID+"\x00"+b.Target+"\x00"+b.EdgeKind] = true
+		seen[b.SeedID+"\x00"+b.Target] = true
 	}
 	for _, b := range src {
-		if len(dst) >= boundaryCap {
+		if len(dst) >= mergedBoundaryCap {
 			break
 		}
-		k := b.SeedID + "\x00" + b.Target + "\x00" + b.EdgeKind
+		k := b.SeedID + "\x00" + b.Target
 		if seen[k] {
 			continue
 		}
@@ -480,39 +521,25 @@ func appendBoundaries(dst, src []graph.EpistemicBoundary) []graph.EpistemicBound
 	return dst
 }
 
-// mergedUsageSummary recomputes the find_usages completeness rollup
-// over the merged rows, mirroring the local usageSummaryOf shape:
-// per-edge file resolution with a from-node fallback, and the shared
-// test classifier on the serialized node stamps (no owner hop — the
-// remote graph is not reachable here, and its stamped rows carry the
-// flag in meta).
-func mergedUsageSummary(sg *query.SubGraph) *query.UsageSummary {
-	if len(sg.Edges) == 0 {
-		return nil
+// appendDynamicBoundaries mirrors appendBoundaries for the dynamic
+// section, keyed by the dispatch site tuple.
+func appendDynamicBoundaries(dst, src []graph.DynamicBoundary) []graph.DynamicBoundary {
+	seen := make(map[string]bool, len(dst))
+	for _, b := range dst {
+		seen[b.Site+"\x00"+b.Form+"\x00"+b.Key] = true
 	}
-	nodeByID := make(map[string]*graph.Node, len(sg.Nodes))
-	for _, n := range sg.Nodes {
-		if n != nil {
-			nodeByID[n.ID] = n
+	for _, b := range src {
+		if len(dst) >= mergedBoundaryCap {
+			break
 		}
+		k := b.Site + "\x00" + b.Form + "\x00" + b.Key
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		dst = append(dst, b)
 	}
-	files := make(map[string]struct{}, len(sg.Edges))
-	testRefs := 0
-	for _, e := range sg.Edges {
-		from := nodeByID[e.From]
-		file := e.FilePath
-		if file == "" && from != nil {
-			file = from.FilePath
-		}
-		if file == "" {
-			file = "(unknown)"
-		}
-		files[file] = struct{}{}
-		if graph.NodeIsTest(nil, from) {
-			testRefs++
-		}
-	}
-	return &query.UsageSummary{NRefs: len(sg.Edges), NFiles: len(files), NTestRefs: testRefs}
+	return dst
 }
 
 // pruneMergedNodes drops nodes (and their origins entries) that the
@@ -528,6 +555,12 @@ func pruneMergedNodes(sg *query.SubGraph, origins map[string]string, keep map[st
 	for id := range origins {
 		if !keep[id] {
 			delete(origins, id)
+		}
+	}
+	// Notes annotate returned rows; one keyed to a pruned node is noise.
+	for id := range sg.CallerNotes {
+		if !keep[id] {
+			delete(sg.CallerNotes, id)
 		}
 	}
 }

--- a/internal/daemon/federation_budget_test.go
+++ b/internal/daemon/federation_budget_test.go
@@ -1,0 +1,77 @@
+package daemon
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestFederator_MergedResultHonorsByteBudget pins the caller's max_bytes
+// on the FINAL federated representation: each daemon budgets its own
+// page independently, so the merge must reapply the caller's cap once,
+// globally, over multiple peers.
+func TestFederator_MergedResultHonorsByteBudget(t *testing.T) {
+	local, remoteJSON := fedUsageBodies(30, 30, false, false)
+	_, remote2JSON := fedUsageBodies(0, 25, false, false)
+	remote2JSON = strings.ReplaceAll(remote2JSON, `"r/`, `"q/`)
+	r1 := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: remoteJSON})
+	r2 := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: remote2JSON})
+
+	out := testFederator().Augment(context.Background(), "find_usages",
+		productionBody(`{"id":"pkg/hot.go::Hot","limit":0,"max_bytes":600}`), local,
+		[]ServerEntry{{Slug: "r1", URL: r1.URL}, {Slug: "r2", URL: r2.URL}})
+
+	tool, _ := unwrapToolJSON(out)
+	if len(tool) > 600 {
+		t.Fatalf("merged response must honor the caller's max_bytes:600, got %d bytes", len(tool))
+	}
+	m := decodeFederated(t, out)
+	if m["_truncated_by_budget"] != true {
+		t.Errorf("a budget-trimmed merge must carry the same truncation meta the local budget path emits")
+	}
+}
+
+// TestFederator_MergedResultHonorsTokenBudget pins the max_tokens axis
+// through the merge: the token cap converts to the same byte ceiling
+// the per-daemon budget layer applies (3.5 bytes/token).
+func TestFederator_MergedResultHonorsTokenBudget(t *testing.T) {
+	local, remoteJSON := fedUsageBodies(30, 30, false, false)
+	r1 := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: remoteJSON})
+
+	out := testFederator().Augment(context.Background(), "find_usages",
+		productionBody(`{"id":"pkg/hot.go::Hot","limit":0,"max_tokens":200}`), local,
+		[]ServerEntry{{Slug: "r1", URL: r1.URL}})
+
+	tool, _ := unwrapToolJSON(out)
+	if ceiling := int(200 * 3.5); len(tool) > ceiling {
+		t.Fatalf("merged response must honor max_tokens:200 (~%d bytes), got %d bytes", ceiling, len(tool))
+	}
+}
+
+// TestFederator_SourceBudgetTruncationSurvivesMerge pins that a source
+// page the budget layer already trimmed cannot merge into a result that
+// claims completeness: the local `_truncated_by_budget` marker does not
+// survive the SubGraph round trip, so the merge must read it off the
+// raw source bytes.
+func TestFederator_SourceBudgetTruncationSurvivesMerge(t *testing.T) {
+	local := envelope(`{
+		"nodes":[{"id":"pkg/hot.go::Hot"},{"id":"l/a.go::LUse"}],
+		"edges":[{"from":"l/a.go::LUse","to":"pkg/hot.go::Hot","kind":"calls","file_path":"l/a.go","line":5}],
+		"total_nodes":2,"total_edges":9,"truncated":false,
+		"_truncated_by_budget":true,"_max_returned_edges":1,"_original_count_edges":9}`)
+	remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: `{
+		"nodes":[{"id":"r/b.go::RUse"}],
+		"edges":[{"from":"r/b.go::RUse","to":"pkg/hot.go::Hot","kind":"calls","file_path":"r/b.go","line":7}],
+		"total_nodes":1,"total_edges":1,"truncated":false}`})
+
+	out := testFederator().Augment(context.Background(), "find_usages",
+		productionBody(`{"id":"pkg/hot.go::Hot","limit":50}`), local,
+		[]ServerEntry{{Slug: "r2", URL: remote.URL}})
+	m := decodeFederated(t, out)
+	if m["truncated"] != true {
+		t.Errorf("a source page trimmed by its own budget makes the merged row set incomplete")
+	}
+	if m["lower_bound"] != true {
+		t.Errorf("a budget-trimmed source's discarded tail makes the merged totals a floor")
+	}
+}

--- a/internal/daemon/federation_caveat_symmetry_test.go
+++ b/internal/daemon/federation_caveat_symmetry_test.go
@@ -1,0 +1,123 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// zeroEdgeBodyUnresolved renders a zero-edge find_usages tool JSON from
+// a source that did NOT resolve the queried symbol: no node row, plus
+// the extraction-gap caveat that source honestly reports about its own
+// graph.
+func zeroEdgeBodyUnresolved(caveatClass string) string {
+	caveat := ""
+	if caveatClass != "" {
+		caveat = fmt.Sprintf(`,"caveat":{"class":%q,"message":"m"}`, caveatClass)
+	}
+	return fmt.Sprintf(`{"nodes":[],"edges":[],"total_nodes":0,"total_edges":0,"truncated":false%s}`, caveat)
+}
+
+// TestFederator_ZeroRowCaveatResolutionGateIsSymmetric pins the gate on
+// extraction-gap caveats in BOTH source orientations: a source that
+// resolved nothing answers a gap caveat about its own graph, not the
+// union, and must not displace a classification from a source that
+// resolved the node — whether the unresolved source is a remote or the
+// local daemon itself. When no resolving source classified the
+// emptiness, the gap caveat is the honest answer and survives.
+func TestFederator_ZeroRowCaveatResolutionGateIsSymmetric(t *testing.T) {
+	cases := []struct {
+		name       string
+		localJSON  string
+		remoteJSON string
+		want       string
+	}{
+		{
+			"remote resolution beats local unresolved gap",
+			zeroEdgeBodyUnresolved("possible_extraction_gap"),
+			zeroEdgeBody("likely_unused"),
+			"likely_unused",
+		},
+		{
+			"local resolution beats remote unresolved gap",
+			zeroEdgeBody("likely_unused"),
+			zeroEdgeBodyUnresolved("possible_extraction_gap"),
+			"likely_unused",
+		},
+		{
+			"no source resolved: the gap caveat survives",
+			zeroEdgeBodyUnresolved("possible_extraction_gap"),
+			zeroEdgeBodyUnresolved(""),
+			"possible_extraction_gap",
+		},
+		{
+			// A resolving source that carried NO caveat has classified
+			// nothing: it must not erase the unresolved source's honest
+			// coverage warning into a bare, confident "0 usages".
+			"caveat-less resolving peer does not erase the gap",
+			zeroEdgeBodyUnresolved("possible_extraction_gap"),
+			zeroEdgeBody(""),
+			"possible_extraction_gap",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: tc.remoteJSON})
+			out := testFederator().Augment(context.Background(), "find_usages",
+				productionBody(`{"id":"pkg/hot.go::Hot","limit":50}`), envelope(tc.localJSON),
+				[]ServerEntry{{Slug: "r2", URL: remote.URL}})
+			m := decodeFederated(t, out)
+			caveat, _ := m["caveat"].(map[string]any)
+			if caveat == nil {
+				t.Fatalf("merged zero-row result must keep a caveat, got none")
+			}
+			if caveat["class"] != tc.want {
+				t.Fatalf("want merged caveat class %q, got %v", tc.want, caveat["class"])
+			}
+		})
+	}
+}
+
+// TestFederator_TierFilteredDoesNotClearAnotherSourcesCaveat pins the
+// independence of cross-source uncertainty: within one response,
+// tier_filtered and the zero-edge caveat are exclusive — the filter
+// explains that source's own emptiness — but one source's filter
+// explains nothing about a DIFFERENT source's incomplete coverage, so
+// the merge must carry both.
+func TestFederator_TierFilteredDoesNotClearAnotherSourcesCaveat(t *testing.T) {
+	tierFilteredJSON := `{
+		"nodes":[{"id":"pkg/hot.go::Hot"}],"edges":[],
+		"total_nodes":1,"total_edges":0,"truncated":false,
+		"tier_filtered":{"class":"tier_filtered","edges_below_min_tier":3,"max_available_tier":"ast_inferred"}}`
+
+	cases := []struct {
+		name       string
+		localJSON  string
+		remoteJSON string
+		wantClass  string
+	}{
+		{"remote tier_filtered vs local coverage_incomplete", zeroEdgeBody("coverage_incomplete"), tierFilteredJSON, "coverage_incomplete"},
+		{"local tier_filtered vs remote coverage_incomplete", tierFilteredJSON, zeroEdgeBody("coverage_incomplete"), "coverage_incomplete"},
+		// The filter marker names edges that exist below the tier — it
+		// refutes a likely_unused CONCLUSION — but an unresolved peer's
+		// gap caveat is coverage UNCERTAINTY about a different graph,
+		// which the filter explains nothing about.
+		{"local tier_filtered vs remote unresolved gap", tierFilteredJSON, zeroEdgeBodyUnresolved("possible_extraction_gap"), "possible_extraction_gap"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: tc.remoteJSON})
+			out := testFederator().Augment(context.Background(), "find_usages",
+				productionBody(`{"id":"pkg/hot.go::Hot","limit":50}`), envelope(tc.localJSON),
+				[]ServerEntry{{Slug: "r2", URL: remote.URL}})
+			m := decodeFederated(t, out)
+			if _, ok := m["tier_filtered"].(map[string]any); !ok {
+				t.Fatalf("the tier_filtered marker must survive the merge")
+			}
+			caveat, _ := m["caveat"].(map[string]any)
+			if caveat == nil || caveat["class"] != tc.wantClass {
+				t.Fatalf("another source's %s must not be cleared by the filter marker, got %v", tc.wantClass, m["caveat"])
+			}
+		})
+	}
+}

--- a/internal/daemon/federation_caveat_test.go
+++ b/internal/daemon/federation_caveat_test.go
@@ -1,0 +1,105 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+// zeroEdgeBody renders a zero-edge find_usages tool JSON with an
+// optional caveat class, in the shape the daemons serialize.
+func zeroEdgeBody(caveatClass string) string {
+	caveat := ""
+	if caveatClass != "" {
+		caveat = fmt.Sprintf(`,"caveat":{"class":%q,"message":"m"}`, caveatClass)
+	}
+	return fmt.Sprintf(`{"nodes":[{"id":"pkg/hot.go::Hot"}],"edges":[],"total_nodes":1,"total_edges":0,"truncated":false%s}`, caveat)
+}
+
+// TestFederator_ZeroRowCaveatConservativePrecedence pins the caveat
+// merge when every source answered zero rows: the merged caveat is the
+// most conservative of the sources' classes, so a local "likely_unused"
+// can never out-rank a peer's "coverage_incomplete" — uncertain removal
+// advice must not read as conclusive.
+func TestFederator_ZeroRowCaveatConservativePrecedence(t *testing.T) {
+	cases := []struct {
+		name        string
+		localClass  string
+		remoteClass string
+		want        string
+	}{
+		{"remote coverage_incomplete beats local likely_unused", "likely_unused", "coverage_incomplete", "coverage_incomplete"},
+		{"local coverage_incomplete survives remote likely_unused", "coverage_incomplete", "likely_unused", "coverage_incomplete"},
+		{"remote-only caveat adopted", "", "coverage_incomplete", "coverage_incomplete"},
+		{"extraction gap beats likely_unused", "likely_unused", "possible_extraction_gap", "possible_extraction_gap"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: zeroEdgeBody(tc.remoteClass)})
+			out := testFederator().Augment(context.Background(), "find_usages",
+				productionBody(`{"id":"pkg/hot.go::Hot","limit":50}`), envelope(zeroEdgeBody(tc.localClass)),
+				[]ServerEntry{{Slug: "r2", URL: remote.URL}})
+			m := decodeFederated(t, out)
+			caveat, _ := m["caveat"].(map[string]any)
+			if caveat == nil {
+				t.Fatalf("merged zero-row result must keep a caveat, got none")
+			}
+			if caveat["class"] != tc.want {
+				t.Fatalf("want merged caveat class %q, got %v", tc.want, caveat["class"])
+			}
+		})
+	}
+}
+
+// TestFederator_RemoteSuppressionMetadataSurvivesMerge pins the
+// completeness counters through the merge: a peer that suppressed
+// text-matched rows or holds name-only candidates makes the merged
+// answer exactly as uncertain as that peer's own answer was.
+func TestFederator_RemoteSuppressionMetadataSurvivesMerge(t *testing.T) {
+	remoteJSON := `{
+		"nodes":[{"id":"pkg/hot.go::Hot"},{"id":"r/a.go::RUse"}],
+		"edges":[{"from":"r/a.go::RUse","to":"pkg/hot.go::Hot","kind":"calls","file_path":"r/a.go","line":7,"origin":"lsp_resolved"}],
+		"total_nodes":2,"total_edges":1,"truncated":false,
+		"text_matched_suppressed":4,"name_only_candidates":7}`
+	remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: remoteJSON})
+	local := envelope(`{
+		"nodes":[{"id":"pkg/hot.go::Hot"},{"id":"l/b.go::LUse"}],
+		"edges":[{"from":"l/b.go::LUse","to":"pkg/hot.go::Hot","kind":"calls","file_path":"l/b.go","line":5,"origin":"lsp_resolved"}],
+		"total_nodes":2,"total_edges":1,"truncated":false}`)
+
+	out := testFederator().Augment(context.Background(), "find_usages",
+		productionBody(`{"id":"pkg/hot.go::Hot","limit":50}`), local,
+		[]ServerEntry{{Slug: "r2", URL: remote.URL}})
+	m := decodeFederated(t, out)
+	if got, _ := m["text_matched_suppressed"].(float64); int(got) < 4 {
+		t.Errorf("remote text_matched_suppressed must survive the merge as a floor, got %v", m["text_matched_suppressed"])
+	}
+	if got, _ := m["name_only_candidates"].(float64); int(got) < 7 {
+		t.Errorf("remote name_only_candidates must survive the merge as a floor, got %v", m["name_only_candidates"])
+	}
+}
+
+// TestFederator_RemoteTierFilteredSurvivesMerge pins the tier_filtered
+// marker through the merge: a peer whose rows were emptied by the
+// caller's min_tier must keep that emptiness legible as "filtered",
+// not silently read as "no usages on that peer".
+func TestFederator_RemoteTierFilteredSurvivesMerge(t *testing.T) {
+	remoteJSON := `{
+		"nodes":[{"id":"pkg/hot.go::Hot"}],"edges":[],
+		"total_nodes":1,"total_edges":0,"truncated":false,
+		"tier_filtered":{"class":"tier_filtered","edges_below_min_tier":3,"max_available_tier":"ast_inferred"}}`
+	remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: remoteJSON})
+	local := envelope(`{"nodes":[{"id":"pkg/hot.go::Hot"}],"edges":[],"total_nodes":1,"total_edges":0,"truncated":false}`)
+
+	out := testFederator().Augment(context.Background(), "find_usages",
+		productionBody(`{"id":"pkg/hot.go::Hot","limit":50,"min_tier":"lsp_resolved"}`), local,
+		[]ServerEntry{{Slug: "r2", URL: remote.URL}})
+	m := decodeFederated(t, out)
+	tf, _ := m["tier_filtered"].(map[string]any)
+	if tf == nil {
+		t.Fatalf("a peer's tier_filtered marker must survive the merge")
+	}
+	if got, _ := tf["edges_below_min_tier"].(float64); int(got) < 3 {
+		t.Errorf("edges_below_min_tier must keep the peer's floor, got %v", tf["edges_below_min_tier"])
+	}
+}

--- a/internal/daemon/federation_format_gate_test.go
+++ b/internal/daemon/federation_format_gate_test.go
@@ -1,0 +1,55 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestFederator_NonMergeableFormatIsExplicitlyLocalOnly pins the gate
+// for renderings that cannot round-trip as JSON (compact, gcx, toon,
+// mermaid, dot): the merge cannot fold remote rows into them, so the
+// response must SAY it is local-only instead of silently presenting a
+// partial result as federated.
+func TestFederator_NonMergeableFormatIsExplicitlyLocalOnly(t *testing.T) {
+	cases := []struct {
+		name      string
+		localText string
+		args      string
+	}{
+		{"mermaid", "graph TD;\n  A-->B;\n", `{"id":"pkg/hot.go::Hot","format":"mermaid"}`},
+		{"compact", "pkg/hot.go::Hot <- l/a.go::LUse (calls)\nedges: 1 of 1 total\n", `{"id":"pkg/hot.go::Hot","compact":true}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: `{
+				"nodes":[{"id":"r/b.go::RUse"}],
+				"edges":[{"from":"r/b.go::RUse","to":"pkg/hot.go::Hot","kind":"calls","file_path":"r/b.go","line":7}],
+				"total_nodes":1,"total_edges":1,"truncated":false}`})
+			out := testFederator().Augment(context.Background(), "find_usages",
+				productionBody(tc.args), envelope(tc.localText),
+				[]ServerEntry{{Slug: "r2", URL: remote.URL}})
+
+			var env struct {
+				Content []struct {
+					Type string `json:"type"`
+					Text string `json:"text"`
+				} `json:"content"`
+			}
+			if err := json.Unmarshal(out, &env); err != nil {
+				t.Fatalf("result must stay a valid MCP envelope: %v", err)
+			}
+			if len(env.Content) == 0 || env.Content[0].Text != tc.localText {
+				t.Fatalf("the local rendering must pass through unchanged")
+			}
+			note := ""
+			for _, c := range env.Content[1:] {
+				note += c.Text
+			}
+			if !strings.Contains(note, "local") || !strings.Contains(note, "format") {
+				t.Fatalf("a non-mergeable format with enabled peers must carry an explicit local-only note, got content: %+v", env.Content)
+			}
+		})
+	}
+}

--- a/internal/daemon/federation_group_order_test.go
+++ b/internal/daemon/federation_group_order_test.go
@@ -1,0 +1,51 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// TestFederator_GroupedCapIsSourceOrderIndependent pins that a capped
+// grouped merge is a function of the row set, not of which peer
+// answered first: two rows identical in every column except Context
+// are distinct rows (the dedup key says so), so the comparator must
+// order them by Context too — otherwise reversing equivalent peer
+// inputs changes which row survives limit:1.
+func TestFederator_GroupedCapIsSourceOrderIndependent(t *testing.T) {
+	rowA := `{"grouped_by":"file","file_count":1,"total_uses":1,"truncated":false,"groups":[
+		{"file":"pkg/a.go","count":1,"uses":[
+			{"line":5,"edge_kind":"calls","context":"alpha()","symbol_id":"pkg/a.go::Use","symbol_name":"Use"}]}]}`
+	rowB := `{"grouped_by":"file","file_count":1,"total_uses":1,"truncated":false,"groups":[
+		{"file":"pkg/a.go","count":1,"uses":[
+			{"line":5,"edge_kind":"calls","context":"beta()","symbol_id":"pkg/a.go::Use","symbol_name":"Use"}]}]}`
+
+	survivor := func(t *testing.T, localJSON, remoteJSON string) string {
+		t.Helper()
+		remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: remoteJSON})
+		out := testFederator().Augment(context.Background(), "find_usages",
+			groupedProductionBody(`,"limit":1`), envelope(localJSON),
+			[]ServerEntry{{Slug: "r2", URL: remote.URL}})
+		tool, _ := unwrapToolJSON(out)
+		var resp struct {
+			Groups []struct {
+				Uses []struct {
+					Context string `json:"context"`
+				} `json:"uses"`
+			} `json:"groups"`
+		}
+		if err := json.Unmarshal(tool, &resp); err != nil {
+			t.Fatalf("unmarshal merged grouped response: %v", err)
+		}
+		if len(resp.Groups) != 1 || len(resp.Groups[0].Uses) != 1 {
+			t.Fatalf("limit:1 must keep exactly one row, got %+v", resp.Groups)
+		}
+		return resp.Groups[0].Uses[0].Context
+	}
+
+	ab := survivor(t, rowA, rowB)
+	ba := survivor(t, rowB, rowA)
+	if ab != ba {
+		t.Fatalf("capped grouped output depends on source order: local-first %q vs reversed %q", ab, ba)
+	}
+}

--- a/internal/daemon/federation_group_test.go
+++ b/internal/daemon/federation_group_test.go
@@ -1,0 +1,103 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+)
+
+// groupedProductionBody is the request shape production routes for a
+// group_by:"file" find_usages call.
+func groupedProductionBody(extra string) []byte {
+	return productionBody(`{"id":"pkg/hot.go::Hot","group_by":"file"` + extra + `}`)
+}
+
+const localGroupedJSON = `{
+	"grouped_by":"file","file_count":2,"total_uses":3,"truncated":false,
+	"groups":[
+		{"file":"l/a.go","count":2,"uses":[
+			{"line":5,"edge_kind":"calls","symbol_id":"l/a.go::A1","symbol_name":"A1"},
+			{"line":9,"edge_kind":"calls","symbol_id":"l/a.go::A2","symbol_name":"A2"}]},
+		{"file":"shared/s.go","count":1,"uses":[
+			{"line":3,"edge_kind":"references","symbol_id":"shared/s.go::S","symbol_name":"S"}]}]}`
+
+const remoteGroupedJSON = `{
+	"grouped_by":"file","file_count":2,"total_uses":3,"truncated":false,
+	"groups":[
+		{"file":"shared/s.go","count":2,"uses":[
+			{"line":3,"edge_kind":"references","symbol_id":"shared/s.go::S","symbol_name":"S"},
+			{"line":8,"edge_kind":"calls","symbol_id":"shared/s.go::S2","symbol_name":"S2"}]},
+		{"file":"r/b.go","count":1,"uses":[
+			{"line":7,"edge_kind":"calls","symbol_id":"r/b.go::B","symbol_name":"B"}]}]}`
+
+// TestFederator_GroupedUsagesSurviveMerge pins group_by:"file" through
+// federation: the grouped representation must merge group-wise (rows
+// deduplicated, counts and totals recomputed), never round-trip
+// through the flat SubGraph shape that discards every grouped field.
+func TestFederator_GroupedUsagesSurviveMerge(t *testing.T) {
+	remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: remoteGroupedJSON})
+	out := testFederator().Augment(context.Background(), "find_usages",
+		groupedProductionBody(""), envelope(localGroupedJSON),
+		[]ServerEntry{{Slug: "r2", URL: remote.URL}})
+	m := decodeFederated(t, out)
+
+	if m["grouped_by"] != "file" {
+		t.Fatalf("the grouped representation must survive federation, got keys %v", keysOf(m))
+	}
+	groups, _ := m["groups"].([]any)
+	if len(groups) != 3 {
+		t.Fatalf("want 3 merged file groups (l/a.go, shared/s.go, r/b.go), got %d", len(groups))
+	}
+	if got, _ := m["file_count"].(float64); int(got) != 3 {
+		t.Errorf("file_count must count the merged groups, got %v", m["file_count"])
+	}
+	// The shared/s.go line-3 reference exists on both daemons: it must
+	// merge to one row, so the merged total is 5, not 6.
+	if got, _ := m["total_uses"].(float64); int(got) != 5 {
+		t.Errorf("total_uses must count deduplicated merged rows, got %v", m["total_uses"])
+	}
+	for _, g := range groups {
+		gm := g.(map[string]any)
+		uses, _ := gm["uses"].([]any)
+		if gm["file"] == "shared/s.go" && len(uses) != 2 {
+			t.Errorf("shared/s.go must hold 2 deduplicated uses, got %d", len(uses))
+		}
+		if int(gm["count"].(float64)) != len(uses) {
+			t.Errorf("group %v count must match its rows: count=%v rows=%d", gm["file"], gm["count"], len(uses))
+		}
+	}
+}
+
+// TestFederator_GroupedUsagesReapplyLimit pins the caller's limit on
+// the merged grouped rows: each daemon capped its own page, so the
+// merge must re-cap the row union once, globally, and mark the cut.
+func TestFederator_GroupedUsagesReapplyLimit(t *testing.T) {
+	remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: remoteGroupedJSON})
+	out := testFederator().Augment(context.Background(), "find_usages",
+		groupedProductionBody(`,"limit":2`), envelope(localGroupedJSON),
+		[]ServerEntry{{Slug: "r2", URL: remote.URL}})
+	m := decodeFederated(t, out)
+
+	groups, _ := m["groups"].([]any)
+	rows := 0
+	for _, g := range groups {
+		uses, _ := g.(map[string]any)["uses"].([]any)
+		rows += len(uses)
+	}
+	if rows != 2 {
+		t.Fatalf("limit:2 must cap the merged grouped rows at 2, got %d", rows)
+	}
+	if m["truncated"] != true {
+		t.Errorf("a capped grouped merge must be marked truncated")
+	}
+	if got, _ := m["total_edges"].(float64); int(got) < 5 {
+		t.Errorf("total_edges must keep the full merged row count as a floor, got %v", m["total_edges"])
+	}
+}
+
+func keysOf(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/daemon/federation_limit_test.go
+++ b/internal/daemon/federation_limit_test.go
@@ -2,66 +2,82 @@ package daemon
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 )
 
-// TestFederator_MergeReappliesUsageLimit pins the global row cap: each
-// daemon applies limit:N independently, so the merged find_usages
-// result must be re-capped once after the merge instead of growing to
-// N times the daemon count. The discarded peer tails make the exact
-// deduplicated total unknowable, so the merged totals are explicitly a
-// floor (lower_bound) and the response is marked truncated.
-func TestFederator_MergeReappliesUsageLimit(t *testing.T) {
-	remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: `{
-		"nodes":[{"id":"r/a.go::RUse1"},{"id":"r/b.go::RUse2"},{"id":"pkg/hot.go::Hot"}],
-		"edges":[
-			{"from":"r/a.go::RUse1","to":"pkg/hot.go::Hot","kind":"calls","file_path":"r/a.go","line":3},
-			{"from":"r/b.go::RUse2","to":"pkg/hot.go::Hot","kind":"calls","file_path":"r/b.go","line":4}
-		],
-		"total_nodes":3,"total_edges":3,"truncated":true}`})
-	local := envelope(`{
-		"nodes":[{"id":"l/a.go::LUse1"},{"id":"l/b.go::LUse2"},{"id":"pkg/hot.go::Hot"}],
-		"edges":[
-			{"from":"l/a.go::LUse1","to":"pkg/hot.go::Hot","kind":"calls","file_path":"l/a.go","line":5},
-			{"from":"l/b.go::LUse2","to":"pkg/hot.go::Hot","kind":"calls","file_path":"l/b.go","line":6}
-		],
-		"total_nodes":3,"total_edges":4,"truncated":true}`)
-
-	out := testFederator().Augment(context.Background(), "find_usages",
-		[]byte(`{"id":"pkg/hot.go::Hot","limit":2}`),
-		local, []ServerEntry{{Slug: "r2", URL: remote.URL}})
-
-	m := decodeFederated(t, out)
-	edges, _ := m["edges"].([]any)
-	if len(edges) != 2 {
-		t.Fatalf("limit:2 must hold globally after the merge, got %d edges", len(edges))
+// fedUsageBodies builds a local result with nLocal edges and a remote
+// result with nRemote edges (disjoint from-sites, one file per edge),
+// in the shape the daemons actually serialize.
+func fedUsageBodies(nLocal, nRemote int, localTruncated, remoteTruncated bool) (local []byte, remoteJSON string) {
+	rows := func(prefix string, n int) (nodes, edges []string) {
+		nodes = append(nodes, `{"id":"pkg/hot.go::Hot"}`)
+		for i := 0; i < n; i++ {
+			id := fmt.Sprintf("%s/u%02d.go::Use%02d", prefix, i, i)
+			nodes = append(nodes, fmt.Sprintf(`{"id":%q}`, id))
+			edges = append(edges, fmt.Sprintf(
+				`{"from":%q,"to":"pkg/hot.go::Hot","kind":"calls","file_path":"%s/u%02d.go","line":5,"origin":"ast_resolved","confidence_label":"EXTRACTED"}`,
+				id, prefix, i))
+		}
+		return nodes, edges
 	}
-	if m["truncated"] != true {
-		t.Errorf("a re-capped merged result must be truncated")
+	ln, le := rows("l", nLocal)
+	rn, re := rows("r", nRemote)
+	local = envelope(fmt.Sprintf(`{"nodes":[%s],"edges":[%s],"total_nodes":%d,"total_edges":%d,"truncated":%v}`,
+		strings.Join(ln, ","), strings.Join(le, ","), len(ln), nLocal, localTruncated))
+	remoteJSON = fmt.Sprintf(`{"nodes":[%s],"edges":[%s],"total_nodes":%d,"total_edges":%d,"truncated":%v}`,
+		strings.Join(rn, ","), strings.Join(re, ","), len(rn), nRemote, remoteTruncated)
+	return local, remoteJSON
+}
+
+// productionBody is the request shape the stdio and streamable MCP
+// dispatch actually route: tool args nested under "arguments".
+func productionBody(args string) []byte {
+	return []byte(fmt.Sprintf(`{"name":"find_usages","arguments":%s}`, args))
+}
+
+// TestFederator_MergeReappliesUsageLimit_ProductionShape pins the
+// global row cap through the request shape production routes: each
+// daemon applied limit independently, so the merge must re-cap once,
+// reading the limit from the arguments envelope. Covers omitted, 0,
+// explicit small, and greater-than-default limits.
+func TestFederator_MergeReappliesUsageLimit_ProductionShape(t *testing.T) {
+	cases := []struct {
+		name      string
+		args      string
+		nLocal    int
+		nRemote   int
+		wantEdges int
+	}{
+		{"explicit small limit", `{"id":"pkg/hot.go::Hot","limit":2}`, 2, 2, 2},
+		{"omitted limit defaults to 50", `{"id":"pkg/hot.go::Hot"}`, 30, 30, 50},
+		{"limit zero opts out", `{"id":"pkg/hot.go::Hot","limit":0}`, 30, 30, 60},
+		{"limit above row count", `{"id":"pkg/hot.go::Hot","limit":120}`, 30, 30, 60},
 	}
-	if m["lower_bound"] != true {
-		t.Errorf("with peer tails discarded the merged totals are a floor; lower_bound must be set")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			local, remoteJSON := fedUsageBodies(tc.nLocal, tc.nRemote, true, true)
+			remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: remoteJSON})
+			out := testFederator().Augment(context.Background(), "find_usages",
+				productionBody(tc.args), local, []ServerEntry{{Slug: "r2", URL: remote.URL}})
+			m := decodeFederated(t, out)
+			edges, _ := m["edges"].([]any)
+			if len(edges) != tc.wantEdges {
+				t.Fatalf("want %d merged edges, got %d", tc.wantEdges, len(edges))
+			}
+		})
 	}
 }
 
 // TestFederator_RemoteOnlyTruncationPropagates pins that a complete
 // local result merged with a truncated remote page cannot claim the
-// merged result is complete: the remote's discarded tail must surface
-// as truncated + lower_bound on the merged response.
+// merged result is complete or its totals exact.
 func TestFederator_RemoteOnlyTruncationPropagates(t *testing.T) {
-	remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: `{
-		"nodes":[{"id":"r/a.go::RUse1"}],
-		"edges":[{"from":"r/a.go::RUse1","to":"pkg/hot.go::Hot","kind":"calls","file_path":"r/a.go","line":3}],
-		"total_nodes":1,"total_edges":10,"truncated":true}`})
-	local := envelope(`{
-		"nodes":[{"id":"l/a.go::LUse1"}],
-		"edges":[{"from":"l/a.go::LUse1","to":"pkg/hot.go::Hot","kind":"calls","file_path":"l/a.go","line":5}],
-		"total_nodes":1,"total_edges":1,"truncated":false}`)
-
+	local, remoteJSON := fedUsageBodies(1, 1, false, true)
+	remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: remoteJSON})
 	out := testFederator().Augment(context.Background(), "find_usages",
-		[]byte(`{"id":"pkg/hot.go::Hot","limit":50}`),
-		local, []ServerEntry{{Slug: "r2", URL: remote.URL}})
-
+		productionBody(`{"id":"pkg/hot.go::Hot","limit":50}`), local, []ServerEntry{{Slug: "r2", URL: remote.URL}})
 	m := decodeFederated(t, out)
 	if m["truncated"] != true {
 		t.Errorf("remote-only truncation must propagate to the merged result")
@@ -72,8 +88,8 @@ func TestFederator_RemoteOnlyTruncationPropagates(t *testing.T) {
 }
 
 // TestFederator_DistinctCallSitesSurviveMerge pins the merge dedup key:
-// two usages of the same (from, to, kind) at different file/line call
-// sites are distinct rows and must both survive the merge.
+// two usages of the same (from, to, kind) at different lines are
+// distinct rows and must both survive.
 func TestFederator_DistinctCallSitesSurviveMerge(t *testing.T) {
 	remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: `{
 		"nodes":[{"id":"l/a.go::LUse1"}],
@@ -83,14 +99,88 @@ func TestFederator_DistinctCallSitesSurviveMerge(t *testing.T) {
 		"nodes":[{"id":"l/a.go::LUse1"}],
 		"edges":[{"from":"l/a.go::LUse1","to":"pkg/hot.go::Hot","kind":"calls","file_path":"l/a.go","line":5}],
 		"total_nodes":1,"total_edges":1,"truncated":false}`)
-
 	out := testFederator().Augment(context.Background(), "find_usages",
-		[]byte(`{"id":"pkg/hot.go::Hot","limit":50}`),
-		local, []ServerEntry{{Slug: "r2", URL: remote.URL}})
-
+		productionBody(`{"id":"pkg/hot.go::Hot","limit":50}`), local, []ServerEntry{{Slug: "r2", URL: remote.URL}})
 	m := decodeFederated(t, out)
 	edges, _ := m["edges"].([]any)
 	if len(edges) != 2 {
 		t.Fatalf("distinct call sites (same from/to/kind, different line) must both survive, got %d", len(edges))
 	}
+}
+
+// TestFederator_MergeRanksByConfidenceLabel pins the sortable rank the
+// federation boundary actually carries: Edge.Confidence is excluded
+// from JSON, so every peer confidence reads zero after unmarshalling
+// and only confidence_label survives. With limit:1, an EXTRACTED row
+// must displace an AMBIGUOUS row of the same origin even when the
+// file/line tie-breakers favor the weaker row.
+func TestFederator_MergeRanksByConfidenceLabel(t *testing.T) {
+	remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: `{
+		"nodes":[{"id":"z/strong.go::Strong"}],
+		"edges":[{"from":"z/strong.go::Strong","to":"pkg/hot.go::Hot","kind":"calls","file_path":"z/strong.go","line":9,"origin":"ast_inferred","confidence_label":"EXTRACTED"}],
+		"total_nodes":1,"total_edges":1,"truncated":false}`})
+	local := envelope(`{
+		"nodes":[{"id":"a/weak.go::Weak"}],
+		"edges":[{"from":"a/weak.go::Weak","to":"pkg/hot.go::Hot","kind":"calls","file_path":"a/weak.go","line":5,"origin":"ast_inferred","confidence_label":"AMBIGUOUS"}],
+		"total_nodes":1,"total_edges":1,"truncated":false}`)
+	out := testFederator().Augment(context.Background(), "find_usages",
+		productionBody(`{"id":"pkg/hot.go::Hot","limit":1}`), local, []ServerEntry{{Slug: "r2", URL: remote.URL}})
+	m := decodeFederated(t, out)
+	edges, _ := m["edges"].([]any)
+	if len(edges) != 1 {
+		t.Fatalf("limit:1 must keep exactly one row, got %d", len(edges))
+	}
+	row, _ := edges[0].(map[string]any)
+	if row["from"] != "z/strong.go::Strong" {
+		t.Fatalf("the EXTRACTED row must win the capped slot, got %v", row["from"])
+	}
+}
+
+// TestFederator_RemoteCompletenessMetadataPropagates pins aggregation
+// of the remote completeness fields the merge previously discarded:
+// lower_bound, boundaries, caller notes, and the usage summary.
+func TestFederator_RemoteCompletenessMetadataPropagates(t *testing.T) {
+	t.Run("lower_bound and boundaries on a call chain", func(t *testing.T) {
+		remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: `{
+			"nodes":[{"id":"r/a.go::RFn"}],
+			"edges":[],
+			"total_nodes":1,"total_edges":0,"truncated":false,
+			"lower_bound":true,
+			"boundaries":[{"seed_id":"r/a.go::RFn","target":"handler","edge_kind":"calls","reason":"dynamic_dispatch","direction":"callees"}]}`})
+		local := envelope(`{"nodes":[{"id":"l/a.go::LFn"}],"edges":[],"total_nodes":1,"total_edges":0,"truncated":false}`)
+		out := testFederator().Augment(context.Background(), "get_call_chain",
+			productionBody(`{"id":"pkg/hot.go::Hot"}`), local, []ServerEntry{{Slug: "r2", URL: remote.URL}})
+		m := decodeFederated(t, out)
+		if m["lower_bound"] != true {
+			t.Errorf("a remote lower_bound result must not merge into a falsely exhaustive one")
+		}
+		bounds, _ := m["boundaries"].([]any)
+		if len(bounds) != 1 {
+			t.Errorf("remote epistemic boundaries must survive the merge, got %v", m["boundaries"])
+		}
+	})
+	t.Run("caller notes and usage summary", func(t *testing.T) {
+		remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: `{
+			"nodes":[{"id":"r/a.go::RUse","meta":{"is_test":true}}],
+			"edges":[{"from":"r/a.go::RUse","to":"pkg/hot.go::Hot","kind":"calls","file_path":"r/a.go","line":3,"confidence_label":"EXTRACTED"}],
+			"total_nodes":1,"total_edges":1,"truncated":false,
+			"caller_notes":{"r/a.go::RUse":{"sync_guarded":true}},
+			"usage_summary":{"n_refs":1,"n_files":1,"n_test_refs":1}}`})
+		local := envelope(`{
+			"nodes":[{"id":"l/a.go::LUse"}],
+			"edges":[{"from":"l/a.go::LUse","to":"pkg/hot.go::Hot","kind":"calls","file_path":"l/a.go","line":5,"confidence_label":"EXTRACTED"}],
+			"total_nodes":1,"total_edges":1,"truncated":false,
+			"usage_summary":{"n_refs":1,"n_files":1,"n_test_refs":0}}`)
+		out := testFederator().Augment(context.Background(), "find_usages",
+			productionBody(`{"id":"pkg/hot.go::Hot","limit":50}`), local, []ServerEntry{{Slug: "r2", URL: remote.URL}})
+		m := decodeFederated(t, out)
+		notes, _ := m["caller_notes"].(map[string]any)
+		if _, ok := notes["r/a.go::RUse"]; !ok {
+			t.Errorf("remote caller notes must survive the merge, got %v", m["caller_notes"])
+		}
+		summary, _ := m["usage_summary"].(map[string]any)
+		if summary["n_refs"] != float64(2) || summary["n_test_refs"] != float64(1) {
+			t.Errorf("the merged summary must describe the merged rows, got %v", m["usage_summary"])
+		}
+	})
 }

--- a/internal/daemon/federation_limit_test.go
+++ b/internal/daemon/federation_limit_test.go
@@ -1,0 +1,96 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+)
+
+// TestFederator_MergeReappliesUsageLimit pins the global row cap: each
+// daemon applies limit:N independently, so the merged find_usages
+// result must be re-capped once after the merge instead of growing to
+// N times the daemon count. The discarded peer tails make the exact
+// deduplicated total unknowable, so the merged totals are explicitly a
+// floor (lower_bound) and the response is marked truncated.
+func TestFederator_MergeReappliesUsageLimit(t *testing.T) {
+	remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: `{
+		"nodes":[{"id":"r/a.go::RUse1"},{"id":"r/b.go::RUse2"},{"id":"pkg/hot.go::Hot"}],
+		"edges":[
+			{"from":"r/a.go::RUse1","to":"pkg/hot.go::Hot","kind":"calls","file_path":"r/a.go","line":3},
+			{"from":"r/b.go::RUse2","to":"pkg/hot.go::Hot","kind":"calls","file_path":"r/b.go","line":4}
+		],
+		"total_nodes":3,"total_edges":3,"truncated":true}`})
+	local := envelope(`{
+		"nodes":[{"id":"l/a.go::LUse1"},{"id":"l/b.go::LUse2"},{"id":"pkg/hot.go::Hot"}],
+		"edges":[
+			{"from":"l/a.go::LUse1","to":"pkg/hot.go::Hot","kind":"calls","file_path":"l/a.go","line":5},
+			{"from":"l/b.go::LUse2","to":"pkg/hot.go::Hot","kind":"calls","file_path":"l/b.go","line":6}
+		],
+		"total_nodes":3,"total_edges":4,"truncated":true}`)
+
+	out := testFederator().Augment(context.Background(), "find_usages",
+		[]byte(`{"id":"pkg/hot.go::Hot","limit":2}`),
+		local, []ServerEntry{{Slug: "r2", URL: remote.URL}})
+
+	m := decodeFederated(t, out)
+	edges, _ := m["edges"].([]any)
+	if len(edges) != 2 {
+		t.Fatalf("limit:2 must hold globally after the merge, got %d edges", len(edges))
+	}
+	if m["truncated"] != true {
+		t.Errorf("a re-capped merged result must be truncated")
+	}
+	if m["lower_bound"] != true {
+		t.Errorf("with peer tails discarded the merged totals are a floor; lower_bound must be set")
+	}
+}
+
+// TestFederator_RemoteOnlyTruncationPropagates pins that a complete
+// local result merged with a truncated remote page cannot claim the
+// merged result is complete: the remote's discarded tail must surface
+// as truncated + lower_bound on the merged response.
+func TestFederator_RemoteOnlyTruncationPropagates(t *testing.T) {
+	remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: `{
+		"nodes":[{"id":"r/a.go::RUse1"}],
+		"edges":[{"from":"r/a.go::RUse1","to":"pkg/hot.go::Hot","kind":"calls","file_path":"r/a.go","line":3}],
+		"total_nodes":1,"total_edges":10,"truncated":true}`})
+	local := envelope(`{
+		"nodes":[{"id":"l/a.go::LUse1"}],
+		"edges":[{"from":"l/a.go::LUse1","to":"pkg/hot.go::Hot","kind":"calls","file_path":"l/a.go","line":5}],
+		"total_nodes":1,"total_edges":1,"truncated":false}`)
+
+	out := testFederator().Augment(context.Background(), "find_usages",
+		[]byte(`{"id":"pkg/hot.go::Hot","limit":50}`),
+		local, []ServerEntry{{Slug: "r2", URL: remote.URL}})
+
+	m := decodeFederated(t, out)
+	if m["truncated"] != true {
+		t.Errorf("remote-only truncation must propagate to the merged result")
+	}
+	if m["lower_bound"] != true {
+		t.Errorf("the remote's discarded tail makes the merged totals a floor")
+	}
+}
+
+// TestFederator_DistinctCallSitesSurviveMerge pins the merge dedup key:
+// two usages of the same (from, to, kind) at different file/line call
+// sites are distinct rows and must both survive the merge.
+func TestFederator_DistinctCallSitesSurviveMerge(t *testing.T) {
+	remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: `{
+		"nodes":[{"id":"l/a.go::LUse1"}],
+		"edges":[{"from":"l/a.go::LUse1","to":"pkg/hot.go::Hot","kind":"calls","file_path":"l/a.go","line":9}],
+		"total_nodes":1,"total_edges":1,"truncated":false}`})
+	local := envelope(`{
+		"nodes":[{"id":"l/a.go::LUse1"}],
+		"edges":[{"from":"l/a.go::LUse1","to":"pkg/hot.go::Hot","kind":"calls","file_path":"l/a.go","line":5}],
+		"total_nodes":1,"total_edges":1,"truncated":false}`)
+
+	out := testFederator().Augment(context.Background(), "find_usages",
+		[]byte(`{"id":"pkg/hot.go::Hot","limit":50}`),
+		local, []ServerEntry{{Slug: "r2", URL: remote.URL}})
+
+	m := decodeFederated(t, out)
+	edges, _ := m["edges"].([]any)
+	if len(edges) != 2 {
+		t.Fatalf("distinct call sites (same from/to/kind, different line) must both survive, got %d", len(edges))
+	}
+}

--- a/internal/daemon/federation_limit_test.go
+++ b/internal/daemon/federation_limit_test.go
@@ -136,9 +136,9 @@ func TestFederator_MergeRanksByConfidenceLabel(t *testing.T) {
 	}
 }
 
-// TestFederator_RemoteCompletenessMetadataPropagates pins aggregation
-// of the remote completeness fields the merge previously discarded:
-// lower_bound, boundaries, caller notes, and the usage summary.
+// TestFederator_RemoteCompletenessMetadataPropagates pins that remote
+// completeness fields survive the merge: lower_bound, boundaries,
+// caller notes, and the usage summary.
 func TestFederator_RemoteCompletenessMetadataPropagates(t *testing.T) {
 	t.Run("lower_bound and boundaries on a call chain", func(t *testing.T) {
 		remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: `{
@@ -183,4 +183,101 @@ func TestFederator_RemoteCompletenessMetadataPropagates(t *testing.T) {
 			t.Errorf("the merged summary must describe the merged rows, got %v", m["usage_summary"])
 		}
 	})
+}
+
+// TestFederator_MergedSummaryKeepsWholeSetFloor pins the summary
+// aggregation floor: the local rollup describes the whole local set
+// (computed before the local cap), so the merged rollup can never
+// report less than any source's own counts.
+func TestFederator_MergedSummaryKeepsWholeSetFloor(t *testing.T) {
+	remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: `{
+		"nodes":[{"id":"r/a.go::RUse"}],
+		"edges":[{"from":"r/a.go::RUse","to":"pkg/hot.go::Hot","kind":"calls","file_path":"r/a.go","line":3,"confidence_label":"EXTRACTED"}],
+		"total_nodes":1,"total_edges":1,"truncated":false,
+		"usage_summary":{"n_refs":1,"n_files":1,"n_test_refs":0}}`})
+	local := envelope(`{
+		"nodes":[{"id":"l/a.go::LUse"}],
+		"edges":[{"from":"l/a.go::LUse","to":"pkg/hot.go::Hot","kind":"calls","file_path":"l/a.go","line":5,"confidence_label":"EXTRACTED"}],
+		"total_nodes":1,"total_edges":500,"truncated":true,
+		"usage_summary":{"n_refs":500,"n_files":120,"n_test_refs":40}}`)
+	out := testFederator().Augment(context.Background(), "find_usages",
+		productionBody(`{"id":"pkg/hot.go::Hot","limit":50}`), local, []ServerEntry{{Slug: "r2", URL: remote.URL}})
+	m := decodeFederated(t, out)
+	summary, _ := m["usage_summary"].(map[string]any)
+	if summary["n_refs"].(float64) < 500 || summary["n_files"].(float64) < 120 || summary["n_test_refs"].(float64) < 40 {
+		t.Fatalf("merged summary must never shrink below a source's whole-set counts, got %v", summary)
+	}
+}
+
+// TestFederator_RemoteOnlyUsagesRefreshSummaryAndCaveat pins the
+// locally-unused case: remote rows must bring a summary with them, and
+// a local zero-edge caveat cannot survive a merged result that carries
+// verified rows it contradicts.
+func TestFederator_RemoteOnlyUsagesRefreshSummaryAndCaveat(t *testing.T) {
+	remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: `{
+		"nodes":[{"id":"r/a.go::RUse"},{"id":"r/b.go::RUse2"}],
+		"edges":[
+			{"from":"r/a.go::RUse","to":"pkg/hot.go::Hot","kind":"calls","file_path":"r/a.go","line":3,"confidence_label":"EXTRACTED","origin":"lsp_resolved"},
+			{"from":"r/b.go::RUse2","to":"pkg/hot.go::Hot","kind":"calls","file_path":"r/b.go","line":4,"confidence_label":"EXTRACTED","origin":"lsp_resolved"}
+		],
+		"total_nodes":2,"total_edges":2,"truncated":false,
+		"usage_summary":{"n_refs":2,"n_files":2,"n_test_refs":0}}`})
+	local := envelope(`{
+		"nodes":[],"edges":[],"total_nodes":0,"total_edges":0,"truncated":false,
+		"caveat":{"class":"coverage_incomplete","message":"this symbol appears unused"}}`)
+	out := testFederator().Augment(context.Background(), "find_usages",
+		productionBody(`{"id":"pkg/hot.go::Hot","limit":50}`), local, []ServerEntry{{Slug: "r2", URL: remote.URL}})
+	m := decodeFederated(t, out)
+	summary, _ := m["usage_summary"].(map[string]any)
+	if summary == nil || summary["n_refs"].(float64) < 2 {
+		t.Fatalf("remote rows must carry a summary into the merged result, got %v", m["usage_summary"])
+	}
+	if _, stale := m["caveat"]; stale {
+		t.Fatalf("a zero-edge caveat cannot survive a merge that added verified rows, got %v", m["caveat"])
+	}
+}
+
+// TestFederator_DynamicBoundariesDedupAndCap pins that dynamic
+// boundaries merge like their static siblings: deduplicated, so a peer
+// reporting the same dispatch sites cannot duplicate the section.
+func TestFederator_DynamicBoundariesDedupAndCap(t *testing.T) {
+	remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: `{
+		"nodes":[],"edges":[],"total_nodes":0,"total_edges":0,"truncated":false,
+		"dynamic_boundaries":[
+			{"site":"pkg/hot.go:42","form":"computed_member","key":"handlers[name]"},
+			{"site":"pkg/hot.go:99","form":"reflection","key":"method"}
+		]}`})
+	local := envelope(`{
+		"nodes":[],"edges":[],"total_nodes":0,"total_edges":0,"truncated":false,
+		"dynamic_boundaries":[{"site":"pkg/hot.go:42","form":"computed_member","key":"handlers[name]"}]}`)
+	out := testFederator().Augment(context.Background(), "find_usages",
+		productionBody(`{"id":"pkg/hot.go::Hot","limit":50}`), local, []ServerEntry{{Slug: "r2", URL: remote.URL}})
+	m := decodeFederated(t, out)
+	bounds, _ := m["dynamic_boundaries"].([]any)
+	if len(bounds) != 2 {
+		t.Fatalf("duplicate dynamic boundaries must collapse, want 2 got %d", len(bounds))
+	}
+}
+
+// TestFederator_CallerNotesPrunedWithCap pins that the post-merge cap
+// prunes caller notes along with their nodes, so no note annotates a
+// row absent from the response.
+func TestFederator_CallerNotesPrunedWithCap(t *testing.T) {
+	remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: `{
+		"nodes":[{"id":"r/b.go::Weak"}],
+		"edges":[{"from":"r/b.go::Weak","to":"pkg/hot.go::Hot","kind":"calls","file_path":"r/b.go","line":3,"confidence_label":"AMBIGUOUS"}],
+		"total_nodes":1,"total_edges":1,"truncated":false,
+		"caller_notes":{"r/b.go::Weak":{"sync_guarded":true}}}`})
+	local := envelope(`{
+		"nodes":[{"id":"l/a.go::Strong"}],
+		"edges":[{"from":"l/a.go::Strong","to":"pkg/hot.go::Hot","kind":"calls","file_path":"l/a.go","line":5,"confidence_label":"EXTRACTED"}],
+		"total_nodes":1,"total_edges":1,"truncated":false}`)
+	out := testFederator().Augment(context.Background(), "find_usages",
+		productionBody(`{"id":"pkg/hot.go::Hot","limit":1}`), local, []ServerEntry{{Slug: "r2", URL: remote.URL}})
+	m := decodeFederated(t, out)
+	if notes, ok := m["caller_notes"].(map[string]any); ok {
+		if _, dangling := notes["r/b.go::Weak"]; dangling {
+			t.Fatalf("a note must not survive the prune of its node, got %v", notes)
+		}
+	}
 }

--- a/internal/daemon/federation_localonly_budget_test.go
+++ b/internal/daemon/federation_localonly_budget_test.go
@@ -1,0 +1,94 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func combinedContentBytes(t *testing.T, out []byte) (int, []string) {
+	t.Helper()
+	var env struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(out, &env); err != nil {
+		t.Fatalf("result must stay a valid MCP envelope: %v", err)
+	}
+	total := 0
+	texts := make([]string, 0, len(env.Content))
+	for _, c := range env.Content {
+		total += len(c.Text)
+		texts = append(texts, c.Text)
+	}
+	return total, texts
+}
+
+// TestFederator_LocalOnlyAnnotationStaysWithinBudget pins the caller's
+// byte/token budget on the COMPLETE local-only response: the handler
+// spends the whole cap on the primary rendering, so a second content
+// item appended outside the budget breaks the contract the cap
+// promises. A note that cannot fit in the remaining headroom is
+// dropped — same rule as the token-budget decoration — never the
+// bytes that push the response past its own cap.
+func TestFederator_LocalOnlyAnnotationStaysWithinBudget(t *testing.T) {
+	// ~90 bytes of local text: a handler-trimmed page near a tiny cap.
+	localText := strings.Repeat("pkg/hot.go::Hot <- l/a.go::LUse (calls)\n", 2) + "edges: 2\n"
+	formats := []struct {
+		name string
+		args string
+	}{
+		{"compact", `"compact":true`},
+		{"gcx", `"format":"gcx"`},
+		{"toon", `"format":"toon"`},
+		{"mermaid", `"format":"mermaid"`},
+		{"dot", `"format":"dot"`},
+	}
+	budgets := []struct {
+		name string
+		arg  string
+		cap  int
+	}{
+		{"max_bytes", `"max_bytes":100`, 100},
+		{"max_tokens", `"max_tokens":30`, 105}, // 30 tokens * 3.5 bytes
+	}
+	for _, f := range formats {
+		for _, b := range budgets {
+			t.Run(f.name+"/"+b.name, func(t *testing.T) {
+				remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: `{"nodes":[],"edges":[],"total_nodes":0,"total_edges":0,"truncated":false}`})
+				body := productionBody(fmt.Sprintf(`{"id":"pkg/hot.go::Hot",%s,%s}`, f.args, b.arg))
+				out := testFederator().Augment(context.Background(), "find_usages",
+					body, envelope(localText),
+					[]ServerEntry{{Slug: "r2", URL: remote.URL}})
+
+				total, texts := combinedContentBytes(t, out)
+				if total > b.cap {
+					t.Fatalf("local-only response is %d combined content bytes, over the %s cap %d; content: %q", total, b.name, b.cap, texts)
+				}
+				if texts[0] != localText {
+					t.Fatalf("the primary rendering must pass through unchanged")
+				}
+			})
+		}
+	}
+
+	t.Run("roomy budget keeps the note", func(t *testing.T) {
+		remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: `{"nodes":[],"edges":[],"total_nodes":0,"total_edges":0,"truncated":false}`})
+		body := productionBody(`{"id":"pkg/hot.go::Hot","format":"mermaid","max_bytes":600}`)
+		out := testFederator().Augment(context.Background(), "find_usages",
+			body, envelope(localText),
+			[]ServerEntry{{Slug: "r2", URL: remote.URL}})
+		total, texts := combinedContentBytes(t, out)
+		if total > 600 {
+			t.Fatalf("combined content %d bytes over the 600 cap", total)
+		}
+		note := strings.Join(texts[1:], "")
+		if !strings.Contains(note, "local") || !strings.Contains(note, "format") {
+			t.Fatalf("with headroom the explicit local-only note must survive, got %q", texts)
+		}
+	})
+}

--- a/internal/daemon/federation_note_reserve_test.go
+++ b/internal/daemon/federation_note_reserve_test.go
@@ -1,0 +1,138 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestReserveLocalNoteBudget pins the headroom reservation for the
+// local-only note: a non-mergeable-format request forwarded to the
+// local handler carries a max_bytes reduced by the note's size, so
+// the note that must ride on the response has room by construction —
+// the same reserve-first rule the token-budget decoration follows —
+// while JSON requests, opt-outs, and note-dwarfing caps pass through
+// untouched.
+func TestReserveLocalNoteBudget(t *testing.T) {
+	f := testFederator()
+	noteLen := len(localOnlyNote(2))
+
+	maxBytesOf := func(t *testing.T, body []byte) (int, bool) {
+		t.Helper()
+		args := argsMapFromBody(body)
+		v, present := args["max_bytes"]
+		if !present {
+			return 0, false
+		}
+		n, _ := v.(float64)
+		return int(n), true
+	}
+
+	t.Run("mermaid request reserves the note bytes", func(t *testing.T) {
+		body := productionBody(`{"id":"pkg/hot.go::Hot","format":"mermaid","max_bytes":1000}`)
+		got := f.ReserveLocalNoteBudget("find_usages", body, 2)
+		mb, ok := maxBytesOf(t, got)
+		if !ok || mb != 1000-noteLen {
+			t.Fatalf("want forwarded max_bytes %d, got %v (present=%v)", 1000-noteLen, mb, ok)
+		}
+	})
+
+	t.Run("default budget is reserved too", func(t *testing.T) {
+		// No explicit budget still budgets to the project default, and
+		// the note must fit under that cap as well.
+		body := productionBody(`{"id":"pkg/hot.go::Hot","compact":true}`)
+		got := f.ReserveLocalNoteBudget("find_usages", body, 2)
+		mb, ok := maxBytesOf(t, got)
+		if !ok || mb >= 40_000 || mb != 40_000-noteLen {
+			t.Fatalf("want forwarded max_bytes %d under the default cap, got %v (present=%v)", 40_000-noteLen, mb, ok)
+		}
+	})
+
+	t.Run("max_tokens axis min-merges with the reserve", func(t *testing.T) {
+		// 200 tokens ≈ 700 bytes; the injected max_bytes must undercut
+		// it by the note's size so the tighter axis is the reserved one.
+		body := productionBody(`{"id":"pkg/hot.go::Hot","format":"dot","max_tokens":200}`)
+		got := f.ReserveLocalNoteBudget("find_usages", body, 2)
+		mb, ok := maxBytesOf(t, got)
+		if !ok || mb != 700-noteLen {
+			t.Fatalf("want forwarded max_bytes %d, got %v (present=%v)", 700-noteLen, mb, ok)
+		}
+	})
+
+	unchanged := []struct {
+		name string
+		tool string
+		body string
+	}{
+		{"json request", "find_usages", `{"id":"pkg/hot.go::Hot","max_bytes":1000}`},
+		{"budget opt-out", "find_usages", `{"id":"pkg/hot.go::Hot","format":"mermaid","max_bytes":0}`},
+		{"cap smaller than the note", "find_usages", `{"id":"pkg/hot.go::Hot","format":"mermaid","max_bytes":100}`},
+		{"non-federated tool", "index_repository", `{"path":".","format":"mermaid"}`},
+	}
+	for _, tc := range unchanged {
+		t.Run(tc.name+" passes through", func(t *testing.T) {
+			body := productionBody(tc.body)
+			got := f.ReserveLocalNoteBudget(tc.tool, body, 2)
+			var a, b any
+			if err := json.Unmarshal(body, &a); err != nil {
+				t.Fatal(err)
+			}
+			if err := json.Unmarshal(got, &b); err != nil {
+				t.Fatal(err)
+			}
+			am, _ := json.Marshal(a)
+			bm, _ := json.Marshal(b)
+			if string(am) != string(bm) {
+				t.Fatalf("body must pass through unchanged, got %s", bm)
+			}
+		})
+	}
+
+	t.Run("zero peers pass through", func(t *testing.T) {
+		body := productionBody(`{"id":"pkg/hot.go::Hot","format":"mermaid","max_bytes":1000}`)
+		got := f.ReserveLocalNoteBudget("find_usages", body, 0)
+		if mb, _ := maxBytesOf(t, got); mb != 1000 {
+			t.Fatalf("no peers, nothing to note: body must pass through, got max_bytes %d", mb)
+		}
+	})
+}
+
+// TestCallLocalFederatedForwardsTheReservedBudget pins the wiring: the
+// LOCAL dispatch runs on the reserved body while the fan-out and the
+// note enforcement keep the caller's ORIGINAL budget — reserving on
+// both sides would shrink the cap the note was reserved out of.
+func TestCallLocalFederatedForwardsTheReservedBudget(t *testing.T) {
+	var localBody []byte
+	r := NewRouter(RouterConfig{
+		LocalExecute: func(_ context.Context, _ string, body []byte) ([]byte, int, error) {
+			localBody = body
+			return envelope("graph TD;\n  A-->B;\n"), 200, nil
+		},
+	})
+	remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: `{"nodes":[],"edges":[],"total_nodes":0,"total_edges":0,"truncated":false}`})
+
+	body := productionBody(`{"id":"pkg/hot.go::Hot","format":"mermaid","max_bytes":1000}`)
+	out, _, err := r.callLocalFederated(context.Background(), "find_usages", body,
+		RouteContext{EnabledRemotes: []ServerEntry{{Slug: "r2", URL: remote.URL}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantLocal := 1000 - len(localOnlyNote(1))
+	args := argsMapFromBody(localBody)
+	if mb, _ := args["max_bytes"].(float64); int(mb) != wantLocal {
+		t.Fatalf("local dispatch must see the reserved cap %d, got %v", wantLocal, args["max_bytes"])
+	}
+	total, texts := combinedContentBytes(t, out)
+	if total > 1000 {
+		t.Fatalf("combined response %d bytes over the caller's cap", total)
+	}
+	note := ""
+	for _, text := range texts[1:] {
+		note += text
+	}
+	if !strings.Contains(note, "local") {
+		t.Fatalf("with the reserve in place the note must ride on the response, got %q", texts)
+	}
+}

--- a/internal/daemon/federation_round4_test.go
+++ b/internal/daemon/federation_round4_test.go
@@ -1,0 +1,163 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestFederator_BudgetTrimKeepsKeyedListOrigins pins provenance through
+// a budget-trimmed keyed-list merge: search_symbols rows live under
+// "results", so the origins prune must key off the surviving rows of
+// whatever lists the payload carries, never off a "nodes" list the
+// shape does not have.
+func TestFederator_BudgetTrimKeepsKeyedListOrigins(t *testing.T) {
+	rows := func(prefix string, n int) string {
+		out := make([]string, 0, n)
+		for i := 0; i < n; i++ {
+			out = append(out, fmt.Sprintf(`{"id":"%s/f%02d.go::Sym%02d","name":"Sym%02d","padding":%q}`,
+				prefix, i, i, i, strings.Repeat("x", 60)))
+		}
+		return strings.Join(out, ",")
+	}
+	local := envelope(fmt.Sprintf(`{"results":[%s],"total":20}`, rows("l", 20)))
+	remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: fmt.Sprintf(`{"results":[%s],"total":20}`, rows("r", 20))})
+
+	out := testFederator().Augment(context.Background(), "search_symbols",
+		[]byte(`{"name":"search_symbols","arguments":{"query":"Sym","max_bytes":2200}}`), local,
+		[]ServerEntry{{Slug: "r2", URL: remote.URL}})
+	m := decodeFederated(t, out)
+	if m["_truncated_by_budget"] != true {
+		t.Fatalf("fixture must overflow the budget so the trim fires")
+	}
+	results, _ := m["results"].([]any)
+	if len(results) == 0 {
+		t.Fatalf("some rows must survive the trim")
+	}
+	origins, _ := m["origins"].(map[string]any)
+	for _, r := range results {
+		id, _ := r.(map[string]any)["id"].(string)
+		if origins[id] == nil {
+			t.Fatalf("surviving row %q lost its origins entry (origins kept: %d of %d rows)", id, len(origins), len(results))
+		}
+	}
+}
+
+// TestFederator_PeerWithoutTheSymbolCannotDisplaceLocalCaveat pins the
+// caveat merge against the expected federation topology: most symbols
+// live in one repo, so a peer that does not track it resolves nothing
+// and answers an extraction-gap caveat about ITS OWN graph. That is
+// not evidence about the union — the local daemon resolved the node,
+// and its likely_unused classification must survive.
+func TestFederator_PeerWithoutTheSymbolCannotDisplaceLocalCaveat(t *testing.T) {
+	// The remote resolved nothing: empty nodes, extraction-gap caveat.
+	remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: `{
+		"nodes":[],"edges":[],"total_nodes":0,"total_edges":0,"truncated":false,
+		"caveat":{"class":"possible_extraction_gap","message":"no symbol with this id is in the graph"}}`})
+	out := testFederator().Augment(context.Background(), "find_usages",
+		productionBody(`{"id":"pkg/hot.go::Hot","limit":50}`), envelope(zeroEdgeBody("likely_unused")),
+		[]ServerEntry{{Slug: "r2", URL: remote.URL}})
+	m := decodeFederated(t, out)
+	caveat, _ := m["caveat"].(map[string]any)
+	if caveat == nil || caveat["class"] != "likely_unused" {
+		t.Fatalf("a peer that resolved nothing must not displace the local classification, got %v", caveat)
+	}
+}
+
+// TestFederator_TierFilteredZeroRowsCarryNoCaveat pins the merge to the
+// handler contract: a tier_filtered emptiness already explains itself,
+// and stacking a zero-edge caveat on top asserts two contradictory
+// reasons for the same empty page.
+func TestFederator_TierFilteredZeroRowsCarryNoCaveat(t *testing.T) {
+	local := envelope(`{
+		"nodes":[{"id":"pkg/hot.go::Hot"}],"edges":[],"total_nodes":1,"total_edges":0,"truncated":false,
+		"tier_filtered":{"class":"tier_filtered","edges_below_min_tier":2,"max_available_tier":"ast_inferred"}}`)
+	remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: zeroEdgeBody("likely_unused")})
+	out := testFederator().Augment(context.Background(), "find_usages",
+		productionBody(`{"id":"pkg/hot.go::Hot","limit":50,"min_tier":"lsp_resolved"}`), local,
+		[]ServerEntry{{Slug: "r2", URL: remote.URL}})
+	m := decodeFederated(t, out)
+	if m["tier_filtered"] == nil {
+		t.Fatalf("the tier_filtered marker must survive")
+	}
+	if m["caveat"] != nil {
+		t.Fatalf("a tier_filtered empty page must not also carry a zero-edge caveat, got %v", m["caveat"])
+	}
+}
+
+// TestFederator_GroupedMergeCarriesOrigins pins provenance on the
+// grouped shape: rows a peer contributed must be attributable, exactly
+// as the flat merge attributes nodes.
+func TestFederator_GroupedMergeCarriesOrigins(t *testing.T) {
+	remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: remoteGroupedJSON})
+	out := testFederator().Augment(context.Background(), "find_usages",
+		groupedProductionBody(""), envelope(localGroupedJSON),
+		[]ServerEntry{{Slug: "r2", URL: remote.URL}})
+	m := decodeFederated(t, out)
+	origins, _ := m["origins"].(map[string]any)
+	if origins["r/b.go::B"] != "remote:r2" {
+		t.Fatalf("a remote-contributed grouped row must carry its origin, got origins=%v", origins)
+	}
+	if origins["l/a.go::A1"] != "local" {
+		t.Fatalf("local grouped rows must be attributed local, got origins=%v", origins)
+	}
+}
+
+// TestFederator_GroupedRowsWithoutSymbolIDStayDistinct pins the grouped
+// dedup key: rows whose enclosing symbol was pruned (empty symbol_id)
+// but that differ in symbol_name or context are distinct references
+// and must both survive.
+func TestFederator_GroupedRowsWithoutSymbolIDStayDistinct(t *testing.T) {
+	local := envelope(`{
+		"grouped_by":"file","file_count":1,"total_uses":1,"truncated":false,
+		"groups":[{"file":"s/s.go","count":1,"uses":[
+			{"line":4,"edge_kind":"calls","symbol_name":"Alpha"}]}]}`)
+	remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: `{
+		"grouped_by":"file","file_count":1,"total_uses":1,"truncated":false,
+		"groups":[{"file":"s/s.go","count":1,"uses":[
+			{"line":4,"edge_kind":"calls","symbol_name":"Beta"}]}]}`})
+	out := testFederator().Augment(context.Background(), "find_usages",
+		groupedProductionBody(""), local, []ServerEntry{{Slug: "r2", URL: remote.URL}})
+	m := decodeFederated(t, out)
+	var rows int
+	groups, _ := m["groups"].([]any)
+	for _, g := range groups {
+		uses, _ := g.(map[string]any)["uses"].([]any)
+		rows += len(uses)
+	}
+	if rows != 2 {
+		t.Fatalf("distinct rows (same site, different enclosing symbol name) must both survive, got %d", rows)
+	}
+}
+
+// TestFederator_UnknownJSONShapeIsNotZeroValueMerged pins the SubGraph
+// merge against shapes it does not understand: a JSON body without the
+// flat nodes/edges contract (a future grouped variant on another tool)
+// must pass through local-only, never round-trip into an empty
+// subgraph that replaces a correct local answer.
+func TestFederator_UnknownJSONShapeIsNotZeroValueMerged(t *testing.T) {
+	grouped := `{"grouped_by":"file","file_count":1,"total_uses":1,"truncated":false,
+		"groups":[{"file":"l/a.go","count":1,"uses":[{"line":5,"edge_kind":"calls","symbol_id":"l/a.go::A"}]}]}`
+	remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: `{
+		"nodes":[{"id":"r/b.go::RUse"}],"edges":[],"total_nodes":1,"total_edges":0,"truncated":false}`})
+	out := testFederator().Augment(context.Background(), "get_callers",
+		[]byte(`{"name":"get_callers","arguments":{"id":"pkg/hot.go::Hot","group_by":"file"}}`), envelope(grouped),
+		[]ServerEntry{{Slug: "r2", URL: remote.URL}})
+	var env struct {
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(out, &env); err != nil || len(env.Content) == 0 {
+		t.Fatalf("result must stay a valid envelope: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(env.Content[0].Text), &m); err != nil {
+		t.Fatalf("payload must stay JSON: %v", err)
+	}
+	if m["grouped_by"] != "file" {
+		t.Fatalf("an unmergeable JSON shape must pass through local-only, got keys %v", keysOf(m))
+	}
+}

--- a/internal/daemon/federation_walk_meta_test.go
+++ b/internal/daemon/federation_walk_meta_test.go
@@ -1,0 +1,69 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+)
+
+// TestFederator_RemoteWalkMetadataSurvivesMerge pins the budgeted-walk
+// and freshness metadata through the subgraph merge: a peer whose walk
+// stopped early (budget_hit / stopped_at_depth) makes the merged
+// result exactly as incomplete as that peer's own answer was, and the
+// stalest peer's last_synced is the merged answer's freshness floor.
+func TestFederator_RemoteWalkMetadataSurvivesMerge(t *testing.T) {
+	remoteJSON := `{
+		"nodes":[{"id":"pkg/hot.go::Hot"},{"id":"r/a.go::RUse"}],
+		"edges":[{"from":"r/a.go::RUse","to":"pkg/hot.go::Hot","kind":"calls","file_path":"r/a.go","line":7}],
+		"total_nodes":2,"total_edges":1,"truncated":false,
+		"budget_hit":true,"stopped_at_depth":2,"last_synced":"2026-08-20T10:00:00Z"}`
+	local := envelope(`{
+		"nodes":[{"id":"pkg/hot.go::Hot"},{"id":"l/b.go::LUse"}],
+		"edges":[{"from":"l/b.go::LUse","to":"pkg/hot.go::Hot","kind":"calls","file_path":"l/b.go","line":5}],
+		"total_nodes":2,"total_edges":1,"truncated":false,
+		"stopped_at_depth":4,"last_synced":"2026-08-23T10:00:00Z"}`)
+
+	remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: remoteJSON})
+	out := testFederator().Augment(context.Background(), "find_usages",
+		productionBody(`{"id":"pkg/hot.go::Hot","limit":50}`), local,
+		[]ServerEntry{{Slug: "r2", URL: remote.URL}})
+	m := decodeFederated(t, out)
+
+	if m["budget_hit"] != true {
+		t.Errorf("a peer's budget_hit must survive the merge, got %v", m["budget_hit"])
+	}
+	if got, _ := m["stopped_at_depth"].(float64); int(got) != 2 {
+		t.Errorf("merged stopped_at_depth is the weakest source guarantee (2), got %v", m["stopped_at_depth"])
+	}
+	if got, _ := m["last_synced"].(string); got != "2026-08-20T10:00:00Z" {
+		t.Errorf("merged last_synced is the stalest source (2026-08-20), got %v", m["last_synced"])
+	}
+}
+
+// TestFederator_BudgetHitWithoutDepthClearsTheDepthClaim pins the
+// unknown-depth case: a peer that reports budget_hit without a
+// stopped_at_depth gives the union NO known depth guarantee, so the
+// merged response must not keep claiming another source's deeper one.
+func TestFederator_BudgetHitWithoutDepthClearsTheDepthClaim(t *testing.T) {
+	remoteJSON := `{
+		"nodes":[{"id":"pkg/hot.go::Hot"}],"edges":[],
+		"total_nodes":1,"total_edges":0,"truncated":false,
+		"budget_hit":true}`
+	local := envelope(`{
+		"nodes":[{"id":"pkg/hot.go::Hot"},{"id":"l/b.go::LUse"}],
+		"edges":[{"from":"l/b.go::LUse","to":"pkg/hot.go::Hot","kind":"calls","file_path":"l/b.go","line":5}],
+		"total_nodes":2,"total_edges":1,"truncated":false,
+		"stopped_at_depth":4}`)
+
+	remote := fakeRemote(t, fakeRemoteOpts{indexed: true, toolJSON: remoteJSON})
+	out := testFederator().Augment(context.Background(), "find_usages",
+		productionBody(`{"id":"pkg/hot.go::Hot","limit":50}`), local,
+		[]ServerEntry{{Slug: "r2", URL: remote.URL}})
+	m := decodeFederated(t, out)
+
+	if m["budget_hit"] != true {
+		t.Errorf("budget_hit must survive, got %v", m["budget_hit"])
+	}
+	if v, present := m["stopped_at_depth"]; present {
+		t.Errorf("a budget-hit source with no depth makes the merged depth unknowable; got claim %v", v)
+	}
+}

--- a/internal/daemon/router.go
+++ b/internal/daemon/router.go
@@ -285,7 +285,16 @@ func (r *Router) callLocal(ctx context.Context, toolName string, body []byte) ([
 // only. The verbatim remote-route path is never federated (no fan-out
 // recursion).
 func (r *Router) callLocalFederated(ctx context.Context, toolName string, body []byte, route RouteContext) ([]byte, int, error) {
-	out, status, err := r.callLocal(ctx, toolName, body)
+	localBody := body
+	if r.federator != nil {
+		// A non-mergeable-format request gets its local budget shrunk by
+		// the local-only note's size, so the note the response must carry
+		// has headroom by construction. The fan-out and the annotation
+		// keep the ORIGINAL body — the caller's cap is what the combined
+		// response is held to.
+		localBody = r.federator.ReserveLocalNoteBudget(toolName, body, len(route.EnabledRemotes))
+	}
+	out, status, err := r.callLocal(ctx, toolName, localBody)
 	if err != nil || r.federator == nil {
 		return out, status, err
 	}

--- a/internal/graph/edge.go
+++ b/internal/graph/edge.go
@@ -1122,6 +1122,22 @@ func ReturnUsageOf(e *Edge) string {
 	return s
 }
 
+// ConfidenceLabelRank orders the labels ConfidenceLabelFor produces,
+// strongest first, for tie-breaking sorts; an unrecognized or empty
+// label ranks lowest. Lives beside its producer so a new or renamed
+// label cannot silently rank below the ones it outranks.
+func ConfidenceLabelRank(label string) int {
+	switch label {
+	case "EXTRACTED":
+		return 3
+	case "INFERRED":
+		return 2
+	case "AMBIGUOUS":
+		return 1
+	}
+	return 0
+}
+
 // ConfidenceLabelFor returns EXTRACTED, INFERRED, or AMBIGUOUS for an edge
 // based on its kind and confidence value.
 //

--- a/internal/graph/epistemic_boundary.go
+++ b/internal/graph/epistemic_boundary.go
@@ -127,9 +127,19 @@ func CalleeBoundaries(g Store, nodeIDs []string, limit int) []EpistemicBoundary 
 // overrides an interface method may be reached through that interface by
 // callers not attributed to it directly. It names the interface so an agent
 // can run find_implementations / get_callers on it to widen the picture.
-func CallerBoundaries(g Store, nodeIDs []string, limit int) []EpistemicBoundary {
+func CallerBoundaries(g BoundaryReader, nodeIDs []string, limit int) []EpistemicBoundary {
 	out, _ := CallerBoundariesContext(context.Background(), g, nodeIDs, limit)
 	return out
+}
+
+// BoundaryReader is the minimal read surface the caller-boundary scan
+// needs. An interface rather than Store so the handlers can pass the
+// request-scoped view: boundaries must be judged against the same
+// graph the query ran on, or an overlay-only implementation reports no
+// dispatch floor while a tombstoned one keeps reporting a stale one.
+type BoundaryReader interface {
+	GetOutEdges(nodeID string) []*Edge
+	GetNodesByIDs(ids []string) map[string]*Node
 }
 
 type callerBoundaryOutgoingContextStore interface {
@@ -143,7 +153,7 @@ type callerBoundaryNodesContextStore interface {
 // CallerBoundariesContext reports interface-dispatch boundaries without
 // allowing SQLite reads to outlive ctx. Stores may opt into cancellable batch
 // reads; the legacy path remains available for in-memory implementations.
-func CallerBoundariesContext(ctx context.Context, g Store, nodeIDs []string, limit int) ([]EpistemicBoundary, bool) {
+func CallerBoundariesContext(ctx context.Context, g BoundaryReader, nodeIDs []string, limit int) ([]EpistemicBoundary, bool) {
 	if g == nil {
 		return nil, false
 	}
@@ -202,7 +212,7 @@ func CallerBoundariesContext(ctx context.Context, g Store, nodeIDs []string, lim
 	return sortBoundaries(out), truncated
 }
 
-func callerBoundaryOutEdgesContext(ctx context.Context, g Store, nodeIDs []string, limit int) (map[string][]*Edge, bool) {
+func callerBoundaryOutEdgesContext(ctx context.Context, g BoundaryReader, nodeIDs []string, limit int) (map[string][]*Edge, bool) {
 	if reader, ok := g.(callerBoundaryOutgoingContextStore); ok {
 		out, truncated, err := reader.GetOutEdgesByNodeIDsContext(ctx, nodeIDs, limit)
 		return out, truncated || err != nil
@@ -224,7 +234,7 @@ func callerBoundaryOutEdgesContext(ctx context.Context, g Store, nodeIDs []strin
 	return out, false
 }
 
-func callerBoundaryNodesContext(ctx context.Context, g Store, nodeIDs []string) (map[string]*Node, error) {
+func callerBoundaryNodesContext(ctx context.Context, g BoundaryReader, nodeIDs []string) (map[string]*Node, error) {
 	if reader, ok := g.(callerBoundaryNodesContextStore); ok {
 		return reader.GetNodesByIDsContext(ctx, nodeIDs)
 	}

--- a/internal/graph/extraction_gap.go
+++ b/internal/graph/extraction_gap.go
@@ -53,6 +53,37 @@ type ZeroEdgeCaveat struct {
 	Message string        `json:"message" toon:"message"`
 }
 
+// ZeroEdgeClassConservatism ranks caveat classes by how strongly they
+// warn against trusting an empty result — higher is more cautious.
+// Coverage-incomplete carries positive (if weak) evidence of use, so it
+// out-ranks the evidence-free classes; likely_unused is the most
+// permissive claim and must never displace either. Merging layers
+// (federation) use this to pick the surviving caveat when sources
+// disagree on a zero-row answer.
+func ZeroEdgeClassConservatism(c ZeroEdgeClass) int {
+	switch c {
+	case ZeroEdgeCoverageIncomplete:
+		return 3
+	case ZeroEdgePossibleExtractionGap:
+		return 2
+	case ZeroEdgeLikelyUnused:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// ZeroEdgeReader is the minimal read surface zero-edge classification
+// needs. Both graph backends and request-scoped overlay views satisfy
+// it, so callers serving an overlay session pass the same view the
+// query ran on — classifying against the base graph misreports symbols
+// the overlay added, removed, or re-wired.
+type ZeroEdgeReader interface {
+	GetNode(id string) *Node
+	GetInEdges(nodeID string) []*Edge
+	GetOutEdges(nodeID string) []*Edge
+}
+
 // ZeroImpactCaveat is the per-symbol caveat attached to an empty impact
 // analysis result, which is computed over a list of symbols. It carries
 // the symbol ID alongside the same machine-checkable classification.
@@ -166,7 +197,7 @@ func IsWeakUsageEvidence(e *Edge) bool {
 // An unknown symbol ID is reported as an extraction gap: a query whose
 // target is not even in the graph is exactly as untrustworthy as one
 // whose target was never wired up.
-func ClassifyZeroEdge(g Store, symbolID string) ZeroEdgeClass {
+func ClassifyZeroEdge(g ZeroEdgeReader, symbolID string) ZeroEdgeClass {
 	if g == nil || symbolID == "" {
 		return ZeroEdgePossibleExtractionGap
 	}
@@ -225,7 +256,7 @@ func ClassifyZeroEdge(g Store, symbolID string) ZeroEdgeClass {
 // yes/no question is the expensive way to ask it. Backends that can count
 // server-side answer every candidate in one round-trip; the rest fall back to
 // the direct edge read.
-func hasUnresolvedSameNameCandidates(g Store, symbolID string) bool {
+func hasUnresolvedSameNameCandidates(g ZeroEdgeReader, symbolID string) bool {
 	n := g.GetNode(symbolID)
 	if n == nil {
 		return false
@@ -260,7 +291,7 @@ func hasUnresolvedSameNameCandidates(g Store, symbolID string) bool {
 // inbound module-level import edges on its file node (a module-level
 // `import ... from './file'` lands on the file, but still proves the
 // file's exports have consumers).
-func importConsumerCount(g Store, symbolID string) int {
+func importConsumerCount(g ZeroEdgeReader, symbolID string) int {
 	count := 0
 	for _, e := range g.GetInEdges(symbolID) {
 		if e.Kind == EdgeImports || e.Kind == EdgeReExports {
@@ -368,7 +399,7 @@ const zeroEdgeNotFoundMessage = "no symbol with this id is in the graph — the 
 // query result on symbolID. It returns nil when the symbol has
 // incoming usage edges (ZeroEdgeNone) — a non-empty result carries no
 // caveat — so callers can attach the return value unconditionally.
-func CaveatForZeroEdge(g Store, symbolID string) *ZeroEdgeCaveat {
+func CaveatForZeroEdge(g ZeroEdgeReader, symbolID string) *ZeroEdgeCaveat {
 	// A target that is not even in the graph is the most common cause of a
 	// "0 usages" surprise — usually a mistyped id or one missing its repo
 	// prefix. Keep the untrustworthy extraction-gap class so safety gates
@@ -383,7 +414,7 @@ func CaveatForZeroEdge(g Store, symbolID string) *ZeroEdgeCaveat {
 // request-scoped view already resolved symbolID: an overlay-served
 // symbol is absent from the base graph, so the mistyped-id fast path
 // would mislabel it. Classification goes straight to the deeper path.
-func CaveatForZeroEdgeResolved(g Store, symbolID string) *ZeroEdgeCaveat {
+func CaveatForZeroEdgeResolved(g ZeroEdgeReader, symbolID string) *ZeroEdgeCaveat {
 	class := ClassifyZeroEdge(g, symbolID)
 	if class == ZeroEdgeNone {
 		return nil

--- a/internal/graph/extraction_gap.go
+++ b/internal/graph/extraction_gap.go
@@ -73,6 +73,27 @@ func ZeroEdgeClassConservatism(c ZeroEdgeClass) int {
 	}
 }
 
+// ZeroEdgeClassRefutedByTierFilter reports whether a tier_filtered
+// marker contradicts this class outright. The marker names edges that
+// EXIST below the requested tier, which refutes the likely_unused
+// CONCLUSION — the symbol is not unused, its evidence is filtered —
+// while coverage_incomplete and possible_extraction_gap are
+// UNCERTAINTY about coverage that a filter explains nothing about.
+// Lives beside the class producer so layers merging caveats
+// (federation) never re-derive class semantics by enum comparison.
+func ZeroEdgeClassRefutedByTierFilter(c ZeroEdgeClass) bool {
+	return c == ZeroEdgeLikelyUnused
+}
+
+// ZeroEdgeClassDescribesOwnGraphOnly reports whether a caveat of this
+// class from a source that did NOT resolve the queried symbol speaks
+// only for that source's graph: an extraction-gap caveat is "MY graph
+// may have failed to extract this", which is evidence about the
+// answering graph, never about the union.
+func ZeroEdgeClassDescribesOwnGraphOnly(c ZeroEdgeClass) bool {
+	return c == ZeroEdgePossibleExtractionGap
+}
+
 // ZeroEdgeReader is the minimal read surface zero-edge classification
 // needs. Both graph backends and request-scoped overlay views satisfy
 // it, so callers serving an overlay session pass the same view the

--- a/internal/graph/extraction_gap.go
+++ b/internal/graph/extraction_gap.go
@@ -376,6 +376,14 @@ func CaveatForZeroEdge(g Store, symbolID string) *ZeroEdgeCaveat {
 	if g != nil && symbolID != "" && g.GetNode(symbolID) == nil {
 		return &ZeroEdgeCaveat{Class: ZeroEdgePossibleExtractionGap, Message: zeroEdgeNotFoundMessage}
 	}
+	return CaveatForZeroEdgeResolved(g, symbolID)
+}
+
+// CaveatForZeroEdgeResolved is CaveatForZeroEdge for callers whose
+// request-scoped view already resolved symbolID: an overlay-served
+// symbol is absent from the base graph, so the mistyped-id fast path
+// would mislabel it. Classification goes straight to the deeper path.
+func CaveatForZeroEdgeResolved(g Store, symbolID string) *ZeroEdgeCaveat {
 	class := ClassifyZeroEdge(g, symbolID)
 	if class == ZeroEdgeNone {
 		return nil

--- a/internal/graph/test_class.go
+++ b/internal/graph/test_class.go
@@ -1,0 +1,47 @@
+package graph
+
+import (
+	"strings"
+
+	"github.com/zzet/gortex/internal/testpath"
+)
+
+// NodeGetter is the single-node lookup NodeIsTest needs to resolve a
+// child node's owner. Both graph stores and the overlay view satisfy it.
+type NodeGetter interface {
+	GetNode(id string) *Node
+}
+
+// NodeIsTest is the one test classifier shared by result filtering
+// (QueryOptions.ExcludeTests) and output metadata (from_is_test,
+// usage_summary.n_test_refs), so a row is never filtered as a test yet
+// labeled as production. Authority order:
+//
+//  1. The node's own is_test stamp — set by the indexer's test-edge
+//     pass on function/method symbols, whether discovered by file
+//     location or by runner annotation (#[test], @Test).
+//  2. For child nodes (params, locals, closures, type params — the
+//     `<owner-id>#...` ID convention), the owner's stamp: an
+//     annotation-discovered test in a production-looking path stamps
+//     only the function, and its children inherit that identity.
+//  3. The canonical path predicate — file-level nodes and any other
+//     kind the stamping pass never visits.
+//
+// A nil getter skips the owner hop; the stamp and path checks still
+// apply.
+func NodeIsTest(g NodeGetter, n *Node) bool {
+	if n == nil {
+		return false
+	}
+	if v, _ := n.Meta["is_test"].(bool); v {
+		return true
+	}
+	if i := strings.IndexByte(n.ID, '#'); i > 0 && g != nil {
+		if owner := g.GetNode(n.ID[:i]); owner != nil {
+			if v, _ := owner.Meta["is_test"].(bool); v {
+				return true
+			}
+		}
+	}
+	return testpath.IsTestFile(n.FilePath)
+}

--- a/internal/mcp/budget.go
+++ b/internal/mcp/budget.go
@@ -5,233 +5,57 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/zzet/gortex/internal/respbudget"
 )
 
-// defaultMaxBytes is the upper bound on a single tool response.
-// Empirically the agent harness (claude-code at the time of writing)
-// starts spilling responses to a side file around ~50 KB of wire
-// text. The MCP `tools/call` envelope wraps our payload as
-// `{"content":[{"type":"text","text":"<payload>"}]}`, then JSON-RPC
-// itself adds one more layer of escaping when serialised across the
-// stdio bridge — round-trip overhead averages 25–30 % on top of the
-// raw payload bytes for our shapes. Capping the inner payload at
-// 40 KB keeps the wire form comfortably under the 50 KB threshold,
-// leaving headroom for the rare row that has unusually heavy meta.
-//
-// Lower this number cautiously: every drop here means more rows get
-// trimmed across every list-shaped tool. Raise it only after
-// re-measuring the harness threshold; "no spill" beats "more rows"
-// because spilled output forces a cold re-read for the agent.
-const defaultMaxBytes = 40_000
+// The budget arithmetic (default cap, token ratio, opt-out semantics,
+// structural trim) lives in internal/respbudget so the daemon's
+// federation merge applies the exact same rules to the final merged
+// representation. The aliases below keep this package's call sites
+// unchanged.
+const defaultMaxBytes = respbudget.DefaultMaxBytes
 
-// avgBytesPerToken is the calibration constant used to translate the
-// `max_tokens` parameter into an effective byte cap. Empirically:
-//
-//   - dense JSON / TOON rows (`{"id":"...","kind":"function",...}`)
-//     tokenise at ~3.0–3.4 chars per BPE token on cl100k_base. The
-//     punctuation density (quotes, colons, braces) drags the ratio
-//     down vs. natural English.
-//   - GCX1 rows (`id\tkind\tname\t...`) tokenise at ~4.0–4.5 chars
-//     per token because tabs collapse into single tokens and the
-//     identifier-heavy payload tokenises more efficiently than JSON.
-//   - smart_context / get_editing_context source-bearing payloads
-//     average ~3.6 chars per token because the source lines push
-//     the ratio toward English text.
-//
-// 3.5 is the safe midpoint: it slightly UNDER-counts tokens for JSON
-// (so the resulting byte cap is tighter than strictly necessary —
-// erring on the side of "fits the budget") and approximately matches
-// the GCX row case. Token estimation is necessarily imperfect across
-// model tokenisers; the budget guard's job is to ride a safe margin,
-// not to count exactly. A caller who needs precise token-counting
-// should run their own tokenizer post-hoc.
-const avgBytesPerToken = 3.5
+const avgBytesPerToken = respbudget.AvgBytesPerToken
 
 // tokenBudgetParamDescription is the canonical description string
 // for the `max_tokens` parameter wired onto every list-shaped tool.
 // Centralised so the wording stays consistent across the registry.
 const tokenBudgetParamDescription = "Cap the marshaled response at approximately this many tokens (3.5 bytes/token heuristic; composable with max_bytes — tighter wins). Use when you have a token budget instead of a byte budget. Omit for no cap; pass 0 to opt out explicitly."
 
-// tokensToBytes converts a token budget into a byte cap using the
-// avgBytesPerToken ratio. Returns 0 for non-positive inputs so
-// `max_tokens: 0` is honoured as "opt out" with the same semantics
-// as `max_bytes: 0`.
+// tokensToBytes converts a token budget into a byte cap; see
+// respbudget.TokensToBytes for the ratio's calibration notes.
 func tokensToBytes(maxTokens int) int {
-	if maxTokens <= 0 {
-		return 0
-	}
-	return int(float64(maxTokens) * avgBytesPerToken)
+	return respbudget.TokensToBytes(maxTokens)
 }
 
-// bytesToTokens is the inverse of tokensToBytes. Used to render a
-// human-readable token-equivalent on the truncation meta so callers
-// see "kept ~N tokens" alongside the raw byte cap. Returns 0 for
-// non-positive inputs.
+// bytesToTokens is the inverse of tokensToBytes.
 func bytesToTokens(byteCount int) int {
-	if byteCount <= 0 {
-		return 0
-	}
-	return int(float64(byteCount) / avgBytesPerToken)
+	return respbudget.BytesToTokens(byteCount)
 }
 
-// numArgInt extracts an integer arg from the request arguments map.
-// JSON numbers arrive as float64; some test harnesses pass int.
-// Returns (value, present). When the arg is the wrong type, returns
-// (0, true) so callers can distinguish "absent" from "malformed
-// zero" — important because a zero value is meaningful here (it is
-// the opt-out signal for both max_bytes and max_tokens).
+// numArgInt extracts an integer arg from the request arguments map;
+// see respbudget.NumArgInt for the absent-vs-malformed semantics.
 func numArgInt(args map[string]any, key string) (int, bool) {
-	raw, ok := args[key]
-	if !ok {
-		return 0, false
-	}
-	switch n := raw.(type) {
-	case float64:
-		return int(n), true
-	case int:
-		return n, true
-	case int64:
-		return int(n), true
-	default:
-		return 0, true
-	}
+	return respbudget.NumArgInt(args, key)
 }
 
 // budgetTruncatedKey is the meta flag appended to a payload trimmed
 // by applyBudget so callers can branch on truncation without scanning
 // for shape-specific signals. Mirrored on the GCX path through the
 // `truncated_by_budget=true` header meta.
-const budgetTruncatedKey = "_truncated_by_budget"
+const budgetTruncatedKey = respbudget.TruncatedKey
 
 // applyBudget enforces a marshaled-size cap on payload by trimming
-// top-level lists in longest-first order until the result fits.
-// Returns the (possibly trimmed) payload and a flag indicating
-// whether trimming happened. The trimmed payload carries inline
-// metadata so callers can surface "narrow your filter" hints:
-//
-//   - _truncated_by_budget: true
-//   - _max_returned_<field>: N
-//   - _original_count_<field>: M (one pair per trimmed list)
-//
-// Multi-list payloads (`nodes` + `edges` for get_file_summary, etc.)
-// are trimmed iteratively: the longest list is binary-searched first;
-// if the result still exceeds the cap, the next-longest list is
-// trimmed too, and so on. We stop when the cap is met or every list
-// has been emptied (the second is a degraded fallback — extremely
-// large per-row payloads can still exceed the budget with zero
-// rows; that case is rare and the MCP transport's spill fallback
-// handles it).
-//
-// Best-effort: if no top-level list is found in the marshaled JSON,
-// the payload is returned unchanged.
+// top-level lists in longest-first order until the result fits; the
+// algorithm and its truncation-meta contract live in respbudget.Apply,
+// shared with the daemon's federation merge.
 func applyBudget(payload any, maxBytes int) (any, bool) {
-	if maxBytes <= 0 || payload == nil {
-		return payload, false
-	}
-	bytes, err := json.Marshal(payload)
-	if err != nil || len(bytes) <= maxBytes {
-		return payload, false
-	}
-
-	// Re-shape into a generic map so we can manipulate any payload
-	// type uniformly (struct, *query.SubGraph, map[string]any). The
-	// JSON round-trip costs one extra alloc — cheap given we already
-	// know we are over budget.
-	var generic map[string]any
-	if err := json.Unmarshal(bytes, &generic); err != nil {
-		return payload, false
-	}
-
-	trimmed := false
-	// Cap iteration count by the number of distinct top-level slices
-	// so we cannot loop forever on a payload whose non-list scalars
-	// alone exceed the cap.
-	for pass := 0; pass < 8; pass++ {
-		longestKey := findLongestSliceKey(generic)
-		if longestKey == "" {
-			break
-		}
-		longest := genericSlice(generic, longestKey)
-		if len(longest) == 0 {
-			// Already-empty list cannot shrink further; pick the
-			// next-longest in the next iteration. Mark this list
-			// completed by removing it from candidate set via length 0.
-			break
-		}
-		originalLen := len(longest)
-		// Binary search for the largest prefix that fits.
-		lo, hi := 0, originalLen
-		for lo < hi {
-			mid := (lo + hi + 1) / 2
-			generic[longestKey] = longest[:mid]
-			generic[budgetTruncatedKey] = true
-			generic["_max_returned_"+longestKey] = mid
-			generic["_original_count_"+longestKey] = originalLen
-			candidate, err := json.Marshal(generic)
-			if err != nil {
-				break
-			}
-			if len(candidate) <= maxBytes {
-				lo = mid
-			} else {
-				hi = mid - 1
-			}
-		}
-		generic[longestKey] = longest[:lo]
-		generic[budgetTruncatedKey] = true
-		generic["_max_returned_"+longestKey] = lo
-		generic["_original_count_"+longestKey] = originalLen
-		trimmed = true
-
-		final, _ := json.Marshal(generic)
-		if len(final) <= maxBytes {
-			return generic, true
-		}
-	}
-	if !trimmed {
-		// No slice candidate was actually trimmed — return the
-		// original payload type intact so callers comparing against
-		// concrete Go types (int vs json's float64, etc.) keep
-		// working unchanged.
-		return payload, false
-	}
-	return generic, trimmed
-}
-
-// findLongestSliceKey returns the top-level field name whose value is
-// the longest []any. Empty string when no slices are present. Used by
-// applyBudget to pick the trimming target without per-tool config.
-func findLongestSliceKey(m map[string]any) string {
-	var key string
-	maxLen := 0
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	// Stable iteration so ties resolve deterministically.
-	sort.Strings(keys)
-	for _, k := range keys {
-		arr, ok := m[k].([]any)
-		if !ok {
-			continue
-		}
-		if len(arr) > maxLen {
-			maxLen = len(arr)
-			key = k
-		}
-	}
-	return key
-}
-
-func genericSlice(m map[string]any, key string) []any {
-	if arr, ok := m[key].([]any); ok {
-		return arr
-	}
-	return nil
+	return respbudget.Apply(payload, maxBytes)
 }
 
 // applyFieldsFilter returns a copy of payload with only the fields
@@ -477,49 +301,7 @@ func trimGCXBytes(payload []byte, maxBytes int) ([]byte, bool) {
 // prefers a partial, inline answer over a spilled file the agent has
 // to re-read.
 func effectiveBudget(req mcp.CallToolRequest) int {
-	args := req.GetArguments()
-	rawBytes, bytesPresent := numArgInt(args, "max_bytes")
-	rawTokens, tokensPresent := numArgInt(args, "max_tokens")
-
-	if !bytesPresent && !tokensPresent {
-		return defaultMaxBytes
-	}
-
-	// Per-axis opt-out: a non-positive value means "skip THIS axis".
-	bytesOptOut := bytesPresent && rawBytes <= 0
-	tokensOptOut := tokensPresent && rawTokens <= 0
-
-	// Both axes opted out → no cap.
-	if bytesPresent && tokensPresent && bytesOptOut && tokensOptOut {
-		return 0
-	}
-	// Only one axis present and it opted out → no cap.
-	if bytesPresent && !tokensPresent && bytesOptOut {
-		return 0
-	}
-	if tokensPresent && !bytesPresent && tokensOptOut {
-		return 0
-	}
-
-	tokensBytes := tokensToBytes(rawTokens) // 0 when token axis absent or opt-out
-
-	switch {
-	case bytesPresent && tokensPresent:
-		switch {
-		case bytesOptOut:
-			return tokensBytes
-		case tokensOptOut:
-			return rawBytes
-		case rawBytes < tokensBytes:
-			return rawBytes
-		default:
-			return tokensBytes
-		}
-	case bytesPresent:
-		return rawBytes
-	default: // tokensPresent
-		return tokensBytes
-	}
+	return respbudget.EffectiveFromArgs(req.GetArguments())
 }
 
 // budgetSource describes which arg drove the resolved byte cap. Used
@@ -621,6 +403,21 @@ func decorateTokenBudgetJSON(payload any, req mcp.CallToolRequest) any {
 		m["_max_tokens"] = rawTokens
 	}
 	return m
+}
+
+// tokenBudgetDecorationReserve is the worst-case byte cost of the
+// token-budget decoration the JSON and GCX renderers append AFTER
+// their fit (the `_max_tokens` / `_truncated_by_tokens` fields, the
+// GCX `# max_tokens=…` comment). Reserving it from the effective
+// budget up front keeps the decorated payload inside the caller's cap
+// — the decoration must never be the bytes that break the contract it
+// documents. Zero when the caller did not pass max_tokens.
+func tokenBudgetDecorationReserve(req mcp.CallToolRequest) int {
+	rawTokens, present := numArgInt(req.GetArguments(), "max_tokens")
+	if !present || rawTokens <= 0 {
+		return 0
+	}
+	return 48 + len(strconv.Itoa(rawTokens))
 }
 
 // decorateTokenBudgetGCX appends a trailing comment to a GCX payload

--- a/internal/mcp/caller_boundaries_overlay_test.go
+++ b/internal/mcp/caller_boundaries_overlay_test.go
@@ -1,0 +1,94 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/search"
+)
+
+type callersBoundaryResp struct {
+	Boundaries []graph.EpistemicBoundary `json:"boundaries"`
+	LowerBound bool                      `json:"lower_bound"`
+}
+
+func getCallersBoundaries(t *testing.T, srv *Server, ctx context.Context, id string) callersBoundaryResp {
+	t.Helper()
+	req := mcplib.CallToolRequest{}
+	req.Params.Name = "get_callers"
+	req.Params.Arguments = map[string]any{"id": id}
+	res, err := srv.handleGetCallers(ctx, req)
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	var resp callersBoundaryResp
+	require.NoError(t, json.Unmarshal([]byte(res.Content[0].(mcplib.TextContent).Text), &resp))
+	return resp
+}
+
+// TestGetCallers_OverlayAddedBoundaryIsVisible pins that the epistemic
+// boundary lookup reads the request-scoped view: an overlay-only
+// implementation of an interface method must surface its dispatch
+// boundary and lower_bound — reading the base graph returns the
+// overlay-only implementation in the result while boundaries stay
+// empty and lower_bound stays false, a self-contradictory answer.
+func TestGetCallers_OverlayAddedBoundaryIsVisible(t *testing.T) {
+	base := graph.New()
+	iface := &graph.Node{ID: "src/iface.go::Iface.Do", Kind: graph.KindMethod, Name: "Do", FilePath: "src/iface.go", StartLine: 1}
+	base.AddNode(iface)
+
+	layer := graph.NewOverlayLayer()
+	impl := &graph.Node{ID: "src/new.go::FreshImpl.Do", Kind: graph.KindMethod, Name: "Do", FilePath: "src/new.go", StartLine: 1}
+	layer.AddNode("src/new.go", impl)
+	layer.AddEdge(&graph.Edge{From: impl.ID, To: iface.ID, Kind: graph.EdgeImplements, FilePath: "src/new.go", Line: 1})
+
+	eng := query.NewEngine(base)
+	eng.SetSearch(search.NewNull())
+	srv := NewServer(eng, base, nil, nil, zap.NewNop(), nil)
+	ctx := WithOverlayView(context.Background(), graph.NewOverlaidView(base, layer))
+
+	resp := getCallersBoundaries(t, srv, ctx, impl.ID)
+	require.NotEmpty(t, resp.Boundaries,
+		"an overlay-added implements edge is a dispatch boundary the request's view can see")
+	require.True(t, resp.LowerBound,
+		"interface dispatch into the overlay-only implementation makes the caller count a floor")
+}
+
+// TestGetCallers_TombstonedBoundaryIsGone pins the reverse orientation:
+// when the overlay tombstones the file carrying the implements edge,
+// the boundary must disappear with it — the base graph would keep
+// reporting a dispatch floor through an interface relationship the
+// session already deleted.
+func TestGetCallers_TombstonedBoundaryIsGone(t *testing.T) {
+	base := graph.New()
+	iface := &graph.Node{ID: "src/iface.go::Iface.Do", Kind: graph.KindMethod, Name: "Do", FilePath: "src/iface.go", StartLine: 1}
+	impl := &graph.Node{ID: "src/impl.go::Impl.Do", Kind: graph.KindMethod, Name: "Do", FilePath: "src/impl.go", StartLine: 1}
+	base.AddNode(iface)
+	base.AddNode(impl)
+	base.AddEdge(&graph.Edge{From: impl.ID, To: iface.ID, Kind: graph.EdgeImplements, FilePath: "src/impl.go", Line: 1})
+
+	// Sanity: without an overlay the boundary is reported.
+	eng := query.NewEngine(base)
+	eng.SetSearch(search.NewNull())
+	srv := NewServer(eng, base, nil, nil, zap.NewNop(), nil)
+	plain := getCallersBoundaries(t, srv, context.Background(), impl.ID)
+	require.NotEmpty(t, plain.Boundaries, "fixture: base graph must report the dispatch boundary")
+
+	layer := graph.NewOverlayLayer()
+	layer.MarkFile("src/impl.go", true)
+	// The session's buffer re-adds the symbol without the interface.
+	fresh := &graph.Node{ID: "src/impl.go::Impl.Do", Kind: graph.KindMethod, Name: "Do", FilePath: "src/impl.go", StartLine: 1}
+	layer.AddNode("src/impl.go", fresh)
+	ctx := WithOverlayView(context.Background(), graph.NewOverlaidView(base, layer))
+
+	resp := getCallersBoundaries(t, srv, ctx, impl.ID)
+	require.Empty(t, resp.Boundaries,
+		"a tombstoned implements edge is no dispatch boundary in the request's view")
+	require.False(t, resp.LowerBound)
+}

--- a/internal/mcp/dynamic_boundary.go
+++ b/internal/mcp/dynamic_boundary.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"regexp"
@@ -107,7 +108,11 @@ func anyAgentNamed(candidates []string) bool {
 // dynamicBoundariesForSymbol reads a symbol's source and detects the runtime
 // dispatch boundaries inside it, resolving candidate targets through the graph.
 // Returns nil when the source can't be read or no dispatch is found.
-func (s *Server) dynamicBoundariesForSymbol(node *graph.Node) []DynamicBoundary {
+// The session's overlay buffer substitutes for the on-disk file when the
+// request carries one: an overlay-served node's line range is a BUFFER
+// coordinate, and slicing the stale disk content by it reads a different
+// body and fabricates boundaries.
+func (s *Server) dynamicBoundariesForSymbol(ctx context.Context, node *graph.Node) []DynamicBoundary {
 	if node == nil || node.StartLine <= 0 {
 		return nil
 	}
@@ -115,11 +120,15 @@ func (s *Server) dynamicBoundariesForSymbol(node *graph.Node) []DynamicBoundary 
 	if err != nil {
 		return nil
 	}
-	content, err := os.ReadFile(absPath) //nolint:gosec // path resolved from the indexed graph
-	if err != nil {
-		return nil
+	text, ok := s.overlayContentFor(ctx, absPath)
+	if !ok {
+		raw, err := os.ReadFile(absPath) //nolint:gosec // path resolved from the indexed graph
+		if err != nil {
+			return nil
+		}
+		text = string(raw)
 	}
-	lines := strings.Split(string(content), "\n")
+	lines := strings.Split(text, "\n")
 	start := node.StartLine - 1
 	end := node.EndLine
 	if end <= 0 || end > len(lines) {

--- a/internal/mcp/dynamic_boundary_overlay_test.go
+++ b/internal/mcp/dynamic_boundary_overlay_test.go
@@ -1,0 +1,64 @@
+package mcp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/daemon"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// TestDynamicBoundariesScanTheOverlayBuffer pins which text the
+// dispatch scan slices: an overlay-modified file's node carries
+// BUFFER coordinates, so slicing the stale on-disk content by those
+// lines reads a different function's body and fabricates boundaries.
+// The scan must substitute the session's buffer, exactly as the
+// source-reading handlers do.
+func TestDynamicBoundariesScanTheOverlayBuffer(t *testing.T) {
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "svc.py")
+	// Disk: the pre-edit file — short, no dispatch anywhere.
+	require.NoError(t, os.WriteFile(fp, []byte("def old(self):\n    return 1\n"), 0o644))
+	// Buffer: an edit inserted a line above, shifting route() down —
+	// its reflection dispatch now lives at buffer line 3.
+	overlay := strings.Join([]string{
+		"# inserted comment",
+		"def route(self, name, payload):",
+		"    handler = getattr(self, name)",
+	}, "\n")
+
+	g := graph.New()
+	eng := query.NewEngine(g)
+	eng.SetSearch(search.NewNull())
+	srv := NewServer(eng, g, nil, nil, zap.NewNop(), nil)
+
+	node := &graph.Node{
+		ID: fp + "::route", Kind: graph.KindFunction, Name: "route",
+		FilePath: fp, StartLine: 2, EndLine: 3,
+	}
+
+	const sessionID = "overlay-dispatch-scan"
+	ctx := WithSessionID(context.Background(), sessionID)
+	ctx = withOverlayRequestSnapshot(ctx, &overlayRequestSnapshot{
+		sessionID: sessionID,
+		canonical: true,
+		files:     []daemon.OverlayFile{{Path: fp, Content: overlay}},
+	})
+
+	got := srv.dynamicBoundariesForSymbol(ctx, node)
+	require.NotEmpty(t, got, "the buffer's getattr dispatch at the node's buffer lines must be detected")
+	require.Equal(t, fp+":3", got[0].Site,
+		"the site is a buffer coordinate — the disk file has no dispatch at all")
+
+	// Without the overlay, the same node coordinates slice the disk
+	// file: no dispatch there, no boundaries — never fabricated ones.
+	require.Empty(t, srv.dynamicBoundariesForSymbol(context.Background(), node))
+}

--- a/internal/mcp/edge_via_test.go
+++ b/internal/mcp/edge_via_test.go
@@ -29,7 +29,7 @@ func TestEncodeSubGraphEmitsViaColumn(t *testing.T) {
 			{From: "a", To: "b", Kind: graph.EdgeCalls, Origin: graph.OriginASTInferred, Via: "observer channel"},
 		},
 	}
-	out, err := encodeSubGraph("walk_graph", sg)
+	out, err := encodeSubGraph("walk_graph", sg, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/mcp/find_usages_output_options_test.go
+++ b/internal/mcp/find_usages_output_options_test.go
@@ -247,6 +247,44 @@ func TestFindUsages_GroupByFileHonorsLimit(t *testing.T) {
 	require.Equal(t, 6, resp.TotalEdges, "a truncated grouped page must carry the full total")
 }
 
+// TestFindUsages_CappedCompactCarriesFullTotal pins the capped-response
+// contract on the compact format: a capped page must be legible as
+// partial, so the edges footer names both the page size and the full
+// row count. (JSON and GCX are pinned by the limit tests above.)
+func TestFindUsages_CappedCompactCarriesFullTotal(t *testing.T) {
+	srv, hotID := usagesLimitServer(t, 6)
+	out := findUsagesText(t, srv, map[string]any{"id": hotID, "limit": 2, "compact": true})
+	require.Contains(t, out, "edges: 2 of 6 total",
+		"a capped compact response must name the full row count, not label the page as the total")
+
+	full := findUsagesText(t, srv, map[string]any{"id": hotID, "limit": 0, "compact": true})
+	require.Contains(t, full, "edges: 6 total", "the uncapped compact footer keeps its wire shape")
+}
+
+// TestFindUsages_CappedTOONCarriesFullTotal pins the same contract on
+// the TOON wire: truncated rides with the full edge total.
+func TestFindUsages_CappedTOONCarriesFullTotal(t *testing.T) {
+	srv, hotID := usagesLimitServer(t, 6)
+	out := findUsagesText(t, srv, map[string]any{"id": hotID, "limit": 2, "format": "toon"})
+	require.Contains(t, out, "truncated: true")
+	require.Contains(t, out, "total_edges: 6", "a capped TOON response must carry the full edge total")
+
+	full := findUsagesText(t, srv, map[string]any{"id": hotID, "limit": 0, "format": "toon"})
+	require.NotContains(t, full, "total_edges", "the uncapped TOON response keeps its wire shape")
+}
+
+// TestFindUsages_CompactHonorsByteBudget pins max_bytes on the compact
+// path, including the compact-over-gcx-default composition: routing a
+// budgeted request to the compact renderer must not shed the budget.
+func TestFindUsages_CompactHonorsByteBudget(t *testing.T) {
+	srv, hotID := usagesLimitServer(t, 55)
+	out := findUsagesText(t, srv, map[string]any{
+		"id": hotID, "limit": 0, "compact": true, "format": "gcx", "max_bytes": 300,
+	})
+	require.LessOrEqual(t, len(out), 300, "compact output must respect max_bytes")
+	require.Contains(t, out, "trimmed", "a budget-trimmed compact response must say so")
+}
+
 // TestFindUsages_CompactWinsOverGCX pins the `compact` option against
 // the GCX format path: compact is an explicit caller choice, so it
 // takes precedence exactly as it does in the shared returnSubGraph

--- a/internal/mcp/find_usages_output_options_test.go
+++ b/internal/mcp/find_usages_output_options_test.go
@@ -3,12 +3,14 @@ package mcp
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
 	"github.com/zzet/gortex/internal/query"
 	"github.com/zzet/gortex/internal/search"
 )
@@ -95,6 +97,135 @@ func TestFindUsages_LimitTruncationMetaGCX(t *testing.T) {
 
 	full := findUsagesText(t, srv, map[string]any{"id": hotID, "format": "gcx", "limit": 0})
 	require.NotContains(t, full, "truncated=true", "an uncapped response must not carry truncation meta")
+}
+
+// TestFindUsages_LimitKeepsStrongestEvidence pins the order the cap
+// consumes: rows are ranked by evidence tier before the page is cut, so
+// a weak ast_inferred row inserted earlier can never evict an
+// lsp_resolved usage from the page.
+func TestFindUsages_LimitKeepsStrongestEvidence(t *testing.T) {
+	g := graph.New()
+	hot := &graph.Node{ID: "pkg/hot.go::Hot", Kind: graph.KindFunction, Name: "Hot", FilePath: "pkg/hot.go", StartLine: 1}
+	g.AddNode(hot)
+	// Weak rows first in insertion order, strong rows last.
+	for i := 0; i < 4; i++ {
+		file := fmt.Sprintf("pkg/weak%d.go", i)
+		caller := &graph.Node{ID: file + "::Weak", Kind: graph.KindFunction, Name: "Weak", FilePath: file, StartLine: 3}
+		g.AddNode(caller)
+		g.AddEdge(&graph.Edge{From: caller.ID, To: hot.ID, Kind: graph.EdgeCalls, FilePath: file, Line: 5, Origin: graph.OriginASTInferred, Confidence: 0.6})
+	}
+	for i := 0; i < 2; i++ {
+		file := fmt.Sprintf("pkg/strong%d.go", i)
+		caller := &graph.Node{ID: file + "::Strong", Kind: graph.KindFunction, Name: "Strong", FilePath: file, StartLine: 3}
+		g.AddNode(caller)
+		g.AddEdge(&graph.Edge{From: caller.ID, To: hot.ID, Kind: graph.EdgeCalls, FilePath: file, Line: 5, Origin: graph.OriginLSPResolved, Confidence: 1.0})
+	}
+	eng := query.NewEngine(g)
+	eng.SetSearch(search.NewNull())
+	srv := NewServer(eng, g, nil, nil, zap.NewNop(), nil)
+
+	var resp usagesLimitResponse
+	require.NoError(t, json.Unmarshal([]byte(findUsagesText(t, srv, map[string]any{"id": hot.ID, "limit": 2})), &resp))
+	require.Len(t, resp.Edges, 2)
+	for _, e := range resp.Edges {
+		require.Equal(t, graph.OriginLSPResolved, e.Origin,
+			"the capped page must keep the strongest evidence, not the earliest-inserted rows")
+	}
+}
+
+// TestFindUsages_LimitPageBackendParity pins that the capped page is
+// identical on the in-memory and SQLite backends. The two stores
+// iterate edges in different orders (insertion vs kind/id), so without
+// one global sort before the cut the default page depends on which
+// backend served it.
+func TestFindUsages_LimitPageBackendParity(t *testing.T) {
+	build := func(g graph.Store) string {
+		hot := &graph.Node{ID: "pkg/hot.go::Hot", Kind: graph.KindFunction, Name: "Hot", FilePath: "pkg/hot.go", StartLine: 1}
+		g.AddNode(hot)
+		// Mixed edge kinds in descending file order: the memory store
+		// iterates in-edges by insertion, SQLite groups them by kind, so
+		// without one global sort the two pages diverge.
+		kinds := []graph.EdgeKind{graph.EdgeReferences, graph.EdgeCalls, graph.EdgeImports, graph.EdgeInstantiates}
+		for i := 9; i >= 0; i-- {
+			file := fmt.Sprintf("pkg/use%d.go", i)
+			caller := &graph.Node{ID: fmt.Sprintf("%s::Use%d", file, i), Kind: graph.KindFunction, Name: fmt.Sprintf("Use%d", i), FilePath: file, StartLine: 3}
+			g.AddNode(caller)
+			g.AddEdge(&graph.Edge{From: caller.ID, To: hot.ID, Kind: kinds[i%len(kinds)], FilePath: file, Line: 5, Origin: graph.OriginASTResolved, Confidence: 0.9})
+		}
+		return hot.ID
+	}
+	page := func(g graph.Store, hotID string) []string {
+		eng := query.NewEngine(g)
+		eng.SetSearch(search.NewNull())
+		srv := NewServer(eng, g, nil, nil, zap.NewNop(), nil)
+		var resp usagesLimitResponse
+		require.NoError(t, json.Unmarshal([]byte(findUsagesText(t, srv, map[string]any{"id": hotID, "limit": 3})), &resp))
+		froms := make([]string, 0, len(resp.Edges))
+		for _, e := range resp.Edges {
+			froms = append(froms, e.From)
+		}
+		return froms
+	}
+
+	mem := graph.New()
+	memID := build(mem)
+
+	sqlite, err := store_sqlite.Open(filepath.Join(t.TempDir(), "usages.sqlite"))
+	require.NoError(t, err)
+	defer sqlite.Close()
+	sqliteID := build(sqlite)
+
+	memPage := page(mem, memID)
+	sqlitePage := page(sqlite, sqliteID)
+	require.Len(t, memPage, 3)
+	require.Equal(t, memPage, sqlitePage, "the capped page must not depend on the store backend")
+}
+
+// TestFindUsages_LimitOrdersReExportUnion pins the stable order on the
+// barrel re-export union path: the page over facade + canonical usages
+// is cut after the merged set is sorted, so the strongest canonical
+// rows win over the facade's weaker direct refs regardless of merge
+// order, and the totals describe the whole union.
+func TestFindUsages_LimitOrdersReExportUnion(t *testing.T) {
+	g := graph.New()
+	facade := &graph.Node{
+		ID: "src/index.ts::persist", Kind: graph.KindFunction, Name: "persist",
+		FilePath: "src/index.ts", StartLine: 1, Meta: map[string]any{"reexport": true},
+	}
+	canon := &graph.Node{ID: "src/middleware.ts::persist", Kind: graph.KindFunction, Name: "persist", FilePath: "src/middleware.ts", StartLine: 10}
+	g.AddNode(facade)
+	g.AddNode(canon)
+	g.AddEdge(&graph.Edge{From: facade.ID, To: canon.ID, Kind: graph.EdgeReExports, FilePath: "src/index.ts", Line: 1})
+	// Facade's own direct refs are weak; the canonical's usages are
+	// lsp_resolved. The merge appends the canonical set second, so an
+	// unsorted cut would keep the weak facade rows.
+	for i := 0; i < 2; i++ {
+		file := fmt.Sprintf("src/facadeuse%d.ts", i)
+		caller := &graph.Node{ID: file + "::useFacade", Kind: graph.KindFunction, Name: "useFacade", FilePath: file, StartLine: 3}
+		g.AddNode(caller)
+		g.AddEdge(&graph.Edge{From: caller.ID, To: facade.ID, Kind: graph.EdgeImports, FilePath: file, Line: 1, Origin: graph.OriginASTInferred, Confidence: 0.6})
+	}
+	for i := 0; i < 4; i++ {
+		file := fmt.Sprintf("src/canonuse%d.ts", i)
+		caller := &graph.Node{ID: file + "::useCanon", Kind: graph.KindFunction, Name: "useCanon", FilePath: file, StartLine: 3}
+		g.AddNode(caller)
+		g.AddEdge(&graph.Edge{From: caller.ID, To: canon.ID, Kind: graph.EdgeCalls, FilePath: file, Line: 5, Origin: graph.OriginLSPResolved, Confidence: 1.0})
+	}
+	eng := query.NewEngine(g)
+	eng.SetSearch(search.NewNull())
+	srv := NewServer(eng, g, nil, nil, zap.NewNop(), nil)
+
+	var resp usagesLimitResponse
+	require.NoError(t, json.Unmarshal([]byte(findUsagesText(t, srv, map[string]any{"id": facade.ID, "limit": 3})), &resp))
+	require.Len(t, resp.Edges, 3)
+	for _, e := range resp.Edges {
+		require.Equal(t, graph.OriginLSPResolved, e.Origin,
+			"the union page must keep the strongest rows across facade + canonical")
+	}
+	require.True(t, resp.Truncated)
+	// 2 facade imports + 1 re-export edge is not a usage of the facade
+	// per se; the union total counts the merged usage rows.
+	require.Equal(t, resp.TotalEdges, 6+1, "total_edges covers the merged union")
 }
 
 // TestFindUsages_GroupByFileHonorsLimit pins the row cap on the

--- a/internal/mcp/find_usages_output_options_test.go
+++ b/internal/mcp/find_usages_output_options_test.go
@@ -1,12 +1,14 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	mcplib "github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
@@ -333,6 +335,120 @@ func TestFindUsages_TestLabelsMatchTheFilter(t *testing.T) {
 			require.NotContains(t, line, "\ttrue", "the production row must stay from_is_test=false: %s", line)
 		}
 	}
+}
+
+// TestFindUsages_OverlayOwnerClassifiesChildren pins that the output
+// classifiers read the same request-scoped graph view as the query: an
+// annotation test that exists only in the session overlay stamps its
+// owner there, so the owner hop for its param child must go through
+// the overlay reader — resolving against the base graph classifies the
+// child as production while the filter (running on the overlay engine)
+// would exclude it.
+func TestFindUsages_OverlayOwnerClassifiesChildren(t *testing.T) {
+	base := graph.New()
+	target := &graph.Node{ID: "src/widget.rs::Widget", Kind: graph.KindType, Name: "Widget", FilePath: "src/widget.rs", StartLine: 3}
+	prod := &graph.Node{ID: "src/main.rs::run", Kind: graph.KindFunction, Name: "run", FilePath: "src/main.rs", StartLine: 10}
+	base.AddNode(target)
+	base.AddNode(prod)
+	base.AddEdge(&graph.Edge{From: prod.ID, To: target.ID, Kind: graph.EdgeCalls, FilePath: "src/main.rs", Line: 12})
+
+	layer := graph.NewOverlayLayer()
+	owner := &graph.Node{
+		ID: "src/lib.rs::check_widget", Kind: graph.KindFunction, Name: "check_widget",
+		FilePath: "src/lib.rs", StartLine: 40, Meta: map[string]any{"is_test": true, "test_role": "test"},
+	}
+	child := &graph.Node{
+		ID: "src/lib.rs::check_widget#param:w", Kind: graph.KindParam, Name: "w",
+		FilePath: "src/lib.rs", StartLine: 40,
+	}
+	layer.AddNode("src/lib.rs", owner)
+	layer.AddNode("src/lib.rs", child)
+	layer.AddEdge(&graph.Edge{From: child.ID, To: target.ID, Kind: graph.EdgeReferences, FilePath: "src/lib.rs", Line: 40})
+
+	eng := query.NewEngine(base)
+	eng.SetSearch(search.NewNull())
+	srv := NewServer(eng, base, nil, nil, zap.NewNop(), nil)
+	ctx := WithOverlayView(context.Background(), graph.NewOverlaidView(base, layer))
+
+	req := mcplib.CallToolRequest{}
+	req.Params.Name = "find_usages"
+	req.Params.Arguments = map[string]any{"id": target.ID}
+	res, err := srv.handleFindUsages(ctx, req)
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	var resp struct {
+		UsageSummary *query.UsageSummary `json:"usage_summary"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(res.Content[0].(mcplib.TextContent).Text), &resp))
+	require.NotNil(t, resp.UsageSummary)
+	require.Equal(t, 2, resp.UsageSummary.NRefs)
+	require.Equal(t, 1, resp.UsageSummary.NTestRefs,
+		"the overlay-stamped owner's child must classify as a test ref through the overlay view")
+}
+
+// TestFindUsages_TOONRowsClassifyTheRightNode pins the TOON is_test
+// join: nodesToTOONRows skips File/Import nodes, so classification must
+// join rows to nodes by ID — indexing the filtered rows with unfiltered
+// node positions shifted every classification after a skipped node and
+// let a production function inherit a skipped test file's flag.
+func TestFindUsages_TOONRowsClassifyTheRightNode(t *testing.T) {
+	g := graph.New()
+	target := &graph.Node{ID: "src/hot.go::Hot", Kind: graph.KindFunction, Name: "Hot", FilePath: "src/hot.go", StartLine: 1}
+	// The file node sorts first by ID (capital T), is a test path, and
+	// is skipped by the TOON row builder.
+	testFile := &graph.Node{
+		ID: `Test\Suite_Tests.cs`, Kind: graph.KindFile,
+		Name: "Suite_Tests.cs", FilePath: `Test\Suite_Tests.cs`,
+		Meta: map[string]any{"is_test_file": true},
+	}
+	prod := &graph.Node{ID: "src/a.go::ProdUse", Kind: graph.KindFunction, Name: "ProdUse", FilePath: "src/a.go", StartLine: 3}
+	testFn := &graph.Node{
+		ID: "src/z_test.go::TestUse", Kind: graph.KindFunction, Name: "TestUse", FilePath: "src/z_test.go", StartLine: 5,
+		Meta: map[string]any{"is_test": true},
+	}
+	for _, n := range []*graph.Node{target, testFile, prod, testFn} {
+		g.AddNode(n)
+	}
+	g.AddEdge(&graph.Edge{From: testFile.ID, To: target.ID, Kind: graph.EdgeImports, FilePath: testFile.FilePath, Line: 1})
+	g.AddEdge(&graph.Edge{From: prod.ID, To: target.ID, Kind: graph.EdgeCalls, FilePath: "src/a.go", Line: 4})
+	g.AddEdge(&graph.Edge{From: testFn.ID, To: target.ID, Kind: graph.EdgeCalls, FilePath: "src/z_test.go", Line: 6})
+	eng := query.NewEngine(g)
+	eng.SetSearch(search.NewNull())
+	srv := NewServer(eng, g, nil, nil, zap.NewNop(), nil)
+
+	out := findUsagesText(t, srv, map[string]any{"id": target.ID, "format": "toon"})
+	// Node rows carry the kind + name columns; edge rows carry from/to
+	// ids only, so gate on the node-row shape.
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, ",function,ProdUse,") {
+			require.NotContains(t, line, "true", "the production row must not inherit a skipped node's test flag: %s", line)
+		}
+		if strings.Contains(line, ",function,TestUse,") {
+			require.Contains(t, line, "true", "the stamped test row keeps its flag: %s", line)
+		}
+	}
+}
+
+// TestTrimTextToBudget_Boundaries pins that the budget is a hard
+// ceiling at every size: the marker itself must fit inside the budget,
+// including budgets smaller than the marker.
+func TestTrimTextToBudget_Boundaries(t *testing.T) {
+	const marker = "... trimmed to byte budget; pass max_bytes:0 for the full result\n"
+	text := strings.Repeat("row line here\n", 40)
+	for _, budget := range []int{1, len(marker) - 1, len(marker), len(marker) + 1, 100} {
+		out := trimTextToBudget(text, budget)
+		require.LessOrEqual(t, len(out), budget, "budget %d is a hard ceiling", budget)
+	}
+}
+
+// TestFindUsages_CompactHonorsTinyTokenBudget pins the same ceiling
+// through the handler on the token axis.
+func TestFindUsages_CompactHonorsTinyTokenBudget(t *testing.T) {
+	srv, hotID := usagesLimitServer(t, 55)
+	out := findUsagesText(t, srv, map[string]any{
+		"id": hotID, "limit": 0, "compact": true, "max_tokens": 1,
+	})
+	require.LessOrEqual(t, len(out), tokensToBytes(1), "max_tokens:1 must bound compact output")
 }
 
 // TestFindUsages_CompactWinsOverGCX pins the `compact` option against

--- a/internal/mcp/find_usages_output_options_test.go
+++ b/internal/mcp/find_usages_output_options_test.go
@@ -386,11 +386,37 @@ func TestFindUsages_OverlayOwnerClassifiesChildren(t *testing.T) {
 		"the overlay-stamped owner's child must classify as a test ref through the overlay view")
 }
 
+// TestFindUsages_OverlayOnlySymbolZeroEdgeCaveat pins the zero-edge
+// caveat under an overlay session: a symbol the request's own view
+// resolved is not a mistyped id, so its empty result classifies
+// through the deeper extraction-gap path, never the not-found message.
+func TestFindUsages_OverlayOnlySymbolZeroEdgeCaveat(t *testing.T) {
+	base := graph.New()
+	layer := graph.NewOverlayLayer()
+	fresh := &graph.Node{ID: "src/new.go::FreshFn", Kind: graph.KindFunction, Name: "FreshFn", FilePath: "src/new.go", StartLine: 1}
+	layer.AddNode("src/new.go", fresh)
+
+	eng := query.NewEngine(base)
+	eng.SetSearch(search.NewNull())
+	srv := NewServer(eng, base, nil, nil, zap.NewNop(), nil)
+	ctx := WithOverlayView(context.Background(), graph.NewOverlaidView(base, layer))
+
+	req := mcplib.CallToolRequest{}
+	req.Params.Name = "find_usages"
+	req.Params.Arguments = map[string]any{"id": fresh.ID}
+	res, err := srv.handleFindUsages(ctx, req)
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	out := res.Content[0].(mcplib.TextContent).Text
+	require.NotContains(t, out, "mistyped",
+		"a symbol the overlay view resolved must not be classified as a mistyped id")
+}
+
 // TestFindUsages_TOONRowsClassifyTheRightNode pins the TOON is_test
 // join: nodesToTOONRows skips File/Import nodes, so classification must
-// join rows to nodes by ID — indexing the filtered rows with unfiltered
-// node positions shifted every classification after a skipped node and
-// let a production function inherit a skipped test file's flag.
+// join rows to nodes by ID — positional indexing would shift every
+// classification after a skipped node and hand a production function a
+// skipped test file's flag.
 func TestFindUsages_TOONRowsClassifyTheRightNode(t *testing.T) {
 	g := graph.New()
 	target := &graph.Node{ID: "src/hot.go::Hot", Kind: graph.KindFunction, Name: "Hot", FilePath: "src/hot.go", StartLine: 1}
@@ -433,9 +459,8 @@ func TestFindUsages_TOONRowsClassifyTheRightNode(t *testing.T) {
 // ceiling at every size: the marker itself must fit inside the budget,
 // including budgets smaller than the marker.
 func TestTrimTextToBudget_Boundaries(t *testing.T) {
-	const marker = "... trimmed to byte budget; pass max_bytes:0 for the full result\n"
 	text := strings.Repeat("row line here\n", 40)
-	for _, budget := range []int{1, len(marker) - 1, len(marker), len(marker) + 1, 100} {
+	for _, budget := range []int{0, 1, len(trimBudgetMarker) - 1, len(trimBudgetMarker), len(trimBudgetMarker) + 1, 100} {
 		out := trimTextToBudget(text, budget)
 		require.LessOrEqual(t, len(out), budget, "budget %d is a hard ceiling", budget)
 	}

--- a/internal/mcp/find_usages_output_options_test.go
+++ b/internal/mcp/find_usages_output_options_test.go
@@ -97,6 +97,25 @@ func TestFindUsages_LimitTruncationMetaGCX(t *testing.T) {
 	require.NotContains(t, full, "truncated=true", "an uncapped response must not carry truncation meta")
 }
 
+// TestFindUsages_GroupByFileHonorsLimit pins the row cap on the
+// group_by:"file" shape: the buckets cover the capped page, and a
+// truncated grouped response carries the full total alongside its
+// per-page counts so the cut stays legible.
+func TestFindUsages_GroupByFileHonorsLimit(t *testing.T) {
+	srv, hotID := usagesLimitServer(t, 6)
+
+	var resp struct {
+		TotalUses  int  `json:"total_uses"`
+		TotalEdges int  `json:"total_edges"`
+		Truncated  bool `json:"truncated"`
+	}
+	out := findUsagesText(t, srv, map[string]any{"id": hotID, "limit": 2, "group_by": "file"})
+	require.NoError(t, json.Unmarshal([]byte(out), &resp))
+	require.Equal(t, 2, resp.TotalUses, "the grouped page covers the capped rows")
+	require.True(t, resp.Truncated)
+	require.Equal(t, 6, resp.TotalEdges, "a truncated grouped page must carry the full total")
+}
+
 // TestFindUsages_CompactWinsOverGCX pins the `compact` option against
 // the GCX format path: compact is an explicit caller choice, so it
 // takes precedence exactly as it does in the shared returnSubGraph

--- a/internal/mcp/find_usages_output_options_test.go
+++ b/internal/mcp/find_usages_output_options_test.go
@@ -1,0 +1,114 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// usagesLimitServer builds a server whose graph references `Hot` from
+// callerCount distinct call sites, one caller per file, so the limit
+// tests can count returned usage rows exactly.
+func usagesLimitServer(t *testing.T, callerCount int) (srv *Server, hotID string) {
+	t.Helper()
+	g := graph.New()
+	hot := &graph.Node{ID: "pkg/hot.go::Hot", Kind: graph.KindFunction, Name: "Hot", FilePath: "pkg/hot.go", StartLine: 1}
+	g.AddNode(hot)
+	for i := 0; i < callerCount; i++ {
+		file := fmt.Sprintf("pkg/use%d.go", i)
+		caller := &graph.Node{
+			ID: fmt.Sprintf("%s::Use%d", file, i), Kind: graph.KindFunction,
+			Name: fmt.Sprintf("Use%d", i), FilePath: file, StartLine: 3,
+		}
+		g.AddNode(caller)
+		g.AddEdge(&graph.Edge{From: caller.ID, To: hot.ID, Kind: graph.EdgeCalls, FilePath: file, Line: 5})
+	}
+	eng := query.NewEngine(g)
+	eng.SetSearch(search.NewNull())
+	return NewServer(eng, g, nil, nil, zap.NewNop(), nil), hot.ID
+}
+
+type usagesLimitResponse struct {
+	Edges        []*graph.Edge       `json:"edges"`
+	Nodes        []json.RawMessage   `json:"nodes"`
+	TotalEdges   int                 `json:"total_edges"`
+	Truncated    bool                `json:"truncated"`
+	UsageSummary *query.UsageSummary `json:"usage_summary"`
+}
+
+// TestFindUsages_LimitCapsUsageRows pins the advertised `limit` option:
+// a call asking for 2 rows gets exactly 2, marked truncated, with the
+// full row count still legible on total_edges and the completeness
+// rollup still covering the whole usage set.
+func TestFindUsages_LimitCapsUsageRows(t *testing.T) {
+	srv, hotID := usagesLimitServer(t, 6)
+
+	var resp usagesLimitResponse
+	require.NoError(t, json.Unmarshal([]byte(findUsagesText(t, srv, map[string]any{"id": hotID, "limit": 2})), &resp))
+	require.Len(t, resp.Edges, 2, "limit:2 must return exactly 2 usage rows")
+	require.True(t, resp.Truncated, "a capped response must be marked truncated")
+	require.Equal(t, 6, resp.TotalEdges, "total_edges must keep the full row count")
+	require.NotNil(t, resp.UsageSummary)
+	require.Equal(t, 6, resp.UsageSummary.NRefs, "the completeness rollup must describe the full set, not the page")
+}
+
+// TestFindUsages_DefaultLimitApplies pins the schema's "default: 50":
+// with no limit argument a 55-caller symbol answers with 50 rows and a
+// truncation marker instead of the whole set.
+func TestFindUsages_DefaultLimitApplies(t *testing.T) {
+	srv, hotID := usagesLimitServer(t, 55)
+
+	var resp usagesLimitResponse
+	require.NoError(t, json.Unmarshal([]byte(findUsagesText(t, srv, map[string]any{"id": hotID})), &resp))
+	require.Len(t, resp.Edges, 50, "the advertised default limit is 50")
+	require.True(t, resp.Truncated)
+	require.Equal(t, 55, resp.TotalEdges)
+}
+
+// TestFindUsages_LimitOptOut pins limit:0 as the explicit no-cap
+// escape hatch, mirroring the max_bytes/max_tokens opt-out semantics.
+func TestFindUsages_LimitOptOut(t *testing.T) {
+	srv, hotID := usagesLimitServer(t, 55)
+
+	var resp usagesLimitResponse
+	require.NoError(t, json.Unmarshal([]byte(findUsagesText(t, srv, map[string]any{"id": hotID, "limit": 0})), &resp))
+	require.Len(t, resp.Edges, 55, "limit:0 opts out of the cap")
+	require.False(t, resp.Truncated)
+}
+
+// TestFindUsages_LimitTruncationMetaGCX pins the truncation indicator
+// on the GCX wire: a capped response carries truncated=true plus the
+// full total, an uncapped response keeps its wire shape unchanged.
+func TestFindUsages_LimitTruncationMetaGCX(t *testing.T) {
+	srv, hotID := usagesLimitServer(t, 6)
+
+	out := findUsagesText(t, srv, map[string]any{"id": hotID, "format": "gcx", "limit": 2})
+	require.Contains(t, out, "truncated=true")
+	require.Contains(t, out, "total_edges=6")
+
+	full := findUsagesText(t, srv, map[string]any{"id": hotID, "format": "gcx", "limit": 0})
+	require.NotContains(t, full, "truncated=true", "an uncapped response must not carry truncation meta")
+}
+
+// TestFindUsages_CompactWinsOverGCX pins the `compact` option against
+// the GCX format path: compact is an explicit caller choice, so it
+// takes precedence exactly as it does in the shared returnSubGraph
+// renderer — including for sessions whose default format is gcx, where
+// isGCX(ctx, req) is true without any format argument. The explicit
+// format:"gcx" arg reproduces that same isGCX=true condition without
+// needing a session handshake.
+func TestFindUsages_CompactWinsOverGCX(t *testing.T) {
+	srv, fooID, _ := usagesSummaryServer(t)
+
+	out := findUsagesText(t, srv, map[string]any{"id": fooID, "format": "gcx", "compact": true})
+	require.Contains(t, out, "edges: 4 total", "compact:true must render the one-line-per-symbol text format")
+	require.Contains(t, out, "function Use1 pkg/a.go:3", "compact rows carry kind, name, and location")
+	require.NotContains(t, out, "from_is_test", "compact output must not be the GCX row encoding")
+}

--- a/internal/mcp/find_usages_output_options_test.go
+++ b/internal/mcp/find_usages_output_options_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -283,6 +284,55 @@ func TestFindUsages_CompactHonorsByteBudget(t *testing.T) {
 	})
 	require.LessOrEqual(t, len(out), 300, "compact output must respect max_bytes")
 	require.Contains(t, out, "trimmed", "a budget-trimmed compact response must say so")
+}
+
+// TestFindUsages_TestLabelsMatchTheFilter pins that the output
+// metadata classifies test rows with the same classifier the
+// exclude_tests filter uses: a file-level node (is_test_file only) and
+// a bare param node under a test directory count in
+// usage_summary.n_test_refs and carry from_is_test=true on the GCX
+// wire, instead of being filtered as tests but labeled as production.
+func TestFindUsages_TestLabelsMatchTheFilter(t *testing.T) {
+	g := graph.New()
+	target := &graph.Node{ID: "src/WidgetService.cs::WidgetService", Kind: graph.KindType, Name: "WidgetService", FilePath: "src/WidgetService.cs", StartLine: 5}
+	prod := &graph.Node{ID: "src/Consumer.cs::Consumer.Use", Kind: graph.KindMethod, Name: "Use", FilePath: "src/Consumer.cs", StartLine: 12}
+	testFile := &graph.Node{
+		ID: `Test\WidgetService_Tests.cs`, Kind: graph.KindFile,
+		Name: "WidgetService_Tests.cs", FilePath: `Test\WidgetService_Tests.cs`,
+		Meta: map[string]any{"is_test_file": true},
+	}
+	testParam := &graph.Node{
+		ID: `Test\WidgetService_Tests.cs::WidgetServiceTests.Run#param:svc`, Kind: graph.KindParam,
+		Name: "svc", FilePath: `Test\WidgetService_Tests.cs`, StartLine: 20,
+	}
+	for _, n := range []*graph.Node{target, prod, testFile, testParam} {
+		g.AddNode(n)
+	}
+	g.AddEdge(&graph.Edge{From: prod.ID, To: target.ID, Kind: graph.EdgeCalls, FilePath: "src/Consumer.cs", Line: 14})
+	g.AddEdge(&graph.Edge{From: testFile.ID, To: target.ID, Kind: graph.EdgeImports, FilePath: testFile.FilePath, Line: 1})
+	g.AddEdge(&graph.Edge{From: testParam.ID, To: target.ID, Kind: graph.EdgeReferences, FilePath: testParam.FilePath, Line: 20})
+	eng := query.NewEngine(g)
+	eng.SetSearch(search.NewNull())
+	srv := NewServer(eng, g, nil, nil, zap.NewNop(), nil)
+
+	var resp struct {
+		UsageSummary *query.UsageSummary `json:"usage_summary"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(findUsagesText(t, srv, map[string]any{"id": target.ID})), &resp))
+	require.NotNil(t, resp.UsageSummary)
+	require.Equal(t, 3, resp.UsageSummary.NRefs)
+	require.Equal(t, 2, resp.UsageSummary.NTestRefs,
+		"n_test_refs must count the unstamped test-path rows the filter would drop")
+
+	gcx := findUsagesText(t, srv, map[string]any{"id": target.ID, "format": "gcx"})
+	for _, line := range strings.Split(gcx, "\n") {
+		if strings.HasPrefix(line, testParam.ID+"\t") || strings.HasPrefix(line, testFile.ID+"\t") {
+			require.Contains(t, line, "\ttrue", "test-path rows must carry from_is_test=true: %s", line)
+		}
+		if strings.HasPrefix(line, prod.ID+"\t") {
+			require.NotContains(t, line, "\ttrue", "the production row must stay from_is_test=false: %s", line)
+		}
+	}
 }
 
 // TestFindUsages_CompactWinsOverGCX pins the `compact` option against

--- a/internal/mcp/gcx.go
+++ b/internal/mcp/gcx.go
@@ -457,6 +457,14 @@ func tierFilteredCaveatMeta(c *graph.TierFilteredCaveat) []string {
 func encodeFindUsages(sg *query.SubGraph, g graph.Store) ([]byte, error) {
 	var buf bytes.Buffer
 	meta := []string{"edges", fmt.Sprintf("%d", len(sg.Edges))}
+	// Truncation meta rides only on a capped result so an uncapped
+	// response keeps its wire shape byte-for-byte.
+	if sg.Truncated {
+		meta = append(meta,
+			"truncated", "true",
+			"total_edges", fmt.Sprintf("%d", sg.TotalEdges),
+		)
+	}
 	meta = append(meta, zeroEdgeCaveatMeta(sg.Caveat)...)
 	meta = append(meta, tierFilteredCaveatMeta(sg.TierFiltered)...)
 	if sg.TextMatchedSuppressed > 0 {

--- a/internal/mcp/gcx.go
+++ b/internal/mcp/gcx.go
@@ -513,7 +513,7 @@ func encodeFindUsages(sg *query.SubGraph, g graph.Store) ([]byte, error) {
 		ftf, fuc := usageFromFlavor(g, e.From, fn)
 		if err := enc.WriteRow(
 			e.From, e.To, string(e.Kind), e.Context, e.ReturnUsage, e.Origin, tier, e.Confidence,
-			fname, fpath, fline, nodeIsTest(fn), nodeTestRole(fn), nodeTestRunner(fn), ftf, fuc,
+			fname, fpath, fline, graph.NodeIsTest(g, fn), nodeTestRole(fn), nodeTestRunner(fn), ftf, fuc,
 		); err != nil {
 			return nil, err
 		}
@@ -533,7 +533,7 @@ func encodeFindUsages(sg *query.SubGraph, g graph.Store) ([]byte, error) {
 // third caller_notes section when get_callers attached concurrency
 // annotations. The third section is omitted entirely when empty so the
 // other traversal tools' wire output is byte-identical to before.
-func encodeSubGraph(tool string, sg *query.SubGraph) ([]byte, error) {
+func encodeSubGraph(tool string, sg *query.SubGraph, g graph.Store) ([]byte, error) {
 	var buf bytes.Buffer
 	nodes := make([]*graph.Node, 0, len(sg.Nodes))
 	for _, n := range sg.Nodes {
@@ -565,7 +565,7 @@ func encodeSubGraph(tool string, sg *query.SubGraph) ([]byte, error) {
 		nodeMeta...,
 	)
 	for _, n := range nodes {
-		if err := nodeEnc.WriteRow(n.ID, string(n.Kind), nodeShort(n), n.FilePath, n.AbsoluteFilePath, n.StartLine, nodeIsTest(n), nodeTestRole(n), nodeTestRunner(n)); err != nil {
+		if err := nodeEnc.WriteRow(n.ID, string(n.Kind), nodeShort(n), n.FilePath, n.AbsoluteFilePath, n.StartLine, graph.NodeIsTest(g, n), nodeTestRole(n), nodeTestRunner(n)); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/mcp/gcx.go
+++ b/internal/mcp/gcx.go
@@ -54,6 +54,11 @@ func (s *Server) isGCX(ctx context.Context, req mcp.CallToolRequest) bool {
 // (full result inline, transport-spilled if the harness cap fires).
 func (s *Server) gcxResponseWithBudget(req mcp.CallToolRequest) func([]byte, error) (*mcp.CallToolResult, error) {
 	budget := effectiveBudget(req)
+	// The token-budget comment lands after the row trim; reserve its
+	// bytes so the decorated payload stays in cap.
+	if reserve := tokenBudgetDecorationReserve(req); reserve < budget {
+		budget -= reserve
+	}
 	return func(payload []byte, err error) (*mcp.CallToolResult, error) {
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("wire encode failed: %v", err)), nil

--- a/internal/mcp/gcx.go
+++ b/internal/mcp/gcx.go
@@ -454,7 +454,7 @@ func tierFilteredCaveatMeta(c *graph.TierFilteredCaveat) []string {
 // encodeFindUsages emits one row per usage edge. Each row names the
 // caller symbol, its location, the edge kind, and the origin tier so
 // agents can filter without a second call.
-func encodeFindUsages(sg *query.SubGraph, g graph.Store) ([]byte, error) {
+func encodeFindUsages(sg *query.SubGraph, g graph.NodeGetter) ([]byte, error) {
 	var buf bytes.Buffer
 	meta := []string{"edges", fmt.Sprintf("%d", len(sg.Edges))}
 	// Truncation meta rides only on a capped result so an uncapped
@@ -533,7 +533,7 @@ func encodeFindUsages(sg *query.SubGraph, g graph.Store) ([]byte, error) {
 // third caller_notes section when get_callers attached concurrency
 // annotations. The third section is omitted entirely when empty so the
 // other traversal tools' wire output is byte-identical to before.
-func encodeSubGraph(tool string, sg *query.SubGraph, g graph.Store) ([]byte, error) {
+func encodeSubGraph(tool string, sg *query.SubGraph, g graph.NodeGetter) ([]byte, error) {
 	var buf bytes.Buffer
 	nodes := make([]*graph.Node, 0, len(sg.Nodes))
 	for _, n := range sg.Nodes {

--- a/internal/mcp/gcx.go
+++ b/internal/mcp/gcx.go
@@ -55,8 +55,12 @@ func (s *Server) isGCX(ctx context.Context, req mcp.CallToolRequest) bool {
 func (s *Server) gcxResponseWithBudget(req mcp.CallToolRequest) func([]byte, error) (*mcp.CallToolResult, error) {
 	budget := effectiveBudget(req)
 	// The token-budget comment lands after the row trim; reserve its
-	// bytes so the decorated payload stays in cap.
-	if reserve := tokenBudgetDecorationReserve(req); reserve < budget {
+	// bytes so the decorated payload stays in cap. A budget the reserve
+	// itself cannot fit inside drops the comment instead of letting it
+	// become the bytes that break the contract.
+	reserve := tokenBudgetDecorationReserve(req)
+	decorate := reserve == 0 || reserve < budget
+	if reserve > 0 && decorate {
 		budget -= reserve
 	}
 	return func(payload []byte, err error) (*mcp.CallToolResult, error) {
@@ -66,7 +70,7 @@ func (s *Server) gcxResponseWithBudget(req mcp.CallToolRequest) func([]byte, err
 		if budget > 0 {
 			if trimmed, didTrim := trimGCXBytes(payload, budget); trimmed != nil {
 				payload = trimmed
-				if didTrim {
+				if didTrim && decorate {
 					payload = decorateTokenBudgetGCX(payload, req)
 				}
 			}

--- a/internal/mcp/gcx_test.go
+++ b/internal/mcp/gcx_test.go
@@ -162,7 +162,7 @@ func TestEncodeSubGraph_DistinctCallSitesNotDeduped(t *testing.T) {
 		},
 		TotalNodes: 2,
 	}
-	payload, err := encodeSubGraph("walk_graph", sg)
+	payload, err := encodeSubGraph("walk_graph", sg, nil)
 	require.NoError(t, err)
 	dec := wire.NewDecoder(strings.NewReader(string(payload)))
 	_, err = dec.Header()
@@ -193,7 +193,7 @@ func TestEncodeSubGraph_NodesAndEdgesSections(t *testing.T) {
 		},
 		TotalNodes: 2,
 	}
-	payload, err := encodeSubGraph("get_callers", sg)
+	payload, err := encodeSubGraph("get_callers", sg, nil)
 	require.NoError(t, err)
 	dec := wire.NewDecoder(strings.NewReader(string(payload)))
 

--- a/internal/mcp/overlay_view.go
+++ b/internal/mcp/overlay_view.go
@@ -169,6 +169,18 @@ func (s *Server) readerFor(ctx context.Context) graph.Reader {
 // Cheap: WithReader is a shallow clone (one struct copy, shares
 // search provider and rerank pipeline). Safe to call inside hot
 // tool-handler paths.
+// nodeGetterFor returns the request-scoped node lookup: the session
+// overlay view when one rides the context, the base graph otherwise.
+// Output classification (is_test labels, usage summary, flavor
+// resolution) must read the same view engineFor's query ran on, or an
+// overlay-only owner classifies differently in the filter and the rows.
+func (s *Server) nodeGetterFor(ctx context.Context) graph.NodeGetter {
+	if v := OverlayViewFromContext(ctx); v != nil {
+		return v
+	}
+	return s.graph
+}
+
 func (s *Server) engineFor(ctx context.Context) *query.Engine {
 	if s == nil || s.engine == nil {
 		return nil

--- a/internal/mcp/overlay_view.go
+++ b/internal/mcp/overlay_view.go
@@ -159,6 +159,15 @@ func (s *Server) readerFor(ctx context.Context) graph.Reader {
 	return s.graph
 }
 
+// nodeGetterFor returns the request-scoped node lookup: the session
+// overlay view when one rides the context, the base graph otherwise.
+// Output classification (is_test labels, usage summary, flavor
+// resolution) must read the same view engineFor's query ran on, or an
+// overlay-only owner classifies differently in the filter and the rows.
+func (s *Server) nodeGetterFor(ctx context.Context) graph.NodeGetter {
+	return s.readerFor(ctx)
+}
+
 // engineFor returns the query engine scoped to the calling request's
 // graph reader. For non-overlay calls this is `s.engine` unchanged;
 // for overlay-active calls the returned engine reads through the
@@ -169,18 +178,6 @@ func (s *Server) readerFor(ctx context.Context) graph.Reader {
 // Cheap: WithReader is a shallow clone (one struct copy, shares
 // search provider and rerank pipeline). Safe to call inside hot
 // tool-handler paths.
-// nodeGetterFor returns the request-scoped node lookup: the session
-// overlay view when one rides the context, the base graph otherwise.
-// Output classification (is_test labels, usage summary, flavor
-// resolution) must read the same view engineFor's query ran on, or an
-// overlay-only owner classifies differently in the filter and the rows.
-func (s *Server) nodeGetterFor(ctx context.Context) graph.NodeGetter {
-	if v := OverlayViewFromContext(ctx); v != nil {
-		return v
-	}
-	return s.graph
-}
-
 func (s *Server) engineFor(ctx context.Context) *query.Engine {
 	if s == nil || s.engine == nil {
 		return nil

--- a/internal/mcp/render_budget_validity_test.go
+++ b/internal/mcp/render_budget_validity_test.go
@@ -1,0 +1,64 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestBudgetedDiagramsStaySyntacticallyValid pins that a budget cut
+// never hands back a broken document: a diagram (or TOON) response is
+// re-rendered over fewer rows, not byte-sliced mid-grammar — a dot
+// fragment without its closing brace, or a TOON table whose header
+// declares more rows than remain, fails every downstream parser while
+// looking like a successful response.
+func TestBudgetedDiagramsStaySyntacticallyValid(t *testing.T) {
+	srv, hotID := usagesLimitServer(t, 80)
+
+	t.Run("dot keeps its closing brace", func(t *testing.T) {
+		out := findUsagesText(t, srv, map[string]any{"id": hotID, "format": "dot", "limit": 0, "max_bytes": 1200})
+		require.LessOrEqual(t, len(out), 1200)
+		require.Contains(t, out, "digraph")
+		require.Contains(t, out, "\n}\n",
+			"a budgeted dot document must still close its digraph block, got tail %q", out[max(0, len(out)-80):])
+		require.NotContains(t, out, "trimmed to byte budget",
+			"the plain-text marker is not dot syntax; the cut must re-render, not slice")
+	})
+
+	t.Run("mermaid carries no prose marker", func(t *testing.T) {
+		out := findUsagesText(t, srv, map[string]any{"id": hotID, "format": "mermaid", "limit": 0, "max_bytes": 1200})
+		require.LessOrEqual(t, len(out), 1200)
+		require.NotContains(t, out, "trimmed to byte budget",
+			"the plain-text marker is not mermaid syntax; the cut must re-render, not slice")
+	})
+
+	t.Run("toon re-renders instead of slicing", func(t *testing.T) {
+		out := findUsagesText(t, srv, map[string]any{"id": hotID, "format": "toon", "limit": 0, "max_bytes": 1200})
+		require.LessOrEqual(t, len(out), 1200)
+		require.NotContains(t, out, "trimmed to byte budget",
+			"a byte-sliced TOON table contradicts its own row-count headers; the cut must re-render")
+	})
+}
+
+// TestTinyTokenBudgetDropsTheDecoration pins the boundary where the
+// token-budget decoration is bigger than the budget itself: the
+// decoration must be dropped — it can never be the bytes that push the
+// payload past the cap it documents. (The JSON structural trim keeps
+// its documented scalar-skeleton floor; the decoration must not add
+// to it.) On the text renderers the same tiny budget stays a hard
+// ceiling outright.
+func TestTinyTokenBudgetDropsTheDecoration(t *testing.T) {
+	srv, hotID := usagesLimitServer(t, 40)
+
+	for _, tokens := range []int{5, 10, 14} {
+		out := findUsagesText(t, srv, map[string]any{"id": hotID, "limit": 0, "max_tokens": tokens})
+		require.NotContains(t, out, `"_truncated_by_tokens"`,
+			"max_tokens:%d cannot fit the decoration, so the decoration must be dropped", tokens)
+		require.NotContains(t, out, `"_max_tokens"`,
+			"max_tokens:%d cannot fit the decoration, so the decoration must be dropped", tokens)
+
+		toonOut := findUsagesText(t, srv, map[string]any{"id": hotID, "format": "toon", "limit": 0, "max_tokens": tokens})
+		require.LessOrEqual(t, len(toonOut), tokensToBytes(tokens),
+			"the text renderers keep max_tokens:%d as a hard ceiling", tokens)
+	}
+}

--- a/internal/mcp/render_node_budget_test.go
+++ b/internal/mcp/render_node_budget_test.go
@@ -1,0 +1,138 @@
+package mcp
+
+import (
+	"fmt"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/query"
+)
+
+// isolatedNodesSubGraph builds the shape a min_tier / speculative
+// filter produces in the wild: every edge dropped, the node list
+// intact. The edge-prefix search has nothing to cut here — only a
+// node-prefix re-render can fit the budget without byte-slicing the
+// grammar.
+func isolatedNodesSubGraph(n int) *query.SubGraph {
+	sg := &query.SubGraph{}
+	for i := 0; i < n; i++ {
+		sg.Nodes = append(sg.Nodes, &graph.Node{
+			ID:       fmt.Sprintf("pkg/iso%03d.go::Isolated%03d", i, i),
+			Kind:     graph.KindFunction,
+			Name:     fmt.Sprintf("Isolated%03d", i),
+			FilePath: fmt.Sprintf("pkg/iso%03d.go", i),
+		})
+	}
+	return sg
+}
+
+func budgetedRequest(maxBytes int) mcplib.CallToolRequest {
+	req := mcplib.CallToolRequest{}
+	req.Params.Name = "find_usages"
+	req.Params.Arguments = map[string]any{"max_bytes": maxBytes}
+	return req
+}
+
+// dotRender mirrors returnSubGraph's production dot callback,
+// including the shared budget note, so the fitted size the test
+// measures is the size production ships.
+func dotRender(base *query.SubGraph) func(*query.SubGraph) string {
+	return func(sg *query.SubGraph) string {
+		text := sg.ToDot()
+		if note := subGraphBudgetNote(sg, base); note != "" {
+			text += "// " + note + "\n"
+		}
+		return text
+	}
+}
+
+// TestNodeOnlySubGraphRendersValidlyWithinBudget pins the node-prefix
+// re-render: a zero-edge, node-heavy subgraph must fit the byte budget
+// by re-rendering over a node prefix — falling through to the
+// plain-text trimmer corrupts the grammar (a dot document loses its
+// closing brace; TOON contradicts its own row counts).
+func TestNodeOnlySubGraphRendersValidlyWithinBudget(t *testing.T) {
+	const cap = 300
+
+	t.Run("dot", func(t *testing.T) {
+		sg := isolatedNodesSubGraph(100)
+		out := renderSubGraphWithinBudget(budgetedRequest(cap), sg, dotRender(sg))
+		require.LessOrEqual(t, len(out), cap)
+		require.Contains(t, out, "digraph")
+		require.Contains(t, out, "\n}",
+			"a budgeted dot document must still close its digraph block, got tail %q", out[max(0, len(out)-80):])
+		require.NotContains(t, out, "trimmed to byte budget")
+	})
+
+	t.Run("mermaid", func(t *testing.T) {
+		sg := isolatedNodesSubGraph(100)
+		out := renderSubGraphWithinBudget(budgetedRequest(cap), sg, func(trial *query.SubGraph) string {
+			text := trial.ToMermaid()
+			if note := subGraphBudgetNote(trial, sg); note != "" {
+				text += "%% " + note + "\n"
+			}
+			return text
+		})
+		require.LessOrEqual(t, len(out), cap)
+		require.NotContains(t, out, "trimmed to byte budget")
+	})
+
+	t.Run("toon", func(t *testing.T) {
+		sg := isolatedNodesSubGraph(100)
+		out := renderSubGraphWithinBudget(budgetedRequest(cap), sg, func(trial *query.SubGraph) string {
+			return subGraphToTOON(trial, nil)
+		})
+		require.LessOrEqual(t, len(out), cap)
+		require.NotContains(t, out, "trimmed to byte budget")
+	})
+
+	t.Run("mixed isolated nodes and edges keep the subject", func(t *testing.T) {
+		// Isolated nodes dominate while a few edges exist: the edge
+		// search alone cannot fit — every page render keeps all 100
+		// isolated nodes — so the node cut must engage, and the cut
+		// must not drop the nodes the result's edges touch (the
+		// queried subject among them).
+		// Dot spends ~120 bytes per node row, so this cap fits about
+		// two nodes — enough for both edge-touched ones, none of the
+		// isolated tail.
+		const mixedCap = 500
+		sg := isolatedNodesSubGraph(100)
+		linked := &graph.Node{ID: "pkg/linked.go::A", Kind: graph.KindFunction, Name: "A", FilePath: "pkg/linked.go"}
+		sg.Nodes = append(sg.Nodes, linked)
+		sg.Edges = append(sg.Edges, &graph.Edge{From: linked.ID, To: sg.Nodes[0].ID, Kind: graph.EdgeCalls})
+		out := renderSubGraphWithinBudget(budgetedRequest(mixedCap), sg, dotRender(sg))
+		require.LessOrEqual(t, len(out), mixedCap)
+		require.Contains(t, out, "digraph")
+		require.Contains(t, out, "\n}")
+		require.Contains(t, out, "linked",
+			"the node cut must keep the nodes the result's edges touch — the queried subject is one of them")
+		require.NotContains(t, out, "trimmed to byte budget")
+	})
+}
+
+// TestBudgetNoteFiresOnlyOnBudgetCuts pins the note's attribution: a
+// handler-side limit cap stamps Truncated and the pre-cut totals on
+// the subgraph, and a rendering of that shape that FITS the budget
+// must carry no "(byte budget)" note — "pass max_bytes:0" cannot
+// restore rows a `limit` removed.
+func TestBudgetNoteFiresOnlyOnBudgetCuts(t *testing.T) {
+	sg := isolatedNodesSubGraph(5)
+	sg.Truncated = true
+	sg.TotalNodes = 200
+	sg.TotalEdges = 400
+
+	out := renderSubGraphWithinBudget(budgetedRequest(100_000), sg, dotRender(sg))
+	require.NotContains(t, out, "byte budget",
+		"a limit-capped result that fits the byte budget must not blame the byte budget")
+
+	// The same shape over a tight budget IS byte-cut, and the note
+	// names the cut relative to the rows the handler returned.
+	cut := renderSubGraphWithinBudget(budgetedRequest(300), sg, dotRender(sg))
+	require.LessOrEqual(t, len(cut), 300)
+	require.Contains(t, cut, "byte budget")
+	require.Contains(t, cut, "of 5 nodes",
+		"the note's denominator is what max_bytes:0 would return — the handler's rows, not the pre-limit total")
+}

--- a/internal/mcp/response_contract_matrix_test.go
+++ b/internal/mcp/response_contract_matrix_test.go
@@ -17,11 +17,11 @@ import (
 
 // TestResponseBudgetContractMatrix sweeps the schema's byte/token
 // budget across EVERY find_usages rendering on BOTH backends: the
-// budget is a contract on the response, not on one renderer, so a new
-// format (or a format newly brought to life) cannot silently bypass it
-// the way the TOON path once did. Text renderers trim to a hard
-// ceiling; structured renderers trim list tails, so their floor is the
-// scalar skeleton — the matrix budget sits above it.
+// budget is a contract on the response, not on one renderer, so no
+// format — new, or newly brought to life — can step outside it
+// silently. Text renderers trim to a hard ceiling; structured
+// renderers trim list tails, so their floor is the scalar skeleton —
+// the matrix budget sits above it.
 func TestResponseBudgetContractMatrix(t *testing.T) {
 	renderings := []struct {
 		name string

--- a/internal/mcp/response_contract_matrix_test.go
+++ b/internal/mcp/response_contract_matrix_test.go
@@ -1,0 +1,159 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// TestResponseBudgetContractMatrix sweeps the schema's byte/token
+// budget across EVERY find_usages rendering on BOTH backends: the
+// budget is a contract on the response, not on one renderer, so a new
+// format (or a format newly brought to life) cannot silently bypass it
+// the way the TOON path once did. Text renderers trim to a hard
+// ceiling; structured renderers trim list tails, so their floor is the
+// scalar skeleton — the matrix budget sits above it.
+func TestResponseBudgetContractMatrix(t *testing.T) {
+	renderings := []struct {
+		name string
+		args map[string]any
+	}{
+		{"json", map[string]any{}},
+		{"compact", map[string]any{"compact": true}},
+		{"toon", map[string]any{"format": "toon"}},
+		{"gcx", map[string]any{"format": "gcx"}},
+		{"mermaid", map[string]any{"format": "mermaid"}},
+		{"dot", map[string]any{"format": "dot"}},
+		{"group_by_file", map[string]any{"group_by": "file"}},
+	}
+	budgets := []struct {
+		name string
+		args map[string]any
+		cap  int
+	}{
+		{"max_bytes", map[string]any{"max_bytes": 900}, 900},
+		{"max_tokens", map[string]any{"max_tokens": 300}, tokensToBytes(300)},
+	}
+	build := func(g graph.Store) string {
+		hot := &graph.Node{ID: "pkg/hot.go::Hot", Kind: graph.KindFunction, Name: "Hot", FilePath: "pkg/hot.go", StartLine: 1}
+		g.AddNode(hot)
+		for i := 0; i < 60; i++ {
+			file := fmt.Sprintf("pkg/use%02d.go", i)
+			caller := &graph.Node{ID: fmt.Sprintf("%s::Use%02d", file, i), Kind: graph.KindFunction, Name: fmt.Sprintf("Use%02d", i), FilePath: file, StartLine: 3}
+			g.AddNode(caller)
+			g.AddEdge(&graph.Edge{From: caller.ID, To: hot.ID, Kind: graph.EdgeCalls, FilePath: file, Line: 5, Origin: graph.OriginASTResolved, Confidence: 0.9})
+		}
+		return hot.ID
+	}
+
+	run := func(t *testing.T, g graph.Store, hotID string) {
+		eng := query.NewEngine(g)
+		eng.SetSearch(search.NewNull())
+		srv := NewServer(eng, g, nil, nil, zap.NewNop(), nil)
+		for _, r := range renderings {
+			for _, b := range budgets {
+				t.Run(r.name+"/"+b.name, func(t *testing.T) {
+					args := map[string]any{"id": hotID, "limit": 0}
+					for k, v := range r.args {
+						args[k] = v
+					}
+					for k, v := range b.args {
+						args[k] = v
+					}
+					out := findUsagesText(t, srv, args)
+					require.LessOrEqual(t, len(out), b.cap,
+						"rendering %q must honor %s (cap %d), got %d bytes", r.name, b.name, b.cap, len(out))
+					require.NotEmpty(t, out, "a budgeted response is trimmed, never blank")
+				})
+			}
+		}
+	}
+
+	t.Run("memory", func(t *testing.T) {
+		g := graph.New()
+		run(t, g, build(g))
+	})
+	t.Run("sqlite", func(t *testing.T) {
+		g, err := store_sqlite.Open(filepath.Join(t.TempDir(), "matrix.sqlite"))
+		require.NoError(t, err)
+		defer g.Close()
+		run(t, g, build(g))
+	})
+}
+
+// TestResponseLimitContractMatrix sweeps the schema's `limit` across
+// the row-bearing renderings on both backends: every shape that lists
+// usages must page by the same cap.
+func TestResponseLimitContractMatrix(t *testing.T) {
+	build := func(g graph.Store) string {
+		hot := &graph.Node{ID: "pkg/hot.go::Hot", Kind: graph.KindFunction, Name: "Hot", FilePath: "pkg/hot.go", StartLine: 1}
+		g.AddNode(hot)
+		for i := 0; i < 8; i++ {
+			file := fmt.Sprintf("pkg/use%d.go", i)
+			caller := &graph.Node{ID: fmt.Sprintf("%s::Use%d", file, i), Kind: graph.KindFunction, Name: fmt.Sprintf("Use%d", i), FilePath: file, StartLine: 3}
+			g.AddNode(caller)
+			g.AddEdge(&graph.Edge{From: caller.ID, To: hot.ID, Kind: graph.EdgeCalls, FilePath: file, Line: 5, Origin: graph.OriginASTResolved, Confidence: 0.9})
+		}
+		return hot.ID
+	}
+	countRows := map[string]func(t *testing.T, out string) int{
+		"json": func(t *testing.T, out string) int {
+			var resp usagesLimitResponse
+			require.NoError(t, json.Unmarshal([]byte(out), &resp))
+			return len(resp.Edges)
+		},
+		"group_by_file": func(t *testing.T, out string) int {
+			var resp struct {
+				Groups []struct {
+					Uses []json.RawMessage `json:"uses"`
+				} `json:"groups"`
+			}
+			require.NoError(t, json.Unmarshal([]byte(out), &resp))
+			rows := 0
+			for _, g := range resp.Groups {
+				rows += len(g.Uses)
+			}
+			return rows
+		},
+	}
+	argsFor := map[string]map[string]any{
+		"json":          {},
+		"group_by_file": {"group_by": "file"},
+	}
+
+	run := func(t *testing.T, g graph.Store, hotID string) {
+		eng := query.NewEngine(g)
+		eng.SetSearch(search.NewNull())
+		srv := NewServer(eng, g, nil, nil, zap.NewNop(), nil)
+		for name, counter := range countRows {
+			t.Run(name, func(t *testing.T) {
+				args := map[string]any{"id": hotID, "limit": 3}
+				for k, v := range argsFor[name] {
+					args[k] = v
+				}
+				out := findUsagesText(t, srv, args)
+				require.Equal(t, 3, counter(t, out), "rendering %q must page by the caller's limit", name)
+			})
+		}
+	}
+
+	t.Run("memory", func(t *testing.T) {
+		g := graph.New()
+		run(t, g, build(g))
+	})
+	t.Run("sqlite", func(t *testing.T) {
+		g, err := store_sqlite.Open(filepath.Join(t.TempDir(), "matrix-limit.sqlite"))
+		require.NoError(t, err)
+		defer g.Close()
+		run(t, g, build(g))
+	})
+}

--- a/internal/mcp/symbol_full_budget_test.go
+++ b/internal/mcp/symbol_full_budget_test.go
@@ -1,0 +1,84 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/respbudget"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// symbolFullBudgetServer builds a graph whose seed symbol carries
+// enough direct edges that a full-detail response dwarfs a small
+// budget. The payload shape matters: typed []*graph.Edge slices
+// inside a map[string]any, which the trimmer only sees after JSON
+// normalization.
+func symbolFullBudgetServer(t *testing.T) (*Server, string) {
+	t.Helper()
+	g := graph.New()
+	seed := &graph.Node{ID: "pkg/svc.go::Handler", Kind: graph.KindFunction, Name: "Handler", FilePath: "pkg/svc.go", StartLine: 1}
+	g.AddNode(seed)
+	for i := 0; i < 40; i++ {
+		file := fmt.Sprintf("pkg/peer%02d.go", i)
+		peer := &graph.Node{ID: fmt.Sprintf("%s::Peer%02d", file, i), Kind: graph.KindFunction, Name: fmt.Sprintf("Peer%02d", i), FilePath: file, StartLine: 3}
+		g.AddNode(peer)
+		g.AddEdge(&graph.Edge{From: peer.ID, To: seed.ID, Kind: graph.EdgeCalls, FilePath: file, Line: 5, Origin: graph.OriginASTResolved, Confidence: 0.9})
+		g.AddEdge(&graph.Edge{From: seed.ID, To: peer.ID, Kind: graph.EdgeReferences, FilePath: "pkg/svc.go", Line: 7 + i, Origin: graph.OriginASTResolved, Confidence: 0.9})
+	}
+	eng := query.NewEngine(g)
+	eng.SetSearch(search.NewNull())
+	return NewServer(eng, g, nil, nil, zap.NewNop(), nil), seed.ID
+}
+
+func getSymbolText(t *testing.T, srv *Server, args map[string]any) string {
+	t.Helper()
+	req := mcplib.CallToolRequest{}
+	req.Params.Name = "get_symbol"
+	req.Params.Arguments = args
+	res, err := srv.handleGetSymbol(context.Background(), req)
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	return res.Content[0].(mcplib.TextContent).Text
+}
+
+// TestGetSymbolFullHonorsBudget pins the byte/token budget on the
+// get_symbol detail:"full" response — the payload whose edge lists are
+// typed slices, so the trim must normalize before it can cut.
+func TestGetSymbolFullHonorsBudget(t *testing.T) {
+	srv, seedID := symbolFullBudgetServer(t)
+
+	full := getSymbolText(t, srv, map[string]any{"id": seedID, "detail": "full"})
+	require.Greater(t, len(full), 600, "fixture must overflow the test cap unbudgeted")
+
+	cases := []struct {
+		name string
+		args map[string]any
+		cap  int
+	}{
+		{"json_max_bytes", map[string]any{"max_bytes": 600}, 600},
+		{"json_max_tokens", map[string]any{"max_tokens": 200}, tokensToBytes(200)},
+		{"toon_max_bytes", map[string]any{"format": "toon", "max_bytes": 600}, 600},
+		{"toon_max_tokens", map[string]any{"format": "toon", "max_tokens": 200}, tokensToBytes(200)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			args := map[string]any{"id": seedID, "detail": "full"}
+			for k, v := range tc.args {
+				args[k] = v
+			}
+			out := getSymbolText(t, srv, args)
+			require.LessOrEqual(t, len(out), tc.cap,
+				"get_symbol full must honor the cap %d, got %d bytes", tc.cap, len(out))
+			require.NotEmpty(t, out)
+			require.Contains(t, out, respbudget.TruncatedKey,
+				"a trimmed response carries the truncation marker in both JSON and TOON")
+		})
+	}
+}

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -1115,7 +1115,7 @@ func (s *Server) registerCoreTools() {
 		mcp.NewTool("find_usages",
 			mcp.WithDescription("Use instead of Grep to find every reference to a symbol across the codebase. Returns precise locations with zero false positives. For just the call sites of a function use get_callers; for the concrete types that implement an interface use find_implementations."),
 			mcp.WithString("id", mcp.Required(), mcp.Description("Node ID")),
-			mcp.WithNumber("limit", mcp.Description("Max nodes (default: 50)")),
+			mcp.WithNumber("limit", mcp.Description("Max usage rows returned (default: 50; 0 = no cap). A capped response is marked truncated and total_edges keeps the full count.")),
 			mcp.WithBoolean("compact", mcp.Description("One-line-per-symbol text output (saves 50-70% tokens)")),
 			mcp.WithString("format", mcp.Description("Output format: json (default), gcx (GCX1 compact wire format), or toon")),
 			mcp.WithNumber("max_bytes", mcp.Description("Cap the marshaled response at this many bytes. The longest list is trimmed; truncation metadata rides on the response. Omit for no cap.")),
@@ -2742,6 +2742,10 @@ func (s *Server) handleFindUsages(ctx context.Context, req mcp.CallToolRequest) 
 	// find_implementations (once per session). Additive — the only response
 	// content the diet adds.
 	s.attachRelatedToolsCue(ctx, sg, id)
+	// Row cap last, after every filter and after the completeness rollup —
+	// the summary stays a statement about the whole usage set while the
+	// page below it is bounded. limit:0 opts out, mirroring max_bytes.
+	truncateUsageRows(sg, req.GetInt("limit", 50), id)
 	// group_by:"file" buckets the usages by the file each reference
 	// originates in -- an opt-in shape for callers that want a
 	// per-file rollup. The flat SubGraph stays the default so
@@ -2749,7 +2753,9 @@ func (s *Server) handleFindUsages(ctx context.Context, req mcp.CallToolRequest) 
 	if gb := strings.ToLower(strings.TrimSpace(req.GetString("group_by", ""))); gb == "file" {
 		return s.respondScopedJSONOrTOON(ctx, req, groupUsagesByFile(sg), resolved)
 	}
-	if s.isGCX(ctx, req) {
+	// compact is an explicit caller choice, so it beats the session's
+	// gcx default — the same precedence returnSubGraph applies.
+	if s.isGCX(ctx, req) && !isCompact(req) {
 		res, err := s.gcxResponseWithBudget(req)(encodeFindUsages(sg, s.graph))
 		return withScopeResult(res, err, resolved)
 	}
@@ -3054,6 +3060,34 @@ func groupUsagesByFile(sg *query.SubGraph) map[string]any {
 		"groups":     out,
 		"truncated":  sg.Truncated,
 	}
+}
+
+// truncateUsageRows enforces find_usages' advertised `limit` on the
+// usage rows (edges). Totals keep the full post-filter counts and
+// Truncated marks the cut, so a capped page is legible as partial
+// rather than complete. Nodes no longer referenced by a surviving edge
+// are pruned; the queried target always stays. A non-positive limit
+// opts out of the cap.
+func truncateUsageRows(sg *query.SubGraph, limit int, targetID string) {
+	if sg == nil || limit <= 0 || len(sg.Edges) <= limit {
+		return
+	}
+	sg.TotalEdges = len(sg.Edges)
+	sg.TotalNodes = len(sg.Nodes)
+	sg.Edges = sg.Edges[:limit]
+	referenced := map[string]struct{}{targetID: {}}
+	for _, e := range sg.Edges {
+		referenced[e.From] = struct{}{}
+		referenced[e.To] = struct{}{}
+	}
+	nodes := make([]*graph.Node, 0, len(referenced))
+	for _, n := range sg.Nodes {
+		if _, ok := referenced[n.ID]; ok {
+			nodes = append(nodes, n)
+		}
+	}
+	sg.Nodes = nodes
+	sg.Truncated = true
 }
 
 // usageSummaryOf computes the compact completeness rollup attached to a

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -251,17 +251,25 @@ func (s *Server) returnSubGraph(ctx context.Context, req mcp.CallToolRequest, sg
 	return s.respondJSONOrTOON(ctx, req, sg)
 }
 
+// trimBudgetMarker closes a budget-trimmed compact payload; package
+// level so the boundary tests exercise the exact marker the trimmer
+// emits.
+const trimBudgetMarker = "... trimmed to byte budget; pass max_bytes:0 for the full result\n"
+
 // trimTextToBudget cuts a line-oriented text payload to at most budget
 // bytes, breaking at a line boundary and closing with a marker line so
 // the cut is legible. The marker's own bytes count against the budget.
 func trimTextToBudget(text string, budget int) string {
-	const marker = "... trimmed to byte budget; pass max_bytes:0 for the full result\n"
-	// The budget is a hard ceiling even below the marker's own size: a
-	// tiny budget gets a truncated marker, never a payload above it.
-	if budget <= len(marker) {
-		return marker[:budget]
+	// The budget is a hard ceiling at every size: a non-positive budget
+	// yields nothing, a budget below the marker's own size gets a
+	// truncated marker, never a payload above it.
+	if budget <= 0 {
+		return ""
 	}
-	keep := budget - len(marker)
+	if budget <= len(trimBudgetMarker) {
+		return trimBudgetMarker[:budget]
+	}
+	keep := budget - len(trimBudgetMarker)
 	if keep > len(text) {
 		keep = len(text)
 	}
@@ -271,7 +279,7 @@ func trimTextToBudget(text string, budget int) string {
 	} else {
 		cut++
 	}
-	return text[:cut] + marker
+	return text[:cut] + trimBudgetMarker
 }
 
 // requestToolName extracts the MCP tool name from a CallToolRequest.
@@ -396,12 +404,7 @@ func subGraphToTOON(sg *query.SubGraph, g graph.NodeGetter) (*mcp.CallToolResult
 	// path); pure listing tools keep the raw stamp. Joined by node ID —
 	// the row builder skips File/Import nodes, so row positions do not
 	// line up with sg.Nodes positions.
-	nodeByID := make(map[string]*graph.Node, len(sg.Nodes))
-	for _, n := range sg.Nodes {
-		if n != nil {
-			nodeByID[n.ID] = n
-		}
-	}
+	nodeByID := indexNodes(sg.Nodes)
 	for i := range nodeRows {
 		if n := nodeByID[nodeRows[i].ID]; n != nil {
 			nodeRows[i].IsTest = graph.NodeIsTest(g, n)
@@ -2512,8 +2515,13 @@ func (s *Server) handleGetCallers(ctx context.Context, req mcp.CallToolRequest) 
 		// already recorded why, and the caller's own min_tier is what
 		// removed them. Classifying on top would double-report it, and
 		// now that classification weighs provenance it would report the
-		// very tier the caller asked to exclude.
-		sg.Caveat = graph.CaveatForZeroEdge(s.graph, id)
+		// very tier the caller asked to exclude. A symbol the request's
+		// view resolved (overlay-served included) is never a mistyped id.
+		if eng.GetSymbol(id) != nil {
+			sg.Caveat = graph.CaveatForZeroEdgeResolved(s.graph, id)
+		} else {
+			sg.Caveat = graph.CaveatForZeroEdge(s.graph, id)
+		}
 	} else if len(sg.Edges) > 0 && graph.WeakUsageEvidenceOnly(sg.Edges) {
 		// Populated, but every caller is a bare-name match — the shape a
 		// common method name (`Get`, `Run`, `Close`) produces. Left
@@ -2735,6 +2743,10 @@ func (s *Server) handleFindUsages(ctx context.Context, req mcp.CallToolRequest) 
 		return errResult, nil
 	}
 	eng := s.engineFor(ctx)
+	// One request-scoped node lookup, resolved once and handed to every
+	// classification/flavor surface below, so none can drift back to the
+	// base graph while the query runs on an overlay view.
+	getter := s.nodeGetterFor(ctx)
 	// Barrel re-export resolve-through: a public import path that names a
 	// forwarded binding (`src/middleware.ts::persist`) may have no node of its
 	// own (an unresolved / over-cap / wildcard barrel) — map it to the
@@ -2798,12 +2810,18 @@ func (s *Server) handleFindUsages(ctx context.Context, req mcp.CallToolRequest) 
 	// structural flavor (the enclosing owner type for a type flavor; the
 	// FROM node's own ui_component for `component`). Orphan nodes left
 	// with no incident edge are pruned.
-	s.filterUsagesByFlavor(s.nodeGetterFor(ctx), sg, id, strings.TrimSpace(req.GetString("flavor", "")))
+	filterUsagesByFlavor(getter, sg, id, strings.TrimSpace(req.GetString("flavor", "")))
 	if len(sg.Edges) == 0 && sg.TierFiltered == nil {
 		// A tier_filtered emptiness is not "no usages" — FilterByMinTier
 		// already recorded why. Only reach for the extraction-gap / unused
 		// classification when the emptiness was NOT caused by min_tier.
-		sg.Caveat = graph.CaveatForZeroEdge(s.graph, id)
+		// A node the request's view resolved (an overlay-served symbol
+		// among them) is never a mistyped id.
+		if node != nil {
+			sg.Caveat = graph.CaveatForZeroEdgeResolved(s.graph, id)
+		} else {
+			sg.Caveat = graph.CaveatForZeroEdge(s.graph, id)
+		}
 	} else if len(sg.Edges) > 0 && graph.WeakUsageEvidenceOnly(sg.Edges) {
 		// Populated, but every usage is a bare-name match — the shape a
 		// common symbol name produces. Left uncaveated this reads as proof
@@ -2815,7 +2833,7 @@ func (s *Server) handleFindUsages(ctx context.Context, req mcp.CallToolRequest) 
 	// tell at a glance whether the usage list already covers tests instead
 	// of re-grepping *_test.go files. Rides every wire format below; nil
 	// for an empty result (the Caveat above covers that case).
-	sg.UsageSummary = usageSummaryOf(sg, s.nodeGetterFor(ctx))
+	sg.UsageSummary = query.UsageSummaryOf(sg, getter)
 	// Proactive discovery cue: when the target is dispatch-heavy, point at
 	// find_implementations (once per session). Additive — the only response
 	// content the diet adds.
@@ -2834,7 +2852,7 @@ func (s *Server) handleFindUsages(ctx context.Context, req mcp.CallToolRequest) 
 	// compact is an explicit caller choice, so it beats the session's
 	// gcx default — the same precedence returnSubGraph applies.
 	if s.isGCX(ctx, req) && !isCompact(req) {
-		res, err := s.gcxResponseWithBudget(req)(encodeFindUsages(sg, s.nodeGetterFor(ctx)))
+		res, err := s.gcxResponseWithBudget(req)(encodeFindUsages(sg, getter))
 		return withScopeResult(res, err, resolved)
 	}
 	// Plain JSON gets curated usage rows that promote the resolved
@@ -2844,7 +2862,7 @@ func (s *Server) handleFindUsages(ctx context.Context, req mcp.CallToolRequest) 
 	format := req.GetString("format", "")
 	if !s.isTOON(ctx, req) && !isCompact(req) && format != "mermaid" && format != "dot" {
 		sg.Nodes = s.withAbsPaths(sg.Nodes)
-		return s.respondScopedJSONOrTOON(ctx, req, newUsageResponse(sg, s.nodeGetterFor(ctx)), resolved)
+		return s.respondScopedJSONOrTOON(ctx, req, newUsageResponse(sg, getter), resolved)
 	}
 	return s.returnScopedSubGraph(ctx, req, sg, resolved)
 }
@@ -3036,7 +3054,7 @@ func usageFromFlavor(g graph.NodeGetter, fromID string, fromNode *graph.Node) (t
 // resolve to a matching structural flavor, then prunes nodes left with
 // no incident edge (the queried target is always kept). An empty flavor
 // argument is a no-op.
-func (s *Server) filterUsagesByFlavor(g graph.NodeGetter, sg *query.SubGraph, targetID, flavorArg string) {
+func filterUsagesByFlavor(g graph.NodeGetter, sg *query.SubGraph, targetID, flavorArg string) {
 	flavors := splitFlavors(flavorArg)
 	if sg == nil || len(flavors) == 0 {
 		return
@@ -3175,46 +3193,6 @@ func truncateUsageRows(sg *query.SubGraph, limit int, targetID string) {
 	}
 	sg.Nodes = nodes
 	sg.Truncated = true
-}
-
-// usageSummaryOf computes the compact completeness rollup attached to a
-// find_usages response: the total reference count, the number of
-// distinct files those references live in, and how many originate in
-// test files. It reuses the shared test classifier (graph.NodeIsTest —
-// the same authority order the exclude_tests filter and the
-// from_is_test column apply) and the same file resolution as the
-// per-usage rows, so the rollup never disagrees with the edges it
-// summarizes. Returns nil for an empty result — the zero-edge Caveat
-// already explains that case, and an all-zero summary would be noise.
-func usageSummaryOf(sg *query.SubGraph, g graph.NodeGetter) *query.UsageSummary {
-	if sg == nil || len(sg.Edges) == 0 {
-		return nil
-	}
-	nodeByID := make(map[string]*graph.Node, len(sg.Nodes))
-	for _, n := range sg.Nodes {
-		nodeByID[n.ID] = n
-	}
-	files := make(map[string]struct{}, len(sg.Edges))
-	testRefs := 0
-	for _, e := range sg.Edges {
-		from := nodeByID[e.From]
-		file := e.FilePath
-		if file == "" && from != nil {
-			file = from.FilePath
-		}
-		if file == "" {
-			file = "(unknown)"
-		}
-		files[file] = struct{}{}
-		if graph.NodeIsTest(g, from) {
-			testRefs++
-		}
-	}
-	return &query.UsageSummary{
-		NRefs:     len(sg.Edges),
-		NFiles:    len(files),
-		NTestRefs: testRefs,
-	}
 }
 
 func (s *Server) handleGetCluster(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -221,22 +221,21 @@ func (s *Server) returnSubGraph(ctx context.Context, req mcp.CallToolRequest, sg
 	// Diagram formats render the subgraph directly — one place serves
 	// every traversal tool (callers/dependencies/usages/...), so a
 	// `gortex query ... --format mermaid|dot` gets a real diagram.
+	// Every text renderer below keeps the same byte/token budget the
+	// JSON and GCX paths enforce: the budget is a contract on the
+	// response, not on one format.
 	switch req.GetString("format", "") {
 	case "mermaid":
-		return mcp.NewToolResultText(sg.ToMermaid()), nil
+		return mcp.NewToolResultText(textWithinBudget(req, sg.ToMermaid())), nil
 	case "dot":
-		return mcp.NewToolResultText(sg.ToDot()), nil
+		return mcp.NewToolResultText(textWithinBudget(req, sg.ToDot())), nil
 	}
 	if isCompact(req) {
 		// Compact is a caller-facing renderer, not an escape hatch from
 		// the byte/token budget: a request routed here (including
 		// compact over a gcx session default) keeps the same
 		// effectiveBudget cap every other format path enforces.
-		text := compactSubGraph(sg)
-		if budget := effectiveBudget(req); budget > 0 && len(text) > budget {
-			text = trimTextToBudget(text, budget)
-		}
-		return mcp.NewToolResultText(text), nil
+		return mcp.NewToolResultText(textWithinBudget(req, compactSubGraph(sg))), nil
 	}
 	if s.isGCX(ctx, req) {
 		tool := requestToolName(req)
@@ -246,7 +245,8 @@ func (s *Server) returnSubGraph(ctx context.Context, req mcp.CallToolRequest, sg
 		return s.gcxResponseWithBudget(req)(encodeSubGraph(tool, sg, s.nodeGetterFor(ctx)))
 	}
 	if s.isTOON(ctx, req) {
-		return subGraphToTOON(sg, s.nodeGetterFor(ctx))
+		res, err := subGraphToTOON(sg, s.nodeGetterFor(ctx))
+		return trimResultToBudget(req, res), err
 	}
 	return s.respondJSONOrTOON(ctx, req, sg)
 }
@@ -280,6 +280,29 @@ func trimTextToBudget(text string, budget int) string {
 		cut++
 	}
 	return text[:cut] + trimBudgetMarker
+}
+
+// textWithinBudget applies the request's effective byte/token budget
+// to a rendered text payload, trimming only on overflow — the fitting
+// case passes through marker-free.
+func textWithinBudget(req mcp.CallToolRequest, text string) string {
+	if budget := effectiveBudget(req); budget > 0 && len(text) > budget {
+		return trimTextToBudget(text, budget)
+	}
+	return text
+}
+
+// trimResultToBudget applies textWithinBudget to a text tool result.
+// Error and non-text results pass through untouched.
+func trimResultToBudget(req mcp.CallToolRequest, res *mcp.CallToolResult) *mcp.CallToolResult {
+	if res == nil || res.IsError || len(res.Content) == 0 {
+		return res
+	}
+	if tc, ok := res.Content[0].(mcp.TextContent); ok {
+		tc.Text = textWithinBudget(req, tc.Text)
+		res.Content[0] = tc
+	}
+	return res
 }
 
 // requestToolName extracts the MCP tool name from a CallToolRequest.
@@ -346,6 +369,11 @@ func returnTOON(payload any) (*mcp.CallToolResult, error) {
 func (s *Server) respondJSONOrTOON(ctx context.Context, req mcp.CallToolRequest, payload any) (*mcp.CallToolResult, error) {
 	payload = applyFieldsFilter(payload, parseFields(req.GetString("fields", "")))
 	if budget := effectiveBudget(req); budget > 0 {
+		// The token-budget decoration below lands after the fit;
+		// reserve its bytes so the decorated payload stays in cap.
+		if reserve := tokenBudgetDecorationReserve(req); reserve < budget {
+			budget -= reserve
+		}
 		var trimmed bool
 		if shape, ok := degradeShapes[req.Params.Name]; ok {
 			payload, trimmed = applyDegradation(payload, shape, budget)
@@ -2517,10 +2545,13 @@ func (s *Server) handleGetCallers(ctx context.Context, req mcp.CallToolRequest) 
 		// now that classification weighs provenance it would report the
 		// very tier the caller asked to exclude. A symbol the request's
 		// view resolved (overlay-served included) is never a mistyped id.
+		// Classification reads the same request-scoped view the query
+		// ran on: the base graph misreports overlay-only symbols and
+		// still counts callers an overlay tombstone removed.
 		if eng.GetSymbol(id) != nil {
-			sg.Caveat = graph.CaveatForZeroEdgeResolved(s.graph, id)
+			sg.Caveat = graph.CaveatForZeroEdgeResolved(s.readerFor(ctx), id)
 		} else {
-			sg.Caveat = graph.CaveatForZeroEdge(s.graph, id)
+			sg.Caveat = graph.CaveatForZeroEdge(s.readerFor(ctx), id)
 		}
 	} else if len(sg.Edges) > 0 && graph.WeakUsageEvidenceOnly(sg.Edges) {
 		// Populated, but every caller is a bare-name match — the shape a
@@ -2816,11 +2847,12 @@ func (s *Server) handleFindUsages(ctx context.Context, req mcp.CallToolRequest) 
 		// already recorded why. Only reach for the extraction-gap / unused
 		// classification when the emptiness was NOT caused by min_tier.
 		// A node the request's view resolved (an overlay-served symbol
-		// among them) is never a mistyped id.
+		// among them) is never a mistyped id. Classification reads the
+		// same request-scoped view the query ran on, never the base graph.
 		if node != nil {
-			sg.Caveat = graph.CaveatForZeroEdgeResolved(s.graph, id)
+			sg.Caveat = graph.CaveatForZeroEdgeResolved(s.readerFor(ctx), id)
 		} else {
-			sg.Caveat = graph.CaveatForZeroEdge(s.graph, id)
+			sg.Caveat = graph.CaveatForZeroEdge(s.readerFor(ctx), id)
 		}
 	} else if len(sg.Edges) > 0 && graph.WeakUsageEvidenceOnly(sg.Edges) {
 		// Populated, but every usage is a bare-name match — the shape a

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -3053,13 +3053,19 @@ func groupUsagesByFile(sg *query.SubGraph) map[string]any {
 		}
 		return out[i].File < out[j].File
 	})
-	return map[string]any{
+	grouped := map[string]any{
 		"grouped_by": "file",
 		"file_count": len(out),
 		"total_uses": len(sg.Edges),
 		"groups":     out,
 		"truncated":  sg.Truncated,
 	}
+	// On a capped page total_uses counts only the rows below; carry the
+	// full row count alongside so the cut stays legible in this shape too.
+	if sg.Truncated {
+		grouped["total_edges"] = sg.TotalEdges
+	}
+	return grouped
 }
 
 // truncateUsageRows enforces find_usages' advertised `limit` on the

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -223,12 +223,26 @@ func (s *Server) returnSubGraph(ctx context.Context, req mcp.CallToolRequest, sg
 	// `gortex query ... --format mermaid|dot` gets a real diagram.
 	// Every text renderer below keeps the same byte/token budget the
 	// JSON and GCX paths enforce: the budget is a contract on the
-	// response, not on one format.
+	// response, not on one format. Structured grammars re-render over
+	// fewer rows instead of taking a byte-level cut — a sliced diagram
+	// or TOON table fails downstream parsers while looking successful.
 	switch req.GetString("format", "") {
 	case "mermaid":
-		return mcp.NewToolResultText(textWithinBudget(req, sg.ToMermaid())), nil
+		return mcp.NewToolResultText(renderSubGraphWithinBudget(req, sg, func(t *query.SubGraph) string {
+			text := t.ToMermaid()
+			if t.Truncated && t.TotalEdges > len(t.Edges) {
+				text += fmt.Sprintf("%%%% %d of %d edges shown (byte budget); pass max_bytes:0 for the full graph\n", len(t.Edges), t.TotalEdges)
+			}
+			return text
+		})), nil
 	case "dot":
-		return mcp.NewToolResultText(textWithinBudget(req, sg.ToDot())), nil
+		return mcp.NewToolResultText(renderSubGraphWithinBudget(req, sg, func(t *query.SubGraph) string {
+			text := t.ToDot()
+			if t.Truncated && t.TotalEdges > len(t.Edges) {
+				text += fmt.Sprintf("// %d of %d edges shown (byte budget); pass max_bytes:0 for the full graph\n", len(t.Edges), t.TotalEdges)
+			}
+			return text
+		})), nil
 	}
 	if isCompact(req) {
 		// Compact is a caller-facing renderer, not an escape hatch from
@@ -245,8 +259,10 @@ func (s *Server) returnSubGraph(ctx context.Context, req mcp.CallToolRequest, sg
 		return s.gcxResponseWithBudget(req)(encodeSubGraph(tool, sg, s.nodeGetterFor(ctx)))
 	}
 	if s.isTOON(ctx, req) {
-		res, err := subGraphToTOON(sg, s.nodeGetterFor(ctx))
-		return trimResultToBudget(req, res), err
+		getter := s.nodeGetterFor(ctx)
+		return mcp.NewToolResultText(renderSubGraphWithinBudget(req, sg, func(t *query.SubGraph) string {
+			return subGraphToTOON(t, getter)
+		})), nil
 	}
 	return s.respondJSONOrTOON(ctx, req, sg)
 }
@@ -292,17 +308,74 @@ func textWithinBudget(req mcp.CallToolRequest, text string) string {
 	return text
 }
 
-// trimResultToBudget applies textWithinBudget to a text tool result.
-// Error and non-text results pass through untouched.
-func trimResultToBudget(req mcp.CallToolRequest, res *mcp.CallToolResult) *mcp.CallToolResult {
-	if res == nil || res.IsError || len(res.Content) == 0 {
-		return res
+// renderSubGraphWithinBudget renders sg through render and, when the
+// full rendering overflows the caller's budget, re-renders over the
+// largest edge prefix that fits — nodes pruned to the surviving rows,
+// Truncated and the TotalEdges floor stamped on the trial — so the
+// output stays syntactically valid in grammars a byte-level cut would
+// corrupt. The page order the prefix consumes is whatever the handler
+// already established. The degenerate case where even a rowless
+// rendering overflows falls back to the plain-text trim.
+func renderSubGraphWithinBudget(req mcp.CallToolRequest, sg *query.SubGraph, render func(*query.SubGraph) string) string {
+	budget := effectiveBudget(req)
+	full := render(sg)
+	if budget <= 0 || len(full) <= budget {
+		return full
 	}
-	if tc, ok := res.Content[0].(mcp.TextContent); ok {
-		tc.Text = textWithinBudget(req, tc.Text)
-		res.Content[0] = tc
+	trial := *sg
+	trial.Truncated = true
+	trial.TotalEdges = max(sg.TotalEdges, len(sg.Edges))
+	fit := ""
+	lo, hi := 0, len(sg.Edges)
+	for lo < hi {
+		mid := (lo + hi + 1) / 2
+		trial.Edges = sg.Edges[:mid]
+		trial.Nodes = nodesForEdgePage(sg, trial.Edges)
+		if text := render(&trial); len(text) <= budget {
+			lo, fit = mid, text
+		} else {
+			hi = mid - 1
+		}
 	}
-	return res
+	if fit != "" {
+		return fit
+	}
+	trial.Edges = nil
+	trial.Nodes = nodesForEdgePage(sg, nil)
+	if text := render(&trial); len(text) <= budget {
+		return text
+	}
+	return trimTextToBudget(full, budget)
+}
+
+// nodesForEdgePage keeps the nodes a trimmed edge page references,
+// plus every node with no incident edge in the full result (the
+// queried seed among them), so the page cut never drops the subject.
+func nodesForEdgePage(sg *query.SubGraph, page []*graph.Edge) []*graph.Node {
+	incident := make(map[string]bool, len(sg.Edges)*2)
+	for _, e := range sg.Edges {
+		if e != nil {
+			incident[e.From] = true
+			incident[e.To] = true
+		}
+	}
+	keep := make(map[string]bool, len(page)*2)
+	for _, e := range page {
+		if e != nil {
+			keep[e.From] = true
+			keep[e.To] = true
+		}
+	}
+	out := make([]*graph.Node, 0, len(page)*2)
+	for _, n := range sg.Nodes {
+		if n == nil {
+			continue
+		}
+		if keep[n.ID] || !incident[n.ID] {
+			out = append(out, n)
+		}
+	}
+	return out
 }
 
 // requestToolName extracts the MCP tool name from a CallToolRequest.
@@ -369,9 +442,13 @@ func returnTOON(payload any) (*mcp.CallToolResult, error) {
 func (s *Server) respondJSONOrTOON(ctx context.Context, req mcp.CallToolRequest, payload any) (*mcp.CallToolResult, error) {
 	payload = applyFieldsFilter(payload, parseFields(req.GetString("fields", "")))
 	if budget := effectiveBudget(req); budget > 0 {
-		// The token-budget decoration below lands after the fit;
-		// reserve its bytes so the decorated payload stays in cap.
-		if reserve := tokenBudgetDecorationReserve(req); reserve < budget {
+		// The token-budget decoration lands after the fit; reserve its
+		// bytes so the decorated payload stays in cap. A budget the
+		// reserve itself cannot fit inside drops the decoration instead
+		// of letting it become the bytes that break the contract.
+		reserve := tokenBudgetDecorationReserve(req)
+		decorate := reserve == 0 || reserve < budget
+		if reserve > 0 && decorate {
 			budget -= reserve
 		}
 		var trimmed bool
@@ -380,7 +457,7 @@ func (s *Server) respondJSONOrTOON(ctx context.Context, req mcp.CallToolRequest,
 		} else {
 			payload, trimmed = applyBudget(payload, budget)
 		}
-		if trimmed {
+		if trimmed && decorate {
 			payload = decorateTokenBudgetJSON(payload, req)
 		}
 	}
@@ -404,8 +481,10 @@ func (s *Server) respondJSONOrTOON(ctx context.Context, req mcp.CallToolRequest,
 	return mcp.NewToolResultJSON(payload)
 }
 
-// subGraphToTOON converts a SubGraph to a TOON-encoded text result.
-func subGraphToTOON(sg *query.SubGraph, g graph.NodeGetter) (*mcp.CallToolResult, error) {
+// subGraphToTOON renders a SubGraph as TOON text; a marshal failure
+// falls back to the JSON rendering so the caller always holds one
+// parseable document.
+func subGraphToTOON(sg *query.SubGraph, g graph.NodeGetter) string {
 	var edgeRows []toonEdgeRow
 	for _, e := range sg.Edges {
 		label := e.ConfidenceLabel
@@ -455,9 +534,12 @@ func subGraphToTOON(sg *query.SubGraph, g graph.NodeGetter) (*mcp.CallToolResult
 	}
 	data, err := toon.Marshal(result)
 	if err != nil {
-		return mcp.NewToolResultJSON(sg)
+		if j, jerr := json.Marshal(sg); jerr == nil {
+			return string(j)
+		}
+		return ""
 	}
-	return mcp.NewToolResultText(string(data)), nil
+	return string(data)
 }
 
 // resolveRepoFilter resolves the optional repo/project/ref params into
@@ -3119,25 +3201,6 @@ func filterUsagesByFlavor(g graph.NodeGetter, sg *query.SubGraph, targetID, flav
 	sg.Nodes = keptNodes
 }
 
-// usageFileGroup is one file's worth of references from a
-// group_by:"file" find_usages response.
-type usageFileGroup struct {
-	File  string           `json:"file"`
-	Count int              `json:"count"`
-	Uses  []usageGroupItem `json:"uses"`
-}
-
-// usageGroupItem is one reference inside a usageFileGroup -- the
-// line it sits on plus the enclosing symbol.
-type usageGroupItem struct {
-	Line        int    `json:"line"`
-	EdgeKind    string `json:"edge_kind"`
-	Context     string `json:"context,omitempty"`
-	ReturnUsage string `json:"return_usage,omitempty"`
-	SymbolID    string `json:"symbol_id,omitempty"`
-	SymbolName  string `json:"symbol_name,omitempty"`
-}
-
 // groupUsagesByFile buckets a find_usages SubGraph by the file each
 // reference originates in. The `from` endpoint of every edge is the
 // usage site; its file path is the bucket key and the from-node's
@@ -3148,7 +3211,7 @@ func groupUsagesByFile(sg *query.SubGraph) map[string]any {
 	for _, n := range sg.Nodes {
 		nodeByID[n.ID] = n
 	}
-	groups := map[string]*usageFileGroup{}
+	groups := map[string]*query.UsageFileGroup{}
 	for _, e := range sg.Edges {
 		from := nodeByID[e.From]
 		file := e.FilePath
@@ -3160,10 +3223,10 @@ func groupUsagesByFile(sg *query.SubGraph) map[string]any {
 		}
 		g := groups[file]
 		if g == nil {
-			g = &usageFileGroup{File: file}
+			g = &query.UsageFileGroup{File: file}
 			groups[file] = g
 		}
-		item := usageGroupItem{Line: e.Line, EdgeKind: string(e.Kind), Context: e.Context, ReturnUsage: e.ReturnUsage}
+		item := query.UsageGroupItem{Line: e.Line, EdgeKind: string(e.Kind), Context: e.Context, ReturnUsage: e.ReturnUsage}
 		if from != nil {
 			item.SymbolID = from.ID
 			item.SymbolName = from.Name
@@ -3171,7 +3234,7 @@ func groupUsagesByFile(sg *query.SubGraph) map[string]any {
 		g.Uses = append(g.Uses, item)
 		g.Count++
 	}
-	out := make([]*usageFileGroup, 0, len(groups))
+	out := make([]*query.UsageFileGroup, 0, len(groups))
 	for _, g := range groups {
 		out = append(out, g)
 	}

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -113,17 +113,37 @@ type toonCallerNoteRow struct {
 }
 
 // toonSubGraphResult wraps nodes and edges for TOON tabular output.
+// toonZeroEdgeCaveat mirrors graph.ZeroEdgeCaveat with a plain string
+// class: toon-go rejects the named ZeroEdgeClass string type, and the
+// silent JSON fallback that error triggered meant a caveat-bearing
+// subgraph never actually rendered as TOON.
+type toonZeroEdgeCaveat struct {
+	Class   string `toon:"class"`
+	Message string `toon:"message"`
+}
+
+func toonCaveat(c *graph.ZeroEdgeCaveat) *toonZeroEdgeCaveat {
+	if c == nil {
+		return nil
+	}
+	return &toonZeroEdgeCaveat{Class: string(c.Class), Message: c.Message}
+}
+
 type toonSubGraphResult struct {
-	Nodes                 []toonNodeRow         `toon:"nodes"`
-	Edges                 []toonEdgeRow         `toon:"edges"`
-	Total                 int                   `toon:"total"`
-	Truncated             bool                  `toon:"truncated"`
-	Caveat                *graph.ZeroEdgeCaveat `toon:"caveat,omitempty"`
-	TextMatchedSuppressed int                   `toon:"text_matched_suppressed,omitempty"`
-	SuppressionCaveat     string                `toon:"suppression_caveat,omitempty"`
-	RelatedTools          string                `toon:"related_tools,omitempty"`
-	CallerNotes           []toonCallerNoteRow   `toon:"caller_notes,omitempty"`
-	UsageSummary          *query.UsageSummary   `toon:"usage_summary,omitempty"`
+	Nodes     []toonNodeRow `toon:"nodes"`
+	Edges     []toonEdgeRow `toon:"edges"`
+	Total     int           `toon:"total"`
+	Truncated bool          `toon:"truncated"`
+	// TotalEdges carries the full row count when a row cap cut the edge
+	// list; zero (and omitted) otherwise, so untrimmed responses and
+	// node-truncated BFS results keep their wire shape.
+	TotalEdges            int                 `toon:"total_edges,omitempty"`
+	Caveat                *toonZeroEdgeCaveat `toon:"caveat,omitempty"`
+	TextMatchedSuppressed int                 `toon:"text_matched_suppressed,omitempty"`
+	SuppressionCaveat     string              `toon:"suppression_caveat,omitempty"`
+	RelatedTools          string              `toon:"related_tools,omitempty"`
+	CallerNotes           []toonCallerNoteRow `toon:"caller_notes,omitempty"`
+	UsageSummary          *query.UsageSummary `toon:"usage_summary,omitempty"`
 }
 
 // toonSearchResult wraps search results for TOON tabular output.
@@ -208,7 +228,15 @@ func (s *Server) returnSubGraph(ctx context.Context, req mcp.CallToolRequest, sg
 		return mcp.NewToolResultText(sg.ToDot()), nil
 	}
 	if isCompact(req) {
-		return mcp.NewToolResultText(compactSubGraph(sg)), nil
+		// Compact is a caller-facing renderer, not an escape hatch from
+		// the byte/token budget: a request routed here (including
+		// compact over a gcx session default) keeps the same
+		// effectiveBudget cap every other format path enforces.
+		text := compactSubGraph(sg)
+		if budget := effectiveBudget(req); budget > 0 && len(text) > budget {
+			text = trimTextToBudget(text, budget)
+		}
+		return mcp.NewToolResultText(text), nil
 	}
 	if s.isGCX(ctx, req) {
 		tool := requestToolName(req)
@@ -221,6 +249,27 @@ func (s *Server) returnSubGraph(ctx context.Context, req mcp.CallToolRequest, sg
 		return subGraphToTOON(sg)
 	}
 	return s.respondJSONOrTOON(ctx, req, sg)
+}
+
+// trimTextToBudget cuts a line-oriented text payload to at most budget
+// bytes, breaking at a line boundary and closing with a marker line so
+// the cut is legible. The marker's own bytes count against the budget.
+func trimTextToBudget(text string, budget int) string {
+	const marker = "... trimmed to byte budget; pass max_bytes:0 for the full result\n"
+	keep := budget - len(marker)
+	if keep < 0 {
+		keep = 0
+	}
+	if keep > len(text) {
+		keep = len(text)
+	}
+	cut := strings.LastIndexByte(text[:keep], '\n')
+	if cut < 0 {
+		cut = 0
+	} else {
+		cut++
+	}
+	return text[:cut] + marker
 }
 
 // requestToolName extracts the MCP tool name from a CallToolRequest.
@@ -344,12 +393,15 @@ func subGraphToTOON(sg *query.SubGraph) (*mcp.CallToolResult, error) {
 		Edges:                 edgeRows,
 		Total:                 sg.TotalNodes,
 		Truncated:             sg.Truncated,
-		Caveat:                sg.Caveat,
+		Caveat:                toonCaveat(sg.Caveat),
 		TextMatchedSuppressed: sg.TextMatchedSuppressed,
 		SuppressionCaveat:     sg.SuppressionCaveat,
 		RelatedTools:          sg.RelatedTools,
 		CallerNotes:           callerNotesToTOONRows(sg.CallerNotes),
 		UsageSummary:          sg.UsageSummary,
+	}
+	if sg.TotalEdges > len(sg.Edges) {
+		result.TotalEdges = sg.TotalEdges
 	}
 	data, err := toon.Marshal(result)
 	if err != nil {
@@ -859,7 +911,14 @@ func compactSubGraph(sg *query.SubGraph) string {
 			}
 			counts[label]++
 		}
-		fmt.Fprintf(&b, "edges: %d total", len(sg.Edges))
+		// A row-capped page names both the page size and the full row
+		// count, so "total" never mislabels a partial result. The
+		// uncapped footer keeps its wire shape.
+		if sg.TotalEdges > len(sg.Edges) {
+			fmt.Fprintf(&b, "edges: %d of %d total", len(sg.Edges), sg.TotalEdges)
+		} else {
+			fmt.Fprintf(&b, "edges: %d total", len(sg.Edges))
+		}
 		for _, label := range []string{"EXTRACTED", "INFERRED", "AMBIGUOUS"} {
 			if c := counts[label]; c > 0 {
 				fmt.Fprintf(&b, ", %d %s", c, label)

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -3080,6 +3080,9 @@ func truncateUsageRows(sg *query.SubGraph, limit int, targetID string) {
 	}
 	sg.TotalEdges = len(sg.Edges)
 	sg.TotalNodes = len(sg.Nodes)
+	// One stable global order before the cut, so the kept subset is the
+	// strongest evidence and identical across store backends.
+	query.SortEdgesForPage(sg.Edges)
 	sg.Edges = sg.Edges[:limit]
 	referenced := map[string]struct{}{targetID: {}}
 	for _, e := range sg.Edges {

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -243,10 +243,10 @@ func (s *Server) returnSubGraph(ctx context.Context, req mcp.CallToolRequest, sg
 		if tool == "" {
 			tool = "subgraph"
 		}
-		return s.gcxResponseWithBudget(req)(encodeSubGraph(tool, sg))
+		return s.gcxResponseWithBudget(req)(encodeSubGraph(tool, sg, s.graph))
 	}
 	if s.isTOON(ctx, req) {
-		return subGraphToTOON(sg)
+		return subGraphToTOON(sg, s.graph)
 	}
 	return s.respondJSONOrTOON(ctx, req, sg)
 }
@@ -367,7 +367,7 @@ func (s *Server) respondJSONOrTOON(ctx context.Context, req mcp.CallToolRequest,
 }
 
 // subGraphToTOON converts a SubGraph to a TOON-encoded text result.
-func subGraphToTOON(sg *query.SubGraph) (*mcp.CallToolResult, error) {
+func subGraphToTOON(sg *query.SubGraph, g graph.Store) (*mcp.CallToolResult, error) {
 	var edgeRows []toonEdgeRow
 	for _, e := range sg.Edges {
 		label := e.ConfidenceLabel
@@ -388,8 +388,17 @@ func subGraphToTOON(sg *query.SubGraph) (*mcp.CallToolResult, error) {
 			Label:      label,
 		})
 	}
+	nodeRows := nodesToTOONRows(sg.Nodes)
+	// Subgraph rows ride next to the exclude_tests filter, so their
+	// is_test column uses the same shared classifier (stamp → owner →
+	// path); pure listing tools keep the raw stamp.
+	for i, n := range sg.Nodes {
+		if i < len(nodeRows) {
+			nodeRows[i].IsTest = graph.NodeIsTest(g, n)
+		}
+	}
 	result := toonSubGraphResult{
-		Nodes:                 nodesToTOONRows(sg.Nodes),
+		Nodes:                 nodeRows,
 		Edges:                 edgeRows,
 		Total:                 sg.TotalNodes,
 		Truncated:             sg.Truncated,
@@ -2796,7 +2805,7 @@ func (s *Server) handleFindUsages(ctx context.Context, req mcp.CallToolRequest) 
 	// tell at a glance whether the usage list already covers tests instead
 	// of re-grepping *_test.go files. Rides every wire format below; nil
 	// for an empty result (the Caveat above covers that case).
-	sg.UsageSummary = usageSummaryOf(sg)
+	sg.UsageSummary = usageSummaryOf(sg, s.graph)
 	// Proactive discovery cue: when the target is dispatch-heavy, point at
 	// find_implementations (once per session). Additive — the only response
 	// content the diet adds.
@@ -3161,12 +3170,13 @@ func truncateUsageRows(sg *query.SubGraph, limit int, targetID string) {
 // usageSummaryOf computes the compact completeness rollup attached to a
 // find_usages response: the total reference count, the number of
 // distinct files those references live in, and how many originate in
-// test files. It reuses the exact per-node test classification
-// (nodeIsTest — the from_is_test column) and file resolution as the
+// test files. It reuses the shared test classifier (graph.NodeIsTest —
+// the same authority order the exclude_tests filter and the
+// from_is_test column apply) and the same file resolution as the
 // per-usage rows, so the rollup never disagrees with the edges it
 // summarizes. Returns nil for an empty result — the zero-edge Caveat
 // already explains that case, and an all-zero summary would be noise.
-func usageSummaryOf(sg *query.SubGraph) *query.UsageSummary {
+func usageSummaryOf(sg *query.SubGraph, g graph.Store) *query.UsageSummary {
 	if sg == nil || len(sg.Edges) == 0 {
 		return nil
 	}
@@ -3186,7 +3196,7 @@ func usageSummaryOf(sg *query.SubGraph) *query.UsageSummary {
 			file = "(unknown)"
 		}
 		files[file] = struct{}{}
-		if nodeIsTest(from) {
+		if graph.NodeIsTest(g, from) {
 			testRefs++
 		}
 	}

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -230,16 +230,16 @@ func (s *Server) returnSubGraph(ctx context.Context, req mcp.CallToolRequest, sg
 	case "mermaid":
 		return mcp.NewToolResultText(renderSubGraphWithinBudget(req, sg, func(t *query.SubGraph) string {
 			text := t.ToMermaid()
-			if t.Truncated && t.TotalEdges > len(t.Edges) {
-				text += fmt.Sprintf("%%%% %d of %d edges shown (byte budget); pass max_bytes:0 for the full graph\n", len(t.Edges), t.TotalEdges)
+			if note := subGraphBudgetNote(t, sg); note != "" {
+				text += "%% " + note + "\n"
 			}
 			return text
 		})), nil
 	case "dot":
 		return mcp.NewToolResultText(renderSubGraphWithinBudget(req, sg, func(t *query.SubGraph) string {
 			text := t.ToDot()
-			if t.Truncated && t.TotalEdges > len(t.Edges) {
-				text += fmt.Sprintf("// %d of %d edges shown (byte budget); pass max_bytes:0 for the full graph\n", len(t.Edges), t.TotalEdges)
+			if note := subGraphBudgetNote(t, sg); note != "" {
+				text += "// " + note + "\n"
 			}
 			return text
 		})), nil
@@ -310,12 +310,16 @@ func textWithinBudget(req mcp.CallToolRequest, text string) string {
 
 // renderSubGraphWithinBudget renders sg through render and, when the
 // full rendering overflows the caller's budget, re-renders over the
-// largest edge prefix that fits — nodes pruned to the surviving rows,
-// Truncated and the TotalEdges floor stamped on the trial — so the
-// output stays syntactically valid in grammars a byte-level cut would
-// corrupt. The page order the prefix consumes is whatever the handler
-// already established. The degenerate case where even a rowless
-// rendering overflows falls back to the plain-text trim.
+// largest structural subset that fits, so the output stays
+// syntactically valid in grammars a byte-level cut would corrupt.
+// Two stages, both stamping Truncated plus the TotalEdges/TotalNodes
+// floors on the trial: first the largest edge prefix (nodes pruned to
+// the surviving rows), then — when no edge prefix fits, the shape a
+// node-heavy result with few or zero edges produces — the largest
+// node prefix over the rowless base. The page order each prefix
+// consumes is whatever the handler already established. Only the
+// degenerate case where even an empty rendering overflows falls back
+// to the plain-text trim.
 func renderSubGraphWithinBudget(req mcp.CallToolRequest, sg *query.SubGraph, render func(*query.SubGraph) string) string {
 	budget := effectiveBudget(req)
 	full := render(sg)
@@ -325,27 +329,96 @@ func renderSubGraphWithinBudget(req mcp.CallToolRequest, sg *query.SubGraph, ren
 	trial := *sg
 	trial.Truncated = true
 	trial.TotalEdges = max(sg.TotalEdges, len(sg.Edges))
-	fit := ""
-	lo, hi := 0, len(sg.Edges)
-	for lo < hi {
-		mid := (lo + hi + 1) / 2
-		trial.Edges = sg.Edges[:mid]
-		trial.Nodes = nodesForEdgePage(sg, trial.Edges)
-		if text := render(&trial); len(text) <= budget {
-			lo, fit = mid, text
-		} else {
-			hi = mid - 1
+	trial.TotalNodes = max(sg.TotalNodes, len(sg.Nodes))
+	// One fit predicate for both stages: the largest prefix count whose
+	// rendering fits, with set() mutating the trial to the candidate.
+	largestFit := func(n int, set func(int)) string {
+		fit := ""
+		lo, hi := 0, n
+		for lo < hi {
+			mid := (lo + hi + 1) / 2
+			set(mid)
+			if text := render(&trial); len(text) <= budget {
+				lo, fit = mid, text
+			} else {
+				hi = mid - 1
+			}
 		}
-	}
-	if fit != "" {
 		return fit
 	}
+	if fit := largestFit(len(sg.Edges), func(m int) {
+		trial.Edges = sg.Edges[:m]
+		trial.Nodes = nodesForEdgePage(sg, trial.Edges)
+	}); fit != "" {
+		return fit
+	}
+	// No edge prefix fits — the shape a node-heavy result with few or
+	// zero edges produces. Cut a node prefix over the edge-touched
+	// nodes first (the queried subject is incident to its own rows),
+	// then the isolated remainder, so the subject survives any cut
+	// that keeps at least one node.
 	trial.Edges = nil
-	trial.Nodes = nodesForEdgePage(sg, nil)
+	baseNodes := edgeIncidentFirst(sg)
+	if fit := largestFit(len(baseNodes), func(m int) {
+		trial.Nodes = baseNodes[:m]
+	}); fit != "" {
+		return fit
+	}
+	trial.Nodes = nil
 	if text := render(&trial); len(text) <= budget {
 		return text
 	}
 	return trimTextToBudget(full, budget)
+}
+
+// edgeIncidentFirst orders the subgraph's nodes with the ones its
+// edges touch ahead of the isolated remainder, keeping the handler's
+// relative order within each class. The node-prefix budget cut
+// consumes this order, so the result's structurally-connected nodes —
+// the queried subject among them — outlive the isolated tail.
+func edgeIncidentFirst(sg *query.SubGraph) []*graph.Node {
+	incident := make(map[string]bool, len(sg.Edges)*2)
+	for _, e := range sg.Edges {
+		if e != nil {
+			incident[e.From] = true
+			incident[e.To] = true
+		}
+	}
+	out := make([]*graph.Node, 0, len(sg.Nodes))
+	for _, n := range sg.Nodes {
+		if n != nil && incident[n.ID] {
+			out = append(out, n)
+		}
+	}
+	for _, n := range sg.Nodes {
+		if n != nil && !incident[n.ID] {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// subGraphBudgetNote names what the BYTE-BUDGET cut left out — edges,
+// nodes, or both — in one grammar-neutral sentence the diagram
+// renderers wrap in their own comment syntax. The cut is measured
+// against base, the row set the handler returned: a handler-side
+// `limit` cap also stamps Truncated and pre-cut totals, and blaming
+// the byte budget for those rows would send the caller on a
+// `max_bytes:0` retry that cannot restore them. The denominators are
+// base's row counts for the same reason — they are what max_bytes:0
+// actually returns. Empty when the rendering was not byte-cut.
+func subGraphBudgetNote(t, base *query.SubGraph) string {
+	var parts []string
+	if len(t.Edges) < len(base.Edges) {
+		parts = append(parts, fmt.Sprintf("%d of %d edges", len(t.Edges), len(base.Edges)))
+	}
+	if len(t.Nodes) < len(base.Nodes) {
+		parts = append(parts, fmt.Sprintf("%d of %d nodes", len(t.Nodes), len(base.Nodes)))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, ", ") + " shown (byte budget); pass max_bytes:0 for the full graph"
 }
 
 // nodesForEdgePage keeps the nodes a trimmed edge page references,
@@ -2646,13 +2719,17 @@ func (s *Server) handleGetCallers(ctx context.Context, req mcp.CallToolRequest) 
 	// Epistemic lower bound: a caller walk over in-edges cannot see callers
 	// that reach this symbol through interface dispatch the resolver left
 	// unbound. Flag the floor + name the interface so the agent can widen it.
-	if bs := graph.CallerBoundaries(s.graph, []string{id}, 0); len(bs) > 0 {
+	// Judged from the request-scoped view — the same graph the query ran
+	// on — so an overlay-added implements edge surfaces its floor and a
+	// tombstoned one stops reporting a stale one.
+	reader := s.readerFor(ctx)
+	if bs := graph.CallerBoundaries(reader, []string{id}, 0); len(bs) > 0 {
 		sg.Boundaries = bs
 		sg.LowerBound = graph.LowerBoundCaveat(bs)
 		// The reach is a floor because dispatch is dynamic — scan the seed's
 		// body for the exact runtime-dispatch sites so the agent gets
 		// {site, form, key, candidates} instead of a read-spiral.
-		if db := s.dynamicBoundariesForSymbol(s.graph.GetNode(id)); len(db) > 0 {
+		if db := s.dynamicBoundariesForSymbol(ctx, reader.GetNode(id)); len(db) > 0 {
 			sg.DynamicBoundaries = db
 		}
 	}

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -243,10 +243,10 @@ func (s *Server) returnSubGraph(ctx context.Context, req mcp.CallToolRequest, sg
 		if tool == "" {
 			tool = "subgraph"
 		}
-		return s.gcxResponseWithBudget(req)(encodeSubGraph(tool, sg, s.graph))
+		return s.gcxResponseWithBudget(req)(encodeSubGraph(tool, sg, s.nodeGetterFor(ctx)))
 	}
 	if s.isTOON(ctx, req) {
-		return subGraphToTOON(sg, s.graph)
+		return subGraphToTOON(sg, s.nodeGetterFor(ctx))
 	}
 	return s.respondJSONOrTOON(ctx, req, sg)
 }
@@ -256,10 +256,12 @@ func (s *Server) returnSubGraph(ctx context.Context, req mcp.CallToolRequest, sg
 // the cut is legible. The marker's own bytes count against the budget.
 func trimTextToBudget(text string, budget int) string {
 	const marker = "... trimmed to byte budget; pass max_bytes:0 for the full result\n"
-	keep := budget - len(marker)
-	if keep < 0 {
-		keep = 0
+	// The budget is a hard ceiling even below the marker's own size: a
+	// tiny budget gets a truncated marker, never a payload above it.
+	if budget <= len(marker) {
+		return marker[:budget]
 	}
+	keep := budget - len(marker)
 	if keep > len(text) {
 		keep = len(text)
 	}
@@ -367,7 +369,7 @@ func (s *Server) respondJSONOrTOON(ctx context.Context, req mcp.CallToolRequest,
 }
 
 // subGraphToTOON converts a SubGraph to a TOON-encoded text result.
-func subGraphToTOON(sg *query.SubGraph, g graph.Store) (*mcp.CallToolResult, error) {
+func subGraphToTOON(sg *query.SubGraph, g graph.NodeGetter) (*mcp.CallToolResult, error) {
 	var edgeRows []toonEdgeRow
 	for _, e := range sg.Edges {
 		label := e.ConfidenceLabel
@@ -391,9 +393,17 @@ func subGraphToTOON(sg *query.SubGraph, g graph.Store) (*mcp.CallToolResult, err
 	nodeRows := nodesToTOONRows(sg.Nodes)
 	// Subgraph rows ride next to the exclude_tests filter, so their
 	// is_test column uses the same shared classifier (stamp → owner →
-	// path); pure listing tools keep the raw stamp.
-	for i, n := range sg.Nodes {
-		if i < len(nodeRows) {
+	// path); pure listing tools keep the raw stamp. Joined by node ID —
+	// the row builder skips File/Import nodes, so row positions do not
+	// line up with sg.Nodes positions.
+	nodeByID := make(map[string]*graph.Node, len(sg.Nodes))
+	for _, n := range sg.Nodes {
+		if n != nil {
+			nodeByID[n.ID] = n
+		}
+	}
+	for i := range nodeRows {
+		if n := nodeByID[nodeRows[i].ID]; n != nil {
 			nodeRows[i].IsTest = graph.NodeIsTest(g, n)
 		}
 	}
@@ -2788,7 +2798,7 @@ func (s *Server) handleFindUsages(ctx context.Context, req mcp.CallToolRequest) 
 	// structural flavor (the enclosing owner type for a type flavor; the
 	// FROM node's own ui_component for `component`). Orphan nodes left
 	// with no incident edge are pruned.
-	s.filterUsagesByFlavor(sg, id, strings.TrimSpace(req.GetString("flavor", "")))
+	s.filterUsagesByFlavor(s.nodeGetterFor(ctx), sg, id, strings.TrimSpace(req.GetString("flavor", "")))
 	if len(sg.Edges) == 0 && sg.TierFiltered == nil {
 		// A tier_filtered emptiness is not "no usages" — FilterByMinTier
 		// already recorded why. Only reach for the extraction-gap / unused
@@ -2805,7 +2815,7 @@ func (s *Server) handleFindUsages(ctx context.Context, req mcp.CallToolRequest) 
 	// tell at a glance whether the usage list already covers tests instead
 	// of re-grepping *_test.go files. Rides every wire format below; nil
 	// for an empty result (the Caveat above covers that case).
-	sg.UsageSummary = usageSummaryOf(sg, s.graph)
+	sg.UsageSummary = usageSummaryOf(sg, s.nodeGetterFor(ctx))
 	// Proactive discovery cue: when the target is dispatch-heavy, point at
 	// find_implementations (once per session). Additive — the only response
 	// content the diet adds.
@@ -2824,7 +2834,7 @@ func (s *Server) handleFindUsages(ctx context.Context, req mcp.CallToolRequest) 
 	// compact is an explicit caller choice, so it beats the session's
 	// gcx default — the same precedence returnSubGraph applies.
 	if s.isGCX(ctx, req) && !isCompact(req) {
-		res, err := s.gcxResponseWithBudget(req)(encodeFindUsages(sg, s.graph))
+		res, err := s.gcxResponseWithBudget(req)(encodeFindUsages(sg, s.nodeGetterFor(ctx)))
 		return withScopeResult(res, err, resolved)
 	}
 	// Plain JSON gets curated usage rows that promote the resolved
@@ -2834,7 +2844,7 @@ func (s *Server) handleFindUsages(ctx context.Context, req mcp.CallToolRequest) 
 	format := req.GetString("format", "")
 	if !s.isTOON(ctx, req) && !isCompact(req) && format != "mermaid" && format != "dot" {
 		sg.Nodes = s.withAbsPaths(sg.Nodes)
-		return s.respondScopedJSONOrTOON(ctx, req, newUsageResponse(sg, s.graph), resolved)
+		return s.respondScopedJSONOrTOON(ctx, req, newUsageResponse(sg, s.nodeGetterFor(ctx)), resolved)
 	}
 	return s.returnScopedSubGraph(ctx, req, sg, resolved)
 }
@@ -2927,7 +2937,7 @@ func (s *Server) suppressionMayBeStale(id string) bool {
 
 // newUsageResponse resolves the from_* fields for each node (pure read
 // — never mutates the graph) and wraps the SubGraph for JSON output.
-func newUsageResponse(sg *query.SubGraph, g graph.Store) *usageResponse {
+func newUsageResponse(sg *query.SubGraph, g graph.NodeGetter) *usageResponse {
 	wrapped := make([]usageNode, 0, len(sg.Nodes))
 	for _, n := range sg.Nodes {
 		tf, uc := usageFromFlavor(g, n.ID, n)
@@ -3000,7 +3010,7 @@ func annotateAndFilterReturnUsage(sg *query.SubGraph, usageFilter string) {
 // node's enclosing owner type, because callers are functions / methods
 // that never carry type_flavor themselves. Nil-safe: a FROM node absent
 // from both the supplied lookup and the graph yields empty strings.
-func usageFromFlavor(g graph.Store, fromID string, fromNode *graph.Node) (typeFlavor, uiComponent string) {
+func usageFromFlavor(g graph.NodeGetter, fromID string, fromNode *graph.Node) (typeFlavor, uiComponent string) {
 	if fromNode == nil && g != nil {
 		fromNode = g.GetNode(fromID)
 	}
@@ -3026,7 +3036,7 @@ func usageFromFlavor(g graph.Store, fromID string, fromNode *graph.Node) (typeFl
 // resolve to a matching structural flavor, then prunes nodes left with
 // no incident edge (the queried target is always kept). An empty flavor
 // argument is a no-op.
-func (s *Server) filterUsagesByFlavor(sg *query.SubGraph, targetID, flavorArg string) {
+func (s *Server) filterUsagesByFlavor(g graph.NodeGetter, sg *query.SubGraph, targetID, flavorArg string) {
 	flavors := splitFlavors(flavorArg)
 	if sg == nil || len(flavors) == 0 {
 		return
@@ -3037,7 +3047,7 @@ func (s *Server) filterUsagesByFlavor(sg *query.SubGraph, targetID, flavorArg st
 	}
 	kept := sg.Edges[:0]
 	for _, e := range sg.Edges {
-		tf, uc := usageFromFlavor(s.graph, e.From, nodeByID[e.From])
+		tf, uc := usageFromFlavor(g, e.From, nodeByID[e.From])
 		if flavorMatchesResolved(tf, uc, flavors) {
 			kept = append(kept, e)
 		}
@@ -3176,7 +3186,7 @@ func truncateUsageRows(sg *query.SubGraph, limit int, targetID string) {
 // per-usage rows, so the rollup never disagrees with the edges it
 // summarizes. Returns nil for an empty result — the zero-edge Caveat
 // already explains that case, and an all-zero summary would be noise.
-func usageSummaryOf(sg *query.SubGraph, g graph.Store) *query.UsageSummary {
+func usageSummaryOf(sg *query.SubGraph, g graph.NodeGetter) *query.UsageSummary {
 	if sg == nil || len(sg.Edges) == 0 {
 		return nil
 	}

--- a/internal/mcp/tools_flavor_usages_test.go
+++ b/internal/mcp/tools_flavor_usages_test.go
@@ -111,7 +111,7 @@ func TestFindUsages_FlavorNilSafety(t *testing.T) {
 	// the graph reader — the filter must not panic and must still resolve.
 	sg.Nodes = nil
 	require.NotPanics(t, func() {
-		srv.filterUsagesByFlavor(sg, helperID, "struct")
+		srv.filterUsagesByFlavor(srv.graph, sg, helperID, "struct")
 	})
 	require.Equal(t, 1, len(sg.Edges), "struct-owned call survives even with no node set")
 }

--- a/internal/mcp/tools_flavor_usages_test.go
+++ b/internal/mcp/tools_flavor_usages_test.go
@@ -111,7 +111,7 @@ func TestFindUsages_FlavorNilSafety(t *testing.T) {
 	// the graph reader — the filter must not panic and must still resolve.
 	sg.Nodes = nil
 	require.NotPanics(t, func() {
-		srv.filterUsagesByFlavor(srv.graph, sg, helperID, "struct")
+		filterUsagesByFlavor(srv.graph, sg, helperID, "struct")
 	})
 	require.Equal(t, 1, len(sg.Edges), "struct-owned call survives even with no node set")
 }

--- a/internal/mcp/toon_budget_test.go
+++ b/internal/mcp/toon_budget_test.go
@@ -1,0 +1,43 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFindUsages_TOONHonorsByteBudget pins that an explicit
+// format:"toon" stays inside the response budget every other format
+// enforces: the schema's max_bytes is a contract on the response, not
+// on one renderer.
+func TestFindUsages_TOONHonorsByteBudget(t *testing.T) {
+	srv, hotID := usagesLimitServer(t, 60)
+
+	out := findUsagesText(t, srv, map[string]any{"id": hotID, "format": "toon", "limit": 0, "max_bytes": 120})
+	require.LessOrEqual(t, len(out), 120,
+		"format:toon must honor max_bytes; got %d bytes", len(out))
+}
+
+// TestFindUsages_TOONHonorsTokenBudget pins the max_tokens axis on the
+// TOON path: the token cap converts to the same byte ceiling the other
+// formats apply.
+func TestFindUsages_TOONHonorsTokenBudget(t *testing.T) {
+	srv, hotID := usagesLimitServer(t, 60)
+
+	out := findUsagesText(t, srv, map[string]any{"id": hotID, "format": "toon", "limit": 0, "max_tokens": 30})
+	require.LessOrEqual(t, len(out), tokensToBytes(30),
+		"format:toon must honor max_tokens; got %d bytes over a %d-byte ceiling", len(out), tokensToBytes(30))
+}
+
+// TestFindUsages_TOONTinyBudgetBoundary pins the boundary the budget
+// helper guarantees everywhere else: a budget at or below the trim
+// marker's own length still never yields a payload above the budget.
+func TestFindUsages_TOONTinyBudgetBoundary(t *testing.T) {
+	srv, hotID := usagesLimitServer(t, 60)
+
+	for _, budget := range []int{1, len(trimBudgetMarker), len(trimBudgetMarker) + 1} {
+		out := findUsagesText(t, srv, map[string]any{"id": hotID, "format": "toon", "limit": 0, "max_bytes": budget})
+		require.LessOrEqual(t, len(out), budget,
+			"budget %d is a hard ceiling on the toon path", budget)
+	}
+}

--- a/internal/mcp/zero_edge_overlay_class_test.go
+++ b/internal/mcp/zero_edge_overlay_class_test.go
@@ -1,0 +1,134 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// caveatOf extracts the zero-edge caveat from a handler's JSON response.
+func caveatOf(t *testing.T, text string) *graph.ZeroEdgeCaveat {
+	t.Helper()
+	var resp struct {
+		Caveat *graph.ZeroEdgeCaveat `json:"caveat"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(text), &resp))
+	return resp.Caveat
+}
+
+// TestFindUsages_OverlayStructuralEvidenceClassifiesLikelyUnused pins the
+// exact caveat class for an overlay-only symbol with structural evidence:
+// the request's view knows the symbol and its outgoing edge, so an empty
+// usage result must classify as likely_unused — classifying against the
+// base graph (where the symbol does not exist) reports an extraction gap
+// for a symbol the request resolved cleanly.
+func TestFindUsages_OverlayStructuralEvidenceClassifiesLikelyUnused(t *testing.T) {
+	base := graph.New()
+	helper := &graph.Node{ID: "src/util.go::Helper", Kind: graph.KindFunction, Name: "Helper", FilePath: "src/util.go", StartLine: 1}
+	base.AddNode(helper)
+
+	layer := graph.NewOverlayLayer()
+	fresh := &graph.Node{ID: "src/new.go::FreshFn", Kind: graph.KindFunction, Name: "FreshFn", FilePath: "src/new.go", StartLine: 1}
+	layer.AddNode("src/new.go", fresh)
+	layer.AddEdge(&graph.Edge{From: fresh.ID, To: helper.ID, Kind: graph.EdgeCalls, FilePath: "src/new.go", Line: 3})
+
+	eng := query.NewEngine(base)
+	eng.SetSearch(search.NewNull())
+	srv := NewServer(eng, base, nil, nil, zap.NewNop(), nil)
+	ctx := WithOverlayView(context.Background(), graph.NewOverlaidView(base, layer))
+
+	req := mcplib.CallToolRequest{}
+	req.Params.Name = "find_usages"
+	req.Params.Arguments = map[string]any{"id": fresh.ID}
+	res, err := srv.handleFindUsages(ctx, req)
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	caveat := caveatOf(t, res.Content[0].(mcplib.TextContent).Text)
+	require.NotNil(t, caveat, "an empty result for a resolved symbol must carry a caveat")
+	require.Equal(t, graph.ZeroEdgeLikelyUnused, caveat.Class,
+		"overlay structural evidence (no incoming, one outgoing) is the likely_unused shape")
+}
+
+// TestFindUsages_OverlayWeakEvidenceClassifiesCoverageIncomplete pins the
+// exact caveat class when the only incoming evidence lives in the overlay
+// and is speculative: the row is hidden from the result by default, so the
+// empty answer must say coverage_incomplete — the base graph knows nothing
+// about the symbol and would misreport an extraction gap.
+func TestFindUsages_OverlayWeakEvidenceClassifiesCoverageIncomplete(t *testing.T) {
+	base := graph.New()
+
+	layer := graph.NewOverlayLayer()
+	fresh := &graph.Node{ID: "src/new.go::FreshFn", Kind: graph.KindFunction, Name: "FreshFn", FilePath: "src/new.go", StartLine: 1}
+	guess := &graph.Node{ID: "src/guess.go::MaybeCalls", Kind: graph.KindFunction, Name: "MaybeCalls", FilePath: "src/guess.go", StartLine: 5}
+	layer.AddNode("src/new.go", fresh)
+	layer.AddNode("src/guess.go", guess)
+	layer.AddEdge(&graph.Edge{
+		From: guess.ID, To: fresh.ID, Kind: graph.EdgeCalls, FilePath: "src/guess.go", Line: 7,
+		Origin: graph.OriginSpeculative, Meta: map[string]any{graph.MetaSpeculative: true},
+	})
+
+	eng := query.NewEngine(base)
+	eng.SetSearch(search.NewNull())
+	srv := NewServer(eng, base, nil, nil, zap.NewNop(), nil)
+	ctx := WithOverlayView(context.Background(), graph.NewOverlaidView(base, layer))
+
+	req := mcplib.CallToolRequest{}
+	req.Params.Name = "find_usages"
+	req.Params.Arguments = map[string]any{"id": fresh.ID}
+	res, err := srv.handleFindUsages(ctx, req)
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	caveat := caveatOf(t, res.Content[0].(mcplib.TextContent).Text)
+	require.NotNil(t, caveat)
+	require.Equal(t, graph.ZeroEdgeCoverageIncomplete, caveat.Class,
+		"a hidden speculative usage is weak evidence, not proof of unuse and not a gap")
+}
+
+// TestGetCallers_TombstonedCallerClassifiesLikelyUnused pins the caveat
+// when the overlay tombstones the file holding a symbol's only base
+// caller: the request's view has zero callers, so the empty result must
+// carry a likely_unused caveat — classifying against the base graph still
+// sees the deleted caller's edge and answers with no caveat at all.
+func TestGetCallers_TombstonedCallerClassifiesLikelyUnused(t *testing.T) {
+	base := graph.New()
+	target := &graph.Node{ID: "src/core.go::Target", Kind: graph.KindFunction, Name: "Target", FilePath: "src/core.go", StartLine: 1}
+	caller := &graph.Node{ID: "src/old.go::OnlyCaller", Kind: graph.KindFunction, Name: "OnlyCaller", FilePath: "src/old.go", StartLine: 3}
+	helper := &graph.Node{ID: "src/util.go::Helper", Kind: graph.KindFunction, Name: "Helper", FilePath: "src/util.go", StartLine: 1}
+	base.AddNode(target)
+	base.AddNode(caller)
+	base.AddNode(helper)
+	base.AddEdge(&graph.Edge{From: caller.ID, To: target.ID, Kind: graph.EdgeCalls, FilePath: "src/old.go", Line: 5})
+	// An outgoing edge keeps the tombstoned view out of the
+	// extraction-gap shape: no incoming, some structure → likely_unused.
+	base.AddEdge(&graph.Edge{From: target.ID, To: helper.ID, Kind: graph.EdgeCalls, FilePath: "src/core.go", Line: 2})
+
+	layer := graph.NewOverlayLayer()
+	layer.MarkFile("src/old.go", true)
+
+	eng := query.NewEngine(base)
+	eng.SetSearch(search.NewNull())
+	srv := NewServer(eng, base, nil, nil, zap.NewNop(), nil)
+	ctx := WithOverlayView(context.Background(), graph.NewOverlaidView(base, layer))
+
+	req := mcplib.CallToolRequest{}
+	req.Params.Name = "get_callers"
+	req.Params.Arguments = map[string]any{"id": target.ID}
+	res, err := srv.handleGetCallers(ctx, req)
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	caveat := caveatOf(t, res.Content[0].(mcplib.TextContent).Text)
+	require.NotNil(t, caveat,
+		"zero callers in the request's view must carry a caveat even when the base graph still holds a deleted caller")
+	require.Equal(t, graph.ZeroEdgeLikelyUnused, caveat.Class)
+}

--- a/internal/query/bfs_page_stability_test.go
+++ b/internal/query/bfs_page_stability_test.go
@@ -1,0 +1,109 @@
+package query
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+)
+
+// buildMixedKindCallers writes one hot symbol with callerCount callers
+// whose edges mix kinds and arrive in descending insertion order, plus
+// one test caller — the shape where the in-memory store (insertion
+// order) and SQLite (kind-grouped) disagree on raw edge order.
+func buildMixedKindCallers(g graph.Store, callerCount int) string {
+	hot := &graph.Node{ID: "pkg/hot.go::Hot", Kind: graph.KindFunction, Name: "Hot", FilePath: "pkg/hot.go", StartLine: 1}
+	g.AddNode(hot)
+	testCaller := &graph.Node{
+		ID: "pkg/hot_test.go::TestHot", Kind: graph.KindFunction, Name: "TestHot",
+		FilePath: "pkg/hot_test.go", StartLine: 3, Meta: map[string]any{"is_test": true},
+	}
+	g.AddNode(testCaller)
+	g.AddEdge(&graph.Edge{From: testCaller.ID, To: hot.ID, Kind: graph.EdgeCalls, FilePath: testCaller.FilePath, Line: 5, Origin: graph.OriginASTResolved, Confidence: 0.9})
+	kinds := []graph.EdgeKind{graph.EdgeReferences, graph.EdgeCalls, graph.EdgeMatches}
+	for i := callerCount - 1; i >= 0; i-- {
+		file := fmt.Sprintf("pkg/use%02d.go", i)
+		caller := &graph.Node{ID: fmt.Sprintf("%s::Use%02d", file, i), Kind: graph.KindFunction, Name: fmt.Sprintf("Use%02d", i), FilePath: file, StartLine: 3}
+		g.AddNode(caller)
+		g.AddEdge(&graph.Edge{From: caller.ID, To: hot.ID, Kind: kinds[i%len(kinds)], FilePath: file, Line: 5, Origin: graph.OriginASTResolved, Confidence: 0.9})
+	}
+	return hot.ID
+}
+
+// TestCappedFilteredBFSPageBackendParity pins the membership of a
+// capped, filtered caller page across backends: the filtered walk takes
+// the per-node path on every backend, so without one deterministic edge
+// order before admission the page depends on backend iteration order
+// (insertion vs kind-grouped) — the same result on the same graph must
+// not change with the storage engine or index history.
+func TestCappedFilteredBFSPageBackendParity(t *testing.T) {
+	page := func(g graph.Store, hotID string) map[string]bool {
+		eng := NewEngine(g)
+		sg := eng.GetCallers(hotID, QueryOptions{Depth: 1, Limit: 4, ExcludeTests: true})
+		got := make(map[string]bool, len(sg.Edges))
+		for _, e := range sg.Edges {
+			got[e.From] = true
+		}
+		return got
+	}
+
+	mem := graph.New()
+	memID := buildMixedKindCallers(mem, 12)
+
+	sqlite, err := store_sqlite.Open(filepath.Join(t.TempDir(), "bfs.sqlite"))
+	require.NoError(t, err)
+	defer sqlite.Close()
+	sqliteID := buildMixedKindCallers(sqlite, 12)
+
+	memPage := page(mem, memID)
+	sqlitePage := page(sqlite, sqliteID)
+	require.Equal(t, memPage, sqlitePage,
+		"the capped filtered caller page must hold the same members on every backend")
+}
+
+// countingStore wraps a backend and counts the point reads the
+// per-node BFS path issues.
+type countingStore struct {
+	graph.Store
+	inEdgeCalls int
+	nodeCalls   int
+}
+
+func (c *countingStore) GetInEdges(id string) []*graph.Edge {
+	c.inEdgeCalls++
+	return c.Store.GetInEdges(id)
+}
+
+func (c *countingStore) GetNode(id string) *graph.Node {
+	c.nodeCalls++
+	return c.Store.GetNode(id)
+}
+
+// TestFilteredBFSQueryCountStaysFrontierLinear guards the cost of the
+// per-node fallback the filtered walk uses: one in-edge fetch per
+// expanded frontier node and at most one node fetch per admitted edge.
+// A regression to per-edge (or worse) fetch patterns multiplies disk
+// round-trips on exactly the path that already gave up batching for
+// correctness.
+func TestFilteredBFSQueryCountStaysFrontierLinear(t *testing.T) {
+	base := graph.New()
+	hotID := buildMixedKindCallers(base, 12)
+	cs := &countingStore{Store: base}
+
+	eng := NewEngine(cs)
+	sg := eng.GetCallers(hotID, QueryOptions{Depth: 1, Limit: 50, ExcludeTests: true})
+	require.NotEmpty(t, sg.Edges)
+
+	// Depth 1 from one seed: the walk may fetch the seed's in-edges
+	// (plus bounded per-call setup reads), never one fetch per edge.
+	require.LessOrEqual(t, cs.inEdgeCalls, 4,
+		"the per-node walk must fetch in-edges once per expanded frontier node, got %d calls for one seed", cs.inEdgeCalls)
+	// 13 raw in-edges (12 production + 1 test): node materialisation
+	// stays linear in edges seen, with bounded setup overhead.
+	require.LessOrEqual(t, cs.nodeCalls, 2*13+6,
+		"node fetches must stay linear in edges seen, got %d", cs.nodeCalls)
+}

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -12,7 +12,6 @@ import (
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/search"
 	"github.com/zzet/gortex/internal/search/rerank"
-	"github.com/zzet/gortex/internal/testpath"
 )
 
 // SearchProvider is a function that returns the current search backend.
@@ -454,7 +453,7 @@ func (e *Engine) FindUsagesScoped(nodeID string, opts QueryOptions) *SubGraph {
 			if opts.hasScopeFilter() && (from == nil || !opts.ScopeAllows(from)) {
 				continue
 			}
-			if opts.ExcludeTests && isTestSource(from) {
+			if opts.ExcludeTests && e.isTestSource(from) {
 				continue
 			}
 			filtered = append(filtered, edge)
@@ -1341,7 +1340,7 @@ func (e *Engine) bfs(nodeID string, opts QueryOptions, forward bool, edgeKinds [
 		}
 		// ExcludeTests drops neighbours flagged as tests during a reverse
 		// traversal — a no-op for forward/bidirectional walks.
-		if opts.ExcludeTests && !forward && !bidir && isTestSource(neighbor) {
+		if opts.ExcludeTests && !forward && !bidir && e.isTestSource(neighbor) {
 			return ""
 		}
 		// Workspace/project scope: neighbours outside the bound scope are
@@ -1804,22 +1803,11 @@ func isCodeSymbolKind(n *graph.Node) bool {
 
 // isTestSource reports whether a node originates in test code. Used by
 // QueryOptions.ExcludeTests to drop callers/users that originate in
-// tests, leaving production callers.
-//
-// The indexer's test-edge pass stamps Meta["is_test"] on function and
-// method symbols only — a file-level from-node under a test directory
-// carries is_test_file instead, and parameter nodes carry no flag at
-// all. Trusting the stamp alone leaks exactly those kinds into a
-// production-only answer, so unflagged nodes fall back to the canonical
-// path predicate — the same signal the stamp is derived from.
-func isTestSource(n *graph.Node) bool {
-	if n == nil {
-		return false
-	}
-	if v, _ := n.Meta["is_test"].(bool); v {
-		return true
-	}
-	return testpath.IsTestFile(n.FilePath)
+// tests, leaving production callers. Delegates to the shared classifier
+// (see graph.NodeIsTest for the stamp → owner → path authority order),
+// so the filter and the output metadata can never disagree.
+func (e *Engine) isTestSource(n *graph.Node) bool {
+	return graph.NodeIsTest(e.g, n)
 }
 
 func dedup(edges []*graph.Edge) []*graph.Edge {

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -1408,6 +1408,14 @@ func (e *Engine) bfs(nodeID string, opts QueryOptions, forward bool, edgeKinds [
 				default:
 					edges = e.g.GetInEdges(cur)
 				}
+				// One deterministic admission order before the cap: the
+				// backends hand back raw edges in storage order (insertion
+				// vs kind-grouped), so without this sort a capped page's
+				// membership would depend on the storage engine and the
+				// graph's write history. Strongest evidence first — the
+				// same order the usage page cap consumes. The backends
+				// return fresh slices, so the in-place sort is safe.
+				SortEdgesForPage(edges)
 				for _, edge := range edges {
 					if !bidir && !kindSet[edge.Kind] {
 						continue

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -1413,9 +1413,18 @@ func (e *Engine) bfs(nodeID string, opts QueryOptions, forward bool, edgeKinds [
 				// vs kind-grouped), so without this sort a capped page's
 				// membership would depend on the storage engine and the
 				// graph's write history. Strongest evidence first — the
-				// same order the usage page cap consumes. The backends
-				// return fresh slices, so the in-place sort is safe.
-				SortEdgesForPage(edges)
+				// same order the usage page cap consumes. Sorted only
+				// when this expansion can reach the cap: an uncapped
+				// expansion admits every eligible edge, so order cannot
+				// change membership and a hub's edge list is not worth
+				// E·log E comparator calls. Scope: this per-node path —
+				// the one post-fetch filters force onto every backend;
+				// the batched expander and BFSCapable fast paths keep
+				// their own store order. The backends return fresh
+				// slices, so the in-place sort is safe.
+				if opts.Limit > 0 && len(allNodes)+len(edges) >= opts.Limit {
+					SortEdgesForPage(edges)
+				}
 				for _, edge := range edges {
 					if !bidir && !kindSet[edge.Kind] {
 						continue

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -12,6 +12,7 @@ import (
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/search"
 	"github.com/zzet/gortex/internal/search/rerank"
+	"github.com/zzet/gortex/internal/testpath"
 )
 
 // SearchProvider is a function that returns the current search backend.
@@ -1801,15 +1802,24 @@ func isCodeSymbolKind(n *graph.Node) bool {
 	return n != nil && (n.Kind == graph.KindFunction || n.Kind == graph.KindMethod)
 }
 
-// isTestSource reports whether a node was flagged as a test by the
-// indexer's test-edge pass. Used by QueryOptions.ExcludeTests to drop
-// callers/users that originate in tests, leaving production callers.
+// isTestSource reports whether a node originates in test code. Used by
+// QueryOptions.ExcludeTests to drop callers/users that originate in
+// tests, leaving production callers.
+//
+// The indexer's test-edge pass stamps Meta["is_test"] on function and
+// method symbols only — a file-level from-node under a test directory
+// carries is_test_file instead, and parameter nodes carry no flag at
+// all. Trusting the stamp alone leaks exactly those kinds into a
+// production-only answer, so unflagged nodes fall back to the canonical
+// path predicate — the same signal the stamp is derived from.
 func isTestSource(n *graph.Node) bool {
-	if n == nil || n.Meta == nil {
+	if n == nil {
 		return false
 	}
-	v, _ := n.Meta["is_test"].(bool)
-	return v
+	if v, _ := n.Meta["is_test"].(bool); v {
+		return true
+	}
+	return testpath.IsTestFile(n.FilePath)
 }
 
 func dedup(edges []*graph.Edge) []*graph.Edge {

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -1365,8 +1365,17 @@ func (e *Engine) bfs(nodeID string, opts QueryOptions, forward bool, edgeKinds [
 	// round-trip — no GetNode per edge, no meta decode. Bidirectional
 	// (cluster) walks and capability-less backends (the in-memory graph,
 	// whose reads are already O(1)) keep the per-node path.
+	//
+	// Post-fetch filters also force the per-node path: the expander caps
+	// RAW rows per call, so a filter (test exclusion, workspace scope)
+	// could discard an entire raw page while eligible rows sit beyond
+	// the cap — starving the result and reporting it untruncated. The
+	// per-node walk filters before any cap and fetches to true
+	// exhaustion; it is the correctness oracle, same as the
+	// BFSCapable gate above.
 	expander, batched := e.g.(graph.FrontierExpander)
-	batched = batched && !bidir && len(edgeKinds) > 0
+	batched = batched && !bidir && len(edgeKinds) > 0 &&
+		!opts.ExcludeTests && !opts.hasScopeFilter()
 
 	frontier := []string{nodeID}
 	for depth := 0; depth < opts.Depth && len(frontier) > 0 && len(allNodes) < opts.Limit; depth++ {

--- a/internal/query/exclude_tests_test.go
+++ b/internal/query/exclude_tests_test.go
@@ -61,3 +61,43 @@ func TestFindUsagesScoped_ExcludeTestsCoversUnstampedKinds(t *testing.T) {
 		require.NotEqual(t, testParam.ID, n.ID, "test param node leaked into a production-only result")
 	}
 }
+
+// TestFindUsagesScoped_ExcludeTestsCoversAnnotationOwnerChildren pins
+// the classifier's owner hop: an annotation-discovered test (a #[test]
+// fn in a production-looking path) is stamped on the function node
+// only, so its parameter child has neither a stamp nor a test-looking
+// path. The child must inherit the owner's test identity through the
+// `<owner-id>#...` ID convention.
+func TestFindUsagesScoped_ExcludeTestsCoversAnnotationOwnerChildren(t *testing.T) {
+	g := graph.New()
+	target := &graph.Node{
+		ID: "src/widget.rs::Widget", Kind: graph.KindType,
+		Name: "Widget", FilePath: "src/widget.rs", StartLine: 3,
+	}
+	// As the annotation pass leaves it: the fn is stamped, the child not.
+	testFn := &graph.Node{
+		ID: "src/lib.rs::check_widget", Kind: graph.KindFunction,
+		Name: "check_widget", FilePath: "src/lib.rs", StartLine: 40,
+		Meta: map[string]any{"is_test": true, "test_role": "test"},
+	}
+	testParam := &graph.Node{
+		ID: "src/lib.rs::check_widget#param:w", Kind: graph.KindParam,
+		Name: "w", FilePath: "src/lib.rs", StartLine: 40,
+	}
+	prodCaller := &graph.Node{
+		ID: "src/main.rs::run", Kind: graph.KindFunction,
+		Name: "run", FilePath: "src/main.rs", StartLine: 10,
+	}
+	for _, n := range []*graph.Node{target, testFn, testParam, prodCaller} {
+		g.AddNode(n)
+	}
+	g.AddEdge(&graph.Edge{From: prodCaller.ID, To: target.ID, Kind: graph.EdgeCalls, FilePath: "src/main.rs", Line: 12})
+	g.AddEdge(&graph.Edge{From: testFn.ID, To: target.ID, Kind: graph.EdgeCalls, FilePath: "src/lib.rs", Line: 42})
+	g.AddEdge(&graph.Edge{From: testParam.ID, To: target.ID, Kind: graph.EdgeReferences, FilePath: "src/lib.rs", Line: 40})
+
+	eng := NewEngine(g)
+	sg := eng.FindUsagesScoped(target.ID, QueryOptions{ExcludeTests: true})
+
+	require.Len(t, sg.Edges, 1, "the stamped owner's param child must be excluded with it")
+	require.Equal(t, prodCaller.ID, sg.Edges[0].From)
+}

--- a/internal/query/exclude_tests_test.go
+++ b/internal/query/exclude_tests_test.go
@@ -1,11 +1,14 @@
 package query
 
 import (
+	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
 )
 
 // TestFindUsagesScoped_ExcludeTestsCoversUnstampedKinds pins the
@@ -100,4 +103,45 @@ func TestFindUsagesScoped_ExcludeTestsCoversAnnotationOwnerChildren(t *testing.T
 
 	require.Len(t, sg.Edges, 1, "the stamped owner's param child must be excluded with it")
 	require.Equal(t, prodCaller.ID, sg.Edges[0].From)
+}
+
+// TestGetCallers_ExcludeTestsSurvivesRawPageOfTests pins the SQLite
+// starvation case: the batched frontier expansion caps RAW rows per
+// call, so when the first raw page is all test callers a post-fetch
+// filter used to discard the entire page and report zero production
+// callers with truncated=false — while a real production caller sat
+// beyond the cap. The filter must never consume the eligible-result
+// limit with rows it then drops.
+func TestGetCallers_ExcludeTestsSurvivesRawPageOfTests(t *testing.T) {
+	g, err := store_sqlite.Open(filepath.Join(t.TempDir(), "callers.sqlite"))
+	require.NoError(t, err)
+	defer g.Close()
+
+	target := &graph.Node{ID: "pkg/hot.go::Hot", Kind: graph.KindFunction, Name: "Hot", FilePath: "pkg/hot.go", StartLine: 1}
+	g.AddNode(target)
+	// Ten stamped test callers whose IDs sort ahead of the production
+	// caller, inserted first, so any raw page of five rows is all tests.
+	for i := 0; i < 10; i++ {
+		file := fmt.Sprintf("pkg/a%02d_test.go", i)
+		caller := &graph.Node{
+			ID: fmt.Sprintf("%s::TestUse%02d", file, i), Kind: graph.KindFunction,
+			Name: fmt.Sprintf("TestUse%02d", i), FilePath: file, StartLine: 3,
+			Meta: map[string]any{"is_test": true},
+		}
+		g.AddNode(caller)
+		g.AddEdge(&graph.Edge{From: caller.ID, To: target.ID, Kind: graph.EdgeCalls, FilePath: file, Line: 5})
+	}
+	prod := &graph.Node{ID: "pkg/z_prod.go::Run", Kind: graph.KindFunction, Name: "Run", FilePath: "pkg/z_prod.go", StartLine: 8}
+	g.AddNode(prod)
+	g.AddEdge(&graph.Edge{From: prod.ID, To: target.ID, Kind: graph.EdgeCalls, FilePath: "pkg/z_prod.go", Line: 9})
+
+	eng := NewEngine(g)
+	sg := eng.GetCallers(target.ID, QueryOptions{ExcludeTests: true, Limit: 5, Depth: 1})
+
+	froms := make(map[string]bool)
+	for _, e := range sg.Edges {
+		froms[e.From] = true
+	}
+	require.True(t, froms[prod.ID],
+		"the production caller must be found even when a raw page of test rows precedes it")
 }

--- a/internal/query/exclude_tests_test.go
+++ b/internal/query/exclude_tests_test.go
@@ -1,0 +1,63 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestFindUsagesScoped_ExcludeTestsCoversUnstampedKinds pins the
+// exclude_tests contract for node kinds the indexer's test-edge pass
+// never stamps. The pass writes Meta["is_test"] on function/method
+// symbols only — a file-level from-node under a test directory carries
+// is_test_file instead, and a parameter node carries no flag at all —
+// so a filter that trusts the stamp alone leaks exactly those kinds
+// into a "production-only" answer while correctly dropping the stamped
+// method callers. The graph below mirrors that indexer output shape.
+func TestFindUsagesScoped_ExcludeTestsCoversUnstampedKinds(t *testing.T) {
+	g := graph.New()
+	target := &graph.Node{
+		ID: "src/WidgetService.cs::WidgetService", Kind: graph.KindType,
+		Name: "WidgetService", FilePath: "src/WidgetService.cs", StartLine: 5,
+	}
+	prodCaller := &graph.Node{
+		ID: "src/Consumer.cs::Consumer.Use", Kind: graph.KindMethod,
+		Name: "Use", FilePath: "src/Consumer.cs", StartLine: 12,
+	}
+	// Stamped test method — the case the filter already handles.
+	testMethod := &graph.Node{
+		ID: `Test\WidgetService_Tests.cs::WidgetServiceTests.Run`, Kind: graph.KindMethod,
+		Name: "Run", FilePath: `Test\WidgetService_Tests.cs`, StartLine: 20,
+		Meta: map[string]any{"is_test": true},
+	}
+	// File-level from-node: the pass stamps is_test_file, never is_test.
+	testFile := &graph.Node{
+		ID: `Test\WidgetService_Tests.cs`, Kind: graph.KindFile,
+		Name: "WidgetService_Tests.cs", FilePath: `Test\WidgetService_Tests.cs`,
+		Meta: map[string]any{"is_test_file": true},
+	}
+	// Parameter node: no test metadata of any kind.
+	testParam := &graph.Node{
+		ID: `Test\WidgetService_Tests.cs::WidgetServiceTests.Run#param:svc`, Kind: graph.KindParam,
+		Name: "svc", FilePath: `Test\WidgetService_Tests.cs`, StartLine: 20,
+	}
+	for _, n := range []*graph.Node{target, prodCaller, testMethod, testFile, testParam} {
+		g.AddNode(n)
+	}
+	g.AddEdge(&graph.Edge{From: prodCaller.ID, To: target.ID, Kind: graph.EdgeCalls, FilePath: "src/Consumer.cs", Line: 14})
+	g.AddEdge(&graph.Edge{From: testMethod.ID, To: target.ID, Kind: graph.EdgeCalls, FilePath: testMethod.FilePath, Line: 22})
+	g.AddEdge(&graph.Edge{From: testFile.ID, To: target.ID, Kind: graph.EdgeImports, FilePath: testFile.FilePath, Line: 1})
+	g.AddEdge(&graph.Edge{From: testParam.ID, To: target.ID, Kind: graph.EdgeReferences, FilePath: testParam.FilePath, Line: 20})
+
+	eng := NewEngine(g)
+	sg := eng.FindUsagesScoped(target.ID, QueryOptions{ExcludeTests: true})
+
+	require.Len(t, sg.Edges, 1, "exclude_tests must drop every test-path from-node, not just stamped methods")
+	require.Equal(t, prodCaller.ID, sg.Edges[0].From, "the production caller is the only edge that may survive")
+	for _, n := range sg.Nodes {
+		require.NotEqual(t, testFile.ID, n.ID, "test file node leaked into a production-only result")
+		require.NotEqual(t, testParam.ID, n.ID, "test param node leaked into a production-only result")
+	}
+}

--- a/internal/query/name_only.go
+++ b/internal/query/name_only.go
@@ -114,7 +114,7 @@ func (e *Engine) FindNameOnlyCandidates(node *graph.Node, bound []*graph.Edge, o
 			out.Total--
 			continue
 		}
-		if opts.ExcludeTests && isTestSource(from) {
+		if opts.ExcludeTests && e.isTestSource(from) {
 			out.Total--
 			continue
 		}

--- a/internal/query/subgraph.go
+++ b/internal/query/subgraph.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -372,6 +373,39 @@ func (sg *SubGraph) FilterByMinTier(minTier string) {
 			MaxAvailableTier:  maxDroppedOrigin,
 		}
 	}
+}
+
+// SortEdgesForPage orders usage edges into the one stable global order
+// a row cap may consume: strongest evidence first (origin tier rank,
+// then confidence), with file/line/kind/from/to as deterministic
+// tie-breakers. Backends iterate in-edges differently (the memory
+// store by insertion, SQLite grouped by kind), so a page cut without
+// this sort would depend on which store served it and could evict an
+// lsp_resolved row in favor of an earlier weak one.
+func SortEdgesForPage(edges []*graph.Edge) {
+	sort.SliceStable(edges, func(i, j int) bool {
+		a, b := edges[i], edges[j]
+		ar, br := graph.OriginRank(effectiveOrigin(a)), graph.OriginRank(effectiveOrigin(b))
+		if ar != br {
+			return ar > br
+		}
+		if a.Confidence != b.Confidence {
+			return a.Confidence > b.Confidence
+		}
+		if a.FilePath != b.FilePath {
+			return a.FilePath < b.FilePath
+		}
+		if a.Line != b.Line {
+			return a.Line < b.Line
+		}
+		if a.Kind != b.Kind {
+			return a.Kind < b.Kind
+		}
+		if a.From != b.From {
+			return a.From < b.From
+		}
+		return a.To < b.To
+	})
 }
 
 // effectiveOrigin returns the edge's origin tier, backfilled for edges

--- a/internal/query/subgraph.go
+++ b/internal/query/subgraph.go
@@ -142,10 +142,12 @@ type QueryOptions struct {
 	// soft breadth control inside any workspace boundary, not a
 	// replacement for caller-side workspace isolation.
 	RepoAllow map[string]bool `json:"repo_allow,omitempty"`
-	// ExcludeTests, when true, drops edges originating from a function
-	// flagged as a test (Node.Meta["is_test"] = true) — set by the
-	// indexer's test-edge pass. Lets find_usages / get_callers answer
-	// "who depends on X *in production*" without test-noise dilution.
+	// ExcludeTests, when true, drops edges originating in test code —
+	// nodes flagged by the indexer's test-edge pass (Node.Meta["is_test"]
+	// = true) plus unflagged node kinds whose file path matches the
+	// canonical test predicate (see isTestSource). Lets find_usages /
+	// get_callers answer "who depends on X *in production*" without
+	// test-noise dilution.
 	ExcludeTests bool `json:"exclude_tests,omitempty"`
 
 	// IncludeDispatch makes a forward call-graph walk (get_call_chain /

--- a/internal/query/subgraph.go
+++ b/internal/query/subgraph.go
@@ -395,7 +395,7 @@ func SortEdgesForPage(edges []*graph.Edge) {
 		// Edge.Confidence is excluded from JSON, so rows that crossed a
 		// serialization boundary (federation peers) read zero and carry
 		// only the label — the sortable rank that survives the wire.
-		if ar, br := confidenceLabelRank(a.ConfidenceLabel), confidenceLabelRank(b.ConfidenceLabel); ar != br {
+		if ar, br := graph.ConfidenceLabelRank(a.ConfidenceLabel), graph.ConfidenceLabelRank(b.ConfidenceLabel); ar != br {
 			return ar > br
 		}
 		if a.FilePath != b.FilePath {
@@ -414,19 +414,40 @@ func SortEdgesForPage(edges []*graph.Edge) {
 	})
 }
 
-// confidenceLabelRank orders the coarse confidence labels
-// (graph.ConfidenceLabelFor) for tie-breaking; unlabeled rows rank
-// lowest.
-func confidenceLabelRank(label string) int {
-	switch label {
-	case "EXTRACTED":
-		return 3
-	case "INFERRED":
-		return 2
-	case "AMBIGUOUS":
-		return 1
+// UsageSummaryOf computes the completeness rollup over a usage
+// SubGraph: total references, distinct files (per-edge path with a
+// from-node fallback), and test-originated references via the shared
+// classifier (graph.NodeIsTest — the same authority order the
+// exclude_tests filter applies, so the rollup never disagrees with the
+// rows). g resolves child-node owners; nil skips only that hop. Nil
+// for an empty result — the zero-edge caveat explains that case.
+func UsageSummaryOf(sg *SubGraph, g graph.NodeGetter) *UsageSummary {
+	if sg == nil || len(sg.Edges) == 0 {
+		return nil
 	}
-	return 0
+	nodeByID := make(map[string]*graph.Node, len(sg.Nodes))
+	for _, n := range sg.Nodes {
+		if n != nil {
+			nodeByID[n.ID] = n
+		}
+	}
+	files := make(map[string]struct{}, len(sg.Edges))
+	testRefs := 0
+	for _, e := range sg.Edges {
+		from := nodeByID[e.From]
+		file := e.FilePath
+		if file == "" && from != nil {
+			file = from.FilePath
+		}
+		if file == "" {
+			file = "(unknown)"
+		}
+		files[file] = struct{}{}
+		if graph.NodeIsTest(g, from) {
+			testRefs++
+		}
+	}
+	return &UsageSummary{NRefs: len(sg.Edges), NFiles: len(files), NTestRefs: testRefs}
 }
 
 // effectiveOrigin returns the edge's origin tier, backfilled for edges

--- a/internal/query/subgraph.go
+++ b/internal/query/subgraph.go
@@ -392,6 +392,12 @@ func SortEdgesForPage(edges []*graph.Edge) {
 		if a.Confidence != b.Confidence {
 			return a.Confidence > b.Confidence
 		}
+		// Edge.Confidence is excluded from JSON, so rows that crossed a
+		// serialization boundary (federation peers) read zero and carry
+		// only the label — the sortable rank that survives the wire.
+		if ar, br := confidenceLabelRank(a.ConfidenceLabel), confidenceLabelRank(b.ConfidenceLabel); ar != br {
+			return ar > br
+		}
 		if a.FilePath != b.FilePath {
 			return a.FilePath < b.FilePath
 		}
@@ -406,6 +412,21 @@ func SortEdgesForPage(edges []*graph.Edge) {
 		}
 		return a.To < b.To
 	})
+}
+
+// confidenceLabelRank orders the coarse confidence labels
+// (graph.ConfidenceLabelFor) for tie-breaking; unlabeled rows rank
+// lowest.
+func confidenceLabelRank(label string) int {
+	switch label {
+	case "EXTRACTED":
+		return 3
+	case "INFERRED":
+		return 2
+	case "AMBIGUOUS":
+		return 1
+	}
+	return 0
 }
 
 // effectiveOrigin returns the edge's origin tier, backfilled for edges

--- a/internal/query/usage_groups.go
+++ b/internal/query/usage_groups.go
@@ -1,0 +1,24 @@
+package query
+
+// UsageFileGroup is one file's worth of references from a
+// group_by:"file" find_usages response. It lives here — beside
+// SubGraph — because two layers speak this wire shape: the MCP
+// renderer serializes it and the daemon's federation merge parses and
+// re-emits it. One definition, so a field added for the renderer can
+// never be silently stripped by the merge round trip.
+type UsageFileGroup struct {
+	File  string           `json:"file"`
+	Count int              `json:"count"`
+	Uses  []UsageGroupItem `json:"uses"`
+}
+
+// UsageGroupItem is one reference inside a UsageFileGroup — the line
+// it sits on plus the enclosing symbol.
+type UsageGroupItem struct {
+	Line        int    `json:"line"`
+	EdgeKind    string `json:"edge_kind"`
+	Context     string `json:"context,omitempty"`
+	ReturnUsage string `json:"return_usage,omitempty"`
+	SymbolID    string `json:"symbol_id,omitempty"`
+	SymbolName  string `json:"symbol_name,omitempty"`
+}

--- a/internal/respbudget/respbudget.go
+++ b/internal/respbudget/respbudget.go
@@ -1,0 +1,307 @@
+// Package respbudget holds the response-budget arithmetic shared by
+// every layer that assembles a tool response: the MCP server applies it
+// per handler, and the daemon's federation merge reapplies it to the
+// final merged representation. One implementation, so the two layers
+// cannot drift on defaults, opt-out semantics, or the token ratio.
+package respbudget
+
+import (
+	"encoding/json"
+	"sort"
+)
+
+// DefaultMaxBytes is the upper bound on a single tool response.
+// Empirically the agent harness (claude-code at the time of writing)
+// starts spilling responses to a side file around ~50 KB of wire
+// text. The MCP `tools/call` envelope wraps our payload as
+// `{"content":[{"type":"text","text":"<payload>"}]}`, then JSON-RPC
+// itself adds one more layer of escaping when serialised across the
+// stdio bridge — round-trip overhead averages 25–30 % on top of the
+// raw payload bytes for our shapes. Capping the inner payload at
+// 40 KB keeps the wire form comfortably under the 50 KB threshold,
+// leaving headroom for the rare row that has unusually heavy meta.
+//
+// Lower this number cautiously: every drop here means more rows get
+// trimmed across every list-shaped tool. Raise it only after
+// re-measuring the harness threshold; "no spill" beats "more rows"
+// because spilled output forces a cold re-read for the agent.
+const DefaultMaxBytes = 40_000
+
+// AvgBytesPerToken is the calibration constant used to translate the
+// `max_tokens` parameter into an effective byte cap. Empirically:
+//
+//   - dense JSON / TOON rows (`{"id":"...","kind":"function",...}`)
+//     tokenise at ~3.0–3.4 chars per BPE token on cl100k_base. The
+//     punctuation density (quotes, colons, braces) drags the ratio
+//     down vs. natural English.
+//   - GCX1 rows (`id\tkind\tname\t...`) tokenise at ~4.0–4.5 chars
+//     per token because tabs collapse into single tokens and the
+//     identifier-heavy payload tokenises more efficiently than JSON.
+//   - smart_context / get_editing_context source-bearing payloads
+//     average ~3.6 chars per token because the source lines push
+//     the ratio toward English text.
+//
+// 3.5 is the safe midpoint: it slightly UNDER-counts tokens for JSON
+// (so the resulting byte cap is tighter than strictly necessary —
+// erring on the side of "fits the budget") and approximately matches
+// the GCX row case. Token estimation is necessarily imperfect across
+// model tokenisers; the budget guard's job is to ride a safe margin,
+// not to count exactly. A caller who needs precise token-counting
+// should run their own tokenizer post-hoc.
+const AvgBytesPerToken = 3.5
+
+// TruncatedKey is the meta flag appended to a payload trimmed by
+// Apply so callers can branch on truncation without scanning for
+// shape-specific signals.
+const TruncatedKey = "_truncated_by_budget"
+
+// TokensToBytes converts a token budget into a byte cap using the
+// AvgBytesPerToken ratio. Returns 0 for non-positive inputs so
+// `max_tokens: 0` is honoured as "opt out" with the same semantics
+// as `max_bytes: 0`.
+func TokensToBytes(maxTokens int) int {
+	if maxTokens <= 0 {
+		return 0
+	}
+	return int(float64(maxTokens) * AvgBytesPerToken)
+}
+
+// BytesToTokens is the inverse of TokensToBytes. Used to render a
+// human-readable token-equivalent on the truncation meta so callers
+// see "kept ~N tokens" alongside the raw byte cap. Returns 0 for
+// non-positive inputs.
+func BytesToTokens(byteCount int) int {
+	if byteCount <= 0 {
+		return 0
+	}
+	return int(float64(byteCount) / AvgBytesPerToken)
+}
+
+// NumArgInt extracts an integer arg from a request arguments map.
+// JSON numbers arrive as float64; some test harnesses pass int.
+// Returns (value, present). When the arg is the wrong type, returns
+// (0, true) so callers can distinguish "absent" from "malformed
+// zero" — important because a zero value is meaningful here (it is
+// the opt-out signal for both max_bytes and max_tokens).
+func NumArgInt(args map[string]any, key string) (int, bool) {
+	raw, ok := args[key]
+	if !ok {
+		return 0, false
+	}
+	switch n := raw.(type) {
+	case float64:
+		return int(n), true
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	default:
+		return 0, true
+	}
+}
+
+// EffectiveFromArgs resolves the per-call byte budget from a tool's
+// arguments map. Budget-by-default — every list-shaped tool runs
+// through graceful degradation so the agent gets a usable in-band
+// response instead of a transport spill. Resolution order:
+//
+//   - `max_bytes` and / or `max_tokens` set explicitly: the tighter
+//     cap wins. `max_tokens` is converted via TokensToBytes and then
+//     min-merged with `max_bytes`. Passing 0 (or negative) on either
+//     axis opts OUT of that axis; opting out of one axis still
+//     respects the other. Opting out of both yields no cap.
+//   - Nothing set: the project default.
+func EffectiveFromArgs(args map[string]any) int {
+	rawBytes, bytesPresent := NumArgInt(args, "max_bytes")
+	rawTokens, tokensPresent := NumArgInt(args, "max_tokens")
+
+	if !bytesPresent && !tokensPresent {
+		return DefaultMaxBytes
+	}
+
+	// Per-axis opt-out: a non-positive value means "skip THIS axis".
+	bytesOptOut := bytesPresent && rawBytes <= 0
+	tokensOptOut := tokensPresent && rawTokens <= 0
+
+	// Both axes opted out → no cap.
+	if bytesPresent && tokensPresent && bytesOptOut && tokensOptOut {
+		return 0
+	}
+	// Only one axis present and it opted out → no cap.
+	if bytesPresent && !tokensPresent && bytesOptOut {
+		return 0
+	}
+	if tokensPresent && !bytesPresent && tokensOptOut {
+		return 0
+	}
+
+	tokensBytes := TokensToBytes(rawTokens) // 0 when token axis absent or opt-out
+
+	switch {
+	case bytesPresent && tokensPresent:
+		switch {
+		case bytesOptOut:
+			return tokensBytes
+		case tokensOptOut:
+			return rawBytes
+		case rawBytes < tokensBytes:
+			return rawBytes
+		default:
+			return tokensBytes
+		}
+	case bytesPresent:
+		return rawBytes
+	default: // tokensPresent
+		return tokensBytes
+	}
+}
+
+// Apply enforces a marshaled-size cap on payload by trimming
+// top-level lists in longest-first order until the result fits.
+// Returns the (possibly trimmed) payload and a flag indicating
+// whether trimming happened. The trimmed payload carries inline
+// metadata so callers can surface "narrow your filter" hints:
+//
+//   - _truncated_by_budget: true
+//   - _max_returned_<field>: N
+//   - _original_count_<field>: M (one pair per trimmed list)
+//
+// Multi-list payloads (`nodes` + `edges` for get_file_summary, etc.)
+// are trimmed iteratively: the longest list is binary-searched first;
+// if the result still exceeds the cap, the next-longest list is
+// trimmed too, and so on. We stop when the cap is met or every list
+// has been emptied (the second is a degraded fallback — extremely
+// large per-row payloads can still exceed the budget with zero
+// rows; that case is rare and the MCP transport's spill fallback
+// handles it).
+//
+// Best-effort: if no top-level list is found in the marshaled JSON,
+// the payload is returned unchanged.
+func Apply(payload any, maxBytes int) (any, bool) {
+	if maxBytes <= 0 || payload == nil {
+		return payload, false
+	}
+	bytes, err := json.Marshal(payload)
+	if err != nil || len(bytes) <= maxBytes {
+		return payload, false
+	}
+
+	// Re-shape into a generic map so we can manipulate any payload
+	// type uniformly (struct, *query.SubGraph, map[string]any). The
+	// JSON round-trip costs one extra alloc — cheap given we already
+	// know we are over budget.
+	var generic map[string]any
+	if err := json.Unmarshal(bytes, &generic); err != nil {
+		return payload, false
+	}
+
+	trimmed := false
+	// Cap iteration count by the number of distinct top-level slices
+	// so we cannot loop forever on a payload whose non-list scalars
+	// alone exceed the cap.
+	for pass := 0; pass < 8; pass++ {
+		longestKey := findLongestSliceKey(generic)
+		if longestKey == "" {
+			break
+		}
+		longest := genericSlice(generic, longestKey)
+		if len(longest) == 0 {
+			// Already-empty list cannot shrink further; pick the
+			// next-longest in the next iteration. Mark this list
+			// completed by removing it from candidate set via length 0.
+			break
+		}
+		originalLen := len(longest)
+		// Binary search for the largest prefix that fits.
+		lo, hi := 0, originalLen
+		for lo < hi {
+			mid := (lo + hi + 1) / 2
+			generic[longestKey] = longest[:mid]
+			generic[TruncatedKey] = true
+			generic["_max_returned_"+longestKey] = mid
+			generic["_original_count_"+longestKey] = originalLen
+			candidate, err := json.Marshal(generic)
+			if err != nil {
+				break
+			}
+			if len(candidate) <= maxBytes {
+				lo = mid
+			} else {
+				hi = mid - 1
+			}
+		}
+		generic[longestKey] = longest[:lo]
+		generic[TruncatedKey] = true
+		generic["_max_returned_"+longestKey] = lo
+		generic["_original_count_"+longestKey] = originalLen
+		trimmed = true
+
+		final, _ := json.Marshal(generic)
+		if len(final) <= maxBytes {
+			return generic, true
+		}
+	}
+	if !trimmed {
+		// No slice candidate was actually trimmed — return the
+		// original payload type intact so callers comparing against
+		// concrete Go types (int vs json's float64, etc.) keep
+		// working unchanged.
+		return payload, false
+	}
+	return generic, trimmed
+}
+
+// ApplyToJSON is Apply over raw marshaled bytes: the federation merge
+// holds the final representation as JSON, not as a typed payload. On
+// any parse failure the input is returned unchanged — a non-JSON body
+// is some other layer's contract.
+func ApplyToJSON(raw []byte, maxBytes int) []byte {
+	if maxBytes <= 0 || len(raw) <= maxBytes {
+		return raw
+	}
+	var generic map[string]any
+	if err := json.Unmarshal(raw, &generic); err != nil {
+		return raw
+	}
+	trimmed, ok := Apply(generic, maxBytes)
+	if !ok {
+		return raw
+	}
+	out, err := json.Marshal(trimmed)
+	if err != nil {
+		return raw
+	}
+	return out
+}
+
+// findLongestSliceKey returns the top-level field name whose value is
+// the longest []any. Empty string when no slices are present. Used by
+// Apply to pick the trimming target without per-tool config.
+func findLongestSliceKey(m map[string]any) string {
+	var key string
+	maxLen := 0
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	// Stable iteration so ties resolve deterministically.
+	sort.Strings(keys)
+	for _, k := range keys {
+		arr, ok := m[k].([]any)
+		if !ok {
+			continue
+		}
+		if len(arr) > maxLen {
+			maxLen = len(arr)
+			key = k
+		}
+	}
+	return key
+}
+
+func genericSlice(m map[string]any, key string) []any {
+	if arr, ok := m[key].([]any); ok {
+		return arr
+	}
+	return nil
+}

--- a/internal/respbudget/respbudget.go
+++ b/internal/respbudget/respbudget.go
@@ -7,6 +7,7 @@ package respbudget
 
 import (
 	"encoding/json"
+	"maps"
 	"sort"
 )
 
@@ -189,9 +190,14 @@ func Apply(payload any, maxBytes int) (any, bool) {
 	// Re-shape into a generic map so we can manipulate any payload
 	// type uniformly (struct, *query.SubGraph, map[string]any). The
 	// JSON round-trip costs one extra alloc — cheap given we already
-	// know we are over budget.
-	var generic map[string]any
-	if err := json.Unmarshal(bytes, &generic); err != nil {
+	// know we are over budget. A payload that already is a generic map
+	// (the federation merge hands one over) skips the round trip; the
+	// trim writes only top-level keys, so a shallow clone keeps the
+	// caller's map — which callers may reuse — untouched.
+	generic, ok := payload.(map[string]any)
+	if ok {
+		generic = maps.Clone(generic)
+	} else if err := json.Unmarshal(bytes, &generic); err != nil {
 		return payload, false
 	}
 
@@ -251,27 +257,14 @@ func Apply(payload any, maxBytes int) (any, bool) {
 	return generic, trimmed
 }
 
-// ApplyToJSON is Apply over raw marshaled bytes: the federation merge
-// holds the final representation as JSON, not as a typed payload. On
-// any parse failure the input is returned unchanged — a non-JSON body
-// is some other layer's contract.
-func ApplyToJSON(raw []byte, maxBytes int) []byte {
-	if maxBytes <= 0 || len(raw) <= maxBytes {
-		return raw
+// Trimmed reports whether raw marshaled JSON carries Apply's
+// truncation marker (TruncatedKey). Lives beside the constant so
+// every layer probing for the marker shares one definition.
+func Trimmed(raw []byte) bool {
+	var probe struct {
+		TruncatedByBudget bool `json:"_truncated_by_budget"`
 	}
-	var generic map[string]any
-	if err := json.Unmarshal(raw, &generic); err != nil {
-		return raw
-	}
-	trimmed, ok := Apply(generic, maxBytes)
-	if !ok {
-		return raw
-	}
-	out, err := json.Marshal(trimmed)
-	if err != nil {
-		return raw
-	}
-	return out
+	return json.Unmarshal(raw, &probe) == nil && probe.TruncatedByBudget
 }
 
 // findLongestSliceKey returns the top-level field name whose value is

--- a/internal/respbudget/respbudget.go
+++ b/internal/respbudget/respbudget.go
@@ -7,7 +7,6 @@ package respbudget
 
 import (
 	"encoding/json"
-	"maps"
 	"sort"
 )
 
@@ -170,11 +169,18 @@ func EffectiveFromArgs(args map[string]any) int {
 // Multi-list payloads (`nodes` + `edges` for get_file_summary, etc.)
 // are trimmed iteratively: the longest list is binary-searched first;
 // if the result still exceeds the cap, the next-longest list is
-// trimmed too, and so on. We stop when the cap is met or every list
-// has been emptied (the second is a degraded fallback — extremely
-// large per-row payloads can still exceed the budget with zero
-// rows; that case is rare and the MCP transport's spill fallback
-// handles it).
+// trimmed too, and so on.
+//
+// FLOOR: the enforceable minimum for a structured payload is its
+// scalar skeleton — the marshaled size with every top-level list
+// emptied, truncation meta included. A budget below that floor still
+// gets every list emptied and the meta stamped, and the response then
+// exceeds the cap by the skeleton's size: scalars are not trimmable
+// without discarding the answer itself, and a byte-level cut would
+// corrupt the JSON. Callers that need a hard ceiling at any size
+// (the text renderers) enforce it with their own grammar-aware trim;
+// for JSON the cap is a contract above the floor and best-effort
+// below it. TestApplyScalarSkeletonFloor pins this exact shape.
 //
 // Best-effort: if no top-level list is found in the marshaled JSON,
 // the payload is returned unchanged.
@@ -190,33 +196,29 @@ func Apply(payload any, maxBytes int) (any, bool) {
 	// Re-shape into a generic map so we can manipulate any payload
 	// type uniformly (struct, *query.SubGraph, map[string]any). The
 	// JSON round-trip costs one extra alloc — cheap given we already
-	// know we are over budget. A payload that already is a generic map
-	// (the federation merge hands one over) skips the round trip; the
-	// trim writes only top-level keys, so a shallow clone keeps the
-	// caller's map — which callers may reuse — untouched.
-	generic, ok := payload.(map[string]any)
-	if ok {
-		generic = maps.Clone(generic)
-	} else if err := json.Unmarshal(bytes, &generic); err != nil {
+	// know we are over budget — and it is load-bearing twice over:
+	// it normalizes TYPED slices (a handler's []*graph.Edge inside a
+	// map[string]any) into the []any the trimmer recognizes, and it
+	// yields a fresh map so the caller's payload — which callers may
+	// reuse — stays untouched. Do not shortcut it with a map
+	// assertion: a shallow clone keeps the typed slices and the trim
+	// silently returns the oversized payload.
+	var generic map[string]any
+	if err := json.Unmarshal(bytes, &generic); err != nil {
 		return payload, false
 	}
 
 	trimmed := false
-	// Cap iteration count by the number of distinct top-level slices
-	// so we cannot loop forever on a payload whose non-list scalars
-	// alone exceed the cap.
-	for pass := 0; pass < 8; pass++ {
+	// Each non-fitting pass empties the then-longest list, so the
+	// number of top-level keys bounds the loop: a payload whose
+	// scalars alone exceed the cap terminates with every list empty
+	// (the documented floor), never spins.
+	for pass := 0; pass < len(generic); pass++ {
 		longestKey := findLongestSliceKey(generic)
 		if longestKey == "" {
 			break
 		}
 		longest := genericSlice(generic, longestKey)
-		if len(longest) == 0 {
-			// Already-empty list cannot shrink further; pick the
-			// next-longest in the next iteration. Mark this list
-			// completed by removing it from candidate set via length 0.
-			break
-		}
 		originalLen := len(longest)
 		// Binary search for the largest prefix that fits.
 		lo, hi := 0, originalLen

--- a/internal/respbudget/respbudget_floor_test.go
+++ b/internal/respbudget/respbudget_floor_test.go
@@ -1,0 +1,61 @@
+package respbudget
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestApplyScalarSkeletonFloor pins the documented budget floor: a cap
+// smaller than the payload's scalar skeleton empties every list and
+// stamps the truncation meta, and the result lands exactly on the
+// skeleton — never above it, never a corrupted byte-cut below it.
+func TestApplyScalarSkeletonFloor(t *testing.T) {
+	payload := map[string]any{
+		"summary": strings.Repeat("scalar text the trim must not cut ", 8),
+		"items":   []any{"row-one", "row-two", "row-three"},
+		"total":   3,
+	}
+
+	const cap = 100
+	got, trimmed := Apply(payload, cap)
+	if !trimmed {
+		t.Fatalf("a cap below the skeleton still trims (empties) the lists")
+	}
+	m, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("Apply returns the generic map on trim, got %T", got)
+	}
+	if items, _ := m["items"].([]any); len(items) != 0 {
+		t.Fatalf("every list must be emptied below the floor, items kept %d rows", len(items))
+	}
+	if m[TruncatedKey] != true {
+		t.Fatalf("the truncation meta must be stamped even below the floor")
+	}
+
+	// The floor itself: the same payload with the list emptied and the
+	// meta stamped. The trimmed result must marshal to exactly that —
+	// the minimum honest representation, nothing more.
+	floor := map[string]any{
+		"summary":               payload["summary"],
+		"items":                 []any{},
+		"total":                 3,
+		TruncatedKey:            true,
+		"_max_returned_items":   0,
+		"_original_count_items": 3,
+	}
+	floorBytes, err := json.Marshal(floor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotBytes, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gotBytes) != len(floorBytes) {
+		t.Fatalf("below the cap the result must land on the scalar-skeleton floor: got %d bytes, floor is %d", len(gotBytes), len(floorBytes))
+	}
+	if len(gotBytes) <= cap {
+		t.Fatalf("fixture must exercise the below-floor case: floor %d fits cap %d", len(gotBytes), cap)
+	}
+}

--- a/internal/respbudget/respbudget_typed_test.go
+++ b/internal/respbudget/respbudget_typed_test.go
@@ -1,0 +1,56 @@
+package respbudget
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+type typedEdge struct {
+	From    string `json:"from"`
+	To      string `json:"to"`
+	Kind    string `json:"kind"`
+	Context string `json:"context,omitempty"`
+}
+
+// TestApplyTrimsTypedSlices pins the normalization contract: Apply must
+// trim a map payload whose lists are TYPED Go slices ([]*graph.Edge in
+// the live get_symbol detail:"full" path), not only pre-normalized
+// []any values. A fast path that inspects the caller's map directly
+// sees no []any and silently returns the oversized payload.
+func TestApplyTrimsTypedSlices(t *testing.T) {
+	edges := make([]typedEdge, 40)
+	for i := range edges {
+		edges[i] = typedEdge{
+			From:    "pkg/service.go::Handler",
+			To:      "pkg/store.go::Query",
+			Kind:    "calls",
+			Context: strings.Repeat("ctx", 20),
+		}
+	}
+	payload := map[string]any{
+		"node":      map[string]any{"id": "pkg/service.go::Handler", "kind": "function"},
+		"out_edges": edges,
+		"in_edges":  edges[:10],
+	}
+
+	const cap = 600
+	got, trimmed := Apply(payload, cap)
+	if !trimmed {
+		t.Fatalf("Apply did not trim a payload of typed slices over the cap")
+	}
+	out, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal trimmed payload: %v", err)
+	}
+	if len(out) > cap {
+		t.Fatalf("trimmed payload is %d bytes, over the %d cap", len(out), cap)
+	}
+	if !Trimmed(out) {
+		t.Fatalf("trimmed payload does not carry %s", TruncatedKey)
+	}
+	// The caller's map must stay untouched: handlers reuse payloads.
+	if len(payload["out_edges"].([]typedEdge)) != 40 {
+		t.Fatalf("Apply mutated the caller's payload map")
+	}
+}


### PR DESCRIPTION
An agent-run evaluation battery against my production C# codebase caught two places where find_usages behaves differently from what its schema declares. Both are fixed here, test-first. The commits are independent if you want them separately.

## 1. `limit` was declared but never read, and `compact` was dead on gcx-default sessions

Observed: a call with `limit:12` returned 64 edge rows, and `compact:true` produced output byte-identical to the run without it. Two separate causes:

- `handleFindUsages` never reads `limit`. The schema promised "Max nodes (default: 50)"; the handler returned everything, always.
- The handler checks `isGCX` before `isCompact`, the opposite order of the shared `returnSubGraph` renderer. For clients whose session default is gcx (claude-code among them), `isGCX` is true with no `format` argument, so `compact:true` never reached the compact renderer.

This is the inverse of the class the #635 lint targets: that one catches keys a handler reads without declaring, this was a declared key the handler never read. A schema-trusting agent gets no signal that its `limit` did nothing; it just pays for the rows.

What the fix does:

- `limit` caps the usage rows (edges). The cap runs after every filter and after the `usage_summary` rollup, so the summary still describes the complete usage set while the page below it is bounded. `total_edges` / `total_nodes` keep the full post-filter counts, `truncated` marks the cut, and nodes no longer referenced by a surviving edge are pruned. `limit:0` opts out, mirroring the `max_bytes` convention.
- On the GCX wire, `truncated=true` plus `total_edges=N` ride the header meta only when the cap fired, so uncapped responses stay byte-identical.
- `compact:true` takes precedence over the gcx session default, the same order `returnSubGraph` already applies for every other traversal tool.
- `group_by:"file"` buckets the same capped page; a truncated grouped response carries the full `total_edges` next to its per-page counts.
- The `limit` schema text now states the real semantics (rows, default 50, 0 = no cap, truncation indicator).

One deliberate behavior change to flag: the default of 50 is now enforced. A symbol with more usages answers with 50 rows, a `truncated` marker, and the full total, instead of everything. That is what the schema has always promised, but callers relying on the undocumented uncapped behavior will see the difference, and `limit:0` restores it per call. If you would rather keep the default uncapped and make the cap opt-in, that is a small change to the same code path; I went with the schema's published promise.

Two scope notes: I deliberately left out a cursor for paging into the truncated tail (`limit:0` reaches it, and a cursor felt like its own discussion), and `max_bytes` / `max_tokens` turned out to be already honored through the shared budget layer, so they are untouched.

## 2. `exclude_tests` leaked node kinds the test-edge pass never stamps

Observed: `exclude_tests:true` on a hot symbol dropped 122 edges to 64, but the "production-only" result still contained rows from `Test\**`: the test file's own file-level reference rows and a `#param` node of a test method. Method and class usages filtered correctly.

Root cause: `markTestSymbolsAndEmitEdges` stamps `Meta["is_test"]` on function and method symbols only. A file node under a test directory gets a different key (`is_test_file`), and parameter nodes get no test metadata at all, while `isTestSource` trusted `is_test` alone. The filter was exactly as good as the stamp, and the stamp only covers two kinds.

I fixed it on the filter side: `isTestSource` keeps the stamp as the first authority and falls back to `testpath.IsTestFile` for unflagged nodes. `testpath` is the canonical predicate the stamp itself derives from, so the fallback cannot disagree with the stamp; it only extends it to kinds the pass never visits. It takes effect on existing stores immediately, with no reindex, and it covers every from-node kind without persisting metadata on high-cardinality param nodes. Query-time path classification is also the established pattern elsewhere in the tree: astquery's `ExcludeTests` and the resolver's test-path gate both do it. Because the fallback lives in `isTestSource`, the `exclude_tests` flag on get_callers and the name-only-candidates path inherit the fix as well.

## Tests

- `TestFindUsagesScoped_ExcludeTestsCoversUnstampedKinds` builds the graph exactly as the indexer leaves it (stamped test method, file node with `is_test_file` only, bare param node, all under `Test\`) and failed with 3 surviving edges where 1 belongs.
- The mcp suite (`find_usages_output_options_test.go`) pins `limit` capping, the default of 50, the `limit:0` opt-out, the capped-only GCX truncation meta, the grouped-page total, and compact precedence over gcx. The limit tests failed with the full row set returned; the compact test failed with GCX bytes.
