### PR TITLE
ci: run full test suite on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,19 @@ jobs:
         run: go build -o gortex ./cmd/gortex/
 
       - name: Test
+        if: matrix.os != 'windows-latest'
         run: go test -race -timeout=45m -coverprofile=coverage.out ./...
+
+      # The Windows shard checks the platform contract, not the race
+      # contract: the race detector multiplies runtime several times over and
+      # the windows runners are already the slowest of the three, so the two
+      # together overran the job cap before the suite finished. Linux and
+      # macOS keep -race, which is where a data race would surface anyway.
+      # -v is temporary: per-test timings are how we find which packages hang
+      # here, and it comes out once the shard is reliably green.
+      - name: Test (windows, no race detector)
+        if: matrix.os == 'windows-latest'
+        run: go test -v -timeout=45m -coverprofile=coverage.out ./...
 
       - name: Upload coverage
         if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.27'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,13 @@ jobs:
       # macOS keep -race, which is where a data race would surface anyway.
       # -v is temporary: per-test timings are how we find which packages hang
       # here, and it comes out once the shard is reliably green.
+      # It writes no coverage profile either: nothing uploads one from this
+      # shard, and the runner's default PowerShell tokenises
+      # -coverprofile=coverage.out into an extra ".out" package argument, so
+      # the job failed on an unresolvable package before any test ran.
       - name: Test (windows, no race detector)
         if: matrix.os == 'windows-latest'
-        run: go test -v -timeout=45m -coverprofile=coverage.out ./...
+        run: go test -v -timeout=45m ./...
 
       - name: Upload coverage
         if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.27'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,9 @@ jobs:
     # per-step budget needs headroom; this job-level cap still bounds a hang.
     timeout-minutes: 60
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         go-version: ['1.27']
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -35,146 +36,6 @@ jobs:
         with:
           files: coverage.out
         continue-on-error: true
-
-  build-windows:
-    # CGO build smoke-test on native Windows. tree-sitter needs a C/C++
-    # compiler — the GitHub windows runner ships mingw-w64 on PATH, so no
-    # extra toolchain setup is required. `go build ./...` compiles every
-    # production package; the focused test steps below exercise the paths
-    # whose behaviour actually differs here — separators, volumes, open-file
-    # semantics, %USERPROFILE%, and the git layouts the checkout catalog is
-    # built from — without opting into the unsupported full test suite.
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: go.mod
-
-      - name: Build CLI
-        run: go build -o gortex.exe ./cmd/gortex/
-
-      - name: Build all packages
-        run: go build ./...
-
-      # ./internal/agents is one package and does not recurse, so the
-      # opencode adapter is named explicitly. Its plugin asset is embedded
-      # verbatim with go:embed and TestPluginFailsOpen parses it by
-      # splitting on "\n}\n", which is the closest thing the suite has to a
-      # detector for a CRLF checkout of an embedded file — and it can only
-      # fire on a runner that converts line endings.
-      - name: Test Windows agent integrations
-        run: >
-          go test -timeout=5m -count=1
-          ./internal/agents ./internal/agents/opencode
-
-      # Symlink confinement keeps out-of-repo files out of the index, and it
-      # reads differently on Windows: a symlink reparse point maps to
-      # ModeSymlink but a directory junction maps to ModeIrregular, and
-      # evalSymlinks normalises path case where Unix does not. Verifying it
-      # only on the linux/macos matrix would leave the platform whose
-      # semantics differ most as the untested one.
-      - name: Test symlink confinement
-        run: go test -timeout=5m -count=1 ./internal/pathguard
-
-      # Windows refuses to unlink an open file, so a leaked sidecar handle
-      # pins its directory and fails the enclosing t.TempDir() cleanup. That
-      # asymmetry is invisible on the linux/macos matrix, which is why this
-      # one test runs here rather than only there.
-      - name: Test sidecar handle release
-        run: go test -timeout=5m -count=1 -run TestCloseSidecar ./internal/persistence
-
-      # Same asymmetry, different holder: the plan-lock fixture opens an
-      # on-disk Store, so a missing Close pins plan_lock.sqlite and fails
-      # its t.TempDir() cleanup here while passing everywhere else. Every
-      # assertion in these tests is platform-neutral — only the cleanup
-      # distinguishes the runners — so nothing but this step can protect
-      # the fixture's Close from being dropped again.
-      - name: Test plan-lock fixture handle release
-        run: >
-          go test -timeout=10m -count=1
-          -run 'PlanLock|PlansLocked|PlansNeverScan'
-          ./internal/graph/store_sqlite
-
-      # os.UserHomeDir reads %USERPROFILE% here and $HOME everywhere else, so
-      # a test that isolates itself with HOME alone keeps resolving the real
-      # profile on Windows — and writes to it. That is invisible to the
-      # linux/macos matrix by construction, so the isolation helper and the
-      # path resolver it protects have to be verified on this runner or not
-      # at all.
-      - name: Test user-state isolation
-        run: go test -timeout=5m -count=1 ./internal/testenv ./internal/platform
-
-      # Indexed paths are repoPrefix + '/' + the rest in native separators, so
-      # on Windows a stored path reads `repo/dir\file.cs`. Every test for that
-      # shape is a no-op on the linux/macos matrix — POSIX treats '\' as an
-      # ordinary filename byte, so filepath.Clean and filepath.ToSlash both
-      # leave the fixture untouched and the assertions pass with or without
-      # the production fix. This runner is the only one where they can fail.
-      - name: Test store path separator handling
-        run: go test -timeout=5m -count=1 ./internal/graphpath
-
-      # The same asymmetry reaches the other direction too: a test that spells
-      # an expected path with '/' passes on POSIX whatever the code does, and
-      # only this runner can tell whether the value under test is a native
-      # filesystem path (filepath.Join / filepath.Clean) or a '/'-keyed store
-      # path. ParseDiffGitPaths, ParseDiffLinesNewSide and FeedbackDir all
-      # assert on native paths, so they belong here rather than nowhere.
-      # The path-domain contracts belong here for the same reason. A graph
-      # key is "<prefix>/" plus a native-separator remainder, so GraphKey,
-      # JoinFileNodes, the prefix-shadow end-to-end pair and RankFileRisk's
-      # per-domain normalization only diverge once '/' and the native
-      # separator differ — every one of them passes on the linux/macos
-      # matrix whatever the code does. internal/review joins the list
-      # because the file-risk normalizer lives there. FidelityGlob is the
-      # same asymmetry once more: filepath.Match's separator is the
-      # platform's, so on Windows '*' crosses a '/' that POSIX already
-      # protects, and `internal/*.go` matching `internal/sub/x.go` is a
-      # Windows-only verdict. Linux and macOS return the same answer from
-      # filepath.Match and path.Match, so this runner is the only one that
-      # can tell the two apart. FindFiles_Glob is the handler-level half of
-      # the same contract: `internal/**/*_test.go` is the schema's own
-      # example, and the two matchers disagree about how deep it reaches
-      # only where '/' is not the separator.
-      - name: Test native-separator store path comparisons
-        run: >
-          go test -timeout=10m -count=1
-          -run 'NativeSeparator|MixedSeparator|ImportAdjacency|ParseDiffGitPaths|ParseDiffLinesNewSide|FeedbackDir|ReviewRulepack|PrefixedGraphReportsRulepack|GraphKey|JoinFileNodes|ChangedSymbolsForFiles|PrefixShadow|IdsOnPrefixedGraph|RankFileRisk|PrefixedDeleteAndRename|FidelityGlob|FindFiles_Glob'
-          ./internal/analysis ./internal/graph/store_sqlite
-          ./internal/mcp ./internal/resolver ./internal/persistence
-          ./internal/review
-
-      # gitstate reads git's own answers and measures them against host paths.
-      # git spells a worktree root with '/' on every platform while a fixture
-      # builds one with the host separator, an absolute path needs a volume
-      # here and not on POSIX, and a repository's admin directory is reached
-      # by joining. None of those distinctions exists on the linux/macos
-      # matrix, so the whole package runs here rather than the one test that
-      # looks path-shaped. The timeout is generous because every fixture
-      # shells out to git and process spawn is the slow axis on this runner.
-      - name: Test git state inspection
-        run: go test -timeout=15m -count=1 ./internal/gitstate
-
-      # The reconcile pass turns that inventory into catalog rows: it joins
-      # admin directories, and it decides which checkout owns a path by
-      # measuring roots against each other. Both are separator-shaped, so a
-      # '/'-spelled expectation passes on POSIX whatever the code does.
-      - name: Test checkout reconciliation
-        run: go test -timeout=10m -count=1 ./internal/reconcile
-
-      # The CLI half of the same code: the checkout verbs, the view router
-      # that answers a probe from the checkout containing the probed path,
-      # and the classifier that tells a linked worktree from a main checkout
-      # by reading its `.git` file. Every one of them decides by comparing
-      # path spellings, and the git layouts they classify are built by git
-      # itself. The selector names those tests only — the rest of the package
-      # is either unrelated or needs a daemon behind an AF_UNIX socket.
-      - name: Test checkout and view path routing
-        run: >
-          go test -timeout=10m -count=1
-          -run '^(TestRepos(Families|SetPrimary|Forget|Reconcile|ExplainView)|TestUntrack(Previews|Reports)|TestController(TrackUntrack|Reload)DrivesTheCheckoutLifecycle|TestControllerAnswersTheFileCoverageVerb|TestProbeOf|TestProbeMatchesAPathSpelledThroughASymlink|TestRoutedProbe|TestUnroutedProbe|TestSearchSymbolsWithoutAPath|TestViewsStatus|TestReload_(Keeps|Untracks)|TestDispatcher_(RegisteredCheckout|UnregisteredWorktree)|TestLinkedWorktreeAt_)'
-          ./cmd/gortex
 
   build-linux-static:
     # The linux release ships a statically linked binary so it runs on any

--- a/cmd/gortex/daemon_integration_test.go
+++ b/cmd/gortex/daemon_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/zzet/gortex/internal/parser"
 	"github.com/zzet/gortex/internal/parser/languages"
 	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/testenv"
 )
 
 // spinUpDaemon builds a daemon with the real realController +
@@ -45,9 +46,7 @@ func spinUpDaemonWithConfig(t *testing.T) (configPath, socket, trackedRoot strin
 
 	// Short base dir so the unix socket stays under the 104-char limit
 	// on macOS even with test-name suffixes.
-	dir, err := os.MkdirTemp("/tmp", "gxi")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	dir := testenv.ShortTempDir(t)
 
 	socket = filepath.Join(dir, "s")
 	t.Setenv("GORTEX_DAEMON_SOCKET", socket)

--- a/cmd/gortex/daemon_mcp_case_identity_test.go
+++ b/cmd/gortex/daemon_mcp_case_identity_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -62,6 +64,15 @@ func TestDispatcher_CaseMismatchedCWD_Tracked(t *testing.T) {
 // rejected — the fold must not over-merge on genuinely case-sensitive
 // volumes.
 func TestDispatcher_CaseSensitiveCWD_RejectsVariant(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// CanonicalHasPathPrefix's fallback re-spells both operands
+		// through filepath.EvalSymlinks, and Windows resolves a handle
+		// to the directory's true on-disk casing — so the case-toggled
+		// variant canonicalizes back to the tracked root no matter what
+		// CaseInsensitivePaths says. The fixture cannot stand in for a
+		// case-sensitive volume here.
+		t.Skip("Windows path canonicalization erases the case difference the fixture relies on")
+	}
 	forceCaseInsensitivePaths(t, false)
 	tracked := t.TempDir()
 	d, _ := trackedPathMCPSetup(t, tracked)
@@ -95,6 +106,9 @@ func TestDispatcher_UntrackedInstructions_IncludeTrackedRoots(t *testing.T) {
 	assert.Contains(t, instr, "INACTIVE")
 	assert.Contains(t, instr, "Tracked repository roots",
 		"instructions must list tracked roots for self-diagnosis")
-	assert.Contains(t, instr, tracked,
+	// The diagnostic Go-quotes each root so a case-only or trailing-space
+	// difference is visible, which doubles the separators of a Windows
+	// path; compare against the rendered spelling, not the raw one.
+	assert.Contains(t, instr, fmt.Sprintf("%q", tracked),
 		"instructions must name the actual tracked root path")
 }

--- a/cmd/gortex/daemon_service_status_test.go
+++ b/cmd/gortex/daemon_service_status_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -427,6 +428,12 @@ func TestServiceStatusNotesRunningDaemonForALoadedStoppedUnit(t *testing.T) {
 // gate to the same discipline as the launchd query: a stat that failed for any
 // other reason establishes neither answer.
 func TestServiceStatusReportsAnUnreadablePlist(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// Windows has no directory search bit: os.Chmod only toggles the
+		// read-only attribute, so the plist keeps stat'ing cleanly and the
+		// gate has no inconclusive case to report.
+		t.Skip("no POSIX directory permissions to make Stat fail with EACCES")
+	}
 	dir := t.TempDir()
 	blocked := filepath.Join(dir, "blocked")
 	if err := os.Mkdir(blocked, 0o755); err != nil {

--- a/cmd/gortex/daemon_service_test.go
+++ b/cmd/gortex/daemon_service_test.go
@@ -144,16 +144,19 @@ func TestRenderSystemdUnit_PropagatesXDG(t *testing.T) {
 // relative values are ignored (the latter per the XDG spec, matching
 // platform.unifiedDir).
 func TestXDGServiceEnv_OnlyAbsoluteSet(t *testing.T) {
-	t.Setenv("XDG_CONFIG_HOME", "/abs/config")
-	t.Setenv("XDG_DATA_HOME", "relative/data") // ignored — not absolute
-	t.Setenv("XDG_CACHE_HOME", "")              // ignored — empty/unset
+	// The absolute fixture has to be native: filepath.IsAbs("/abs/config")
+	// is false on Windows, where an absolute path carries a volume.
+	absConfig := filepath.Join(t.TempDir(), "config")
+	t.Setenv("XDG_CONFIG_HOME", absConfig)
+	t.Setenv("XDG_DATA_HOME", filepath.Join("relative", "data")) // ignored — not absolute
+	t.Setenv("XDG_CACHE_HOME", "")                               // ignored — empty/unset
 
 	got := map[string]string{}
 	for _, e := range xdgServiceEnv() {
 		got[e.Key] = e.Value
 	}
 
-	assert.Equal(t, "/abs/config", got["XDG_CONFIG_HOME"])
+	assert.Equal(t, absConfig, got["XDG_CONFIG_HOME"])
 	_, hasData := got["XDG_DATA_HOME"]
 	assert.False(t, hasData, "relative XDG_DATA_HOME must be ignored")
 	_, hasCache := got["XDG_CACHE_HOME"]

--- a/cmd/gortex/daemon_teardown_test.go
+++ b/cmd/gortex/daemon_teardown_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -28,6 +30,8 @@ type teardownProbe struct {
 	watcherStops atomic.Int32
 	sharedCloses atomic.Int32
 	store        *store_sqlite.Store
+	closeOnce    sync.Once
+	closeErr     error
 }
 
 func newTeardownProbe(t *testing.T) *teardownProbe {
@@ -38,17 +42,30 @@ func newTeardownProbe(t *testing.T) *teardownProbe {
 	store.AddBatch([]*graph.Node{
 		{ID: "pkg/a.go::Alpha", Kind: graph.KindFunction, Name: "Alpha", FilePath: "pkg/a.go"},
 	}, nil)
-	return &teardownProbe{store: store}
+	p := &teardownProbe{store: store}
+	// A test that never reaches the teardown (an early skip, a failed
+	// assertion) would otherwise leave the sqlite handle open, and an open
+	// file cannot be deleted on Windows — t.TempDir's RemoveAll then fails
+	// the test that was already done.
+	t.Cleanup(func() { _ = p.closeStore() })
+	return p
 }
 
 func (p *teardownProbe) stopWatcher() { p.watcherStops.Add(1) }
+
+// closeStore closes the backing store at most once, so the cleanup safety net
+// and the teardown chain cannot both check-point a closed database.
+func (p *teardownProbe) closeStore() error {
+	p.closeOnce.Do(func() { p.closeErr = p.store.Close() })
+	return p.closeErr
+}
 
 // closeShared stands in for the shared stack's Close: it runs the backend
 // close that checkpoints the WAL. Closing an already-closed store is exactly
 // the double-teardown this chain must not perform, so the count matters.
 func (p *teardownProbe) closeShared() error {
 	p.sharedCloses.Add(1)
-	return p.store.Close()
+	return p.closeStore()
 }
 
 // TestDaemonTeardownRunsOnASignalledExit drives the real signal path. The
@@ -58,6 +75,13 @@ func (p *teardownProbe) closeShared() error {
 // daemon skipped watcher shutdown, the savings flush, and the final WAL
 // checkpoint outright — the store was left as the process found it.
 func TestDaemonTeardownRunsOnASignalledExit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// os/exec aside, a Windows process cannot deliver a signal to
+		// itself: Process.Signal returns "not supported by windows" for
+		// everything except Kill. Skipping before the listener is up
+		// keeps the serve goroutine from outliving the test.
+		t.Skip("a process cannot signal itself on Windows")
+	}
 	shutdownSignals := platform.ShutdownSignals()
 	if len(shutdownSignals) == 0 {
 		t.Skip("no shutdown signals on this platform")

--- a/cmd/gortex/enrich_test.go
+++ b/cmd/gortex/enrich_test.go
@@ -7,17 +7,15 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"github.com/zzet/gortex/internal/testenv"
 )
 
 // noDaemonSocket points GORTEX_DAEMON_SOCKET at a path with no listener
 // so daemon.IsRunning() reports false for the duration of the test.
 func noDaemonSocket(t *testing.T) {
 	t.Helper()
-	dir, err := os.MkdirTemp("/tmp", "gx-enrich")
-	if err != nil {
-		t.Fatalf("mktemp: %v", err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	dir := testenv.ShortTempDir(t)
 	t.Setenv("GORTEX_DAEMON_SOCKET", filepath.Join(dir, "no-such-socket"))
 }
 

--- a/cmd/gortex/gain.go
+++ b/cmd/gortex/gain.go
@@ -335,6 +335,10 @@ func loadHistory(cacheDir string, since time.Duration) (*gainHistory, error) {
 	if err != nil {
 		return nil, err
 	}
+	// One-shot read: release the sidecar handle before returning. Leaving it
+	// open pins the sqlite file for the rest of the process, which on Windows
+	// makes the containing directory undeletable.
+	defer func() { _ = store.Close() }()
 	// Same rule as `gortex savings`: the legacy import only runs against
 	// the default location — a --cache-dir read must not rename files.
 	if cacheDir == "" {

--- a/cmd/gortex/gain_test.go
+++ b/cmd/gortex/gain_test.go
@@ -151,6 +151,7 @@ func TestLoadHistory_SinceZeroUsesCumulative(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { _ = store.Close() })
 	store.AddObservation(savings.Observation{Repo: "/r", Language: "go", Tool: "get_symbol_source", Returned: 50, Saved: 500})
 	h, err := loadHistory(dir, 0)
 	if err != nil {
@@ -167,6 +168,7 @@ func TestLoadHistory_WindowFiltersEvents(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { _ = store.Close() })
 	store.AddObservation(savings.Observation{Repo: "/r", Language: "go", Tool: "read_file", Returned: 10, Saved: 90})
 
 	h, err := loadHistory(dir, 24*time.Hour)

--- a/cmd/gortex/mcp.go
+++ b/cmd/gortex/mcp.go
@@ -171,8 +171,15 @@ func reapStaleEmbeddedStores(logger *zap.Logger) {
 			// Owned by a live one-shot server — nothing to reap here.
 			continue
 		}
-		rmErr := os.RemoveAll(dir)
+		// TryLock created (or reopened) the lock file INSIDE dir, and
+		// Windows refuses to delete a file that is still open — leaving the
+		// handle up until after RemoveAll makes the reap a silent no-op
+		// there. Unlock closes the handle, and releasing early is safe: a
+		// store directory is never adopted, only freshly created by
+		// newEmbeddedStorePath, so the only racer is another reaper, whose
+		// RemoveAll on an already-removed directory succeeds.
 		_ = lock.Unlock()
+		rmErr := os.RemoveAll(dir)
 		if rmErr != nil {
 			logger.Debug("mcp: could not reap stale embedded store", zap.String("dir", dir), zap.Error(rmErr))
 			continue

--- a/cmd/gortex/mcp_test.go
+++ b/cmd/gortex/mcp_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -175,7 +176,10 @@ func TestLoadEmbeddedMCPGlobalConfig(t *testing.T) {
 				if cfg != nil {
 					t.Fatalf("denied config = %#v, want nil", cfg)
 				}
-				if !strings.Contains(err.Error(), path) {
+				// The message Go-quotes the path, which doubles the
+				// separators of a Windows path; compare against the
+				// rendered spelling rather than the raw one.
+				if !strings.Contains(err.Error(), fmt.Sprintf("%q", path)) {
 					t.Fatalf("error %q does not identify config path %q", err, path)
 				}
 				return
@@ -205,7 +209,7 @@ func TestRunMCPDefaultDenyIgnoresRepoConfig(t *testing.T) {
 		t.Fatalf("runMCP error = %v, want default-deny guidance", err)
 	}
 	globalPath := filepath.Join(dirs.Config, "gortex", "config.yaml")
-	if !strings.Contains(err.Error(), globalPath) {
+	if !strings.Contains(err.Error(), fmt.Sprintf("%q", globalPath)) {
 		t.Fatalf("runMCP error %q does not identify machine-global config %q", err, globalPath)
 	}
 }

--- a/cmd/gortex/proxy.go
+++ b/cmd/gortex/proxy.go
@@ -369,8 +369,8 @@ func resolveLaunchCWD() (string, error) {
 }
 
 // isAmbiguousLaunchCWD returns true when `p` is an editor-launch cwd
-// we can't trust to point at the active project — empty, `/`, or the
-// user's home directory.
+// we can't trust to point at the active project — empty, a filesystem
+// root, or the user's home directory.
 //
 // The home comparison goes through filepath.EvalSymlinks so the
 // macOS `/var → /private/var` redirect (and similar symlinks) don't
@@ -378,6 +378,13 @@ func resolveLaunchCWD() (string, error) {
 // then Getwd reports the resolved form.
 func isAmbiguousLaunchCWD(p string) bool {
 	if p == "" || p == "/" {
+		return true
+	}
+	// A root directory is as uninformative as `/`, and on Windows a root
+	// is spelled with a volume — `D:\`, or a UNC share root — so the `/`
+	// literal above never matches what os.Getwd reports there. Every root
+	// is its own filepath.Dir; no other absolute path is.
+	if clean := filepath.Clean(p); filepath.IsAbs(clean) && clean == filepath.Dir(clean) {
 		return true
 	}
 	home, err := os.UserHomeDir()

--- a/cmd/gortex/proxy_relay_restart_test.go
+++ b/cmd/gortex/proxy_relay_restart_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/zzet/gortex/internal/daemon"
+	"github.com/zzet/gortex/internal/testenv"
 	"go.uber.org/zap"
 )
 
@@ -85,11 +86,7 @@ func TestRelayProxySessionRestoresProtocolAgainstRealRestartedDaemon(t *testing.
 	proxyDialRetryInterval = time.Millisecond
 	t.Setenv("XDG_CACHE_HOME", t.TempDir())
 
-	dir, err := os.MkdirTemp("/tmp", "gxpr")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	dir := testenv.ShortTempDir(t)
 	socket := filepath.Join(dir, "s")
 	h := daemon.Handshake{
 		Version:          daemon.ProtocolVersion,
@@ -207,10 +204,7 @@ func startProxyRestartDaemon(t *testing.T, socket string, dispatcher daemon.MCPD
 
 func testProtocolRestoreClient(t *testing.T) (*daemon.Client, func()) {
 	t.Helper()
-	dir, err := os.MkdirTemp("/tmp", "gxpd")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := testenv.ShortTempDir(t)
 	socket := filepath.Join(dir, "s")
 	server, done := startProxyRestartDaemon(t, socket, &proxyRestartDispatcher{})
 	client, err := daemon.DialTo(socket, daemon.Handshake{
@@ -222,13 +216,11 @@ func testProtocolRestoreClient(t *testing.T) (*daemon.Client, func()) {
 	})
 	if err != nil {
 		stopProxyRestartDaemon(t, server, done)
-		_ = os.RemoveAll(dir)
 		t.Fatal(err)
 	}
 	cleanup := func() {
 		_ = client.Close()
 		stopProxyRestartDaemon(t, server, done)
-		_ = os.RemoveAll(dir)
 	}
 	return client, cleanup
 }
@@ -256,11 +248,7 @@ func stopProxyRestartDaemon(t *testing.T, server *daemon.Server, done <-chan err
 }
 
 func BenchmarkProxyRestartDaemonLifecycle(b *testing.B) {
-	dir, err := os.MkdirTemp("/tmp", "gxpb")
-	if err != nil {
-		b.Fatal(err)
-	}
-	b.Cleanup(func() { _ = os.RemoveAll(dir) })
+	dir := testenv.ShortTempDir(b)
 	b.Setenv("XDG_CACHE_HOME", filepath.Join(dir, "cache"))
 	b.Setenv("GORTEX_DAEMON_PIDFILE", filepath.Join(dir, "p"))
 	socket := filepath.Join(dir, "s")

--- a/cmd/gortex/savings.go
+++ b/cmd/gortex/savings.go
@@ -85,6 +85,8 @@ func runSavings(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("open savings ledger: %w", err)
 	}
+	// One-shot CLI read: release the sidecar handle on every exit path.
+	defer func() { _ = store.Close() }()
 	// Legacy flat-file import runs only against the default locations:
 	// pointing the dashboard at a directory with --cache-dir must never
 	// rename files there as a side effect of looking.

--- a/cmd/gortex/track_wait_budget_test.go
+++ b/cmd/gortex/track_wait_budget_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/zzet/gortex/internal/config"
 	"github.com/zzet/gortex/internal/daemon"
 	"github.com/zzet/gortex/internal/pathkey"
+	"github.com/zzet/gortex/internal/testenv"
 )
 
 func TestBeforeTrackDeadlineBoundsDaemonReadiness(t *testing.T) {
@@ -35,7 +36,7 @@ func TestBeforeTrackDeadlineBoundsDaemonReadiness(t *testing.T) {
 }
 
 func TestNotifyDaemonTrackUsesRemainingDeadline(t *testing.T) {
-	socket := filepath.Join("/tmp", filepath.Base(filepath.Dir(t.TempDir()))+".sock")
+	socket := filepath.Join(testenv.ShortTempDir(t), "s")
 	listener, err := net.Listen("unix", socket)
 	if err != nil {
 		t.Fatalf("listen: %v", err)

--- a/cmd/gortex/uninstall.go
+++ b/cmd/gortex/uninstall.go
@@ -276,12 +276,19 @@ func runUninstall(cmd *cobra.Command, _ []string) error {
 // silent about a Gortex one it is about to delete.
 func filterPresentUninstallTargets() ([]string, []string) {
 	var pf, pd []string
+	// The literal targets are written with '/' for readability, while the
+	// owned-entry targets come out of filepath.Join. Normalising the
+	// literals to the native separator keeps one spelling in the confirm
+	// wizard: on Windows a list that mixes `.opencode/plugin/gortex.js`
+	// with `.agents\skills\gortex-stub` reads as two different things.
 	for _, f := range uninstallFiles {
+		f = filepath.FromSlash(f)
 		if _, err := os.Stat(f); err == nil {
 			pf = append(pf, f)
 		}
 	}
 	for _, d := range uninstallDirs {
+		d = filepath.FromSlash(d)
 		if _, err := os.Stat(d); err == nil {
 			pd = append(pd, d)
 		}

--- a/cmd/gortex/workspace_cmd.go
+++ b/cmd/gortex/workspace_cmd.go
@@ -187,11 +187,24 @@ func matchRepo(repos []config.RepoEntry, target string) (int, error) {
 		}
 		// Allow short suffix matches like "tuck-api" against
 		// "/Users/x/code/work/tuck-api".
-		if strings.HasSuffix(r.Path, string(filepath.Separator)+target) {
+		if hasTrailingComponent(r.Path, target) {
 			return i, nil
 		}
 	}
 	return -1, fmt.Errorf("no tracked repo matches %q (try `gortex daemon status` for the list)", target)
+}
+
+// hasTrailingComponent reports whether name is the last path component of p.
+// Both separators are accepted because a configured repo path is a string a
+// human (or a Git-for-Windows tool) wrote: on Windows the same entry turns up
+// as `C:\code\tuck-api` and `C:/code/tuck-api`, and a short-name lookup must
+// find either. On POSIX the two branches are the same test.
+func hasTrailingComponent(p, name string) bool {
+	if name == "" {
+		return false
+	}
+	return strings.HasSuffix(p, "/"+name) ||
+		strings.HasSuffix(p, string(filepath.Separator)+name)
 }
 
 // workspaceListEntry is one repo's resolved workspace/project view —

--- a/internal/agents/claudecode/hooks_test.go
+++ b/internal/agents/claudecode/hooks_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -133,15 +134,32 @@ func TestHealStaleHookCommands(t *testing.T) {
 	})
 }
 
+// writeGortexStub drops a stand-in `gortex` binary in dir and returns its
+// path. The name carries .exe on Windows because exec.LookPath only
+// considers files whose extension is in PATHEXT there — an extensionless
+// stub is invisible to it, and every PATH-resolution assertion below would
+// silently degrade to the bare-name fallback.
+func writeGortexStub(t *testing.T, dir string) string {
+	t.Helper()
+	name := "gortex"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+	return path
+}
+
 func TestResolveHookCommand(t *testing.T) {
 	t.Run("foundOnPath", func(t *testing.T) {
 		dir := t.TempDir()
-		fake := filepath.Join(dir, "gortex")
-		require.NoError(t, os.WriteFile(fake, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+		fake := writeGortexStub(t, dir)
 		t.Setenv("PATH", dir)
 
 		got := ResolveHookCommand(io.Discard)
-		assert.Equal(t, fake+" hook", got, "should resolve to absolute path on PATH")
+		// shellSafeHookBinary rewrites separators for the shell that runs
+		// the hook, so the expectation is the slash spelling of the path.
+		assert.Equal(t, filepath.ToSlash(fake)+" hook", got, "should resolve to absolute path on PATH")
 	})
 
 	t.Run("notFoundFallsBackToBare", func(t *testing.T) {
@@ -152,8 +170,7 @@ func TestResolveHookCommand(t *testing.T) {
 
 	t.Run("commandNeverContainsBackslash", func(t *testing.T) {
 		dir := t.TempDir()
-		fake := filepath.Join(dir, "gortex")
-		require.NoError(t, os.WriteFile(fake, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+		writeGortexStub(t, dir)
 		t.Setenv("PATH", dir)
 
 		got := ResolveHookCommand(io.Discard)
@@ -168,19 +185,20 @@ func TestResolveHookCommand(t *testing.T) {
 		// absolute path while the stanza collapses to the bare name — both
 		// resolve to the same file.
 		dir := t.TempDir()
-		fake := filepath.Join(dir, "gortex")
-		require.NoError(t, os.WriteFile(fake, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+		fake := writeGortexStub(t, dir)
 		t.Setenv("PATH", dir)
 
 		hookBin := strings.TrimSuffix(ResolveHookCommand(io.Discard), " hook")
 		mcpCmd := agents.ResolveGortexCommand()
 		// Map the bare name to the PATH gortex it launches, then compare
-		// the concrete on-disk binaries.
+		// the concrete on-disk binaries. The hook command carries the
+		// slash spelling, so both sides come back to native separators
+		// before they are compared.
 		launched := func(cmd string) string {
 			if cmd == "gortex" {
 				return fake
 			}
-			return cmd
+			return filepath.Clean(filepath.FromSlash(cmd))
 		}
 		assert.Equal(t, launched(mcpCmd), launched(hookBin),
 			"hook command and MCP stanza must resolve to the same gortex binary")

--- a/internal/agents/claudecode/plugin_test.go
+++ b/internal/agents/claudecode/plugin_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -226,6 +227,12 @@ func TestEmitPluginBundle_HookHandlerExecBit(t *testing.T) {
 	info, err := os.Stat(filepath.Join(dir, "hooks-handlers", "gortex-hook.sh"))
 	if err != nil {
 		t.Fatal(err)
+	}
+	if runtime.GOOS == "windows" {
+		// NTFS carries no POSIX permission bits: os.Chmod there only
+		// toggles the read-only attribute and every file reports 0666.
+		// The bundle still has to be emitted, which the Stat above pins.
+		return
 	}
 	if info.Mode()&0o111 == 0 {
 		t.Errorf("hooks-handlers/gortex-hook.sh should be executable (mode=%v)", info.Mode())

--- a/internal/analysis/diffmap.go
+++ b/internal/analysis/diffmap.go
@@ -562,9 +562,9 @@ func parseDiffFiles(output string) ([]DiffHunk, []FileChange) {
 // header and the file records — so a hunk and its file record always join.
 //
 // Git spells diff paths with forward slashes on every platform, and so does
-// every consumer of DiffHunk.FilePath: GraphKey re-spells the key natively
-// itself (filepath.FromSlash), forge review comments and report rows are a
-// '/'-separated API. filepath.Clean would therefore be wrong on Windows —
+// every consumer of DiffHunk.FilePath: a graph key is '/'-spelled (GraphKey
+// folds through filepath.ToSlash), and forge review comments and report rows
+// are a '/'-separated API. filepath.Clean would therefore be wrong on Windows —
 // it hands back "internal\forge\forge.go" and misses every join — so the
 // clean is path.Clean over the slash spelling. filepath.ToSlash is the
 // identity on POSIX, where a backslash is an ordinary filename byte.

--- a/internal/analysis/diffmap.go
+++ b/internal/analysis/diffmap.go
@@ -127,11 +127,14 @@ func GraphKey(repoPrefix, path string, domain PathDomain) string {
 		return path
 	}
 	// A repo-relative path is always converted, prefix or not. The key's shape
-	// is "<prefix>/" + the remainder in the indexing machine's native
-	// separators (see internal/graphpath); with no prefix the remainder IS the
-	// key, and a '/'-spelled git or forge path still misses a key stored with
-	// native separators on Windows. FromSlash is the identity on POSIX.
-	key := filepath.FromSlash(path)
+	// is "<prefix>/" + the remainder, and the indexer keys every graph path
+	// with forward slashes on every platform (Indexer.relKey folds through
+	// filepath.ToSlash), so the remainder stays '/'-spelled. Re-spelling it
+	// natively here produced "repo-a/pkg\widget.go" on Windows and missed
+	// every file node below the repo root — the diff joined no symbols at
+	// all. ToSlash is the identity on POSIX, where a backslash is an
+	// ordinary filename byte and must survive.
+	key := filepath.ToSlash(path)
 	if repoPrefix == "" {
 		return key
 	}

--- a/internal/analysis/diffmap.go
+++ b/internal/analysis/diffmap.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"path"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -305,7 +306,7 @@ func parseDiffLines(output string) map[string][]HunkLine {
 		line := scanner.Text()
 
 		if strings.HasPrefix(line, "+++ b/") {
-			currentFile = filepath.Clean(strings.TrimPrefix(line, "+++ b/"))
+			currentFile = cleanDiffPath(strings.TrimPrefix(line, "+++ b/"))
 			newLine = 0
 			continue
 		}
@@ -553,14 +554,23 @@ func parseDiffFiles(output string) ([]DiffHunk, []FileChange) {
 	return hunks, changes
 }
 
-// cleanDiffPath normalizes a path lifted out of a diff header the same way
-// DiffHunk.FilePath and parseDiffLines do, so a hunk and its file record join.
-func cleanDiffPath(path string) string {
-	path = strings.TrimSpace(path)
-	if path == "" {
+// cleanDiffPath normalizes a path lifted out of a diff header. It is the one
+// cleaner every diff path goes through — the hunk header, the "+++ b/" file
+// header and the file records — so a hunk and its file record always join.
+//
+// Git spells diff paths with forward slashes on every platform, and so does
+// every consumer of DiffHunk.FilePath: GraphKey re-spells the key natively
+// itself (filepath.FromSlash), forge review comments and report rows are a
+// '/'-separated API. filepath.Clean would therefore be wrong on Windows —
+// it hands back "internal\forge\forge.go" and misses every join — so the
+// clean is path.Clean over the slash spelling. filepath.ToSlash is the
+// identity on POSIX, where a backslash is an ordinary filename byte.
+func cleanDiffPath(p string) string {
+	p = strings.TrimSpace(p)
+	if p == "" {
 		return ""
 	}
-	return filepath.Clean(path)
+	return path.Clean(filepath.ToSlash(p))
 }
 
 // parseDiffGitPaths recovers the path from a "diff --git a/P b/P" header. It is
@@ -624,7 +634,7 @@ func parseHunkHeader(line, filePath, side string) *DiffHunk {
 			}
 
 			// Normalize file path to be relative
-			relPath := filepath.Clean(filePath)
+			relPath := cleanDiffPath(filePath)
 
 			return &DiffHunk{
 				FilePath:  relPath,

--- a/internal/analysis/diffmap_test.go
+++ b/internal/analysis/diffmap_test.go
@@ -789,7 +789,12 @@ func TestMapGitDiffUntrackedStaysUnobserved(t *testing.T) {
 // well-formed graph key for a different, untouched file.
 func TestJoinHunksToSymbolsPrefixedDeleteAndRename(t *testing.T) {
 	const prefix = "repo-a"
-	key := func(rel string) string { return prefix + "/" + filepath.FromSlash(rel) }
+	// A graph key is '/'-spelled on every platform (the indexer folds through
+	// filepath.ToSlash), so the fixture keys are built with path.Join, not
+	// filepath.Join. Re-spelling them natively made the node "repo-a/repo-a\
+	// pkg\gone.go::Gone" on Windows, which GraphKey — correctly emitting the
+	// slash key — could never match.
+	key := func(rel string) string { return path.Join(prefix, rel) }
 
 	g := graph.New()
 	add := func(rel, sym string) {

--- a/internal/analysis/diffmap_test.go
+++ b/internal/analysis/diffmap_test.go
@@ -3,6 +3,7 @@ package analysis
 import (
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -56,10 +57,10 @@ func TestParseDiffHunksEqualsInternal(t *testing.T) {
 }
 
 // diffKey spells a repo-relative path the way parseDiffLines keys its map and
-// DiffHunk.FilePath is cleaned: filepath.Clean, so the key carries the running
-// platform's separators. Writing the '/' form directly reads fine on POSIX and
-// misses on Windows, where the map key is `pkg\foo.go`.
-func diffKey(p string) string { return filepath.Clean(p) }
+// DiffHunk.FilePath is cleaned: cleanDiffPath, i.e. path.Clean over the slash
+// spelling. The key therefore carries forward slashes on every platform, so
+// the '/' literal is the key verbatim — no per-platform re-spelling.
+func diffKey(p string) string { return path.Clean(p) }
 
 func TestParseDiffLinesNewSide(t *testing.T) {
 	lines := parseDiffLines(sampleDiff)
@@ -726,14 +727,11 @@ func TestParseDiffGitPaths(t *testing.T) {
 		{`diff --git "a/od\td.go" "b/od\td.go"`, ""},
 		{"diff --git nonsense", ""},
 	} {
-		// The recovered path is cleaned, so it carries native separators;
-		// the '/' spelling above is the diff's, not the result's.
-		want := tc.want
-		if want != "" {
-			want = filepath.Clean(want)
-		}
-		if got := parseDiffGitPaths(tc.line); got != want {
-			t.Fatalf("parseDiffGitPaths(%q) = %q, want %q", tc.line, got, want)
+		// The recovered path is cleaned by cleanDiffPath, which keeps the
+		// slash spelling on every platform: the '/' form above is both the
+		// diff's and the result's.
+		if got := parseDiffGitPaths(tc.line); got != tc.want {
+			t.Fatalf("parseDiffGitPaths(%q) = %q, want %q", tc.line, got, tc.want)
 		}
 	}
 }

--- a/internal/analysis/diffmap_test.go
+++ b/internal/analysis/diffmap_test.go
@@ -300,11 +300,10 @@ func TestMapGitDiffMnemonicPrefixConfig(t *testing.T) {
 }
 
 func TestJoinFileNodes(t *testing.T) {
-	// Graph keys are "<prefix>/" + the remainder in native separators, so the
-	// fixture is built the same way the indexer would build it. Writing the
-	// '/'-joined form here would pass on POSIX and describe a key that does not
-	// exist on Windows.
-	key := func(rel string) string { return "myrepo/" + filepath.FromSlash(rel) }
+	// Graph keys are "<prefix>/" + the remainder, forward-slashed throughout
+	// on every platform: the indexer folds every key it mints through
+	// filepath.ToSlash. The fixture is built the same way.
+	key := func(rel string) string { return "myrepo/" + rel }
 
 	g := graph.New()
 	g.AddNode(&graph.Node{ID: key("a.go") + "::A", Kind: graph.KindFunction, Name: "A", FilePath: key("a.go")})
@@ -336,33 +335,39 @@ func TestJoinFileNodes(t *testing.T) {
 		t.Fatalf("a miss must stay a miss: %#v", nodes)
 	}
 
-	// Standalone indexer: no repo prefix, but the keys are still native. A
-	// forge or git path arrives '/'-spelled and must still resolve.
+	// Standalone indexer: no repo prefix, and the keys are the '/'-spelled
+	// relative paths. A natively-spelled path from filepath.Rel / filepath.Join
+	// must still land on them.
 	standalone := graph.New()
-	nested := filepath.FromSlash("pkg/auth/x.go")
+	const nested = "pkg/auth/x.go"
 	standalone.AddNode(&graph.Node{ID: nested + "::Login", Kind: graph.KindFunction, Name: "Login", FilePath: nested})
 	if nodes := JoinFileNodes(standalone, "", "pkg/auth/x.go", RepoRelativePath); len(nodes) != 1 || nodes[0].ID != nested+"::Login" {
-		t.Fatalf("empty prefix must still convert separators: %#v", nodes)
+		t.Fatalf("empty prefix must resolve the '/'-spelled path: %#v", nodes)
+	}
+	if nodes := JoinFileNodes(standalone, "", filepath.FromSlash("pkg/auth/x.go"), RepoRelativePath); len(nodes) != 1 || nodes[0].ID != nested+"::Login" {
+		t.Fatalf("a natively-spelled path must be folded onto the graph key: %#v", nodes)
 	}
 }
 
 func TestGraphKey(t *testing.T) {
-	native := func(rel string) string { return "myrepo/" + filepath.FromSlash(rel) }
 	for _, tc := range []struct {
 		name         string
 		prefix, path string
 		domain       PathDomain
 		want         string
 	}{
-		{"repo-relative gains the prefix", "myrepo", "a.go", RepoRelativePath, native("a.go")},
-		{"prefix-shadowed path still gains it", "myrepo", "myrepo/a.go", RepoRelativePath, native("myrepo/a.go")},
+		{"repo-relative gains the prefix", "myrepo", "a.go", RepoRelativePath, "myrepo/a.go"},
+		{"prefix-shadowed path still gains it", "myrepo", "myrepo/a.go", RepoRelativePath, "myrepo/myrepo/a.go"},
 		{"graph-keyed path is untouched", "myrepo", "myrepo/a.go", GraphKeyedPath, "myrepo/a.go"},
 		{"no prefix is a no-op", "", "a.go", RepoRelativePath, "a.go"},
-		// Multi-segment with no prefix: the standalone indexer's keys still
-		// carry native separators, so a '/'-spelled forge path must be
-		// converted even though there is nothing to prefix. A single-segment
-		// fixture cannot show this — there is no separator to get wrong.
-		{"no prefix still converts separators", "", "pkg/auth/x.go", RepoRelativePath, filepath.FromSlash("pkg/auth/x.go")},
+		// A nested path is where the spelling can go wrong: the graph keys it
+		// with forward slashes on every platform, so the key must stay
+		// '/'-spelled whether the caller handed over git's spelling or the
+		// running platform's. A single-segment fixture cannot show this —
+		// there is no separator to get wrong.
+		{"nested path keeps the graph spelling", "myrepo", "pkg/auth/x.go", RepoRelativePath, "myrepo/pkg/auth/x.go"},
+		{"a native spelling is folded onto it", "myrepo", filepath.FromSlash("pkg/auth/x.go"), RepoRelativePath, "myrepo/pkg/auth/x.go"},
+		{"no prefix still folds the separators", "", filepath.FromSlash("pkg/auth/x.go"), RepoRelativePath, "pkg/auth/x.go"},
 		{"no prefix, graph-keyed stays verbatim", "", "pkg/auth/x.go", GraphKeyedPath, "pkg/auth/x.go"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/audit/discover.go
+++ b/internal/audit/discover.go
@@ -74,7 +74,12 @@ func DiscoverConfigFiles(root string) []string {
 			if rerr != nil {
 				rel = p
 			}
-			out = append(out, rel)
+			// Discovered paths are slash-separated: the entries above are
+			// slash-separated literals, and callers match them against that
+			// list and report them to agents. filepath.Rel hands back the
+			// native spelling, so a Windows walk would otherwise emit
+			// ".cursor\rules\foo.md" beside ".github/copilot-instructions.md".
+			out = append(out, filepath.ToSlash(rel))
 			return nil
 		})
 	}

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -239,13 +239,12 @@ func ShouldFallBackToEmbedded(err error) bool {
 // broken." We treat connection-refused, no-such-file, and timeout as
 // "unavailable" because spinning up the daemon or falling back is the
 // right answer to all three.
+//
+// The errno set is per-platform (unavailableDialErrnos): Winsock reports its
+// own refusal code, which shares no value with the POSIX name.
 func isNoDaemonErr(err error) bool {
-	var se syscall.Errno
-	if errors.As(err, &se) {
-		switch se {
-		case syscall.ECONNREFUSED, syscall.ENOENT:
-			return true
-		}
+	if isUnavailableDialErrno(err) {
+		return true
 	}
 	var ne net.Error
 	if errors.As(err, &ne) && ne.Timeout() {
@@ -254,8 +253,21 @@ func isNoDaemonErr(err error) bool {
 	// net.OpError wrapping "no such file or directory" is how Go reports
 	// a missing socket path on some platforms.
 	var op *net.OpError
-	if errors.As(err, &op) {
-		if errors.Is(op.Err, syscall.ECONNREFUSED) || errors.Is(op.Err, syscall.ENOENT) {
+	if errors.As(err, &op) && isUnavailableDialErrno(op.Err) {
+		return true
+	}
+	return false
+}
+
+// isUnavailableDialErrno reports whether err carries (at any depth) an errno
+// this platform uses for "nothing is listening there".
+func isUnavailableDialErrno(err error) bool {
+	var se syscall.Errno
+	if !errors.As(err, &se) {
+		return false
+	}
+	for _, candidate := range unavailableDialErrnos {
+		if se == candidate {
 			return true
 		}
 	}

--- a/internal/daemon/client_errno_test.go
+++ b/internal/daemon/client_errno_test.go
@@ -1,0 +1,55 @@
+package daemon
+
+import (
+	"errors"
+	"net"
+	"os"
+	"syscall"
+	"testing"
+)
+
+// wsaeconnrefused is the Winsock code a Windows dial against an AF_UNIX socket
+// path with no acceptor returns ("No connection could be made because the
+// target machine actively refused it"). It is written as a literal so this
+// test compiles and runs on every platform: Go's syscall.ECONNREFUSED is an
+// invented, different value on Windows, which is exactly the trap this pins.
+const wsaeconnrefused = syscall.Errno(10061)
+
+// errorFileNotFound is the Win32 code for a path that holds no socket.
+const errorFileNotFound = syscall.Errno(2)
+
+// TestUnavailableDialErrnoIsPlatformScoped pins the per-platform errno table
+// behind ErrDaemonUnavailable. Misclassifying the Windows refusal is not a
+// cosmetic wording difference: startup selection, the hook probes, and the MCP
+// proxy's reconnect retry all key off ErrDaemonUnavailable, so an unrecognised
+// refusal turns "the daemon is not running" into a hard error.
+func TestUnavailableDialErrnoIsPlatformScoped(t *testing.T) {
+	refused := &net.OpError{
+		Op:  "dial",
+		Net: "unix",
+		Err: os.NewSyscallError("connect", wsaeconnrefused),
+	}
+	if got := isNoDaemonErr(refused); got != wsaeconnrefusedMeansNoDaemon {
+		t.Fatalf("isNoDaemonErr(WSAECONNREFUSED) = %v, want %v", got, wsaeconnrefusedMeansNoDaemon)
+	}
+	classified := classifyDaemonProbeError(refused)
+	if errors.Is(classified, ErrDaemonUnavailable) != wsaeconnrefusedMeansNoDaemon {
+		t.Fatalf("classifyDaemonProbeError(WSAECONNREFUSED) = %v, want ErrDaemonUnavailable == %v",
+			classified, wsaeconnrefusedMeansNoDaemon)
+	}
+
+	// ENOENT keeps its POSIX meaning everywhere, and its Win32 twin
+	// (ERROR_FILE_NOT_FOUND) carries the same value, so this arm holds on
+	// both platforms without a build-tagged expectation.
+	missing := &net.OpError{Op: "dial", Net: "unix", Err: errorFileNotFound}
+	if !isNoDaemonErr(missing) {
+		t.Fatal("a socket path that does not exist must classify as no-daemon")
+	}
+
+	// A refusal that is neither is still a real error: classification must not
+	// widen to "any errno".
+	denied := &net.OpError{Op: "dial", Net: "unix", Err: syscall.EACCES}
+	if isNoDaemonErr(denied) {
+		t.Fatal("a permission failure must not classify as no-daemon")
+	}
+}

--- a/internal/daemon/client_errno_unix.go
+++ b/internal/daemon/client_errno_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package daemon
+
+import "syscall"
+
+// unavailableDialErrnos are the errno values a unix-socket dial reports when
+// no daemon is listening: ECONNREFUSED for a socket file with no acceptor,
+// ENOENT for a socket that was never created (or was unlinked on shutdown).
+// Anything else is a real system error the caller must surface.
+var unavailableDialErrnos = []syscall.Errno{
+	syscall.ECONNREFUSED,
+	syscall.ENOENT,
+}

--- a/internal/daemon/client_errno_unix_test.go
+++ b/internal/daemon/client_errno_unix_test.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package daemon
+
+// wsaeconnrefusedMeansNoDaemon is the expectation for the Winsock refusal code
+// on this platform: nothing here produces it, and an unknown errno must stay
+// an unknown errno rather than be laundered into ErrDaemonUnavailable.
+const wsaeconnrefusedMeansNoDaemon = false

--- a/internal/daemon/client_errno_windows.go
+++ b/internal/daemon/client_errno_windows.go
@@ -1,0 +1,28 @@
+//go:build windows
+
+package daemon
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// unavailableDialErrnos are the errno values an AF_UNIX dial reports on
+// Windows when no daemon is listening.
+//
+// Winsock has its own errno space and Go defines the POSIX names on Windows as
+// distinct invented values, so syscall.ECONNREFUSED never equals what a real
+// dial returns: connecting to a socket path with no acceptor surfaces
+// WSAECONNREFUSED (10061, "No connection could be made because the target
+// machine actively refused it"), and a path that holds no socket at all
+// surfaces the file-system errors. The POSIX names stay in the set because
+// callers (and tests) construct them directly, and matching them costs
+// nothing.
+var unavailableDialErrnos = []syscall.Errno{
+	windows.WSAECONNREFUSED,
+	windows.ERROR_FILE_NOT_FOUND,
+	windows.ERROR_PATH_NOT_FOUND,
+	syscall.ECONNREFUSED,
+	syscall.ENOENT,
+}

--- a/internal/daemon/client_errno_windows_test.go
+++ b/internal/daemon/client_errno_windows_test.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package daemon
+
+// wsaeconnrefusedMeansNoDaemon is the expectation for the Winsock refusal
+// code on this platform: it is what dialing a daemon socket with no acceptor
+// actually returns, so it must classify as "no daemon".
+const wsaeconnrefusedMeansNoDaemon = true

--- a/internal/daemon/control_lifetime_test.go
+++ b/internal/daemon/control_lifetime_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -13,6 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/testenv"
 )
 
 // blockingController blocks Status (and Shutdown) until released, standing in
@@ -215,9 +216,7 @@ func silentDaemon(t *testing.T) string {
 // at ~104 bytes and t.TempDir() with a long test name blows past it.
 func listenShort(t *testing.T) net.Listener {
 	t.Helper()
-	dir, err := os.MkdirTemp("/tmp", "gx")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	dir := testenv.ShortTempDir(t)
 	ln, err := net.Listen("unix", filepath.Join(dir, "s"))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = ln.Close() })

--- a/internal/daemon/handshake_warming_test.go
+++ b/internal/daemon/handshake_warming_test.go
@@ -1,7 +1,6 @@
 package daemon
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -9,15 +8,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/testenv"
 )
 
 // startWarmingTestServer brings up a daemon on a temp socket with the given
 // optional Ready probe and returns the live socket path.
 func startWarmingTestServer(t *testing.T, ready func() (bool, string)) string {
 	t.Helper()
-	dir, err := os.MkdirTemp("/tmp", "gx-warm")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	dir := testenv.ShortTempDir(t)
 	socket := filepath.Join(dir, "s")
 	t.Setenv("GORTEX_DAEMON_SOCKET", socket)
 	t.Setenv("GORTEX_DAEMON_PIDFILE", filepath.Join(dir, "p"))

--- a/internal/daemon/mcp_roundtrip_test.go
+++ b/internal/daemon/mcp_roundtrip_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -12,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/testenv"
 )
 
 // echoDispatcher returns a canned JSON-RPC response whenever a frame
@@ -47,9 +48,7 @@ func (e *echoDispatcher) Dispatch(_ context.Context, sess *Session, frame []byte
 // session context, response flows back to the proxy.
 func TestDaemon_MCPRoundTrip(t *testing.T) {
 	disp := &echoDispatcher{seen: make(chan echoFrame, 4)}
-	dir, err := os.MkdirTemp("/tmp", "gx")
-	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(dir) }()
+	dir := testenv.ShortTempDir(t)
 	socket := filepath.Join(dir, "s")
 	t.Setenv("GORTEX_DAEMON_SOCKET", socket)
 	t.Setenv("GORTEX_DAEMON_PIDFILE", filepath.Join(dir, "p"))
@@ -102,9 +101,7 @@ func TestDaemon_MCPRoundTrip(t *testing.T) {
 // cleanly when no dispatcher is attached — caller sees a JSON-RPC
 // error frame rather than a hang or a broken connection.
 func TestDaemon_MCPNoDispatcher(t *testing.T) {
-	dir, err := os.MkdirTemp("/tmp", "gx")
-	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(dir) }()
+	dir := testenv.ShortTempDir(t)
 	socket := filepath.Join(dir, "s")
 	t.Setenv("GORTEX_DAEMON_SOCKET", socket)
 	t.Setenv("GORTEX_DAEMON_PIDFILE", filepath.Join(dir, "p"))
@@ -155,9 +152,7 @@ func (h *hookDispatcher) SessionEnded(sess *Session) {
 // closes its connection. Without this, per-session state allocated in
 // the dispatcher would leak for the daemon's lifetime.
 func TestDaemon_SessionEndedHook_FiresOnDisconnect(t *testing.T) {
-	dir, err := os.MkdirTemp("/tmp", "gx")
-	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(dir) }()
+	dir := testenv.ShortTempDir(t)
 	socket := filepath.Join(dir, "s")
 	t.Setenv("GORTEX_DAEMON_SOCKET", socket)
 	t.Setenv("GORTEX_DAEMON_PIDFILE", filepath.Join(dir, "p"))
@@ -205,9 +200,7 @@ func (p *pushDispatcher) SessionStarted(_ *Session, write func([]byte) error) {
 // pending request — the transport leg that lets tools/list_changed
 // (and every other MCP push) reach unix-socket proxy clients.
 func TestDaemon_SessionStartedHook_PushesFrames(t *testing.T) {
-	dir, err := os.MkdirTemp("/tmp", "gx")
-	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(dir) }()
+	dir := testenv.ShortTempDir(t)
 	socket := filepath.Join(dir, "s")
 	t.Setenv("GORTEX_DAEMON_SOCKET", socket)
 	t.Setenv("GORTEX_DAEMON_PIDFILE", filepath.Join(dir, "p"))

--- a/internal/daemon/router_reload_test.go
+++ b/internal/daemon/router_reload_test.go
@@ -168,10 +168,22 @@ func TestRouter_EffectiveEnabledRemotes(t *testing.T) {
 // TestRouter_ReloadConfig_ConcurrentNoRace hammers ReloadConfig against
 // concurrent routing + reads; the race detector must stay clean and no
 // call may panic on a torn router.
+//
+// The reloaded roster points at a local httptest server, and the cwd resolver
+// is stubbed, because every routing iteration here reaches the remote hop for
+// real: with a bogus host each of the ~530 proxied calls paid a full DNS
+// resolution, which is cheap only where a single-label name fails fast. On
+// Windows, where the resolver also walks the DNS suffix list and falls back to
+// LLMNR/NetBIOS, that turned a 0.2s test into a 183s one.
 func TestRouter_ReloadConfig_ConcurrentNoRace(t *testing.T) {
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"from":"remote"}`))
+	}))
+	t.Cleanup(remote.Close)
 	router := NewRouter(RouterConfig{
-		Servers: &ServersConfig{},
-		Rosters: NewWorkspaceRosterCache(time.Minute),
+		Servers:     &ServersConfig{},
+		Rosters:     NewWorkspaceRosterCache(time.Minute),
+		CwdResolver: func(string) (string, bool) { return "", false },
 		LocalExecute: func(context.Context, string, []byte) ([]byte, int, error) {
 			return []byte(`{}`), 200, nil
 		},
@@ -184,7 +196,7 @@ func TestRouter_ReloadConfig_ConcurrentNoRace(t *testing.T) {
 			for j := 0; j < 200; j++ {
 				switch (i + j) % 3 {
 				case 0:
-					cfg := &ServersConfig{Server: []ServerEntry{{Slug: "r2", URL: "https://r2:4747"}}}
+					cfg := &ServersConfig{Server: []ServerEntry{{Slug: "r2", URL: remote.URL}}}
 					router.ReloadConfig(cfg, NewWorkspaceRosterCache(time.Minute))
 				case 1:
 					_, _, _ = router.RouteToolCall(context.Background(), "find_usages", []byte(`{}`), RouteContext{})

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/testenv"
 )
 
 // osStat is an alias so fileExists() reads linearly without import rearrangement.
@@ -152,9 +154,7 @@ func (f *fakeController) EnrichCochange(_ context.Context, p EnrichCochangeParam
 // our own short directory under /tmp/gx-<random>.
 func newDaemon(t *testing.T, ctrl Controller) (*Server, string) {
 	t.Helper()
-	dir, err := os.MkdirTemp("/tmp", "gx")
-	require.NoError(t, err, "short tmp dir for unix socket")
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	dir := testenv.ShortTempDir(t)
 
 	socket := filepath.Join(dir, "s")
 	t.Setenv("GORTEX_DAEMON_SOCKET", socket)
@@ -307,20 +307,16 @@ func TestDaemon_ProtocolMismatchRejected(t *testing.T) {
 }
 
 func TestDial_NoDaemon_ReturnsErrUnavailable(t *testing.T) {
-	dir, err := os.MkdirTemp("/tmp", "gx")
-	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(dir) }()
+	dir := testenv.ShortTempDir(t)
 	missing := filepath.Join(dir, "missing")
-	_, err = DialTo(missing, Handshake{Mode: ModeControl})
+	_, err := DialTo(missing, Handshake{Mode: ModeControl})
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrDaemonUnavailable),
 		"Dial against missing socket must wrap ErrDaemonUnavailable; got %v", err)
 }
 
 func TestIsRunningAt(t *testing.T) {
-	dir, err := os.MkdirTemp("/tmp", "gx")
-	require.NoError(t, err)
-	defer func() { _ = os.RemoveAll(dir) }()
+	dir := testenv.ShortTempDir(t)
 	missing := filepath.Join(dir, "nope")
 	assert.False(t, IsRunningAt(missing))
 

--- a/internal/daemon/servers_save_test.go
+++ b/internal/daemon/servers_save_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -20,13 +21,17 @@ func TestServersConfig_SaveLoadRoundTrip(t *testing.T) {
 		t.Fatalf("Save: %v", err)
 	}
 
-	// File created with restrictive perms.
+	// File created with restrictive perms. NTFS carries no POSIX mode
+	// bits — Go reports 0666 for every writable file there and the real
+	// protection is the ACL — so the check is Unix-only.
 	fi, err := os.Stat(path)
 	if err != nil {
 		t.Fatalf("stat: %v", err)
 	}
-	if perm := fi.Mode().Perm(); perm != 0o600 {
-		t.Fatalf("file perm = %o, want 0600", perm)
+	if runtime.GOOS != "windows" {
+		if perm := fi.Mode().Perm(); perm != 0o600 {
+			t.Fatalf("file perm = %o, want 0600", perm)
+		}
 	}
 
 	got, err := LoadServersConfig(path)

--- a/internal/daemon/session_reconnect_test.go
+++ b/internal/daemon/session_reconnect_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/testenv"
 )
 
 func TestSessionRegistryRebindsLogicalSession(t *testing.T) {
@@ -132,11 +134,7 @@ func TestDaemonRebindsLogicalMCPStateAcrossRealSocketReconnect(t *testing.T) {
 	}
 	t.Setenv("XDG_CACHE_HOME", t.TempDir())
 
-	socketDir, err := os.MkdirTemp("/tmp", "gxr")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	socketDir := testenv.ShortTempDir(t)
 	socket := filepath.Join(socketDir, "s")
 	dispatcher := &reconnectDispatcher{}
 	server := New(socket, "test", zap.NewNop())
@@ -220,11 +218,7 @@ func TestDaemonReplaysCanonicalIDAfterRealSocketLoss(t *testing.T) {
 		t.Skip("Unix socket reconnect test")
 	}
 	t.Setenv("XDG_CACHE_HOME", t.TempDir())
-	socketDir, err := os.MkdirTemp("/tmp", "gxrc")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(socketDir) })
+	socketDir := testenv.ShortTempDir(t)
 
 	dispatcher := &reconnectDispatcher{}
 	server := New(filepath.Join(socketDir, "s"), "test", zap.NewNop())

--- a/internal/daemon/streamable_test.go
+++ b/internal/daemon/streamable_test.go
@@ -7,13 +7,14 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/testenv"
 )
 
 // newDaemonNoServe is newDaemon's twin that stops short of calling
@@ -21,9 +22,7 @@ import (
 // HTTPHandler before the listener comes up.
 func newDaemonNoServe(t *testing.T, ctrl Controller) (*Server, string) {
 	t.Helper()
-	dir, err := os.MkdirTemp("/tmp", "gx")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	dir := testenv.ShortTempDir(t)
 
 	socket := filepath.Join(dir, "s")
 	t.Setenv("GORTEX_DAEMON_SOCKET", socket)

--- a/internal/embedding/hugot.go
+++ b/internal/embedding/hugot.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/knights-analytics/hugot"
 	"github.com/knights-analytics/hugot/pipelines"
@@ -239,11 +240,81 @@ func ensureHugotModel(spec HugotVariant) (string, error) {
 
 	opts := hugot.NewDownloadOptions()
 	opts.OnnxFilePath = spec.OnnxFile
-	path, err := hugot.DownloadModel(context.Background(), spec.RepoID, dest, opts)
+	path, err := downloadHugotModel(spec, dest, opts)
 	if err != nil {
 		return "", fmt.Errorf("download %s (%s): %w", spec.RepoID, spec.OnnxFile, err)
 	}
 	return path, nil
+}
+
+// embeddingDownloadBudgetEnv overrides how long a first-use model
+// download may take before it is abandoned. Accepts any Go duration
+// ("90s", "5m"); an unset or unparseable value keeps the default.
+const embeddingDownloadBudgetEnv = "GORTEX_EMBEDDING_DOWNLOAD_TIMEOUT"
+
+// defaultDownloadBudget bounds a cold model fetch. MiniLM is ~90MB and
+// lands in well under a minute on a working link, so ten minutes is
+// generous for a slow one and still short enough that a wedged
+// connection degrades to the static provider instead of stalling the
+// process that asked for an embedder.
+const defaultDownloadBudget = 10 * time.Minute
+
+// downloadBudget resolves the wall-clock budget for one model download.
+func downloadBudget() time.Duration {
+	if d, err := time.ParseDuration(os.Getenv(embeddingDownloadBudgetEnv)); err == nil && d > 0 {
+		return d
+	}
+	return defaultDownloadBudget
+}
+
+// hugotDownloadModel is the upstream fetch, indirected so the watchdog
+// below can be tested against a stalled download without a network.
+var hugotDownloadModel = hugot.DownloadModel
+
+// downloadHugotModel fetches a model repo under a wall-clock budget and
+// gives up rather than blocking forever on a stalled transfer. The
+// returned error wraps context.DeadlineExceeded when the budget ran out,
+// so a caller can tell "the network stalled" from "the model is broken".
+//
+// The budget has to be enforced out here because nothing inside the
+// download honours one. hugot.DownloadModel takes a context but only
+// passes it to the post-download file copy: the fetch itself goes
+// through hub.Repo.DownloadFiles, which starts from
+// context.Background(). Under that, go-huggingface builds its own
+// http.Client per request with no Timeout and exposes no hook to supply
+// one, and its worker pool waits on a plain sync.Cond that no context
+// can interrupt — which is exactly how a stalled transfer parks the
+// caller in Semaphore.Acquire indefinitely. So the fetch runs on its own
+// goroutine and this call abandons it when the budget is spent; the
+// orphan finishes into a buffered channel and exits whenever the
+// connection finally breaks, leaving only a discarded ".part" file the
+// next download overwrites.
+func downloadHugotModel(spec HugotVariant, dest string, opts hugot.DownloadOptions) (string, error) {
+	budget := downloadBudget()
+	ctx, cancel := context.WithTimeout(context.Background(), budget)
+	defer cancel()
+
+	type outcome struct {
+		path string
+		err  error
+	}
+	// Read the indirection here, not inside the goroutine: the goroutine
+	// can outlive this call by design, and a test that restores the
+	// original fetch would otherwise be writing the variable while the
+	// abandoned goroutine still reads it.
+	fetch := hugotDownloadModel
+	done := make(chan outcome, 1)
+	go func() {
+		path, err := fetch(ctx, spec.RepoID, dest, opts)
+		done <- outcome{path: path, err: err}
+	}()
+
+	select {
+	case got := <-done:
+		return got.path, got.err
+	case <-ctx.Done():
+		return "", fmt.Errorf("no progress within %s: %w", budget, ctx.Err())
+	}
 }
 
 // hfCacheDirName turns a HuggingFace repo path ("org/name") into the

--- a/internal/embedding/provider_test.go
+++ b/internal/embedding/provider_test.go
@@ -2,8 +2,11 @@ package embedding
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
+	"github.com/knights-analytics/hugot"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -121,6 +124,13 @@ func TestStaticProvider_SemanticSimilarity(t *testing.T) {
 	assert.Greater(t, dot, 0.3, "semantically similar queries should have cosine > 0.3")
 }
 
+// testDownloadBudget bounds the cold model download this test triggers.
+// The fetch takes ~26s on a healthy runner, so three minutes is many
+// times the honest cost while still failing fast: without a bound, a
+// Hugging Face transfer that stalls parks the whole package until the
+// go test timeout kills it (a 45-minute CI kill, observed on Windows).
+const testDownloadBudget = 3 * time.Minute
+
 func TestNewLocalProvider_ReturnsWorkingProvider(t *testing.T) {
 	if raceEnabled {
 		// NewLocalProvider falls through to Hugot on a fresh machine,
@@ -133,8 +143,21 @@ func TestNewLocalProvider_ReturnsWorkingProvider(t *testing.T) {
 		// patch. Non-race builds still exercise the full fallback.
 		t.Skip("upstream data race in go-huggingface/hub.DownloadFilesCtx — skipping under -race")
 	}
-	p, err := NewLocalProvider()
-	require.NoError(t, err)
+	t.Setenv(embeddingDownloadBudgetEnv, testDownloadBudget.String())
+
+	// The report variant is the same chain NewLocalProvider runs — it
+	// just keeps the per-backend errors instead of discarding them, and
+	// those errors are the only place a stalled download is visible: a
+	// Hugot that gave up on the network falls through to the static
+	// provider, so the constructor succeeds either way.
+	p, report := NewLocalProviderWithReport()
+	for _, attempt := range report.Attempts {
+		if errors.Is(attempt.Err, context.DeadlineExceeded) {
+			t.Skipf("embedding model %s did not download within %s — network conditions, not a defect (%s backend: %v)",
+				miniLMRepo, testDownloadBudget, attempt.Backend, attempt.Err)
+		}
+	}
+	require.NotNil(t, p, "no backend constructed, not even the static fallback: %+v", report.Attempts)
 	defer p.Close()
 
 	// Default build walks ONNX → GoMLX → Hugot → Static and returns
@@ -142,8 +165,56 @@ func TestNewLocalProvider_ReturnsWorkingProvider(t *testing.T) {
 	// onnx/model.onnx, Hugot succeeds when the model is cached or
 	// the network is reachable. Either is fine — the invariant is
 	// "NewLocalProvider returns a working provider."
-	assert.NotNil(t, p)
 	assert.Greater(t, p.Dimensions(), 0, "provider must report positive dimensions")
+}
+
+// TestDownloadHugotModelAbandonsAStalledFetch pins the watchdog the test
+// above leans on. Nothing inside the download honours a deadline —
+// hugot.DownloadModel hands its context only to the post-fetch copy, and
+// go-huggingface's worker pool waits on a context-blind sync.Cond — so
+// the budget has to expire out in our own code. The stub stands in for a
+// transfer that never progresses.
+func TestDownloadHugotModelAbandonsAStalledFetch(t *testing.T) {
+	stalled := make(chan struct{})
+	defer close(stalled)
+	restore := hugotDownloadModel
+	t.Cleanup(func() { hugotDownloadModel = restore })
+	hugotDownloadModel = func(context.Context, string, string, hugot.DownloadOptions) (string, error) {
+		<-stalled // context-blind, exactly like the upstream semaphore wait
+		return "", nil
+	}
+	t.Setenv(embeddingDownloadBudgetEnv, "50ms")
+
+	spec, ok := LookupHugotVariant(DefaultHugotVariant)
+	require.True(t, ok)
+	start := time.Now()
+	path, err := downloadHugotModel(spec, t.TempDir(), hugot.NewDownloadOptions())
+
+	require.Error(t, err, "a stalled download returned a path (%q) instead of giving up", path)
+	require.ErrorIs(t, err, context.DeadlineExceeded, "the error must name the deadline so callers can tell a stall from a broken model")
+	assert.Less(t, time.Since(start), 10*time.Second, "the budget did not bind")
+}
+
+// TestDownloadBudgetHonoursTheEnvOverride pins both halves of the budget
+// resolution: a generous default for a real cold fetch, and an override
+// a test or an operator on a slow link can dial in.
+func TestDownloadBudgetHonoursTheEnvOverride(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value string
+		want  time.Duration
+	}{
+		{"unset", "", defaultDownloadBudget},
+		{"override", "90s", 90 * time.Second},
+		{"unparseable", "soon", defaultDownloadBudget},
+		{"zero", "0s", defaultDownloadBudget},
+		{"negative", "-1m", defaultDownloadBudget},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(embeddingDownloadBudgetEnv, tc.value)
+			assert.Equal(t, tc.want, downloadBudget())
+		})
+	}
 }
 
 func TestTokenizeForEmbedding(t *testing.T) {

--- a/internal/eval/http_handler_test.go
+++ b/internal/eval/http_handler_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
@@ -54,6 +55,14 @@ func newTestHandler(t *testing.T) *Handler {
 
 func TestHealthEndpoint(t *testing.T) {
 	h := newTestHandler(t)
+	// Uptime is reported from the handler's start instant, so backdate it
+	// rather than race the clock for a positive reading. Windows advances
+	// the runtime's monotonic clock in ~0.5-15.6 ms ticks, and a handler
+	// this test builds microseconds before the request still lands inside
+	// the tick it started in: time.Since returns exactly 0 there and the
+	// old "> 0" assertion failed on a correct handler.
+	const uptime = 3 * time.Second
+	h.SetStartTimeForTest(time.Now().Add(-uptime))
 	req := httptest.NewRequest(http.MethodGet, "/v1/health", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
@@ -68,7 +77,7 @@ func TestHealthEndpoint(t *testing.T) {
 	assert.Equal(t, 2, resp.Nodes)
 	assert.Equal(t, 0, resp.Edges)
 	assert.Equal(t, "0.0.1-test", resp.Version)
-	assert.Greater(t, resp.UptimeSeconds, float64(0))
+	assert.GreaterOrEqual(t, resp.UptimeSeconds, uptime.Seconds())
 }
 
 func TestStatsEndpoint(t *testing.T) {

--- a/internal/eval/integration_test.go
+++ b/internal/eval/integration_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
@@ -63,6 +64,14 @@ func TestEvalServerLifecycle(t *testing.T) {
 
 	logger := zap.NewNop()
 	handler := NewHandler(srv, g, "0.1.0-test", logger)
+	// Uptime is reported from the handler's start instant, so backdate it
+	// rather than race the clock for a positive reading. Windows advances
+	// the runtime's monotonic clock in ~0.5-15.6 ms ticks, and a handler
+	// this test builds microseconds before the request still lands inside
+	// the tick it started in: time.Since returns exactly 0 there and the
+	// old "> 0" assertion failed on a correct handler.
+	const uptime = 3 * time.Second
+	handler.SetStartTimeForTest(time.Now().Add(-uptime))
 
 	// --- Start: use httptest.NewServer for a real HTTP server ---
 	ts := httptest.NewServer(handler)
@@ -87,7 +96,7 @@ func TestEvalServerLifecycle(t *testing.T) {
 		assert.Equal(t, 2, health.Nodes)
 		assert.Equal(t, 1, health.Edges)
 		assert.Equal(t, "0.1.0-test", health.Version)
-		assert.Greater(t, health.UptimeSeconds, float64(0))
+		assert.GreaterOrEqual(t, health.UptimeSeconds, uptime.Seconds())
 	})
 
 	// --- Step 2: Tool call (echo) ---

--- a/internal/excludes/pattern_test.go
+++ b/internal/excludes/pattern_test.go
@@ -1,6 +1,9 @@
 package excludes
 
-import "testing"
+import (
+	"runtime"
+	"testing"
+)
 
 // The regression this whole file exists for: pandas' .gitignore carries
 // "*$" on line 7 as an Emacs autosave pattern. go-gitignore used to
@@ -63,11 +66,18 @@ func TestMatcher_RegexOnlyMetacharactersAreLiteral(t *testing.T) {
 // go-gitignore discarded the error and dropped the line, so the ignore
 // silently stopped applying. Both must now be honoured as literal text.
 func TestMatcher_UncompilablePatternsStillApply(t *testing.T) {
-	cases := []struct{ pattern, excluded string }{
+	type patternCase struct{ pattern, excluded string }
+	cases := []patternCase{
 		{"lib[", "lib["},
 		{"build(", "build("},
 		{"a)b", "a)b"},
-		{"weird\\", "weird\\"},
+	}
+	// A trailing backslash is the fourth shape that failed to compile, but the
+	// file it names can only exist on a POSIX filesystem: on Windows "\" is the
+	// path separator, so MatchRel normalises "weird\" to the directory "weird"
+	// and there is no such filename left to exclude.
+	if runtime.GOOS != "windows" {
+		cases = append(cases, patternCase{"weird\\", "weird\\"})
 	}
 	for _, tc := range cases {
 		if !New([]string{tc.pattern}).MatchRel(tc.excluded) {

--- a/internal/githooks/install_test.go
+++ b/internal/githooks/install_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -52,8 +53,14 @@ func TestInstallHookPostCommit_FreshFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat hook: %v", err)
 	}
-	if mode := info.Mode().Perm(); mode&0o100 == 0 {
-		t.Errorf("hook not executable: mode = %v", mode)
+	// NTFS has no exec bit — every file there reports 0666 and os.Chmod
+	// only toggles the read-only attribute, so the mode says nothing about
+	// whether Git will run the hook. Git for Windows runs hooks through its
+	// bundled sh regardless of permissions.
+	if runtime.GOOS != "windows" {
+		if mode := info.Mode().Perm(); mode&0o100 == 0 {
+			t.Errorf("hook not executable: mode = %v", mode)
+		}
 	}
 }
 

--- a/internal/graph/store_sqlite/import_adjacency_projection.go
+++ b/internal/graph/store_sqlite/import_adjacency_projection.go
@@ -2,7 +2,7 @@ package store_sqlite
 
 import (
 	"encoding/json"
-	"path/filepath"
+	gopath "path"
 
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/graphpath"
@@ -54,15 +54,15 @@ func (s *Store) ProjectImportAdjacency(filePaths []string) (map[string][]string,
 		if path == "" || path == "." {
 			return nil, false
 		}
-		// Indexed paths keep '/' after the repo prefix with the rest
-		// OS-native, so on Windows filepath.Clean rewrites separators on
-		// every stored path. A separator-only difference is not a
-		// canonicality violation — only a structural one (traversal,
-		// duplicate separators, a trailing "/." segment) rejects the
-		// request. Comparing the normalized forms is the whole test: Clean
-		// never inserts characters, so equal normalized forms mean the two
-		// spellings differ only in separators.
-		if cleaned := filepath.Clean(path); graphpath.Norm(cleaned) != graphpath.Norm(path) {
+		// Canonicality is judged in slash space, not OS space: a graph
+		// path is a stored identity, not a filesystem path, so only a
+		// structural violation (traversal, duplicate separators, a
+		// trailing "/." segment) may reject the request. filepath.Clean
+		// cannot make that call on Windows — it rewrites separators on
+		// every stored path, and prepends ".\" to any relative path whose
+		// first segment carries a colon, so a perfectly canonical
+		// "repo::pkg/a.go" would be refused there and nowhere else.
+		if norm := graphpath.Norm(path); gopath.Clean(norm) != norm {
 			return nil, false
 		}
 		if _, duplicate := seen[path]; duplicate {

--- a/internal/graph/store_sqlite/sqlite_busy_test.go
+++ b/internal/graph/store_sqlite/sqlite_busy_test.go
@@ -446,9 +446,26 @@ func TestCheckpointBusyResultIsRetriedAndNeverReportedAsSuccess(t *testing.T) {
 	require.NoError(t, readTx.QueryRow(`SELECT COUNT(*) FROM nodes`).Scan(&count))
 	store.AddNode(&graph.Node{ID: "repo/b.go::B", Kind: graph.KindFunction, Name: "B"})
 
+	// PASSIVE never waits for a reader: SQLite documents the busy handler as
+	// never invoked in that mode, and the read-slot lock the checkpointer wants
+	// is attempted exactly once and abandoned the moment it is refused. What
+	// PASSIVE does do is back-fill every frame below the reader's mark, and
+	// that copy is ordinary file I/O which the context deadline cannot
+	// interrupt mid-syscall. Here it is 408 frames: under a millisecond on a
+	// warm local disk, seconds on a contended CI disk. Timing that first drain
+	// measures the disk rather than the contention rule, so it is given room to
+	// finish and the rule is measured on the pass after it — with nothing left
+	// below the reader's mark that pass copies nothing at all, so it can only
+	// be slow by waiting for the long reader.
+	store.passiveCheckpointTimeout = 30 * time.Second
+	require.True(t, store.checkpointWALPassive(), "draining up to the reader's mark leaves an incomplete checkpoint")
+
 	started := time.Now()
-	store.checkpointWALPassive()
-	assert.Less(t, time.Since(started), time.Second, "PASSIVE maintenance must not wait for the long reader")
+	retryUnderReader := store.checkpointWALPassive()
+	passiveElapsed := time.Since(started)
+	store.passiveCheckpointTimeout = 0
+	assert.Less(t, passiveElapsed, time.Second, "PASSIVE maintenance must not wait for the long reader")
+	assert.True(t, retryUnderReader, "PASSIVE must report the frames the long reader still pins as an incomplete drain")
 
 	setWriterBusyTimeout(t, store, 0)
 	store.busyRetryTimeout = 80 * time.Millisecond

--- a/internal/graphpath/graphpath.go
+++ b/internal/graphpath/graphpath.go
@@ -1,10 +1,18 @@
-// Package graphpath interprets store/graph file paths. Indexed paths are
-// repoPrefix + '/' + the repo-relative path in the indexing machine's native
-// separators — on Windows that is one forward slash followed by backslashes
-// (`repo/dir\file`). Slash-only string logic applied to that shape sees the
-// whole repo as a single directory; these helpers normalize before any
-// dir/prefix reasoning. Norm is filepath.ToSlash on purpose: on POSIX a
-// backslash is an ordinary filename byte, not a separator, and must survive.
+// Package graphpath interprets store/graph file paths. A freshly indexed path
+// is repoPrefix + '/' + the repo-relative path spelled with forward slashes on
+// every platform — the indexer keys graph paths through
+// pathkey.Normalize(filepath.ToSlash(rel)), so Windows and POSIX stores agree.
+//
+// Graphs written by older versions keyed the repo-relative half in the
+// indexing machine's native separators, so a Windows-indexed store of that
+// vintage holds one forward slash followed by backslashes (`repo/dir\file`).
+// Slash-only string logic applied to that shape sees the whole repo as a
+// single directory, so these helpers keep normalizing before any dir/prefix
+// reasoning and PrefixForms keeps emitting the native spelling as a second
+// form. Both are pure back-compat folding for those legacy stores; they are
+// no-ops against anything indexed since. Norm is filepath.ToSlash on purpose:
+// on POSIX a backslash is an ordinary filename byte, not a separator, and must
+// survive.
 package graphpath
 
 import (
@@ -43,11 +51,12 @@ func Dir(p string) string {
 }
 
 // PrefixForms returns the spellings a stored path may use for a caller's
-// path prefix: the '/'-joined form plus the repo-prefixed native form
-// (`repo/` + FromSlash(rest)). Deduped — a single entry on POSIX, where the
-// two spellings coincide. Callers that filter storage directly (e.g. SQL
-// LIKE, where the column cannot be normalized cheaply) match against every
-// form.
+// path prefix: the '/'-joined form that every current store uses, plus the
+// repo-prefixed native form (`repo/` + FromSlash(rest)) that a legacy
+// Windows-indexed store may still hold. Deduped — a single entry on POSIX,
+// where the two spellings coincide, and the second form only ever widens the
+// match. Callers that filter storage directly (e.g. SQL LIKE, where the column
+// cannot be normalized cheaply) match against every form.
 func PrefixForms(prefix string) []string {
 	n := Norm(prefix)
 	forms := []string{n}

--- a/internal/hooks/codex_test.go
+++ b/internal/hooks/codex_test.go
@@ -322,7 +322,15 @@ func TestRunCodexHardDenyRequiresIndexedWorkspaceMatch(t *testing.T) {
 		return []grepSymbolHit{{Name: "Foo", FilePath: "internal/a.go", Line: 1}}, nil
 	}
 	t.Cleanup(func() { grepProbe = oldProbe })
-	external := []byte(`{"hook_event_name":"PreToolUse","tool_name":"Bash","cwd":"/repo","tool_input":{"command":"rg Foo /tmp/external"}}`)
+	// The search target has to be absolute in the platform's own spelling:
+	// filepath.IsAbs("/tmp/external") is false on Windows, so a POSIX literal
+	// would be joined onto the cwd and land back inside the workspace.
+	external := mustJSON(t, map[string]any{
+		"hook_event_name": "PreToolUse",
+		"tool_name":       "Bash",
+		"cwd":             repoFixtureRoot,
+		"tool_input":      map[string]any{"command": "rg Foo " + fixtureAbs("/tmp/external")},
+	})
 	externalOut := captureStdout(t, func() { runCodex(external, 0, CodexModeDeny) })
 	externalHSO := decodeHookOutput(t, externalOut).HookSpecificOutput
 	if externalHSO == nil || externalHSO.PermissionDecision != "" || externalHSO.AdditionalContext == "" {

--- a/internal/hooks/daemon_degraded_test.go
+++ b/internal/hooks/daemon_degraded_test.go
@@ -2,6 +2,7 @@ package hooks
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -21,8 +22,8 @@ func preToolReadPayload(t *testing.T, sessionID string) []byte {
 	return mustJSON(t, map[string]any{
 		"hook_event_name": "PreToolUse",
 		"tool_name":       "Read",
-		"tool_input":      map[string]any{"file_path": "/repo/internal/server.go"},
-		"cwd":             "/repo",
+		"tool_input":      map[string]any{"file_path": filepath.Join(repoFixtureRoot, "internal", "server.go")},
+		"cwd":             repoFixtureRoot,
 		"session_id":      sessionID,
 	})
 }
@@ -74,9 +75,9 @@ func TestPreToolUseDaemonDownGatesForceCompressDeny(t *testing.T) {
 		"tool_name":       gortexCompactReadTool,
 		"tool_input": map[string]any{
 			"operation": "file",
-			"target":    map[string]any{"file": "/repo/internal/server.go"},
+			"target":    map[string]any{"file": filepath.Join(repoFixtureRoot, "internal", "server.go")},
 		},
-		"cwd": "/repo",
+		"cwd": repoFixtureRoot,
 	})
 
 	withDaemonReachable(t, true)
@@ -104,7 +105,7 @@ func TestPreToolUseTerminalDenyStaysLiveDuringOutage(t *testing.T) {
 	payload := mustJSON(t, map[string]any{
 		"hook_event_name": "PreToolUse",
 		"tool_name":       "Read",
-		"tool_input":      map[string]any{"file_path": "/repo/internal/server.go"},
+		"tool_input":      map[string]any{"file_path": filepath.Join(repoFixtureRoot, "internal", "server.go")},
 		"cwd":             cwd,
 		"session_id":      "sess-terminal-outage",
 		"agent_id":        "agent-1",
@@ -128,9 +129,9 @@ func TestPostToolUseDaemonDownSuppressesFollowUps(t *testing.T) {
 	payload := mustJSON(t, map[string]any{
 		"hook_event_name": "PostToolUse",
 		"tool_name":       "Read",
-		"tool_input":      map[string]any{"file_path": "/repo/internal/server.go"},
+		"tool_input":      map[string]any{"file_path": filepath.Join(repoFixtureRoot, "internal", "server.go")},
 		"tool_response":   "package server",
-		"cwd":             "/repo",
+		"cwd":             repoFixtureRoot,
 	})
 
 	withDaemonReachable(t, true)
@@ -184,9 +185,9 @@ func TestCodexMCPReadDaemonDownStaysSilent(t *testing.T) {
 		"tool_name":       gortexCompactReadTool,
 		"tool_input": map[string]any{
 			"operation": "file",
-			"target":    map[string]any{"file": "/repo/internal/server.go"},
+			"target":    map[string]any{"file": filepath.Join(repoFixtureRoot, "internal", "server.go")},
 		},
-		"cwd": "/repo",
+		"cwd": repoFixtureRoot,
 	})
 
 	withDaemonReachable(t, true)
@@ -204,7 +205,7 @@ func TestCodexMCPReadDaemonDownStaysSilent(t *testing.T) {
 
 func TestKimiPreToolUseDaemonDownStaysSilent(t *testing.T) {
 	stubIndexedFile(t, true, 4)
-	input := map[string]any{"file_path": "/repo/internal/server.go"}
+	input := map[string]any{"file_path": filepath.Join(repoFixtureRoot, "internal", "server.go")}
 
 	withDaemonReachable(t, true)
 	control := captureHookStdout(t, func() { runKimiPreToolUse("Read", input, "sess", 0, ModeDeny) })
@@ -240,8 +241,8 @@ func TestPiToolCallDaemonDownEmptyDecision(t *testing.T) {
 	ev := PiEvent{
 		Event:     "tool_call",
 		ToolName:  "Read",
-		ToolInput: map[string]any{"file_path": "/repo/internal/server.go"},
-		CWD:       "/repo",
+		ToolInput: map[string]any{"file_path": filepath.Join(repoFixtureRoot, "internal", "server.go")},
+		CWD:       repoFixtureRoot,
 		SessionID: "sess",
 	}
 
@@ -261,8 +262,8 @@ func TestHermesPreToolCallDaemonDownNeverBlocks(t *testing.T) {
 	payload := mustJSON(t, map[string]any{
 		"hook_event_name": hermesEventPreToolCall,
 		"tool_name":       hermesReadFileTool,
-		"tool_input":      map[string]any{"path": "/repo/internal/server.go"},
-		"cwd":             "/repo",
+		"tool_input":      map[string]any{"path": filepath.Join(repoFixtureRoot, "internal", "server.go")},
+		"cwd":             repoFixtureRoot,
 		"session_id":      "sess",
 	})
 
@@ -340,15 +341,15 @@ func TestDaemonDownNoticeScopedToTrackedRepos(t *testing.T) {
 	withDaemonReachable(t, false)
 	oldRepos := hookTrackedReposFn
 	hookTrackedReposFn = func() []daemon.TrackedRepoStatus {
-		return []daemon.TrackedRepoStatus{{Path: "/repo", Name: "repo"}}
+		return []daemon.TrackedRepoStatus{{Path: repoFixtureRoot, Name: "repo"}}
 	}
 	t.Cleanup(func() { hookTrackedReposFn = oldRepos })
 
 	untracked := mustJSON(t, map[string]any{
 		"hook_event_name": "PreToolUse",
 		"tool_name":       "Read",
-		"tool_input":      map[string]any{"file_path": "/elsewhere/scratch.go"},
-		"cwd":             "/elsewhere",
+		"tool_input":      map[string]any{"file_path": filepath.Join(elsewhereFixtureRoot, "scratch.go")},
+		"cwd":             elsewhereFixtureRoot,
 		"session_id":      "sess-scoped",
 	})
 	if out := captureHookStdout(t, func() { runPreToolUse(untracked, 0, ModeDeny) }); out != "" {
@@ -369,9 +370,9 @@ func TestPreToolUseDaemonDownSkipsNudgeUnderAutoApprove(t *testing.T) {
 		"tool_name":       gortexCompactReadTool,
 		"tool_input": map[string]any{
 			"operation": "file",
-			"target":    map[string]any{"file": "/repo/internal/server.go"},
+			"target":    map[string]any{"file": filepath.Join(repoFixtureRoot, "internal", "server.go")},
 		},
-		"cwd":             "/repo",
+		"cwd":             repoFixtureRoot,
 		"permission_mode": "acceptEdits",
 	})
 
@@ -421,7 +422,7 @@ func TestPiAdaptiveNudgeStreakFrozenDuringOutage(t *testing.T) {
 	ev := PiEvent{
 		Event:        "tool_call",
 		ToolName:     "search_symbols",
-		CWD:          "/repo",
+		CWD:          repoFixtureRoot,
 		SessionID:    session,
 		IsGortexTool: true,
 	}

--- a/internal/hooks/external_agent_test.go
+++ b/internal/hooks/external_agent_test.go
@@ -28,12 +28,12 @@ func TestHandleExternalAgent_SessionStartEmitsOrientation(t *testing.T) {
 	withFakeStatus(t, func() (*daemon.StatusResponse, error) {
 		return &daemon.StatusResponse{
 			Version: "1.0.0", Ready: true,
-			TrackedRepos: []daemon.TrackedRepoStatus{{Name: "repo", Path: "/tmp/repo", Workspace: "repo", Nodes: 10}},
+			TrackedRepos: []daemon.TrackedRepoStatus{{Name: "repo", Path: repoTmpFixtureRoot, Workspace: "repo", Nodes: 10}},
 			Workspaces:   []daemon.WorkspaceSummary{{Slug: "repo"}},
 		}, nil
 	})
 	out := captureStdout(t, func() {
-		handleExternalAgent([]byte(`{"hook_event_name":"SessionStart","cwd":"/tmp/repo"}`))
+		handleExternalAgent(mustJSON(t, map[string]any{"hook_event_name": "SessionStart", "cwd": repoTmpFixtureRoot}))
 	})
 	var payload HookOutput
 	if err := json.Unmarshal([]byte(out), &payload); err != nil {
@@ -52,7 +52,7 @@ func TestHandleExternalAgent_AfterToolDaemonDown(t *testing.T) {
 		return nil, errDaemonUnreachable
 	})
 	out := captureStdout(t, func() {
-		handleExternalAgent([]byte(`{"hook_event_name":"AfterTool","tool_name":"run_shell_command","cwd":"/tmp/repo"}`))
+		handleExternalAgent(mustJSON(t, map[string]any{"hook_event_name": "AfterTool", "tool_name": "run_shell_command", "cwd": repoTmpFixtureRoot}))
 	})
 	var payload HookOutput
 	if err := json.Unmarshal([]byte(out), &payload); err != nil {
@@ -71,11 +71,11 @@ func TestHandleExternalAgent_AfterToolQuietWhenReadyAndCovered(t *testing.T) {
 	withFakeStatus(t, func() (*daemon.StatusResponse, error) {
 		return &daemon.StatusResponse{
 			Ready:        true,
-			TrackedRepos: []daemon.TrackedRepoStatus{{Name: "repo", Path: "/tmp/repo"}},
+			TrackedRepos: []daemon.TrackedRepoStatus{{Name: "repo", Path: repoTmpFixtureRoot}},
 		}, nil
 	})
 	out := captureStdout(t, func() {
-		handleExternalAgent([]byte(`{"hook_event_name":"AfterTool","cwd":"/tmp/repo"}`))
+		handleExternalAgent(mustJSON(t, map[string]any{"hook_event_name": "AfterTool", "cwd": repoTmpFixtureRoot}))
 	})
 	if strings.TrimSpace(out) != "" {
 		t.Errorf("AfterTool should stay quiet when the graph is fresh and the cwd is covered, got:\n%s", out)
@@ -86,11 +86,11 @@ func TestHandleExternalAgent_AfterToolHintsUncoveredCwd(t *testing.T) {
 	withFakeStatus(t, func() (*daemon.StatusResponse, error) {
 		return &daemon.StatusResponse{
 			Ready:        true,
-			TrackedRepos: []daemon.TrackedRepoStatus{{Name: "other", Path: "/some/other/repo"}},
+			TrackedRepos: []daemon.TrackedRepoStatus{{Name: "other", Path: fixtureAbs("/some/other/repo")}},
 		}, nil
 	})
 	out := captureStdout(t, func() {
-		handleExternalAgent([]byte(`{"hook_event_name":"AfterTool","cwd":"/tmp/untracked"}`))
+		handleExternalAgent(mustJSON(t, map[string]any{"hook_event_name": "AfterTool", "cwd": fixtureAbs("/tmp/untracked")}))
 	})
 	if !strings.Contains(out, "is not tracked") {
 		t.Errorf("expected an untracked-cwd hint, got:\n%s", out)

--- a/internal/hooks/file_coverage_e2e_test.go
+++ b/internal/hooks/file_coverage_e2e_test.go
@@ -2,13 +2,13 @@ package hooks
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/zzet/gortex/internal/daemon"
+	"github.com/zzet/gortex/internal/testenv"
 )
 
 // coverageController answers the coverage verb over the real control socket
@@ -85,12 +85,7 @@ func TestFileIndexedViaDaemonFailsOpenOnAnUnroutedWorktree(t *testing.T) {
 // a probe that started reporting "covered" — or blocking — when the daemon is
 // down would deny every read on a machine with no daemon at all.
 func TestFileIndexedViaDaemonFailsOpenWithNoDaemon(t *testing.T) {
-	dir, err := os.MkdirTemp("/tmp", "gx-hook-nocov")
-	if err != nil {
-		t.Fatalf("mktemp: %v", err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
-	t.Setenv("GORTEX_DAEMON_SOCKET", filepath.Join(dir, "missing"))
+	t.Setenv("GORTEX_DAEMON_SOCKET", filepath.Join(testenv.ShortTempDir(t), "missing"))
 
 	start := time.Now()
 	indexed, symbols := fileIndexedViaDaemon("/wt", "internal/live.go")

--- a/internal/hooks/fixture_paths_test.go
+++ b/internal/hooks/fixture_paths_test.go
@@ -1,0 +1,49 @@
+package hooks
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"runtime"
+)
+
+// fixtureAbs renders a slash-separated POSIX-style fixture root in the running
+// platform's native absolute spelling: "/repo" stays "/repo" on Unix and
+// becomes `C:\repo` on Windows.
+//
+// The scope gate, the tracked-repo registry and the ownership attribution all
+// branch on filepath.IsAbs and resolve relative input through filepath.Abs.
+// filepath.IsAbs("/repo") is false on Windows — an absolute path needs a
+// volume there — so a POSIX literal makes those tests exercise the
+// relative-path branch instead of the containment logic they were written for.
+// The volume is synthetic; nothing under these roots is ever created on disk.
+func fixtureAbs(p string) string {
+	if runtime.GOOS != "windows" {
+		return p
+	}
+	return filepath.Clean("C:" + filepath.FromSlash(p))
+}
+
+// The synthetic checkouts the attribution, scope-gate and outage fixtures share.
+var (
+	repoFixtureRoot      = fixtureAbs("/repo")
+	otherFixtureRoot     = fixtureAbs("/other")
+	trackedFixtureRoot   = fixtureAbs("/tracked")
+	untrackedFixtureRoot = fixtureAbs("/untracked")
+	elsewhereFixtureRoot = fixtureAbs("/elsewhere")
+
+	// The tracked checkouts the SessionStart / external-agent briefings use.
+	repoTmpFixtureRoot     = fixtureAbs("/tmp/repo")
+	gortexTmpFixtureRoot   = fixtureAbs("/tmp/gortex")
+	cloudWebTmpFixtureRoot = fixtureAbs("/tmp/cloud_web")
+)
+
+// jsonPathFixture escapes a native path for embedding in a raw-string JSON
+// fixture. A Windows path's backslashes are not valid JSON escapes, so a
+// `\t` in `C:\tmp\...` would decode as a tab — or fail the decode outright.
+func jsonPathFixture(p string) string {
+	encoded, err := json.Marshal(p)
+	if err != nil {
+		return p
+	}
+	return string(encoded[1 : len(encoded)-1])
+}

--- a/internal/hooks/hook_tier_test.go
+++ b/internal/hooks/hook_tier_test.go
@@ -22,7 +22,7 @@ func leanTestStatus() (*daemon.StatusResponse, error) {
 		UptimeSeconds: 3600,
 		Ready:         true,
 		TrackedRepos: []daemon.TrackedRepoStatus{
-			{Name: "gortex", Path: "/tmp/gortex", Workspace: "gortex", Nodes: 6604, Edges: 27403},
+			{Name: "gortex", Path: gortexTmpFixtureRoot, Workspace: "gortex", Nodes: 6604, Edges: 27403},
 		},
 		Workspaces: []daemon.WorkspaceSummary{{Slug: "gortex"}},
 	}, nil
@@ -35,7 +35,7 @@ func TestSessionStart_LeanTier_TrackedCwd(t *testing.T) {
 	withFakeStatus(t, leanTestStatus)
 	withHookTier(t, profiles.HookTierLean)
 
-	briefing := buildSessionStartBriefing("/tmp/gortex")
+	briefing := buildSessionStartBriefing(gortexTmpFixtureRoot)
 
 	if !strings.Contains(briefing, "enforcement active") {
 		t.Errorf("lean briefing lost the enforcement signal:\n%s", briefing)
@@ -49,7 +49,7 @@ func TestSessionStart_LeanTier_TrackedCwd(t *testing.T) {
 	}
 	// And the lean rendering must actually be smaller.
 	withHookTier(t, profiles.HookTierStandard)
-	standard := buildSessionStartBriefing("/tmp/gortex")
+	standard := buildSessionStartBriefing(gortexTmpFixtureRoot)
 	if len(briefing) >= len(standard) {
 		t.Errorf("lean briefing (%d bytes) is not smaller than standard (%d bytes)", len(briefing), len(standard))
 	}
@@ -61,7 +61,7 @@ func TestSessionStart_LeanTier_KeepsUncoveredWarning(t *testing.T) {
 	withFakeStatus(t, leanTestStatus)
 	withHookTier(t, profiles.HookTierLean)
 
-	briefing := buildSessionStartBriefing("/somewhere/else")
+	briefing := buildSessionStartBriefing(fixtureAbs("/somewhere/else"))
 	if !strings.Contains(briefing, "not covered by any tracked repo") {
 		t.Errorf("lean briefing lost the uncovered-cwd warning:\n%s", briefing)
 	}

--- a/internal/hooks/localization_terminal.go
+++ b/internal/hooks/localization_terminal.go
@@ -7,8 +7,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"syscall"
@@ -28,6 +30,10 @@ const (
 	localizationTerminalSessionHardCap  = 128
 	localizationTerminalAgentHardCap    = 64
 	localizationTerminalJanitorDeletes  = 32
+	// A state rename can lose a race with a concurrent reader on Windows (see
+	// renameLocalizationState); 20 attempts 3ms apart bound the wait at 60ms.
+	localizationStateRenameAttempts = 20
+	localizationStateRenameDelay    = 3 * time.Millisecond
 
 	localizationTerminalContext    = "[Gortex] Localization for this task is complete. Answer now from completion.final_response, naming the files and symbols you rely on; if its evidence does not fit the request, say so and name what does. Either way, do not call another tool."
 	localizationTerminalDenyReason = "[Gortex] Localization for this task is complete, so this tool call is blocked. Answer now from the retained evidence below, naming what you rely on; if it does not fit the request, say so in your answer."
@@ -637,7 +643,7 @@ func consumeLocalizationToolSnapshot(input localizationTerminalHookInput) (local
 		return localizationTerminalIdentity{}, "", false
 	}
 	claimPath := path + ".consume-" + claimToken
-	if err := os.Rename(path, claimPath); err != nil {
+	if err := renameLocalizationState(path, claimPath); err != nil {
 		return localizationTerminalIdentity{}, "", false
 	}
 	defer os.Remove(claimPath) //nolint:errcheck // one-shot cleanup is best effort
@@ -851,11 +857,37 @@ func writeLocalizationState(path string, value any) bool {
 	if err := tmp.Close(); err != nil {
 		return false
 	}
-	if err := os.Rename(tmpPath, path); err != nil {
+	if err := renameLocalizationState(tmpPath, path); err != nil {
 		return false
 	}
 	committed = true
 	return true
+}
+
+// renameLocalizationState renames from onto to, retrying briefly while either
+// end is still held open by somebody else.
+//
+// POSIX rename(2) replaces the destination atomically and never fails because
+// a reader has it open. Windows MoveFileEx cannot touch a file another handle
+// owns unless that handle was opened with FILE_SHARE_DELETE, and os.Open does
+// not ask for it — so a concurrent reader of the very state file being
+// replaced makes the rename fail with a sharing violation and the hook drops a
+// terminal marker it believed it had written. Readers hold the handle for
+// microseconds, so a short bounded retry turns a lost write into a slightly
+// later one.
+func renameLocalizationState(from, to string) error {
+	err := os.Rename(from, to)
+	for attempt := 1; err != nil && attempt < localizationStateRenameAttempts; attempt++ {
+		// Only Windows fails this transiently, and only while the source is
+		// still there to move: a vanished source means another caller already
+		// claimed it, which no amount of retrying changes.
+		if runtime.GOOS != "windows" || errors.Is(err, fs.ErrNotExist) {
+			break
+		}
+		time.Sleep(localizationStateRenameDelay)
+		err = os.Rename(from, to)
+	}
+	return err
 }
 
 // writeBoundedLocalizationState keeps transient marker/snapshot storage

--- a/internal/hooks/localization_terminal.go
+++ b/internal/hooks/localization_terminal.go
@@ -7,10 +7,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 	"syscall"
@@ -19,6 +17,7 @@ import (
 	"github.com/gofrs/flock"
 
 	"github.com/zzet/gortex/internal/localizationauth"
+	"github.com/zzet/gortex/internal/platform"
 )
 
 const (
@@ -30,10 +29,6 @@ const (
 	localizationTerminalSessionHardCap  = 128
 	localizationTerminalAgentHardCap    = 64
 	localizationTerminalJanitorDeletes  = 32
-	// A state rename can lose a race with a concurrent reader on Windows (see
-	// renameLocalizationState); 20 attempts 3ms apart bound the wait at 60ms.
-	localizationStateRenameAttempts = 20
-	localizationStateRenameDelay    = 3 * time.Millisecond
 
 	localizationTerminalContext    = "[Gortex] Localization for this task is complete. Answer now from completion.final_response, naming the files and symbols you rely on; if its evidence does not fit the request, say so and name what does. Either way, do not call another tool."
 	localizationTerminalDenyReason = "[Gortex] Localization for this task is complete, so this tool call is blocked. Answer now from the retained evidence below, naming what you rely on; if it does not fit the request, say so in your answer."
@@ -638,15 +633,13 @@ func consumeLocalizationToolSnapshot(input localizationTerminalHookInput) (local
 	if promptID := strings.TrimSpace(input.PromptID); promptID != "" && promptID != snapshot.Identity.PromptID {
 		return localizationTerminalIdentity{}, "", false
 	}
-	claimToken, ok := localizationauth.NewToken()
-	if !ok {
+	// Claiming the snapshot has to name exactly one winner. A rename does
+	// that on POSIX, but two racing MoveFileEx calls on one source can both
+	// fail on Windows and hand the turn to nobody, so the claim is an
+	// exclusive marker that arbitrates identically on both.
+	if !platform.ClaimFile(path) {
 		return localizationTerminalIdentity{}, "", false
 	}
-	claimPath := path + ".consume-" + claimToken
-	if err := renameLocalizationState(path, claimPath); err != nil {
-		return localizationTerminalIdentity{}, "", false
-	}
-	defer os.Remove(claimPath) //nolint:errcheck // one-shot cleanup is best effort
 	return snapshot.Identity, snapshot.AuthToken, true
 }
 
@@ -857,37 +850,15 @@ func writeLocalizationState(path string, value any) bool {
 	if err := tmp.Close(); err != nil {
 		return false
 	}
-	if err := renameLocalizationState(tmpPath, path); err != nil {
+	// A concurrent reader of the very state file being replaced makes the
+	// commit fail with a sharing violation on Windows, and the hook would drop
+	// a terminal marker it believed it had written; platform.ReplaceFile
+	// retries that refusal briefly.
+	if err := platform.ReplaceFile(tmpPath, path); err != nil {
 		return false
 	}
 	committed = true
 	return true
-}
-
-// renameLocalizationState renames from onto to, retrying briefly while either
-// end is still held open by somebody else.
-//
-// POSIX rename(2) replaces the destination atomically and never fails because
-// a reader has it open. Windows MoveFileEx cannot touch a file another handle
-// owns unless that handle was opened with FILE_SHARE_DELETE, and os.Open does
-// not ask for it — so a concurrent reader of the very state file being
-// replaced makes the rename fail with a sharing violation and the hook drops a
-// terminal marker it believed it had written. Readers hold the handle for
-// microseconds, so a short bounded retry turns a lost write into a slightly
-// later one.
-func renameLocalizationState(from, to string) error {
-	err := os.Rename(from, to)
-	for attempt := 1; err != nil && attempt < localizationStateRenameAttempts; attempt++ {
-		// Only Windows fails this transiently, and only while the source is
-		// still there to move: a vanished source means another caller already
-		// claimed it, which no amount of retrying changes.
-		if runtime.GOOS != "windows" || errors.Is(err, fs.ErrNotExist) {
-			break
-		}
-		time.Sleep(localizationStateRenameDelay)
-		err = os.Rename(from, to)
-	}
-	return err
 }
 
 // writeBoundedLocalizationState keeps transient marker/snapshot storage

--- a/internal/hooks/localization_terminal_receipt_test.go
+++ b/internal/hooks/localization_terminal_receipt_test.go
@@ -3,6 +3,7 @@ package hooks
 import (
 	"encoding/json"
 	"os"
+	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -509,7 +510,9 @@ func TestLocalizationProblemRewriteDirectAndPluginIsIdempotent(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got := info.Mode().Perm(); got != 0o600 {
+			// Windows has no POSIX mode bits: os.Chmod only toggles the
+			// read-only attribute, so a writable file always reports 0666.
+			if got := info.Mode().Perm(); runtime.GOOS != "windows" && got != 0o600 {
 				t.Fatalf("turn state mode = %o, want 600", got)
 			}
 			rawState, err := os.ReadFile(statePath)

--- a/internal/hooks/localization_terminal_test.go
+++ b/internal/hooks/localization_terminal_test.go
@@ -3,7 +3,6 @@ package hooks
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1012,22 +1011,35 @@ func configureLocalizationTerminalTestHome(t *testing.T) {
 	testenv.Sandbox(t)
 }
 
+// captureHookStdout runs fn with os.Stdout on a pipe and returns what it
+// wrote.
+//
+// The read has to run concurrently with fn, which is why this delegates to
+// captureStdout rather than reading after fn returns: an OS pipe holds only a
+// bounded amount of unread data, and the writer blocks once it is full. The
+// buffer is 64KiB on Linux/macOS but only 4KiB on Windows (Go's os.Pipe asks
+// CreatePipe for the system default), and the SessionStart briefing this
+// helper captures is ~4.7KiB — so a drain-after-fn helper deadlocked the
+// whole hooks test binary on Windows and only there. It was killed by the
+// go test timeout at 49m30s, which is the package's entire reported runtime.
 func captureHookStdout(t *testing.T, fn func()) string {
 	t.Helper()
-	original := os.Stdout
-	reader, writer, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
+	return captureStdout(t, fn)
+}
+
+// TestCaptureHookStdoutOutlivesThePipeBuffer guards the property above against
+// a future helper that reads only after fn returns. A hook that writes more
+// than the pipe holds must still complete, so the assertion is that this test
+// finishes at all — a helper without a concurrent drain deadlocks here and
+// takes the whole package down with the go test timeout, which is how the
+// SessionStart briefing (~4.7KiB, over the 4KiB Windows pipe buffer) hung the
+// Windows shard.
+func TestCaptureHookStdoutOutlivesThePipeBuffer(t *testing.T) {
+	const size = 128 << 10 // over every platform's pipe buffer
+	out := captureHookStdout(t, func() {
+		_, _ = os.Stdout.WriteString(strings.Repeat("x", size))
+	})
+	if len(out) != size {
+		t.Fatalf("captured %d bytes, want %d", len(out), size)
 	}
-	os.Stdout = writer
-	defer func() { os.Stdout = original }()
-	fn()
-	if err := writer.Close(); err != nil {
-		t.Fatal(err)
-	}
-	data, err := io.ReadAll(reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return string(data)
 }

--- a/internal/hooks/posttask_test.go
+++ b/internal/hooks/posttask_test.go
@@ -3,6 +3,7 @@ package hooks
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -293,7 +294,8 @@ func TestRenderTestTargets_CapsBytes(t *testing.T) {
 // incidentChangeSet mirrors the reported failure: a session that edited one Go
 // file while a sibling session on the same checkout left three release-config
 // files dirty.
-const incidentChangeSet = `{
+func incidentChangeSet() string {
+	return `{
 	"changed_files":["internal/hooks/posttask.go",".goreleaser.yml",".github/workflows/ci.yml",".github/workflows/release.yml"],
 	"changed_symbols":[
 		{"id":"gortex/internal/hooks/posttask.go::runPostTask","name":"runPostTask","kind":"function","file_path":"gortex/internal/hooks/posttask.go"},
@@ -302,27 +304,28 @@ const incidentChangeSet = `{
 		{"id":"gortex/.github/workflows/release.yml::jobs","name":"jobs","kind":"config","file_path":"gortex/.github/workflows/release.yml"}
 	],
 	"risk":"HIGH","summary":"4 symbols touched",
-	"scope":"all","repo":"gortex","repo_root":"/repo"
+	"scope":"all","repo":"gortex","repo_root":"` + jsonPathFixture(repoFixtureRoot) + `"
 }`
+}
 
 // TestRunPostTask_AttributesOnlyThisSessionsEdits is the regression test for
 // the reported bug: session A's Stop hook reported session B's in-flight edits
 // and told A to run tests for files it never touched.
 func TestRunPostTask_AttributesOnlyThisSessionsEdits(t *testing.T) {
 	withSessionDir(t)
-	withTrackedRepos(t, daemon.TrackedRepoStatus{Prefix: "gortex", Path: "/repo"})
+	withTrackedRepos(t, daemon.TrackedRepoStatus{Prefix: "gortex", Path: repoFixtureRoot})
 	saveSessionState("sess-a", sessionState{
-		WrittenPaths: []string{"/repo/internal/hooks/posttask.go"},
+		WrittenPaths: []string{filepath.Join(repoFixtureRoot, "internal", "hooks", "posttask.go")},
 	})
 
 	srv := newRecordingFakeServer(map[string]string{
-		"detect_changes":        incidentChangeSet,
+		"detect_changes":        incidentChangeSet(),
 		"get_test_targets":      "internal/hooks/posttask_test.go TestRunPostTask\nrun: go test ./internal/hooks/\n",
 		"explain_change_impact": `{"risk":"LOW","summary":"1 symbol","total_affected":2}`,
 	})
 	defer srv.Close()
 
-	data := []byte(`{"hook_event_name":"Stop","stop_hook_active":false,"session_id":"sess-a","cwd":"/repo"}`)
+	data := mustJSON(t, map[string]any{"hook_event_name": "Stop", "stop_hook_active": false, "session_id": "sess-a", "cwd": repoFixtureRoot})
 	out := captureStdout(t, func() { runPostTask(data, portFromURL(t, srv.URL)) })
 	if out == "" {
 		t.Fatal("expected a briefing for the session's own edit")
@@ -370,19 +373,19 @@ func TestRunPostTask_AttributesOnlyThisSessionsEdits(t *testing.T) {
 // Stop fires every turn, so this must be silent rather than a repeated notice.
 func TestRunPostTask_SessionOwnsNothing_Silent(t *testing.T) {
 	withSessionDir(t)
-	withTrackedRepos(t, daemon.TrackedRepoStatus{Prefix: "gortex", Path: "/repo"})
+	withTrackedRepos(t, daemon.TrackedRepoStatus{Prefix: "gortex", Path: repoFixtureRoot})
 	// The session wrote only outside the repo — scratchpad and memory files.
 	saveSessionState("sess-a", sessionState{
-		WrittenPaths: []string{"/tmp/scratch/report.html", "/Users/dev/.claude/memory/MEMORY.md"},
+		WrittenPaths: []string{fixtureAbs("/tmp/scratch/report.html"), fixtureAbs("/Users/dev/.claude/memory/MEMORY.md")},
 	})
 
 	srv := newRecordingFakeServer(map[string]string{
-		"detect_changes":   incidentChangeSet,
+		"detect_changes":   incidentChangeSet(),
 		"get_test_targets": "should-never-be-called\n",
 	})
 	defer srv.Close()
 
-	data := []byte(`{"hook_event_name":"Stop","stop_hook_active":false,"session_id":"sess-a","cwd":"/repo"}`)
+	data := mustJSON(t, map[string]any{"hook_event_name": "Stop", "stop_hook_active": false, "session_id": "sess-a", "cwd": repoFixtureRoot})
 	out := captureStdout(t, func() { runPostTask(data, portFromURL(t, srv.URL)) })
 
 	if out != "" {
@@ -398,20 +401,20 @@ func TestRunPostTask_SessionOwnsNothing_Silent(t *testing.T) {
 // own risk already describes it.
 func TestRunPostTask_OwnsAll_SkipsImpactCall(t *testing.T) {
 	withSessionDir(t)
-	withTrackedRepos(t, daemon.TrackedRepoStatus{Prefix: "gortex", Path: "/repo"})
-	saveSessionState("sess-a", sessionState{WrittenPaths: []string{"/repo/internal/foo.go"}})
+	withTrackedRepos(t, daemon.TrackedRepoStatus{Prefix: "gortex", Path: repoFixtureRoot})
+	saveSessionState("sess-a", sessionState{WrittenPaths: []string{filepath.Join(repoFixtureRoot, "internal", "foo.go")}})
 
 	srv := newRecordingFakeServer(map[string]string{
 		"detect_changes": `{
 			"changed_files":["internal/foo.go"],
 			"changed_symbols":[{"id":"gortex/internal/foo.go::Foo","name":"Foo","kind":"function","file_path":"gortex/internal/foo.go"}],
-			"risk":"MEDIUM","summary":"1","scope":"all","repo":"gortex","repo_root":"/repo"
+			"risk":"MEDIUM","summary":"1","scope":"all","repo":"gortex","repo_root":"` + jsonPathFixture(repoFixtureRoot) + `"
 		}`,
 		"get_test_targets": "internal/foo_test.go TestFoo\n",
 	})
 	defer srv.Close()
 
-	data := []byte(`{"hook_event_name":"Stop","stop_hook_active":false,"session_id":"sess-a","cwd":"/repo"}`)
+	data := mustJSON(t, map[string]any{"hook_event_name": "Stop", "stop_hook_active": false, "session_id": "sess-a", "cwd": repoFixtureRoot})
 	out := captureStdout(t, func() { runPostTask(data, portFromURL(t, srv.URL)) })
 
 	if n := srv.callCount("explain_change_impact"); n != 0 {

--- a/internal/hooks/probe_e2e_test.go
+++ b/internal/hooks/probe_e2e_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net"
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -12,6 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/zzet/gortex/internal/daemon"
+	"github.com/zzet/gortex/internal/testenv"
 )
 
 // fakeController implements daemon.Controller with stubbed SearchSymbols
@@ -64,11 +64,7 @@ func (f *fakeController) EnrichCochange(_ context.Context, _ daemon.EnrichCochan
 // points GORTEX_DAEMON_SOCKET at it so daemon.Dial finds it.
 func startTestDaemon(t *testing.T, ctrl daemon.Controller) {
 	t.Helper()
-	dir, err := os.MkdirTemp("/tmp", "gx-hook-e2e")
-	if err != nil {
-		t.Fatalf("mktemp: %v", err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	dir := testenv.ShortTempDir(t)
 
 	socket := filepath.Join(dir, "s")
 	t.Setenv("GORTEX_DAEMON_SOCKET", socket)
@@ -112,15 +108,9 @@ func TestProbeViaDaemon_Hit_E2E(t *testing.T) {
 
 func TestProbeViaDaemon_NoDaemon_ReturnsUnreachable(t *testing.T) {
 	// Point at a path that has no listener.
-	dir, err := os.MkdirTemp("/tmp", "gx-hook-empty")
-	if err != nil {
-		t.Fatalf("mktemp: %v", err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
-	t.Setenv("GORTEX_DAEMON_SOCKET", filepath.Join(dir, "missing"))
+	t.Setenv("GORTEX_DAEMON_SOCKET", filepath.Join(testenv.ShortTempDir(t), "missing"))
 
-	_, err = probeViaDaemon("handleFoo", "", 500*time.Millisecond)
-	if err != errDaemonUnreachable {
+	if _, err := probeViaDaemon("handleFoo", "", 500*time.Millisecond); err != errDaemonUnreachable {
 		t.Errorf("expected errDaemonUnreachable, got %v", err)
 	}
 }

--- a/internal/hooks/scope_gate_test.go
+++ b/internal/hooks/scope_gate_test.go
@@ -1,6 +1,7 @@
 package hooks
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/zzet/gortex/internal/daemon"
@@ -25,7 +26,7 @@ func stubTrackedRepos(t *testing.T, paths ...string) {
 // a pattern that existed in some *other* tracked repo hard-denied a search of
 // an untracked one.
 func TestUntrackedCwdSilencesEveryHostToolPolicy(t *testing.T) {
-	stubTrackedRepos(t, "/tracked")
+	stubTrackedRepos(t, trackedFixtureRoot)
 	stubTrackedScope(t, false)
 	stubProbe(t, []grepSymbolHit{{Name: "Handler", FilePath: "pkg/a.go", Line: 1}}, nil)
 	stubIndexedFile(t, true, 9)
@@ -44,7 +45,7 @@ func TestUntrackedCwdSilencesEveryHostToolPolicy(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.input.CWD = "/untracked"
+			tc.input.CWD = untrackedFixtureRoot
 			result := enrich(tc.input, 0)
 			if result.deny || result.context != "" {
 				t.Fatalf("policy fired in an untracked checkout: %#v", result)
@@ -57,13 +58,13 @@ func TestUntrackedCwdSilencesEveryHostToolPolicy(t *testing.T) {
 // checkout can still name a file in a tracked one, and that file's repo is the
 // one with an answer.
 func TestTrackedTargetOutsideCwdStillEnforced(t *testing.T) {
-	stubTrackedRepos(t, "/tracked")
+	stubTrackedRepos(t, trackedFixtureRoot)
 	stubIndexedFile(t, true, 9)
 
 	result := enrich(HookInput{
 		ToolName:  "Read",
-		ToolInput: map[string]any{"file_path": "/tracked/pkg/a.go"},
-		CWD:       "/untracked",
+		ToolInput: map[string]any{"file_path": filepath.Join(trackedFixtureRoot, "pkg", "a.go")},
+		CWD:       untrackedFixtureRoot,
 	}, 0)
 	if !result.deny {
 		t.Fatalf("Read of an indexed file in a tracked repo must still be denied: %#v", result)
@@ -73,13 +74,13 @@ func TestTrackedTargetOutsideCwdStillEnforced(t *testing.T) {
 // The mirror of the case above: a cwd inside a tracked repo does not license a
 // redirect for a file that lives outside every tracked repo.
 func TestUntrackedTargetFromTrackedCwdIsSilent(t *testing.T) {
-	stubTrackedRepos(t, "/tracked")
+	stubTrackedRepos(t, trackedFixtureRoot)
 	stubIndexedFile(t, true, 9)
 
 	result := enrich(HookInput{
 		ToolName:  "Read",
-		ToolInput: map[string]any{"file_path": "/elsewhere/pkg/a.go"},
-		CWD:       "/tracked",
+		ToolInput: map[string]any{"file_path": filepath.Join(elsewhereFixtureRoot, "pkg", "a.go")},
+		CWD:       trackedFixtureRoot,
 	}, 0)
 	if result.deny || result.context != "" {
 		t.Fatalf("policy fired on a target outside every tracked repo: %#v", result)
@@ -87,13 +88,13 @@ func TestUntrackedTargetFromTrackedCwdIsSilent(t *testing.T) {
 }
 
 func TestTrackedCwdKeepsEnforcement(t *testing.T) {
-	stubTrackedRepos(t, "/tracked")
+	stubTrackedRepos(t, trackedFixtureRoot)
 	stubTrackedScope(t, true)
 
 	result := enrich(HookInput{
 		ToolName:  "Grep",
 		ToolInput: map[string]any{"pattern": "Handler"},
-		CWD:       "/tracked/internal",
+		CWD:       filepath.Join(trackedFixtureRoot, "internal"),
 	}, 0)
 	if !result.deny {
 		t.Fatalf("tracked cwd must keep the indexed-search deny: %#v", result)
@@ -109,7 +110,7 @@ func TestUnknownTrackedRepoListLeavesPostureUnchanged(t *testing.T) {
 	result := enrich(HookInput{
 		ToolName:  "Grep",
 		ToolInput: map[string]any{"pattern": "Handler"},
-		CWD:       "/anywhere",
+		CWD:       fixtureAbs("/anywhere"),
 	}, 0)
 	if !result.deny {
 		t.Fatalf("an unknown tracked-repo list must not disable the policy: %#v", result)
@@ -117,12 +118,12 @@ func TestUnknownTrackedRepoListLeavesPostureUnchanged(t *testing.T) {
 }
 
 func TestGortexMCPCallsAreNotRepoGated(t *testing.T) {
-	stubTrackedRepos(t, "/tracked")
+	stubTrackedRepos(t, trackedFixtureRoot)
 
 	result := enrich(HookInput{
 		ToolName:  gortexReadFileTool,
 		ToolInput: map[string]any{"path": "pkg/a.go"},
-		CWD:       "/untracked",
+		CWD:       untrackedFixtureRoot,
 	}, 0)
 	if result.context == "" && !result.deny {
 		t.Fatal("a Gortex MCP read is not repo-scoped and must still be enriched")
@@ -145,7 +146,7 @@ func TestGrepRestrictedToNonSourceStaysSilent(t *testing.T) {
 		{"pattern": "Handler", "path": "README.md"},
 		{"pattern": "Handler", "path": ".github/workflows/ci.yml"},
 	} {
-		result := enrichGrep(toolInput, 0, "/repo")
+		result := enrichGrep(toolInput, 0, repoFixtureRoot)
 		if result.deny || result.context != "" {
 			t.Fatalf("non-source Grep %v fired: %#v", toolInput, result)
 		}
@@ -164,7 +165,7 @@ func TestGrepWithSourceFilterStillEnforced(t *testing.T) {
 		{"pattern": "Handler", "type": "not-a-known-type"},
 		{"pattern": "Handler"},
 	} {
-		result := enrichGrep(toolInput, 0, "/repo")
+		result := enrichGrep(toolInput, 0, repoFixtureRoot)
 		if !result.deny {
 			t.Fatalf("source-scoped Grep %v was not denied: %#v", toolInput, result)
 		}
@@ -177,7 +178,7 @@ func TestGlobNonSourceScopeStaysSilent(t *testing.T) {
 	result := enrichGlob(map[string]any{
 		"pattern": "**/*.go",
 		"path":    "docs/README.md",
-	}, "/repo")
+	}, repoFixtureRoot)
 	if result.deny || result.context != "" {
 		t.Fatalf("Glob scoped to a non-source file fired: %#v", result)
 	}
@@ -187,7 +188,7 @@ func TestGlobNonSourceScopeStaysSilent(t *testing.T) {
 // search verb cannot be satisfied by a graph query, so it must pass through
 // untouched even in a fully tracked, fully indexed repo.
 func TestBashWithoutSearchVerbNeverFires(t *testing.T) {
-	stubTrackedRepos(t, "/tracked")
+	stubTrackedRepos(t, trackedFixtureRoot)
 	stubIndexedFile(t, true, 12)
 	stubProbe(t, []grepSymbolHit{{Name: "version", FilePath: "pkg/a.go", Line: 1}}, nil)
 
@@ -204,7 +205,7 @@ func TestBashWithoutSearchVerbNeverFires(t *testing.T) {
 		result := enrich(HookInput{
 			ToolName:  "Bash",
 			ToolInput: map[string]any{"command": command},
-			CWD:       "/tracked",
+			CWD:       trackedFixtureRoot,
 		}, 0)
 		if result.deny || result.context != "" {
 			t.Fatalf("Bash %q has no search verb but fired: %#v", command, result)
@@ -240,16 +241,16 @@ func TestHookAbsScopePathRequiresAnAnchor(t *testing.T) {
 	if _, ok := hookAbsScopePath("pkg/a.go", "relative/cwd"); ok {
 		t.Fatal("a relative cwd cannot anchor a relative path")
 	}
-	abs, ok := hookAbsScopePath("pkg/a.go", "/repo")
-	if !ok || abs != "/repo/pkg/a.go" {
-		t.Fatalf("hookAbsScopePath = %q, %v", abs, ok)
+	abs, ok := hookAbsScopePath("pkg/a.go", repoFixtureRoot)
+	if want := filepath.Join(repoFixtureRoot, "pkg", "a.go"); !ok || abs != want {
+		t.Fatalf("hookAbsScopePath = %q, %v; want %q", abs, ok, want)
 	}
 }
 
 // An unresolvable path proves nothing about where the call lives, so it must
 // leave the historical posture in place rather than silence the policy.
 func TestUnresolvablePathLeavesPostureUnchanged(t *testing.T) {
-	stubTrackedRepos(t, "/tracked")
+	stubTrackedRepos(t, trackedFixtureRoot)
 	if !hookCallTargetsTrackedRepo("Read", map[string]any{"file_path": "pkg/a.go"}, "") {
 		t.Fatal("an unanchored relative path must not be treated as untracked")
 	}

--- a/internal/hooks/session_paths_test.go
+++ b/internal/hooks/session_paths_test.go
@@ -2,6 +2,7 @@ package hooks
 
 import (
 	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -25,30 +26,30 @@ func TestWriteTargetPaths(t *testing.T) {
 	}{
 		{
 			name: "Edit uses file_path",
-			tool: "Edit", input: map[string]any{"file_path": "/repo/a.go"},
-			want: []string{"/repo/a.go"},
+			tool: "Edit", input: map[string]any{"file_path": filepath.Join(repoFixtureRoot, "a.go")},
+			want: []string{filepath.Join(repoFixtureRoot, "a.go")},
 		},
 		{
 			name: "Write uses file_path",
-			tool: "Write", input: map[string]any{"file_path": "/repo/b.go"},
-			want: []string{"/repo/b.go"},
+			tool: "Write", input: map[string]any{"file_path": filepath.Join(repoFixtureRoot, "b.go")},
+			want: []string{filepath.Join(repoFixtureRoot, "b.go")},
 		},
 		{
 			// MultiEdit is outside preToolUsePolicyTools, so capture has to
 			// happen before that gate.
 			name: "MultiEdit uses one file_path for all edits",
-			tool: "MultiEdit", input: map[string]any{"file_path": "/repo/c.go"},
-			want: []string{"/repo/c.go"},
+			tool: "MultiEdit", input: map[string]any{"file_path": filepath.Join(repoFixtureRoot, "c.go")},
+			want: []string{filepath.Join(repoFixtureRoot, "c.go")},
 		},
 		{
 			name: "NotebookEdit prefers notebook_path",
-			tool: "NotebookEdit", input: map[string]any{"notebook_path": "/repo/n.ipynb"},
-			want: []string{"/repo/n.ipynb"},
+			tool: "NotebookEdit", input: map[string]any{"notebook_path": filepath.Join(repoFixtureRoot, "n.ipynb")},
+			want: []string{filepath.Join(repoFixtureRoot, "n.ipynb")},
 		},
 		{
 			name: "NotebookEdit falls back to file_path",
-			tool: "NotebookEdit", input: map[string]any{"file_path": "/repo/n2.ipynb"},
-			want: []string{"/repo/n2.ipynb"},
+			tool: "NotebookEdit", input: map[string]any{"file_path": filepath.Join(repoFixtureRoot, "n2.ipynb")},
+			want: []string{filepath.Join(repoFixtureRoot, "n2.ipynb")},
 		},
 		{
 			name: "Bash reuses the shell write classifier",
@@ -112,7 +113,7 @@ func TestWriteTargetPaths(t *testing.T) {
 		},
 		{
 			name: "Read records nothing",
-			tool: "Read", input: map[string]any{"file_path": "/repo/a.go"},
+			tool: "Read", input: map[string]any{"file_path": filepath.Join(repoFixtureRoot, "a.go")},
 			want: nil,
 		},
 	}
@@ -142,18 +143,18 @@ func TestWriteTargetPaths_RespectsPerCallCap(t *testing.T) {
 }
 
 func TestRepoRelativeForOwnership(t *testing.T) {
-	const root = "/Users/dev/code/gortex"
+	root := fixtureAbs("/Users/dev/code/gortex")
 	cases := []struct {
 		name, raw, want string
 	}{
-		{"absolute inside the repo", root + "/internal/a.go", "internal/a.go"},
-		{"absolute outside the repo", "/Users/dev/other/b.go", ""},
-		{"home-dir file outside the repo", "/Users/dev/.claude/MEMORY.md", ""},
+		{"absolute inside the repo", filepath.Join(root, "internal", "a.go"), "internal/a.go"},
+		{"absolute outside the repo", fixtureAbs("/Users/dev/other/b.go"), ""},
+		{"home-dir file outside the repo", fixtureAbs("/Users/dev/.claude/MEMORY.md"), ""},
 		{"already repo-relative", "internal/a.go", "internal/a.go"},
 		{"repo-prefixed stays unchanged", "gortex/internal/a.go", "gortex/internal/a.go"},
 		{"parent escape rejected", "../elsewhere/a.go", ""},
 		{"symbol id reduces to its path", "internal/a.go::Foo", "internal/a.go"},
-		{"absolute symbol id", root + "/internal/a.go::Foo", "internal/a.go"},
+		{"absolute symbol id", filepath.Join(root, "internal", "a.go") + "::Foo", "internal/a.go"},
 		{"blank", "   ", ""},
 	}
 	for _, tc := range cases {
@@ -167,8 +168,8 @@ func TestRepoRelativeForOwnership(t *testing.T) {
 
 func TestAttributeChanges_PartitionsOwnedAndRest(t *testing.T) {
 	withSessionDir(t)
-	withTrackedRepos(t, daemon.TrackedRepoStatus{Prefix: "gortex", Path: "/repo"})
-	saveSessionState("sess-a", sessionState{WrittenPaths: []string{"/repo/internal/mine.go"}})
+	withTrackedRepos(t, daemon.TrackedRepoStatus{Prefix: "gortex", Path: repoFixtureRoot})
+	saveSessionState("sess-a", sessionState{WrittenPaths: []string{filepath.Join(repoFixtureRoot, "internal", "mine.go")}})
 
 	changes := &changeSet{
 		ChangedFiles: []string{"internal/mine.go", ".goreleaser.yml", ".github/workflows/ci.yml"},
@@ -177,7 +178,7 @@ func TestAttributeChanges_PartitionsOwnedAndRest(t *testing.T) {
 			{ID: "gortex/.goreleaser.yml::builds", FilePath: "gortex/.goreleaser.yml"},
 		},
 	}
-	got := attributeChanges(sessionScope{SessionID: "sess-a", CWD: "/repo"}, changes)
+	got := attributeChanges(sessionScope{SessionID: "sess-a", CWD: repoFixtureRoot}, changes)
 
 	if !got.Attributed {
 		t.Fatal("expected attribution to resolve")
@@ -203,10 +204,10 @@ func TestAttributeChanges_PartitionsOwnedAndRest(t *testing.T) {
 // path carrying the prefix while changed_files does not.
 func TestAttributeChanges_PrefixCollision(t *testing.T) {
 	withSessionDir(t)
-	withTrackedRepos(t, daemon.TrackedRepoStatus{Prefix: "gortex", Path: "/repo"})
+	withTrackedRepos(t, daemon.TrackedRepoStatus{Prefix: "gortex", Path: repoFixtureRoot})
 	saveSessionState("sess-a", sessionState{WrittenPaths: []string{"gortex/internal/x.go"}})
 
-	got := attributeChanges(sessionScope{SessionID: "sess-a", CWD: "/repo"}, &changeSet{
+	got := attributeChanges(sessionScope{SessionID: "sess-a", CWD: repoFixtureRoot}, &changeSet{
 		ChangedFiles:   []string{"internal/x.go"},
 		ChangedSymbols: []changedSymbol{{ID: "gortex/internal/x.go::X", FilePath: "gortex/internal/x.go"}},
 	})
@@ -224,13 +225,13 @@ func TestAttributeChanges_PrefixCollision(t *testing.T) {
 func TestAttributeChanges_NoCrossRepoMatch(t *testing.T) {
 	withSessionDir(t)
 	withTrackedRepos(t,
-		daemon.TrackedRepoStatus{Prefix: "gortex", Path: "/repo"},
-		daemon.TrackedRepoStatus{Prefix: "other", Path: "/other"},
+		daemon.TrackedRepoStatus{Prefix: "gortex", Path: repoFixtureRoot},
+		daemon.TrackedRepoStatus{Prefix: "other", Path: otherFixtureRoot},
 	)
 	// The session edited /other/internal/x.go; the diff is of /repo.
-	saveSessionState("sess-a", sessionState{WrittenPaths: []string{"/other/internal/x.go"}})
+	saveSessionState("sess-a", sessionState{WrittenPaths: []string{filepath.Join(otherFixtureRoot, "internal", "x.go")}})
 
-	got := attributeChanges(sessionScope{SessionID: "sess-a", CWD: "/repo"}, &changeSet{
+	got := attributeChanges(sessionScope{SessionID: "sess-a", CWD: repoFixtureRoot}, &changeSet{
 		ChangedFiles:   []string{"internal/x.go"},
 		ChangedSymbols: []changedSymbol{{ID: "gortex/internal/x.go::X", FilePath: "gortex/internal/x.go"}},
 	})
@@ -251,23 +252,23 @@ func TestAttributeChanges_NoCrossRepoMatch(t *testing.T) {
 func TestOwnershipRepoScope_PrefersEcho(t *testing.T) {
 	t.Run("echo wins with no tracked repos at all", func(t *testing.T) {
 		withTrackedRepos(t) // simulates the timed-out status call
-		root, prefix := ownershipRepoScope("/repo", &changeSet{RepoRoot: "/repo", Repo: "gortex"})
-		if root != "/repo" || prefix != "gortex" {
-			t.Errorf("got (%q, %q), want (/repo, gortex)", root, prefix)
+		root, prefix := ownershipRepoScope(repoFixtureRoot, &changeSet{RepoRoot: repoFixtureRoot, Repo: "gortex"})
+		if root != repoFixtureRoot || prefix != "gortex" {
+			t.Errorf("got (%q, %q), want (%q, gortex)", root, prefix, repoFixtureRoot)
 		}
 	})
 	t.Run("echo wins over a different tracked repo", func(t *testing.T) {
-		withTrackedRepos(t, daemon.TrackedRepoStatus{Prefix: "other", Path: "/other"})
-		root, _ := ownershipRepoScope("/other", &changeSet{RepoRoot: "/repo", Repo: "gortex"})
-		if root != "/repo" {
-			t.Errorf("root = %q, want the echoed /repo", root)
+		withTrackedRepos(t, daemon.TrackedRepoStatus{Prefix: "other", Path: otherFixtureRoot})
+		root, _ := ownershipRepoScope(otherFixtureRoot, &changeSet{RepoRoot: repoFixtureRoot, Repo: "gortex"})
+		if root != repoFixtureRoot {
+			t.Errorf("root = %q, want the echoed %q", root, repoFixtureRoot)
 		}
 	})
 	t.Run("falls back to cwd when the echo is absent", func(t *testing.T) {
-		withTrackedRepos(t, daemon.TrackedRepoStatus{Prefix: "gortex", Path: "/repo"})
-		root, prefix := ownershipRepoScope("/repo", &changeSet{})
-		if root != "/repo" || prefix != "gortex" {
-			t.Errorf("got (%q, %q), want (/repo, gortex)", root, prefix)
+		withTrackedRepos(t, daemon.TrackedRepoStatus{Prefix: "gortex", Path: repoFixtureRoot})
+		root, prefix := ownershipRepoScope(repoFixtureRoot, &changeSet{})
+		if root != repoFixtureRoot || prefix != "gortex" {
+			t.Errorf("got (%q, %q), want (%q, gortex)", root, prefix, repoFixtureRoot)
 		}
 	})
 	t.Run("ignores the server's non-absolute fallback root", func(t *testing.T) {
@@ -283,12 +284,12 @@ func TestOwnershipRepoScope_PrefersEcho(t *testing.T) {
 func TestAttributeChanges_WorksWithoutDaemonStatus(t *testing.T) {
 	withSessionDir(t)
 	withTrackedRepos(t) // status unavailable / timed out
-	saveSessionState("sess-a", sessionState{WrittenPaths: []string{"/repo/internal/mine.go"}})
+	saveSessionState("sess-a", sessionState{WrittenPaths: []string{filepath.Join(repoFixtureRoot, "internal", "mine.go")}})
 
-	got := attributeChanges(sessionScope{SessionID: "sess-a", CWD: "/repo"}, &changeSet{
+	got := attributeChanges(sessionScope{SessionID: "sess-a", CWD: repoFixtureRoot}, &changeSet{
 		ChangedFiles:   []string{"internal/mine.go", "theirs.go"},
 		ChangedSymbols: []changedSymbol{{ID: "gortex/internal/mine.go::Mine", FilePath: "gortex/internal/mine.go"}},
-		RepoRoot:       "/repo",
+		RepoRoot:       repoFixtureRoot,
 		Repo:           "gortex",
 	})
 
@@ -311,21 +312,21 @@ func TestAttributeChanges_UnresolvableFallsBack(t *testing.T) {
 	}
 
 	t.Run("no session id", func(t *testing.T) {
-		withTrackedRepos(t, daemon.TrackedRepoStatus{Path: "/repo"})
-		if attributeChanges(sessionScope{CWD: "/repo"}, changes).Attributed {
+		withTrackedRepos(t, daemon.TrackedRepoStatus{Path: repoFixtureRoot})
+		if attributeChanges(sessionScope{CWD: repoFixtureRoot}, changes).Attributed {
 			t.Error("expected fallback with no session id")
 		}
 	})
 	t.Run("no recorded writes", func(t *testing.T) {
-		withTrackedRepos(t, daemon.TrackedRepoStatus{Path: "/repo"})
-		if attributeChanges(sessionScope{SessionID: "sess-fresh", CWD: "/repo"}, changes).Attributed {
+		withTrackedRepos(t, daemon.TrackedRepoStatus{Path: repoFixtureRoot})
+		if attributeChanges(sessionScope{SessionID: "sess-fresh", CWD: repoFixtureRoot}, changes).Attributed {
 			t.Error("expected fallback for a session that wrote nothing")
 		}
 	})
 	t.Run("daemon unreachable", func(t *testing.T) {
 		withTrackedRepos(t)
-		saveSessionState("sess-b", sessionState{WrittenPaths: []string{"/repo/a.go"}})
-		if attributeChanges(sessionScope{SessionID: "sess-b", CWD: "/repo"}, changes).Attributed {
+		saveSessionState("sess-b", sessionState{WrittenPaths: []string{filepath.Join(repoFixtureRoot, "a.go")}})
+		if attributeChanges(sessionScope{SessionID: "sess-b", CWD: repoFixtureRoot}, changes).Attributed {
 			t.Error("expected fallback when no repo resolves")
 		}
 	})
@@ -336,9 +337,9 @@ func TestRecordSessionWriteTargets(t *testing.T) {
 		withSessionDir(t)
 		recordSessionWriteTargets(HookInput{
 			SessionID: "s1", ToolName: "Edit",
-			ToolInput: map[string]any{"file_path": "/repo/a.go"},
+			ToolInput: map[string]any{"file_path": filepath.Join(repoFixtureRoot, "a.go")},
 		})
-		if got := loadSessionState("s1").WrittenPaths; !reflect.DeepEqual(got, []string{"/repo/a.go"}) {
+		if got := loadSessionState("s1").WrittenPaths; !reflect.DeepEqual(got, []string{filepath.Join(repoFixtureRoot, "a.go")}) {
 			t.Errorf("WrittenPaths = %v", got)
 		}
 	})
@@ -347,7 +348,7 @@ func TestRecordSessionWriteTargets(t *testing.T) {
 		dir := withSessionDir(t)
 		recordSessionWriteTargets(HookInput{
 			ToolName:  "Edit",
-			ToolInput: map[string]any{"file_path": "/repo/a.go"},
+			ToolInput: map[string]any{"file_path": filepath.Join(repoFixtureRoot, "a.go")},
 		})
 		assertNoStateFiles(t, dir)
 	})
@@ -356,7 +357,7 @@ func TestRecordSessionWriteTargets(t *testing.T) {
 		dir := withSessionDir(t)
 		recordSessionWriteTargets(HookInput{
 			SessionID: "s2", ToolName: "Read",
-			ToolInput: map[string]any{"file_path": "/repo/a.go"},
+			ToolInput: map[string]any{"file_path": filepath.Join(repoFixtureRoot, "a.go")},
 		})
 		assertNoStateFiles(t, dir)
 	})
@@ -366,7 +367,7 @@ func TestRecordSessionWriteTargets(t *testing.T) {
 		for i := 0; i < 3; i++ {
 			recordSessionWriteTargets(HookInput{
 				SessionID: "s3", ToolName: "Edit",
-				ToolInput: map[string]any{"file_path": "/repo/a.go"},
+				ToolInput: map[string]any{"file_path": filepath.Join(repoFixtureRoot, "a.go")},
 			})
 		}
 		if got := loadSessionState("s3").WrittenPaths; len(got) != 1 {
@@ -378,13 +379,13 @@ func TestRecordSessionWriteTargets(t *testing.T) {
 		withSessionDir(t)
 		seed := make([]string, sessionWrittenPathsCap)
 		for i := range seed {
-			seed[i] = "/repo/seed" + string(rune('a'+i%26)) + string(rune('a'+i/26)) + ".go"
+			seed[i] = filepath.Join(repoFixtureRoot, "seed"+string(rune('a'+i%26))+string(rune('a'+i/26))+".go")
 		}
 		saveSessionState("s4", sessionState{WrittenPaths: seed})
 
 		recordSessionWriteTargets(HookInput{
 			SessionID: "s4", ToolName: "Edit",
-			ToolInput: map[string]any{"file_path": "/repo/overflow.go"},
+			ToolInput: map[string]any{"file_path": filepath.Join(repoFixtureRoot, "overflow.go")},
 		})
 
 		st := loadSessionState("s4")

--- a/internal/hooks/sessionstart_test.go
+++ b/internal/hooks/sessionstart_test.go
@@ -210,8 +210,8 @@ func TestRunSessionStart_DaemonReady_CwdExactMatch(t *testing.T) {
 			UptimeSeconds: 3600,
 			Ready:         true,
 			TrackedRepos: []daemon.TrackedRepoStatus{
-				{Name: "gortex", Path: "/tmp/gortex", Workspace: "gortex", Nodes: 6604, Edges: 27403},
-				{Name: "cloud_web", Path: "/tmp/cloud_web", Workspace: "cloud_web", Nodes: 265, Edges: 276},
+				{Name: "gortex", Path: gortexTmpFixtureRoot, Workspace: "gortex", Nodes: 6604, Edges: 27403},
+				{Name: "cloud_web", Path: cloudWebTmpFixtureRoot, Workspace: "cloud_web", Nodes: 265, Edges: 276},
 			},
 			Workspaces: []daemon.WorkspaceSummary{
 				{Slug: "gortex"}, {Slug: "cloud_web"},
@@ -219,7 +219,7 @@ func TestRunSessionStart_DaemonReady_CwdExactMatch(t *testing.T) {
 		}, nil
 	})
 
-	data := []byte(`{"hook_event_name":"SessionStart","cwd":"/tmp/gortex"}`)
+	data := mustJSON(t, map[string]any{"hook_event_name": "SessionStart", "cwd": gortexTmpFixtureRoot})
 	out := captureStdout(t, func() { runSessionStart(data, 0) })
 
 	var payload HookOutput
@@ -245,14 +245,14 @@ func TestRunSessionStart_DaemonReady_CwdContainsRepos(t *testing.T) {
 			UptimeSeconds: 60,
 			Ready:         true,
 			TrackedRepos: []daemon.TrackedRepoStatus{
-				{Name: "gortex", Path: "/tmp/gortex"},
-				{Name: "cloud_web", Path: "/tmp/cloud_web"},
-				{Name: "project1", Path: "/opt/project1"}, // unrelated: NOT under cwd /tmp
+				{Name: "gortex", Path: gortexTmpFixtureRoot},
+				{Name: "cloud_web", Path: cloudWebTmpFixtureRoot},
+				{Name: "project1", Path: fixtureAbs("/opt/project1")}, // unrelated: NOT under cwd /tmp
 			},
 		}, nil
 	})
 
-	data := []byte(`{"hook_event_name":"SessionStart","cwd":"/tmp"}`)
+	data := mustJSON(t, map[string]any{"hook_event_name": "SessionStart", "cwd": fixtureAbs("/tmp")})
 	out := captureStdout(t, func() { runSessionStart(data, 0) })
 
 	var payload HookOutput
@@ -283,12 +283,13 @@ func TestRunSessionStart_DaemonReady_CwdNotTracked(t *testing.T) {
 			Version: "0.15.0",
 			Ready:   true,
 			TrackedRepos: []daemon.TrackedRepoStatus{
-				{Name: "gortex", Path: "/tmp/gortex"},
+				{Name: "gortex", Path: gortexTmpFixtureRoot},
 			},
 		}, nil
 	})
 
-	data := []byte(`{"hook_event_name":"SessionStart","cwd":"/tmp/playground"}`)
+	playground := fixtureAbs("/tmp/playground")
+	data := mustJSON(t, map[string]any{"hook_event_name": "SessionStart", "cwd": playground})
 	out := captureStdout(t, func() { runSessionStart(data, 0) })
 
 	var payload HookOutput
@@ -299,7 +300,7 @@ func TestRunSessionStart_DaemonReady_CwdNotTracked(t *testing.T) {
 	if !strings.Contains(ac, "is not covered by any tracked repo") {
 		t.Errorf("expected untracked notice, got:\n%s", ac)
 	}
-	if !strings.Contains(ac, "gortex track /tmp/playground") {
+	if !strings.Contains(ac, "gortex track "+playground) {
 		t.Errorf("expected actionable track command, got:\n%s", ac)
 	}
 }
@@ -403,7 +404,7 @@ func TestDispatch_RoutesSessionStart(t *testing.T) {
 		}, nil
 	})
 
-	data := []byte(`{"hook_event_name":"SessionStart","cwd":"/tmp"}`)
+	data := mustJSON(t, map[string]any{"hook_event_name": "SessionStart", "cwd": fixtureAbs("/tmp")})
 	withStdin(t, data, func() {
 		out := captureStdout(t, func() { Run(0, ModeDeny) })
 		if !strings.Contains(out, "Gortex Session Orientation") {

--- a/internal/hooks/tracked_repos_config_test.go
+++ b/internal/hooks/tracked_repos_config_test.go
@@ -1,6 +1,7 @@
 package hooks
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -24,15 +25,16 @@ func writeGlobalConfig(t *testing.T, body string) string {
 // downstream, "no repo owns this path" downgrades an indexed-file decision to
 // generic guidance.
 func TestLoadTrackedRepos_IncludesProjectNestedRepos(t *testing.T) {
-	path := writeGlobalConfig(t, `
+	alpha, beta, gamma := fixtureAbs("/work/alpha"), fixtureAbs("/work/beta"), fixtureAbs("/work/gamma")
+	path := writeGlobalConfig(t, fmt.Sprintf(`
 repos:
-  - path: /work/alpha
+  - path: '%s'
 projects:
   side:
     repos:
-      - path: /work/beta
-      - path: /work/gamma
-`)
+      - path: '%s'
+      - path: '%s'
+`, alpha, beta, gamma))
 	repos, ok := loadTrackedReposFromPath(path)
 	require.True(t, ok)
 
@@ -41,9 +43,9 @@ projects:
 		got[r.Path] = r.Prefix
 	}
 	assert.Equal(t, map[string]string{
-		"/work/alpha": "alpha",
-		"/work/beta":  "beta",
-		"/work/gamma": "gamma",
+		alpha: "alpha",
+		beta:  "beta",
+		gamma: "gamma",
 	}, got, "top-level and project-nested repos are both tracked")
 }
 
@@ -51,12 +53,12 @@ projects:
 // path's base. hookRepoScope hands this value out as the graph repo prefix, so
 // a wrong one mis-attributes a Stop-time diff.
 func TestLoadTrackedRepos_PrefixPrefersExplicitName(t *testing.T) {
-	path := writeGlobalConfig(t, `
+	path := writeGlobalConfig(t, fmt.Sprintf(`
 repos:
-  - path: /work/checkout
+  - path: '%s'
     name: canonical
-  - path: /work/plain
-`)
+  - path: '%s'
+`, fixtureAbs("/work/checkout"), fixtureAbs("/work/plain")))
 	repos, ok := loadTrackedReposFromPath(path)
 	require.True(t, ok)
 	require.Len(t, repos, 2)
@@ -66,14 +68,14 @@ repos:
 
 // The same path reachable twice (top-level and under a project) is one repo.
 func TestLoadTrackedRepos_DedupesRepeatedPath(t *testing.T) {
-	path := writeGlobalConfig(t, `
+	path := writeGlobalConfig(t, fmt.Sprintf(`
 repos:
-  - path: /work/alpha
+  - path: '%s'
 projects:
   dup:
     repos:
-      - path: /work/alpha
-`)
+      - path: '%s'
+`, fixtureAbs("/work/alpha"), fixtureAbs("/work/alpha")))
 	repos, ok := loadTrackedReposFromPath(path)
 	require.True(t, ok)
 	assert.Len(t, repos, 1)
@@ -107,26 +109,28 @@ func TestLoadTrackedRepos_UnestablishedRegistryFallsBack(t *testing.T) {
 // A blank path entry cannot own any file and must not become a row — an empty
 // Path would prefix-match nothing but still pad the registry.
 func TestLoadTrackedRepos_SkipsBlankPaths(t *testing.T) {
-	path := writeGlobalConfig(t, `
+	real := fixtureAbs("/work/real")
+	path := writeGlobalConfig(t, fmt.Sprintf(`
 repos:
   - path: ""
-  - path: /work/real
-`)
+  - path: '%s'
+`, real))
 	repos, ok := loadTrackedReposFromPath(path)
 	require.True(t, ok)
 	require.Len(t, repos, 1)
-	assert.Equal(t, "/work/real", repos[0].Path)
+	assert.Equal(t, real, repos[0].Path)
 }
 
 // The registry feeds trackedRepoForPath, whose longest-match rule resolves
 // nested checkouts. Proving it here pins the end-to-end contract the PreToolUse
 // probe depends on, not just the parse.
 func TestLoadTrackedRepos_FeedsLongestMatchLookup(t *testing.T) {
-	path := writeGlobalConfig(t, `
+	outer, inner := fixtureAbs("/work/outer"), fixtureAbs("/work/outer/inner")
+	path := writeGlobalConfig(t, fmt.Sprintf(`
 repos:
-  - path: /work/outer
-  - path: /work/outer/inner
-`)
+  - path: '%s'
+  - path: '%s'
+`, outer, inner))
 	repos, ok := loadTrackedReposFromPath(path)
 	require.True(t, ok)
 
@@ -134,15 +138,15 @@ repos:
 	hookTrackedReposFn = func() []daemon.TrackedRepoStatus { return repos }
 	t.Cleanup(func() { hookTrackedReposFn = prev })
 
-	got, found := trackedRepoForPath(filepath.Join("/work/outer/inner", "pkg", "f.go"))
+	got, found := trackedRepoForPath(filepath.Join(inner, "pkg", "f.go"))
 	require.True(t, found)
-	assert.Equal(t, "/work/outer/inner", got.Path,
+	assert.Equal(t, inner, got.Path,
 		"the nested checkout owns its own files, not the outer one")
 
-	got, found = trackedRepoForPath(filepath.Join("/work/outer", "pkg", "f.go"))
+	got, found = trackedRepoForPath(filepath.Join(outer, "pkg", "f.go"))
 	require.True(t, found)
-	assert.Equal(t, "/work/outer", got.Path)
+	assert.Equal(t, outer, got.Path)
 
-	_, found = trackedRepoForPath("/elsewhere/pkg/f.go")
+	_, found = trackedRepoForPath(filepath.Join(fixtureAbs("/elsewhere"), "pkg", "f.go"))
 	assert.False(t, found, "a path outside every tracked repo owns no repo")
 }

--- a/internal/hooks/transcript_test.go
+++ b/internal/hooks/transcript_test.go
@@ -54,9 +54,15 @@ func TestCaptureModelHint_FromTranscript(t *testing.T) {
 	if err := os.WriteFile(tp, []byte(`{"type":"assistant","message":{"model":"gpt-4.1"}}`+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	// PreToolUse has no model field — it falls back to the transcript.
-	payload := `{"hook_event_name":"PreToolUse","cwd":"/work/repo","transcript_path":"` + tp + `"}`
-	captureModelHint([]byte(payload))
+	// PreToolUse has no model field — it falls back to the transcript. The
+	// payload is marshalled rather than concatenated because tp is a native
+	// path: pasting `C:\Users\…` into a JSON string literal produces invalid
+	// escapes and the whole payload fails to decode.
+	captureModelHint(mustJSON(t, map[string]any{
+		"hook_event_name": "PreToolUse",
+		"cwd":             "/work/repo",
+		"transcript_path": tp,
+	}))
 	if h, ok := modelhint.Read("/work/repo"); !ok || h.Model != "gpt-4.1" {
 		t.Fatalf("hint from transcript = %+v, ok=%v", h, ok)
 	}

--- a/internal/indexer/cpp_compile_db_test.go
+++ b/internal/indexer/cpp_compile_db_test.go
@@ -10,6 +10,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// compileDBDir renders an absolute directory the way a compile_commands.json
+// carries it: forward-separated, so the JSON body stays valid. A Windows
+// t.TempDir() is "C:\Users\...\001", and pasting those backslashes into a JSON
+// string literal makes "\U" / "\A" invalid escapes — the whole database then
+// fails to parse and every translation unit disappears. CMake and Ninja emit
+// forward slashes on Windows for the same reason, and filepath.IsAbs / Join /
+// Rel all accept that spelling.
+func compileDBDir(root string) string { return filepath.ToSlash(root) }
+
+// toolchainIncludeDir is an absolute include directory outside the repository,
+// the shape a `-isystem` flag carries. Prefixing the root's volume is what makes
+// it absolute on Windows: filepath.IsAbs("/usr/include") is false there, so the
+// bare POSIX spelling would be joined onto the build directory and land back
+// INSIDE the repo instead of being dropped. VolumeName is "" on POSIX, so the
+// spelling is unchanged there.
+func toolchainIncludeDir(root string) string {
+	return filepath.ToSlash(filepath.VolumeName(root)) + "/usr/include"
+}
+
 // writeCompileDB writes a compile_commands.json at path and registers cleanup of
 // the per-root include-dir cache so each test starts cold.
 func writeCompileDB(t *testing.T, repoRoot, path, body string) {
@@ -21,11 +40,12 @@ func writeCompileDB(t *testing.T, repoRoot, path, body string) {
 
 func TestLoadCompileCommands_CommandString(t *testing.T) {
 	root := t.TempDir()
+	dbDir := compileDBDir(root)
 	writeCompileDB(t, root, filepath.Join(root, "compile_commands.json"), `[
 	  {
-	    "directory": "`+root+`/build",
+	    "directory": "`+dbDir+`/build",
 	    "file": "../src/main.c",
-	    "command": "clang -I../gen/include -isystem /usr/include -c ../src/main.c -o main.o"
+	    "command": "clang -I../gen/include -isystem `+toolchainIncludeDir(root)+` -c ../src/main.c -o main.o"
 	  }
 	]`)
 
@@ -40,9 +60,10 @@ func TestLoadCompileCommands_CommandString(t *testing.T) {
 
 func TestLoadCompileCommands_ArgumentsArray(t *testing.T) {
 	root := t.TempDir()
+	dbDir := compileDBDir(root)
 	writeCompileDB(t, root, filepath.Join(root, "compile_commands.json"), `[
 	  {
-	    "directory": "`+root+`",
+	    "directory": "`+dbDir+`",
 	    "file": "src/main.cpp",
 	    "arguments": ["clang++", "-Igen/include", "-I", "vendor/inc", "-iquote", "local", "-c", "src/main.cpp"]
 	  }
@@ -56,10 +77,11 @@ func TestLoadCompileCommands_ArgumentsArray(t *testing.T) {
 
 func TestLoadCompileCommands_BuildDirGlob(t *testing.T) {
 	root := t.TempDir()
+	dbDir := compileDBDir(root)
 	// No root compile_commands.json — only build-debug/compile_commands.json.
 	writeCompileDB(t, root, filepath.Join(root, "build-debug", "compile_commands.json"), `[
 	  {
-	    "directory": "`+root+`/build-debug",
+	    "directory": "`+dbDir+`/build-debug",
 	    "file": "../src/app.c",
 	    "command": "cc -I../include -c ../src/app.c"
 	  }
@@ -115,6 +137,7 @@ func TestHeuristicIncludeDirs_Empty(t *testing.T) {
 func TestLoadCompileCommands_CacheAndClear(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "compile_commands.json")
+	dbDir := compileDBDir(root)
 	t.Cleanup(func() { clearCppIncludeDirCache(root) })
 
 	// write replaces the DB body while preserving its modtime, so this test
@@ -125,7 +148,7 @@ func TestLoadCompileCommands_CacheAndClear(t *testing.T) {
 		if fi, err := os.Stat(path); err == nil {
 			keep = fi.ModTime()
 		}
-		body := `[{"directory":"` + root + `","file":"src/main.c","command":"cc -I` + incDir + ` -c src/main.c"}]`
+		body := `[{"directory":"` + dbDir + `","file":"src/main.c","command":"cc -I` + incDir + ` -c src/main.c"}]`
 		require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
 		if !keep.IsZero() {
 			require.NoError(t, os.Chtimes(path, keep, keep))
@@ -154,10 +177,11 @@ func TestLoadCompileCommands_CacheAndClear(t *testing.T) {
 func TestLoadCompileCommands_MtimeReload(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "compile_commands.json")
+	dbDir := compileDBDir(root)
 	t.Cleanup(func() { clearCppIncludeDirCache(root) })
 
 	write := func(incDir string, mtime time.Time) {
-		body := `[{"directory":"` + root + `","file":"src/main.c","command":"cc -I` + incDir + ` -c src/main.c"}]`
+		body := `[{"directory":"` + dbDir + `","file":"src/main.c","command":"cc -I` + incDir + ` -c src/main.c"}]`
 		require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
 		require.NoError(t, os.Chtimes(path, mtime, mtime))
 	}

--- a/internal/indexer/deferred_enrich_scope.go
+++ b/internal/indexer/deferred_enrich_scope.go
@@ -99,7 +99,7 @@ func (idx *Indexer) semanticDependencyFrontierForDeletedFiles(relPaths []string)
 	graphPaths := make([]string, 0, len(relPaths))
 	for _, relPath := range relPaths {
 		if relPath != "" {
-			graphPaths = append(graphPaths, idx.prefixPath(filepath.FromSlash(relPath)))
+			graphPaths = append(graphPaths, idx.prefixPath(relPath))
 		}
 	}
 	graphPaths = appendUniqueSorted(nil, graphPaths...)

--- a/internal/indexer/deferred_work_test.go
+++ b/internal/indexer/deferred_work_test.go
@@ -160,9 +160,14 @@ func TestDeferredIncrementalGoFrontierUsesOneBatchAndNoRepoPass(t *testing.T) {
 			assert.Zero(t, provider.singleCalls)
 			assert.Zero(t, provider.fullCalls, "known Go files must not fall back to repo enrichment")
 			require.Len(t, provider.batches, 1)
+			// A deferred batch carries graph paths, not OS paths: the indexer
+			// keys them with pathkey.Normalize(filepath.ToSlash(rel)), so the
+			// fixture's own '/' spelling is the expectation verbatim on every
+			// platform. FromSlash here would want `pkg\a.go` on Windows and
+			// match nothing.
 			wantGraphPaths := make([]string, 0, len(tc.files))
 			for _, fixture := range tc.files {
-				wantGraphPaths = append(wantGraphPaths, filepath.FromSlash(fixture.relPath))
+				wantGraphPaths = append(wantGraphPaths, fixture.relPath)
 			}
 			assert.ElementsMatch(t, wantGraphPaths, provider.batches[0])
 			assert.False(t, idx.pendingEnrich.Load())

--- a/internal/indexer/file_delta.go
+++ b/internal/indexer/file_delta.go
@@ -104,12 +104,12 @@ func (idx *Indexer) prepareFileDeltaWithAdmission(filePath string, tryOnly bool)
 			parseLease.Release()
 		}
 	}()
-	// graphRelKey, not relKey: this path is stamped onto node IDs by the
-	// extractor below and becomes the graph key at prefixPath(). relKey
-	// slash-normalises, which on Windows mints "repo/a/b.go" while the
-	// cold walk already stored "repo/a\b.go" — a second node for the
-	// same file rather than an update of the first.
-	relPath := idx.graphRelKey(absPath)
+	// relKey: this path is stamped onto node IDs by the extractor below
+	// and becomes the graph key at prefixPath(), so it must be the same
+	// slash-separated spelling the cold walk stamped. A native-separator
+	// key would mint a second node for the same file on Windows rather
+	// than an update of the first.
+	relPath := idx.relKey(absPath)
 
 	started := time.Now()
 	src, readVersion, err := idx.readFileWithVersion(absPath)

--- a/internal/indexer/file_delta_pathkey_test.go
+++ b/internal/indexer/file_delta_pathkey_test.go
@@ -21,13 +21,11 @@ const pathKeyFixtureV2 = "package sub\n\nfunc Helper() int { return 2 }\n"
 // TestFileDeltaReusesColdWalkPathKey pins the fix for #437.
 //
 // The cold walk and the single-file delta path both stamp their relPath onto
-// node IDs. graphRelKey deliberately keeps OS-native separators so an
-// incremental lookup matches what the cold walk wrote; relKey slash-normalises
-// for the mtime map. file_delta.go handed the extractor relKey's form, so on
-// Windows the cold walk stored "sub\file.go::Helper" and the first edit moved
-// the symbol to "sub/file.go::Helper" — a different node identity for a file
-// that never moved. On a persistent store the abandoned ID stays behind with
-// whatever line numbers it last held.
+// node IDs, and both must use relKey's slash-separated spelling. When the two
+// disagreed, the cold walk stored "sub\file.go::Helper" on Windows and the
+// first edit moved the symbol to "sub/file.go::Helper" — a different node
+// identity for a file that never moved. On a persistent store the abandoned ID
+// stays behind with whatever line numbers it last held.
 //
 // On POSIX filepath.Rel already yields "/" and the two forms coincide, so this
 // is a no-op guard there and a real regression test on Windows.
@@ -61,21 +59,19 @@ func TestFileDeltaReusesColdWalkPathKey(t *testing.T) {
 			"which on a persistent store leaves the old node behind as a stale twin")
 }
 
-// TestGraphRelKeyMatchesColdWalkForm states the contract the fix relies on:
-// whatever graphRelKey returns is the form the cold walk stamps, so a delta
-// re-index keyed on it lands on the existing node.
-func TestGraphRelKeyMatchesColdWalkForm(t *testing.T) {
+// TestRelKeyMatchesColdWalkForm states the contract the fix relies on: relKey
+// returns the slash-separated form the cold walk stamps, so a delta re-index
+// keyed on it lands on the existing node. Asserting the literal is the point —
+// deriving the expectation with filepath.Rel would restate the bug on Windows.
+func TestRelKeyMatchesColdWalkForm(t *testing.T) {
 	dir := t.TempDir()
 	idx := New(graph.New(), parser.NewRegistry(), config.Default().Index, zap.NewNop())
 	idx.SetRootPath(dir)
 
 	abs := filepath.Join(dir, "sub", "file.go")
-	graphKey := idx.graphRelKey(abs)
-	coldWalkRel, err := filepath.Rel(dir, abs)
-	require.NoError(t, err)
 
-	require.Equal(t, coldWalkRel, graphKey,
-		"graphRelKey must keep the cold walk's separators, not slash-normalise them")
+	require.Equal(t, "sub/file.go", idx.relKey(abs),
+		"the graph key is slash-separated on every platform, never OS-native")
 }
 
 func helperNodeIDs(store graph.Store) []string {

--- a/internal/indexer/file_delta_read_version_test.go
+++ b/internal/indexer/file_delta_read_version_test.go
@@ -58,7 +58,7 @@ func TestPreparedMetadataRefreshDoesNotStampWriteDuringCommit(t *testing.T) {
 	require.NoError(t, os.Chtimes(path, firstMtime, firstMtime))
 	_, prepared := idx.prepareFileDelta(path)
 	require.True(t, prepared)
-	prior := base.GetFileNodes(idx.graphRelKey(path))
+	prior := base.GetFileNodes(idx.relKey(path))
 
 	type refreshResult struct {
 		applied bool
@@ -140,7 +140,7 @@ func TestIncrementalBatchDoesNotStampWriteDuringCommit(t *testing.T) {
 	require.Empty(t, versionChange)
 	require.Contains(t, reparsed, path)
 	require.Equal(t, secondMtime.UnixNano(), idx.FileMtimes()[idx.relKey(path)])
-	assertFileNodeName(t, base, idx.graphRelKey(path), "Second")
+	assertFileNodeName(t, base, idx.relKey(path), "Second")
 }
 
 func TestIncrementalManifestDoesNotStampWriteDuringCommit(t *testing.T) {

--- a/internal/indexer/file_meta.go
+++ b/internal/indexer/file_meta.go
@@ -87,7 +87,7 @@ func (idx *Indexer) indexedFileReceiptMatches(filePath string) bool {
 	if !ok {
 		return false
 	}
-	relPath := idx.graphRelKey(absPath)
+	relPath := idx.relKey(absPath)
 	graphPath := idx.prefixPath(relPath)
 	rows, err := reader.FileMetasByPaths(idx.repoPrefix, []string{graphPath})
 	if err != nil {

--- a/internal/indexer/gc_tune.go
+++ b/internal/indexer/gc_tune.go
@@ -340,12 +340,23 @@ func shouldRaiseGCPercent(calculated, installed int64) bool {
 // only the first concurrent caller mutates the runtime, and only the last
 // restore reverts it — so a sibling index can't clobber another's restore.
 func applyIndexGCTuning(logger *zap.Logger) func() {
+	return applyIndexGCTuningWithBudget(
+		logger, indexMemoryBudget(hostPhysicalMemory(), cgroupMemoryLimit()))
+}
+
+// applyIndexGCTuningWithBudget is applyIndexGCTuning with the window's memory
+// budget passed in rather than read from the host. The budget is the single
+// input that decides whether the GC-percent knob is installed at all, and
+// hostPhysicalMemory has no portable reader everywhere — it returns 0 on any
+// platform without one, which makes the knob a property of the runner rather
+// than of this code. Supplying it keeps that decision testable, the same way
+// indexMemoryBudget takes its own inputs as parameters.
+func applyIndexGCTuningWithBudget(logger *zap.Logger, budget int64) func() {
 	if !gcTuneEnabled() {
 		return func() {}
 	}
 
 	gcPct := indexGCPercent()
-	budget := indexMemoryBudget(hostPhysicalMemory(), cgroupMemoryLimit())
 
 	gcTuneMu.Lock()
 	if gcTuneDepth == 0 {

--- a/internal/indexer/gc_tune_test.go
+++ b/internal/indexer/gc_tune_test.go
@@ -2,6 +2,7 @@ package indexer
 
 import (
 	"errors"
+	"math"
 	"os"
 	"runtime"
 	"runtime/debug"
@@ -238,11 +239,19 @@ func TestApplyIndexGCTuningRestores(t *testing.T) {
 	defer debug.SetGCPercent(originalPct)
 	originalLimit := debug.SetMemoryLimit(-1)
 	defer debug.SetMemoryLimit(originalLimit)
+	// Pin both inputs the GC-percent knob keys on instead of inheriting them
+	// from the host: an unbounded standing limit, and a budget the window can
+	// own. Reading the budget from the machine makes the assertion below a
+	// property of the runner — a host with no physical-memory reader (Windows)
+	// derives no budget at all, and the knob is then never installed.
+	standingLimit := int64(math.MaxInt64)
+	debug.SetMemoryLimit(standingLimit)
+	const windowBudget = int64(2) << 30
 
 	t.Setenv("GORTEX_INDEX_GC_TUNE", "1")
 	t.Setenv("GORTEX_INDEX_GC_PERCENT", "275")
 
-	restore := applyIndexGCTuning(nil)
+	restore := applyIndexGCTuningWithBudget(nil, windowBudget)
 
 	// While tuned, the GC percent must be the configured value, not the prior.
 	if cur := debug.SetGCPercent(275); cur != 275 {
@@ -262,9 +271,9 @@ func TestApplyIndexGCTuningRestores(t *testing.T) {
 	}
 	debug.SetGCPercent(priorPct)
 
-	// And the memory limit is back to its captured prior.
-	if cur := debug.SetMemoryLimit(-1); cur != originalLimit {
-		t.Fatalf("expected memory limit restored to %d, got %d", originalLimit, cur)
+	// And the memory limit is back to the standing limit the window captured.
+	if cur := debug.SetMemoryLimit(-1); cur != standingLimit {
+		t.Fatalf("expected memory limit restored to %d, got %d", standingLimit, cur)
 	}
 }
 

--- a/internal/indexer/incremental_batch.go
+++ b/internal/indexer/incremental_batch.go
@@ -170,7 +170,7 @@ func (idx *Indexer) reindexIncrementalChunk(
 
 	graphPaths := make([]string, len(files))
 	for i, filePath := range files {
-		graphPaths[i] = idx.prefixPath(idx.graphRelKey(filePath))
+		graphPaths[i] = idx.prefixPath(idx.relKey(filePath))
 	}
 	priorByFile := idx.graph.GetFileNodesByPaths(graphPaths)
 
@@ -1471,7 +1471,7 @@ func (idx *Indexer) evictFileIncrementalRaw(relPath string) forcedFileEviction {
 	dependencyFiles := idx.semanticDependencyFrontierForDeletedFiles([]string{relPath})
 	var invalidation DerivedInvalidationPlan
 	nodesRemoved, edgesRemoved := idx.evictDeletedFilesBatched([]string{relPath}, &invalidation)
-	graphPath := idx.prefixPath(filepath.FromSlash(relPath))
+	graphPath := idx.prefixPath(relPath)
 	idx.removeIncrementalContractsForFile(graphPath, &invalidation)
 	invalidation.Files = appendUniqueSorted(invalidation.Files, dependencyFiles...)
 
@@ -1529,7 +1529,7 @@ func (idx *Indexer) evictDeletedFilesBatched(deleted []string, plan *DerivedInva
 		relPaths := deleted[start:end]
 		graphPaths := make([]string, len(relPaths))
 		for i, relPath := range relPaths {
-			graphPaths[i] = idx.prefixPath(filepath.FromSlash(relPath))
+			graphPaths[i] = idx.prefixPath(relPath)
 		}
 		nodesByFile := idx.graph.GetFileNodesByPaths(graphPaths)
 		stages := make([]*incrementalBatchStage, 0, len(graphPaths))

--- a/internal/indexer/incremental_batch_test.go
+++ b/internal/indexer/incremental_batch_test.go
@@ -316,10 +316,11 @@ func TestIncrementalMultiFileBatchKeepsFailedFileAndCommitsSiblings(t *testing.T
 	oldBadMtime := idx.FileMtimes()[idx.relKey(bad)]
 
 	bumpMtime(t, good, "package isolation\n\nfunc Good() {}\nfunc GoodCommitted() {}\n")
-	require.NoError(t, os.Chmod(bad, 0o000))
-	t.Cleanup(func() { _ = os.Chmod(bad, 0o644) })
+	// Stale first, unreadable second: denyFileRead may hold the file open
+	// exclusively, and Chtimes needs its own write handle.
 	future := time.Now().Add(4 * time.Second)
 	require.NoError(t, os.Chtimes(bad, future, future))
+	allowBadRead := denyFileRead(t, bad)
 
 	result, err := idx.IncrementalReindexPaths(dir, []string{good, bad})
 	require.NoError(t, err)
@@ -331,7 +332,7 @@ func TestIncrementalMultiFileBatchKeepsFailedFileAndCommitsSiblings(t *testing.T
 	require.Equal(t, oldBadMtime, idx.FileMtimes()[idx.relKey(bad)],
 		"failed file must not advance its durable retry watermark")
 
-	require.NoError(t, os.Chmod(bad, 0o644))
+	allowBadRead()
 	recovered, err := idx.IncrementalReindexPaths(dir, []string{bad})
 	require.NoError(t, err)
 	require.Empty(t, recovered.FailedFiles)

--- a/internal/indexer/incremental_contracts.go
+++ b/internal/indexer/incremental_contracts.go
@@ -129,7 +129,7 @@ func (idx *Indexer) refreshIncrementalContractManifests(files []string) (Derived
 	receipts := make([]fileReadReceipt, 0, len(files))
 	failed := make([]string, 0)
 	for _, absPath := range files {
-		relPath := idx.graphRelKey(absPath)
+		relPath := idx.relKey(absPath)
 		graphPath := idx.prefixPath(relPath)
 		src, readVersion, err := idx.readFileWithVersion(absPath)
 		if err != nil || !readVersion.valid {

--- a/internal/indexer/incremental_reindex_test.go
+++ b/internal/indexer/incremental_reindex_test.go
@@ -184,12 +184,12 @@ func TestIncrementalReindex_FailedFileSurfacedAndRetried(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, g.FindNodesByName("Bad"))
 
-	// Make bad.go unreadable and stale: the incremental pass discovers
-	// it (stat works) but fails to read its content.
-	require.NoError(t, os.Chmod(bad, 0o000))
-	t.Cleanup(func() { _ = os.Chmod(bad, 0o644) })
+	// Make bad.go stale and unreadable: the incremental pass discovers it
+	// (stat works) but fails to read its content. Stale first — denyFileRead
+	// may hold the file open exclusively, and Chtimes needs a write handle.
 	future := time.Now().Add(2 * time.Second)
 	require.NoError(t, os.Chtimes(bad, future, future))
+	allowBadRead := denyFileRead(t, bad)
 
 	res, err := idx.IncrementalReindexPaths(dir, nil)
 	require.NoError(t, err)
@@ -198,7 +198,7 @@ func TestIncrementalReindex_FailedFileSurfacedAndRetried(t *testing.T) {
 
 	// Readable again: the file is still stale (its failed pass never
 	// recorded an mtime), so the next incremental pass recovers it.
-	require.NoError(t, os.Chmod(bad, 0o644))
+	allowBadRead()
 	res2, err := idx.IncrementalReindexPaths(dir, nil)
 	require.NoError(t, err)
 	assert.Empty(t, res2.FailedFiles, "the file indexes cleanly once readable")

--- a/internal/indexer/incremental_watcher_batch.go
+++ b/internal/indexer/incremental_watcher_batch.go
@@ -2,7 +2,6 @@ package indexer
 
 import (
 	"fmt"
-	"path/filepath"
 	"sort"
 	"strings"
 
@@ -246,7 +245,7 @@ func (idx *Indexer) incrementalEvictWatcherPath(path string) (nodesRemoved, edge
 	// Captured BEFORE eviction: deleting a global-usings file (or a
 	// csproj, which draws the unit boundaries) removes visibility every
 	// dependent's extension bind was narrowed under.
-	graphPath := idx.prefixPath(filepath.FromSlash(path))
+	graphPath := idx.prefixPath(path)
 	evictedGlobals := csharpVisibilityStampForNodes(idx.graph.GetFileNodes(graphPath)).globals != "" ||
 		strings.HasSuffix(strings.ToLower(graphPath), ".csproj")
 

--- a/internal/indexer/index_file_read_version_test.go
+++ b/internal/indexer/index_file_read_version_test.go
@@ -70,12 +70,12 @@ func TestIndexFileDoesNotStampWriteThatLandsDuringParse(t *testing.T) {
 
 	key := idx.relKey(path)
 	require.NotEqual(t, secondMtime.UnixNano(), idx.FileMtimes()[key])
-	require.Equal(t, []string{"First"}, watcherSymbolNames(g.GetFileNodes(idx.graphRelKey(path))))
+	require.Equal(t, []string{"First"}, watcherSymbolNames(g.GetFileNodes(idx.relKey(path))))
 
 	registry.Register(goExtractor)
 	require.NoError(t, idx.IndexFile(path))
 	require.Equal(t, secondMtime.UnixNano(), idx.FileMtimes()[key])
-	require.Equal(t, []string{"Second"}, watcherSymbolNames(g.GetFileNodes(idx.graphRelKey(path))))
+	require.Equal(t, []string{"Second"}, watcherSymbolNames(g.GetFileNodes(idx.relKey(path))))
 }
 
 func TestIndexFileSyntheticSkipsStampAcceptedReadVersion(t *testing.T) {

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -1414,6 +1415,15 @@ func (idx *Indexer) ResolveFilePath(graphPath string) string {
 // repo-relative key the graph and the mtime map are indexed by: forward
 // slashes, and Unicode NFC.
 //
+// One key, every platform. A graph key — a file node's FilePath, the
+// prefix of every symbol ID under it, a contract bridge endpoint — is
+// slash-separated by contract, so the bulk walk, the single-file delta
+// and the watcher all stamp the same spelling. Keying the cold walk in
+// OS-native separators instead would mint "pkg\sub\thing.go" on Windows
+// and split every downstream lookup (GetFileNodes / EvictFile match the
+// exact string, with no separator folding) from the ID a caller builds
+// with '/'.
+//
 // The NFC fold is load-bearing. A file with a non-ASCII name is handed
 // to the indexer in different byte forms depending on the source — the
 // filesystem walk (filepath.WalkDir) yields decomposed NFD on macOS,
@@ -1434,27 +1444,6 @@ func (idx *Indexer) relKey(absPath string) string {
 		return pathkey.Normalize(filepath.ToSlash(absPath))
 	}
 	return pathkey.Normalize(filepath.ToSlash(rel))
-}
-
-// graphRelKey reduces an absolute path to the key the GRAPH stores a
-// file's nodes under: repo-relative, OS-native separators (the exact
-// form the bulk-walk extractor stamps on node IDs / FilePaths),
-// NFC-folded. It is the graph-node analogue of relKey — relKey
-// slash-normalises for the mtime map, graphRelKey keeps the OS-native
-// separators so an incremental re-index's evict lookup actually matches
-// the nodes the cold walk created (graph.GetFileNodes / EvictFile key on
-// the exact string, with no separator folding). On POSIX the two are
-// identical (filepath.Rel already yields '/'); they diverge only on
-// Windows, where relKey's ToSlash would key the lookup as
-// "repo/a/b.go" while the cold walk stored "repo/a\b.go" — the miss
-// leaves the stale nodes un-evicted and the re-parse leaks a duplicate
-// set on every save (issue: slash-path duplicate indexing).
-func (idx *Indexer) graphRelKey(absPath string) string {
-	rel, err := filepath.Rel(idx.rootPath, absPath)
-	if err != nil {
-		return pathkey.Normalize(absPath)
-	}
-	return pathkey.Normalize(rel)
 }
 
 // RelKey exposes relKey to in-package collaborators (the watcher) that
@@ -1565,7 +1554,7 @@ func (idx *Indexer) graphFilePaths(files []string) []string {
 		if !filepath.IsAbs(abs) && idx.rootPath != "" {
 			abs = filepath.Join(idx.rootPath, f)
 		}
-		out = append(out, idx.prefixPath(idx.graphRelKey(abs)))
+		out = append(out, idx.prefixPath(idx.relKey(abs)))
 	}
 	return out
 }
@@ -2439,17 +2428,17 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 	admitWalkedFile := func(wf walkedFile) {
 		if reason, skip := untrackedGate.skip(wf.lang, wf.path); skip {
 			skippedContentBytes += wf.size
-			rel, _ := filepath.Rel(absRoot, wf.path)
+			relPath := idx.relKey(wf.path)
 			skippedByContent = append(skippedByContent, skippedFile{
-				relPath: pathkey.Normalize(rel), lang: wf.lang, size: wf.size, reason: reason,
+				relPath: relPath, lang: wf.lang, size: wf.size, reason: reason,
 			})
 			return
 		}
 		if reason, skip := contentGate.skip(wf.lang, wf.size); skip {
 			skippedContentBytes += wf.size
-			rel, _ := filepath.Rel(absRoot, wf.path)
+			relPath := idx.relKey(wf.path)
 			skippedByContent = append(skippedByContent, skippedFile{
-				relPath: pathkey.Normalize(rel), lang: wf.lang, size: wf.size, reason: reason,
+				relPath: relPath, lang: wf.lang, size: wf.size, reason: reason,
 			})
 			return
 		}
@@ -2467,9 +2456,8 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 			if adm.oversize {
 				skippedLarge++
 				skippedBytes += wf.size
-				rel, _ := filepath.Rel(absRoot, wf.path)
 				skippedBySize = append(skippedBySize, skippedFile{
-					relPath: pathkey.Normalize(rel), lang: wf.lang, size: wf.size,
+					relPath: idx.relKey(wf.path), lang: wf.lang, size: wf.size,
 				})
 				return nil
 			}
@@ -2502,9 +2490,8 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 			if adm.oversize {
 				skippedLarge++
 				skippedBytes += info.Size()
-				rel, _ := filepath.Rel(absRoot, path)
 				skippedBySize = append(skippedBySize, skippedFile{
-					relPath: pathkey.Normalize(rel), lang: adm.lang, size: info.Size(),
+					relPath: idx.relKey(path), lang: adm.lang, size: info.Size(),
 				})
 				return nil
 			}
@@ -3305,7 +3292,13 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 						atomic.AddInt64(&parseSemWaitNS, int64(time.Since(semStart)))
 					}
 
-					relPath, _ := filepath.Rel(absRoot, path)
+					// relKey, not a raw filepath.Rel: this path is stamped onto
+					// every node ID and FilePath the extractor emits, and a graph
+					// key is slash-separated and NFC-folded on every platform.
+					// A native filepath.Rel would mint "pkg\sub\thing.go" on
+					// Windows, which no slash-keyed lookup — the watcher's evict,
+					// a symbol ID, a contract bridge — can ever match.
+					relPath := idx.relKey(path)
 					// Streaming content extractors (PDF / office docs) read the
 					// file themselves — one page/slide/sheet at a time — instead
 					// of materialising the whole file. Only the in-process route
@@ -4301,19 +4294,14 @@ func (idx *Indexer) indexFile(
 		return err
 	}
 
-	// Two keys for the same file, deliberately distinct on Windows.
-	// mtimeKey (relKey: slash form + NFC) is the fileMtimes map key.
-	// relPath (graphRelKey: OS-native separators + NFC) is what the
-	// graph stores a file's nodes under — the exact form the cold bulk
-	// walk stamped on their IDs / FilePaths. The evict below MUST use
-	// the graph form: a slash-keyed lookup misses the backslash-keyed
-	// cold nodes on Windows, so the re-parse would leak a duplicate node
-	// set on every save. On POSIX the two keys are identical
-	// (filepath.Rel already yields '/'), so this split is a Windows-only
-	// correction. Both drive an FSEvents-NFD / git-watcher-NFC path onto
-	// the same NFC key so a re-index still lands on the bulk-walk key.
-	mtimeKey := idx.relKey(absPath)
-	relPath := idx.graphRelKey(absPath)
+	// One key for the file: the slash-separated, NFC-folded spelling the
+	// cold bulk walk stamped on its nodes' IDs / FilePaths and recorded in
+	// fileMtimes. The evict below matches the graph string byte-for-byte,
+	// so a divergent spelling would leave the cold nodes un-evicted and
+	// leak a duplicate node set on every save. The NFC fold drives an
+	// FSEvents-NFD / git-watcher-NFC path onto the bulk-walk key.
+	relPath := idx.relKey(absPath)
+	mtimeKey := relPath
 
 	// In multi-repo mode, the graph stores prefixed file paths.
 	graphPath := idx.prefixPath(relPath)
@@ -4826,10 +4814,9 @@ func (idx *Indexer) StructuralSymbols(filePath string) ([]*graph.Node, bool) {
 	if err != nil {
 		return nil, false
 	}
-	relPath, err := filepath.Rel(idx.rootPath, absPath)
-	if err != nil {
-		relPath = filePath
-	}
+	// relKey: the probe compares its symbols against the graph's, so it
+	// must parse under the same slash-separated key the index pass stamps.
+	relPath := idx.relKey(absPath)
 
 	src, err := os.ReadFile(absPath)
 	if err != nil {
@@ -5016,10 +5003,10 @@ func (idx *Indexer) reresolveFileScopedRaw(filePath string) error {
 	if !filepath.IsAbs(absPath) {
 		absPath = filepath.Join(idx.rootPath, filePath)
 	}
-	// graphRelKey (OS-native + NFC): the graph keys nodes under OS-native
-	// separators, so a relKey slash-form graphPath would miss them on
-	// Windows and wrongly report the file as evicted.
-	graphPath := idx.prefixPath(idx.graphRelKey(absPath))
+	// relKey (slash + NFC) is the spelling the graph keys nodes under, so
+	// an empty node set here really means the file is gone rather than
+	// keyed under a form this lookup cannot see.
+	graphPath := idx.prefixPath(idx.relKey(absPath))
 	if len(idx.graph.GetFileNodes(graphPath)) == 0 {
 		return nil // file gone / evicted; nothing to re-resolve
 	}
@@ -5909,7 +5896,7 @@ func (idx *Indexer) indexedFilesAbsentFromDisk(diskFiles map[string]bool) []stri
 	return out
 }
 
-// graphPathRelKey inverts prefixPath∘graphRelKey: it maps a graph file path
+// graphPathRelKey inverts prefixPath∘relKey: it maps a graph file path
 // back to the canonical repo-relative key fileMtimes and the disk walk share.
 // owned is false when the path does not belong to this repo, which is the only
 // safe answer — a path under another prefix must never be resolved against
@@ -5926,14 +5913,14 @@ func (idx *Indexer) graphPathRelKey(graphPath string) (relPath string, owned boo
 	if rel == "" {
 		return "", false
 	}
-	// relKey slash-normalises; graphRelKey keeps OS-native separators. Fold
-	// back to the slash form so the key matches diskFiles and fileMtimes on
-	// Windows too.
+	// Fold the same way relKey does, so a stored path that predates the
+	// slash contract (or arrives through another spelling) still matches
+	// diskFiles and fileMtimes.
 	return pathkey.Normalize(filepath.ToSlash(rel)), true
 }
 
 func (idx *Indexer) incrementalPathOwned(absPath string) bool {
-	graphPath := idx.prefixPath(idx.graphRelKey(absPath))
+	graphPath := idx.prefixPath(idx.relKey(absPath))
 	if len(idx.graph.GetFileNodes(graphPath)) > 0 {
 		return true
 	}
@@ -6186,7 +6173,7 @@ func (idx *Indexer) incrementalReindexPathsMode(
 	if len(deletedFiles) > 0 {
 		graphPaths := make([]string, len(deletedFiles))
 		for i, relPath := range deletedFiles {
-			graphPaths[i] = idx.prefixPath(filepath.FromSlash(relPath))
+			graphPaths[i] = idx.prefixPath(relPath)
 		}
 		nodesByFile := idx.graph.GetFileNodesByPaths(graphPaths)
 		for _, graphPath := range graphPaths {
@@ -6825,12 +6812,16 @@ func (idx *Indexer) resolveProviderHandlers(reg *contracts.Registry) {
 		if src, _ := c.Meta["schema_source"].(string); src == "extracted" || src == "partial" {
 			continue
 		}
+		// srcDir goes through path.Dir, not filepath.Dir: c.FilePath is a
+		// graph path, slash-separated on every platform, and filepath.Dir
+		// would hand back "pkg\sub" on Windows for a directory the
+		// candidate filter then compares against slash spellings.
 		todo = append(todo, pending{
 			contractID: c.ID,
 			trail:      trail,
 			fallback:   fallback,
 			repoHint:   c.RepoPrefix,
-			srcDir:     filepath.Dir(c.FilePath),
+			srcDir:     path.Dir(c.FilePath),
 		})
 	}
 	// Always strip the internal handler hints from Meta at the end of
@@ -7100,7 +7091,7 @@ func pickHandlerCandidate(candidates []*graph.Node, repoHint, srcDir string) *gr
 		}
 		var samePkg []*graph.Node
 		for _, n := range pool {
-			if filepath.Dir(n.FilePath) == srcDir {
+			if path.Dir(n.FilePath) == srcDir {
 				samePkg = append(samePkg, n)
 			}
 		}

--- a/internal/indexer/parse_tree_release_test.go
+++ b/internal/indexer/parse_tree_release_test.go
@@ -161,7 +161,7 @@ func TestApplyPreparedMetadataRefreshReleasesParseTree(t *testing.T) {
 	require.True(t, ok)
 	tree := preparedTree(t, idx, path)
 
-	prior := idx.graph.GetFileNodes(idx.graphRelKey(path))
+	prior := idx.graph.GetFileNodes(idx.relKey(path))
 	idx.applyPreparedMetadataRefresh(path, prior)
 	require.Nil(t, tree.Tree(), "the metadata refresh must release the tree it took")
 }

--- a/internal/indexer/poller.go
+++ b/internal/indexer/poller.go
@@ -797,7 +797,7 @@ func (p *Poller) contentReceiptMatches(
 	if err != nil || !sameFileVersion(before, after) {
 		return false, false, bytesRead
 	}
-	relPath := idx.graphRelKey(absPath)
+	relPath := idx.relKey(absPath)
 	src = idx.transforms.run(relPath, src)
 	return int64(len(src)) == receipt.Size && contentHashForSource(src) == receipt.ContentHash,
 		true, bytesRead

--- a/internal/indexer/realtime_reliability_test.go
+++ b/internal/indexer/realtime_reliability_test.go
@@ -469,11 +469,11 @@ func TestWatcher_NewSubdirScanIndexesPreWatchFile(t *testing.T) {
 	require.NoError(t, os.MkdirAll(subdir, 0o755))
 	ext.setFuncs("Buried")
 	writeFile(t, filepath.Join(subdir, "buried.fk"), "buried body")
-	// The graph keys file nodes under OS-native separators (see
-	// graphRelKey), so build the expected key with filepath.Join instead
-	// of a hard-coded "pkg/buried.fk" — the slash form only matches on
-	// POSIX and would spuriously fail this test on Windows.
-	buriedKey := filepath.Join("pkg", "buried.fk")
+	// The graph keys file nodes under the slash-separated repo-relative
+	// spelling relKey mints, on every platform — never filepath.Join's
+	// native form, which would key this file as "pkg\buried.fk" on
+	// Windows and hide it from every other lookup.
+	const buriedKey = "pkg/buried.fk"
 	require.Empty(t, g.GetFileNodes(buriedKey),
 		"the pre-watch file must be absent before the directory scan")
 

--- a/internal/indexer/repository_mutation_paths_test.go
+++ b/internal/indexer/repository_mutation_paths_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -57,7 +58,16 @@ func TestCanonicalRepositoryMutationPathsValidation(t *testing.T) {
 
 	t.Run("invalid stat is rejected", func(t *testing.T) {
 		_, err := canonicalRepositoryMutationPaths(root, []string{"bad\x00.go"})
-		require.ErrorContains(t, err, "repository mutation stat")
+		// A NUL byte is rejected at a different stage per platform, and both
+		// stages are the caller-local refusal this pins. POSIX absolutises the
+		// path by string manipulation alone and only the stat syscall refuses
+		// it; Windows resolves through syscall.FullPath inside filepath.Abs,
+		// which rejects the NUL one step earlier.
+		want := "repository mutation stat"
+		if runtime.GOOS == "windows" {
+			want = "repository mutation path"
+		}
+		require.ErrorContains(t, err, want)
 	})
 }
 

--- a/internal/indexer/slash_path_test.go
+++ b/internal/indexer/slash_path_test.go
@@ -14,13 +14,13 @@ import (
 // TestIncrementalReindex_NestedFileNoDuplicate guards the
 // slash-path duplicate indexing regression on Windows.
 //
-// The cold bulk walk keys a nested file's graph nodes under OS-native
-// separators — "myrepo/pkg\sub\thing.go" on Windows. The incremental
-// re-index must evict via the SAME OS-native key (graphRelKey), not the
-// relKey slash form; otherwise graph.GetFileNodes / EvictFile (which
-// match the key byte-for-byte, with no separator folding) miss the cold
-// nodes, the stale set survives, and the re-parse appends a second,
-// forward-slash-keyed copy — a duplicate that grows on every save.
+// The cold bulk walk and the incremental re-index must key a nested
+// file's graph nodes under the SAME spelling — relKey's
+// "myrepo/pkg/sub/thing.go" — because graph.GetFileNodes / EvictFile
+// match the key byte-for-byte, with no separator folding. When the two
+// disagreed on Windows the evict missed the cold nodes, the stale set
+// survived, and the re-parse appended a second copy under the other
+// separator — a duplicate that grew on every save.
 //
 // On POSIX filepath.Rel already yields '/', so the two key forms
 // coincide and this is a Windows-only correction; the assertions below
@@ -61,7 +61,7 @@ func TestIncrementalReindex_NestedFileNoDuplicate(t *testing.T) {
 
 	// And the whole file's node set must be reachable under that one key
 	// — never split across a slash and a backslash spelling.
-	nodesUnderColdKey := g.GetFileNodes(idx.prefixPath(idx.graphRelKey(nested)))
+	nodesUnderColdKey := g.GetFileNodes(idx.prefixPath(idx.relKey(nested)))
 	assert.NotEmpty(t, nodesUnderColdKey,
 		"the file's nodes must be retrievable under the graph key form")
 }

--- a/internal/indexer/spring_datasource_test.go
+++ b/internal/indexer/spring_datasource_test.go
@@ -14,6 +14,13 @@ import (
 	"github.com/zzet/gortex/internal/parser/languages"
 )
 
+// springJavaGraphPath is the graph path of the fixture's Java file. The
+// indexer keys graph paths — and therefore the symbol IDs built from them —
+// with pathkey.Normalize(filepath.ToSlash(rel)), so a node ID carries forward
+// slashes on every platform. filepath.Join here would spell `src\main\...`
+// on Windows and match no node.
+const springJavaGraphPath = "src/main/java/com/example/JdbcConfig.java"
+
 func TestIndex_SpringDatasourceConditionalOnPropertyReadsConfig(t *testing.T) {
 	dir := t.TempDir()
 	javaDir := filepath.Join(dir, "src", "main", "java", "com", "example")
@@ -46,7 +53,7 @@ spring:
 	_, err := idx.Index(dir)
 	require.NoError(t, err)
 
-	javaGraphPath := filepath.Join("src", "main", "java", "com", "example", "JdbcConfig.java")
+	javaGraphPath := springJavaGraphPath
 	cfgID := javaGraphPath + "::JdbcConfig"
 	keyID := "cfg::spring::spring.datasource.url"
 	if g.GetNode(keyID) == nil {
@@ -90,7 +97,7 @@ public class JdbcConfig {
 	_, err := idx.Index(dir)
 	require.NoError(t, err)
 
-	javaGraphPath := filepath.Join("src", "main", "java", "com", "example", "JdbcConfig.java")
+	javaGraphPath := springJavaGraphPath
 	classID := javaGraphPath + "::JdbcConfig"
 	dataSourceID := classID + ".dataSource"
 	if !hasEdge(g, classID, dataSourceID, graph.EdgeCalls) {
@@ -130,7 +137,7 @@ public class JdbcConfig {
 	_, err := idx.Index(dir)
 	require.NoError(t, err)
 
-	javaGraphPath := filepath.Join("src", "main", "java", "com", "example", "JdbcConfig.java")
+	javaGraphPath := springJavaGraphPath
 	classID := javaGraphPath + "::JdbcConfig"
 	dataSourceID := classID + ".dataSource"
 	if hasEdge(g, classID, dataSourceID, graph.EdgeCalls) {

--- a/internal/indexer/startup_marker_block_test.go
+++ b/internal/indexer/startup_marker_block_test.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package indexer
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// blockStartupMarkerCreation makes the startup-marker create inside dir fail,
+// and returns the initialReplayMarkerCreating seam a caller must install on the
+// watcher (composing it with any seam of its own).
+//
+// POSIX denies it the direct way: a 0555 directory refuses new entries, so the
+// marker's O_CREATE fails with EACCES before the seam matters. The returned
+// seam therefore does nothing here.
+func blockStartupMarkerCreation(t *testing.T, dir string) func(string) {
+	t.Helper()
+	require.NoError(t, os.Chmod(dir, 0o555))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+	return func(string) {}
+}

--- a/internal/indexer/startup_marker_block_windows_test.go
+++ b/internal/indexer/startup_marker_block_windows_test.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package indexer
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// blockStartupMarkerCreation makes the startup-marker create inside dir fail,
+// and returns the initialReplayMarkerCreating seam a caller must install on the
+// watcher (composing it with any seam of its own).
+//
+// Windows has no directory write permission bit to take away: os.Chmod only
+// toggles the read-only attribute, which does not stop a file being created in
+// the directory, so the POSIX 0555 route would silently let the marker through
+// and turn a fail-closed assertion into a false pass. The portable equivalent
+// claims the marker's own path with a directory, so the O_EXCL create fails
+// with ErrExist — a different errno reaching the same branch: not ErrPermission
+// and not EROFS, therefore fail-closed rather than a degraded barrier.
+func blockStartupMarkerCreation(t *testing.T, dir string) func(string) {
+	t.Helper()
+	_ = dir
+	return func(marker string) {
+		require.NoError(t, os.Mkdir(marker, 0o755))
+		t.Cleanup(func() { _ = os.Remove(marker) })
+	}
+}

--- a/internal/indexer/unreadable_file_test.go
+++ b/internal/indexer/unreadable_file_test.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+package indexer
+
+import (
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// denyFileRead makes path unreadable for the rest of the test and returns a
+// closure that restores it; the restore also runs from t.Cleanup, so a test
+// that fails before calling it still leaves the file removable.
+//
+// POSIX takes the direct route: mode 0000 denies read to a non-root owner.
+// Callers must still stat the file afterwards, so this only removes the read.
+func denyFileRead(t *testing.T, path string) func() {
+	t.Helper()
+	require.NoError(t, os.Chmod(path, 0o000))
+	var once sync.Once
+	restore := func() { once.Do(func() { _ = os.Chmod(path, 0o644) }) }
+	t.Cleanup(restore)
+	return restore
+}

--- a/internal/indexer/unreadable_file_windows_test.go
+++ b/internal/indexer/unreadable_file_windows_test.go
@@ -1,0 +1,38 @@
+//go:build windows
+
+package indexer
+
+import (
+	"sync"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// denyFileRead makes path unreadable for the rest of the test and returns a
+// closure that restores it; the restore also runs from t.Cleanup, so a test
+// that fails before calling it still leaves the file deletable — an open
+// handle would otherwise fail t.TempDir's RemoveAll.
+//
+// Windows has no read permission bit: os.Chmod only toggles the read-only
+// attribute, and a read-only file still reads fine, so mode 0000 would leave
+// the indexer perfectly able to parse the file. The portable equivalent is an
+// exclusive handle — dwShareMode 0 lets no other opener read, write or delete
+// the file — which turns the indexer's os.ReadFile into a sharing violation
+// while os.Stat (attribute-only, no handle) keeps succeeding. That is exactly
+// the shape the failure path needs: the file is discovered, then fails to read.
+func denyFileRead(t *testing.T, path string) func() {
+	t.Helper()
+	name, err := syscall.UTF16PtrFromString(path)
+	require.NoError(t, err)
+	handle, err := syscall.CreateFile(
+		name, syscall.GENERIC_READ, 0, nil,
+		syscall.OPEN_EXISTING, syscall.FILE_ATTRIBUTE_NORMAL, 0,
+	)
+	require.NoError(t, err)
+	var once sync.Once
+	restore := func() { once.Do(func() { _ = syscall.CloseHandle(handle) }) }
+	t.Cleanup(restore)
+	return restore
+}

--- a/internal/indexer/watcher.go
+++ b/internal/indexer/watcher.go
@@ -1051,7 +1051,7 @@ func (w *Watcher) matchingInitialReplayReceipts(
 		if _, supported := w.indexer.effectiveLanguage(path, nil); !supported {
 			continue
 		}
-		relPath := w.indexer.graphRelKey(path)
+		relPath := w.indexer.relKey(path)
 		candidates = append(candidates, initialReplayReceiptCandidate{
 			path:      path,
 			relPath:   relPath,
@@ -2436,7 +2436,7 @@ func (w *Watcher) patchGraphWithReceiptStateRawModern(
 		return nil
 	}
 
-	relPath := idx.graphRelKey(path)
+	relPath := idx.relKey(path)
 	callbackPath := idx.RelKey(path)
 	graphKey := idx.prefixPath(relPath)
 	priorNodes := idx.graph.GetFileNodes(graphKey)

--- a/internal/indexer/watcher_point_pipeline_test.go
+++ b/internal/indexer/watcher_point_pipeline_test.go
@@ -39,7 +39,7 @@ func TestWatcherPointPipelineForcesReceiptCheckedEqualMtime(t *testing.T) {
 func TestWatcherPointPipelineDeletesOwnedFileWithoutMtime(t *testing.T) {
 	dir, idx, watcher := inertTestWatcher(t, "main.go", "package main\n\nfunc Value() int { return 0 }\n")
 	path := filepath.Join(dir, "main.go")
-	graphPath := idx.prefixPath(idx.graphRelKey(path))
+	graphPath := idx.prefixPath(idx.relKey(path))
 	require.NotEmpty(t, idx.graph.GetFileNodes(graphPath))
 
 	idx.mtimeMu.Lock()

--- a/internal/indexer/watcher_start_barrier_filter_test.go
+++ b/internal/indexer/watcher_start_barrier_filter_test.go
@@ -164,8 +164,7 @@ func TestStartupBarrierMarkerCreationStaysFailClosed(t *testing.T) {
 	w, err := NewWatcher(idx, config.WatchConfig{DebounceMs: 1}, zap.NewNop())
 	require.NoError(t, err)
 	w.fsw = newStartupBarrierFakeWatcher()
-	require.NoError(t, os.Chmod(dir, 0o555))
-	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+	w.initialReplayMarkerCreating = blockStartupMarkerCreation(t, dir)
 
 	err = w.reconcileInitialReplayThroughMarkers([]string{dir}, time.Second)
 	require.Error(t, err)

--- a/internal/indexer/watcher_start_barrier_test.go
+++ b/internal/indexer/watcher_start_barrier_test.go
@@ -212,8 +212,7 @@ func TestWatcherInitialReplayMarkerPermissionFailureIsFailClosed(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "main.go")
 	writeTestFile(t, path, "package sample\n\nfunc Original() {}\n")
-	require.NoError(t, os.Chmod(dir, 0o555))
-	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+	blockMarker := blockStartupMarkerCreation(t, dir)
 
 	idx := New(graph.New(), parser.NewRegistry(), config.Default().Index, zap.NewNop())
 	idx.SetRootPath(dir)
@@ -221,12 +220,13 @@ func TestWatcherInitialReplayMarkerPermissionFailureIsFailClosed(t *testing.T) {
 	require.NoError(t, err)
 	w.fsw = newStartupBarrierFakeWatcher()
 	writeSucceeded := false
-	w.initialReplayMarkerCreating = func(string) {
-		// Directory mode forbids creating the marker, but the existing 0644
-		// source remains writable. Silently skipping the barrier would lose this
-		// exact concurrent edit.
+	w.initialReplayMarkerCreating = func(marker string) {
+		// The marker cannot be created, but the existing 0644 source remains
+		// writable. Silently skipping the barrier would lose this exact
+		// concurrent edit.
 		require.NoError(t, os.WriteFile(path, []byte("package sample\n\nfunc ChangedDuringMarker() {}\n"), 0o644))
 		writeSucceeded = true
+		blockMarker(marker)
 	}
 
 	err = w.reconcileInitialReplayThroughMarkers([]string{dir}, time.Second)

--- a/internal/indexer/watcher_storm_batch_test.go
+++ b/internal/indexer/watcher_storm_batch_test.go
@@ -347,10 +347,11 @@ func TestWatcherStormBatchDeletionFailureIsolationAndOneResolve(t *testing.T) {
 
 	bumpMtime(t, good, "package storm\n\nfunc Good() {}\nfunc GoodCommitted() { MissingTarget() }\n")
 	require.NoError(t, os.Remove(deleted))
-	require.NoError(t, os.Chmod(bad, 0o000))
-	t.Cleanup(func() { _ = os.Chmod(bad, 0o644) })
+	// Stale first, unreadable second: denyFileRead may hold the file open
+	// exclusively, and Chtimes needs its own write handle.
 	future := time.Now().Add(4 * time.Second)
 	require.NoError(t, os.Chtimes(bad, future, future))
+	denyFileRead(t, bad)
 
 	resolveCalls := 0
 	var resolvedFiles []string

--- a/internal/llm/provider/claudecli/claudecli_test.go
+++ b/internal/llm/provider/claudecli/claudecli_test.go
@@ -1,11 +1,15 @@
 package claudecli
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -13,63 +17,110 @@ import (
 	"github.com/zzet/gortex/internal/llm"
 )
 
-// fakeClaude writes a tiny shell script that impersonates the
-// `claude` CLI: it echoes the script-baked stdout payload, optionally
-// captures the args + stdin into sidecar files for assertions, and
-// exits with the script-baked exit code. The returned path is the
-// absolute path to the script.
+// fakeCLIEnv carries the fake-CLI script to a re-exec'd copy of this test
+// binary. TestMain acts on it before the test framework starts, so the
+// provider can be pointed at this binary as if it were `claude`.
+const fakeCLIEnv = "GORTEX_FAKE_CLAUDE"
+
+// TestMain doubles as the fake `claude` CLI. The provider spawns its binary
+// as a subprocess, and the fake used to be a /bin/sh script — which is not
+// executable on Windows ("%1 is not a valid Win32 application"). Re-execing
+// the test binary is the portable equivalent: it impersonates the CLI on
+// every OS, exercising the same paths (argv construction, stdin piping,
+// stdout/stderr capture, exit status) the script did.
+func TestMain(m *testing.M) {
+	if spec := os.Getenv(fakeCLIEnv); spec != "" {
+		os.Exit(runFakeCLI(spec))
+	}
+	os.Exit(m.Run())
+}
+
+// fakeOpts is the scripted behaviour of one fake-CLI invocation. It is
+// JSON-encoded into fakeCLIEnv, so every field has to be exported.
+type fakeOpts struct {
+	Dir      string        `json:"dir"` // where args.txt / stdin.txt land
+	Stdout   string        `json:"stdout"`
+	Stderr   string        `json:"stderr"`
+	ExitCode int           `json:"exit_code"`
+	Sleep    time.Duration `json:"sleep"`
+}
+
+// runFakeCLI is the child-process half: it records the argv and stdin it was
+// given, emits the scripted payloads, and returns the scripted exit code. The
+// order matches the shell script it replaces — record, then sleep, then
+// stderr, then stdout.
+func runFakeCLI(spec string) int {
+	var opts fakeOpts
+	if err := json.Unmarshal([]byte(spec), &opts); err != nil {
+		fmt.Fprintf(os.Stderr, "fake claude: bad spec: %v\n", err)
+		return 111
+	}
+	// NUL-separated so an argument carrying newlines (the JSON-Schema rider
+	// does) still round-trips as exactly one argv entry.
+	var argv bytes.Buffer
+	for _, a := range os.Args[1:] {
+		argv.WriteString(a)
+		argv.WriteByte(0)
+	}
+	if err := os.WriteFile(filepath.Join(opts.Dir, "args.txt"), argv.Bytes(), 0o600); err != nil {
+		fmt.Fprintf(os.Stderr, "fake claude: record argv: %v\n", err)
+		return 111
+	}
+	stdin, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fake claude: read stdin: %v\n", err)
+		return 111
+	}
+	if err := os.WriteFile(filepath.Join(opts.Dir, "stdin.txt"), stdin, 0o600); err != nil {
+		fmt.Fprintf(os.Stderr, "fake claude: record stdin: %v\n", err)
+		return 111
+	}
+	if opts.Sleep > 0 {
+		time.Sleep(opts.Sleep + time.Second)
+	}
+	if opts.Stderr != "" {
+		fmt.Fprint(os.Stderr, opts.Stderr)
+	}
+	if opts.Stdout != "" {
+		fmt.Fprint(os.Stdout, opts.Stdout)
+	}
+	return opts.ExitCode
+}
+
+// fakeCLI is the parent-process handle on one armed fake: the binary path to
+// hand the provider, plus the directory its sidecar recordings land in.
+type fakeCLI struct {
+	binary string
+	dir    string
+}
+
+// fakeClaude arms the fake `claude` CLI for one test and returns the handle.
+// The provider is pointed at this test binary; fakeCLIEnv (inherited by the
+// spawn) tells the child to impersonate the CLI instead of running tests.
 //
-// A shell-script fake is the smallest portable surface that exercises
-// every code path the provider has — arg construction, stdin
-// piping, exit-status handling, stderr capture — without pulling in
-// the full TestHelperProcess re-exec dance.
-func fakeClaude(t *testing.T, dir string, opts fakeOpts) string {
+// Because it uses t.Setenv, a test that calls it must not run in parallel.
+func fakeClaude(t *testing.T, dir string, opts fakeOpts) fakeCLI {
 	t.Helper()
 	if dir == "" {
 		dir = t.TempDir()
 	}
-	script := filepath.Join(dir, "fake-claude.sh")
+	opts.Dir = dir
+	spec, err := json.Marshal(opts)
+	if err != nil {
+		t.Fatalf("encode fake spec: %v", err)
+	}
+	t.Setenv(fakeCLIEnv, string(spec))
 
-	argsLog := filepath.Join(dir, "args.txt")
-	stdinLog := filepath.Join(dir, "stdin.txt")
-	stderrPayload := strings.ReplaceAll(opts.stderr, "'", "'\\''")
-	stdoutPayload := strings.ReplaceAll(opts.stdout, "'", "'\\''")
-
-	// NUL-separated so an argument carrying newlines (the JSON-Schema
-	// rider does) still round-trips as exactly one argv entry.
-	body := "#!/bin/sh\n" +
-		"set -e\n" +
-		"printf '%s\\0' \"$@\" > '" + argsLog + "'\n" +
-		"cat > '" + stdinLog + "'\n"
-	if opts.sleep > 0 {
-		body += fmt.Sprintf("sleep %d\n", int(opts.sleep.Seconds()+1))
+	bin, err := os.Executable()
+	if err != nil {
+		bin = os.Args[0]
 	}
-	if stderrPayload != "" {
-		body += "printf '%s' '" + stderrPayload + "' >&2\n"
-	}
-	if stdoutPayload != "" {
-		body += "printf '%s' '" + stdoutPayload + "'\n"
-	}
-	if opts.exitCode != 0 {
-		body += fmt.Sprintf("exit %d\n", opts.exitCode)
-	}
-
-	if err := os.WriteFile(script, []byte(body), 0o700); err != nil {
-		t.Fatalf("write fake script: %v", err)
-	}
-	return script
+	return fakeCLI{binary: bin, dir: dir}
 }
 
-type fakeOpts struct {
-	stdout   string
-	stderr   string
-	exitCode int
-	sleep    time.Duration
-}
-
-func readSidecar(t *testing.T, scriptPath, name string) string {
+func (f fakeCLI) sidecar(t *testing.T, name string) string {
 	t.Helper()
-	b, err := os.ReadFile(filepath.Join(filepath.Dir(scriptPath), name))
+	b, err := os.ReadFile(filepath.Join(f.dir, name))
 	if err != nil {
 		t.Fatalf("read %s: %v", name, err)
 	}
@@ -77,9 +128,9 @@ func readSidecar(t *testing.T, scriptPath, name string) string {
 }
 
 // argv reconstructs the exact argument vector the fake CLI received.
-func argv(t *testing.T, scriptPath string) []string {
+func (f fakeCLI) argv(t *testing.T) []string {
 	t.Helper()
-	raw := readSidecar(t, scriptPath, "args.txt")
+	raw := f.sidecar(t, "args.txt")
 	raw = strings.TrimSuffix(raw, "\x00")
 	if raw == "" {
 		return nil
@@ -119,8 +170,14 @@ func TestNew_BinaryNotFound(t *testing.T) {
 
 func TestNew_DefaultsBinary(t *testing.T) {
 	dir := t.TempDir()
-	bin := filepath.Join(dir, "claude")
-	if err := os.WriteFile(bin, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+	// exec.LookPath only resolves a name that carries a PATHEXT extension on
+	// Windows — an extensionless `claude` file is invisible to it — so the
+	// stub is named for the host. It is never executed; New only resolves it.
+	name, body := "claude", "#!/bin/sh\nexit 0\n"
+	if runtime.GOOS == "windows" {
+		name, body = "claude.cmd", "@echo off\r\nexit /b 0\r\n"
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o700); err != nil {
 		t.Fatalf("write fake binary: %v", err)
 	}
 	// Stash a fake `claude` on PATH so the default binary name resolves.
@@ -137,9 +194,9 @@ func TestNew_DefaultsBinary(t *testing.T) {
 }
 
 func TestComplete_FreeformSuccess(t *testing.T) {
-	script := fakeClaude(t, "", fakeOpts{stdout: "hello world"})
+	fake := fakeClaude(t, "", fakeOpts{Stdout: "hello world"})
 
-	p, err := New(llm.ClaudeCLIConfig{Binary: script})
+	p, err := New(llm.ClaudeCLIConfig{Binary: fake.binary})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -158,7 +215,7 @@ func TestComplete_FreeformSuccess(t *testing.T) {
 		t.Errorf("text=%q want hello world", resp.Text)
 	}
 
-	args := argv(t, script)
+	args := fake.argv(t)
 	for _, want := range []string{"--print", "--output-format", "text"} {
 		if !hasArg(args, want) {
 			t.Errorf("args missing %q\nargs=%q", want, args)
@@ -167,7 +224,7 @@ func TestComplete_FreeformSuccess(t *testing.T) {
 	if got, ok := flagValue(args, "--system-prompt"); !ok || got != "be terse" {
 		t.Errorf("--system-prompt=%q present=%v, want %q", got, ok, "be terse")
 	}
-	stdin := readSidecar(t, script, "stdin.txt")
+	stdin := fake.sidecar(t, "stdin.txt")
 	if !strings.Contains(stdin, "User: hi") {
 		t.Errorf("stdin missing user turn:\n%s", stdin)
 	}
@@ -181,9 +238,9 @@ func TestComplete_FreeformSuccess(t *testing.T) {
 // the discovered CLAUDE.md files and the injected cwd/environment block
 // in force, and that context beats the structured-output instruction.
 func TestComplete_ReplacesDefaultSystemPrompt(t *testing.T) {
-	script := fakeClaude(t, "", fakeOpts{stdout: "ok"})
+	fake := fakeClaude(t, "", fakeOpts{Stdout: "ok"})
 
-	p, _ := New(llm.ClaudeCLIConfig{Binary: script})
+	p, _ := New(llm.ClaudeCLIConfig{Binary: fake.binary})
 	defer p.Close()
 
 	if _, err := p.Complete(context.Background(), llm.CompletionRequest{
@@ -191,7 +248,7 @@ func TestComplete_ReplacesDefaultSystemPrompt(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Complete: %v", err)
 	}
-	args := argv(t, script)
+	args := fake.argv(t)
 	if hasArg(args, "--append-system-prompt") {
 		t.Errorf("must not append to the default system prompt; args=%q", args)
 	}
@@ -207,9 +264,9 @@ func TestComplete_ReplacesDefaultSystemPrompt(t *testing.T) {
 // SessionEnd hook exiting nonzero failed the whole call), no native
 // toolset, no MCP servers.
 func TestComplete_HeadlessDefaults(t *testing.T) {
-	script := fakeClaude(t, "", fakeOpts{stdout: "ok"})
+	fake := fakeClaude(t, "", fakeOpts{Stdout: "ok"})
 
-	p, _ := New(llm.ClaudeCLIConfig{Binary: script})
+	p, _ := New(llm.ClaudeCLIConfig{Binary: fake.binary})
 	defer p.Close()
 
 	if _, err := p.Complete(context.Background(), llm.CompletionRequest{
@@ -217,7 +274,7 @@ func TestComplete_HeadlessDefaults(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Complete: %v", err)
 	}
-	args := argv(t, script)
+	args := fake.argv(t)
 
 	if got, ok := flagValue(args, "--settings"); !ok || !strings.Contains(got, `"disableAllHooks":true`) {
 		t.Errorf("--settings=%q present=%v, want disableAllHooks", got, ok)
@@ -233,9 +290,9 @@ func TestComplete_HeadlessDefaults(t *testing.T) {
 // --tools is variadic: it swallows every following argument up to the
 // next flag. The value must therefore always be followed by one.
 func TestComplete_ToolsFlagIsFollowedByAFlag(t *testing.T) {
-	script := fakeClaude(t, "", fakeOpts{stdout: "ok"})
+	fake := fakeClaude(t, "", fakeOpts{Stdout: "ok"})
 
-	p, _ := New(llm.ClaudeCLIConfig{Binary: script})
+	p, _ := New(llm.ClaudeCLIConfig{Binary: fake.binary})
 	defer p.Close()
 
 	if _, err := p.Complete(context.Background(), llm.CompletionRequest{
@@ -243,7 +300,7 @@ func TestComplete_ToolsFlagIsFollowedByAFlag(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Complete: %v", err)
 	}
-	args := argv(t, script)
+	args := fake.argv(t)
 	i := -1
 	for n, a := range args {
 		if a == "--tools" {
@@ -265,10 +322,10 @@ func TestComplete_ToolsFlagIsFollowedByAFlag(t *testing.T) {
 // Any flag in llm.claudecli.args wins over the matching headless
 // default — the config file stays the final word.
 func TestComplete_ArgsOverrideHeadlessDefaults(t *testing.T) {
-	script := fakeClaude(t, "", fakeOpts{stdout: "ok"})
+	fake := fakeClaude(t, "", fakeOpts{Stdout: "ok"})
 
 	p, _ := New(llm.ClaudeCLIConfig{
-		Binary: script,
+		Binary: fake.binary,
 		Args:   []string{"--tools", "default", "--settings=/etc/claude.json"},
 	})
 	defer p.Close()
@@ -278,7 +335,7 @@ func TestComplete_ArgsOverrideHeadlessDefaults(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Complete: %v", err)
 	}
-	args := argv(t, script)
+	args := fake.argv(t)
 
 	var tools, settings int
 	for _, a := range args {
@@ -308,10 +365,10 @@ func TestComplete_ArgsOverrideHeadlessDefaults(t *testing.T) {
 // provider's own instruction (which carries the JSON-Schema rider) must
 // survive as an append rather than be dropped.
 func TestComplete_UserSystemPromptKeepsSchemaRider(t *testing.T) {
-	script := fakeClaude(t, "", fakeOpts{stdout: `{"terms":["a"]}`})
+	fake := fakeClaude(t, "", fakeOpts{Stdout: `{"terms":["a"]}`})
 
 	p, _ := New(llm.ClaudeCLIConfig{
-		Binary: script,
+		Binary: fake.binary,
 		Args:   []string{"--system-prompt", "you are terse"},
 	})
 	defer p.Close()
@@ -322,7 +379,7 @@ func TestComplete_UserSystemPromptKeepsSchemaRider(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Complete: %v", err)
 	}
-	args := argv(t, script)
+	args := fake.argv(t)
 
 	if got, ok := flagValue(args, "--system-prompt"); !ok || got != "you are terse" {
 		t.Errorf("--system-prompt=%q present=%v, want the user's", got, ok)
@@ -337,9 +394,9 @@ func TestComplete_UserSystemPromptKeepsSchemaRider(t *testing.T) {
 }
 
 func TestComplete_PassesModel(t *testing.T) {
-	script := fakeClaude(t, "", fakeOpts{stdout: "ok"})
+	fake := fakeClaude(t, "", fakeOpts{Stdout: "ok"})
 
-	p, _ := New(llm.ClaudeCLIConfig{Binary: script, Model: "sonnet"})
+	p, _ := New(llm.ClaudeCLIConfig{Binary: fake.binary, Model: "sonnet"})
 	defer p.Close()
 
 	if _, err := p.Complete(context.Background(), llm.CompletionRequest{
@@ -347,16 +404,16 @@ func TestComplete_PassesModel(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Complete: %v", err)
 	}
-	if got, ok := flagValue(argv(t, script), "--model"); !ok || got != "sonnet" {
+	if got, ok := flagValue(fake.argv(t), "--model"); !ok || got != "sonnet" {
 		t.Errorf("--model=%q present=%v, want sonnet", got, ok)
 	}
 }
 
 func TestComplete_StructuredExtractsJSON(t *testing.T) {
 	wrapped := "Sure, here you go:\n```json\n{\"terms\":[\"bcrypt\",\"argon2\"]}\n```\n"
-	script := fakeClaude(t, "", fakeOpts{stdout: wrapped})
+	fake := fakeClaude(t, "", fakeOpts{Stdout: wrapped})
 
-	p, _ := New(llm.ClaudeCLIConfig{Binary: script})
+	p, _ := New(llm.ClaudeCLIConfig{Binary: fake.binary})
 	defer p.Close()
 
 	resp, err := p.Complete(context.Background(), llm.CompletionRequest{
@@ -370,16 +427,16 @@ func TestComplete_StructuredExtractsJSON(t *testing.T) {
 		t.Errorf("text=%q want the unwrapped JSON object", resp.Text)
 	}
 
-	rider, ok := flagValue(argv(t, script), "--system-prompt")
+	rider, ok := flagValue(fake.argv(t), "--system-prompt")
 	if !ok || !strings.Contains(rider, "JSON Schema") {
 		t.Errorf("structured request must inject a JSON Schema rider; got %q", rider)
 	}
 }
 
 func TestComplete_StructuredNoJSONErrors(t *testing.T) {
-	script := fakeClaude(t, "", fakeOpts{stdout: "I cannot help with that."})
+	fake := fakeClaude(t, "", fakeOpts{Stdout: "I cannot help with that."})
 
-	p, _ := New(llm.ClaudeCLIConfig{Binary: script})
+	p, _ := New(llm.ClaudeCLIConfig{Binary: fake.binary})
 	defer p.Close()
 
 	if _, err := p.Complete(context.Background(), llm.CompletionRequest{
@@ -391,9 +448,9 @@ func TestComplete_StructuredNoJSONErrors(t *testing.T) {
 }
 
 func TestComplete_NonZeroExit(t *testing.T) {
-	script := fakeClaude(t, "", fakeOpts{exitCode: 2, stderr: "auth required"})
+	fake := fakeClaude(t, "", fakeOpts{ExitCode: 2, Stderr: "auth required"})
 
-	p, _ := New(llm.ClaudeCLIConfig{Binary: script})
+	p, _ := New(llm.ClaudeCLIConfig{Binary: fake.binary})
 	defer p.Close()
 
 	_, err := p.Complete(context.Background(), llm.CompletionRequest{
@@ -411,9 +468,9 @@ func TestComplete_NonZeroExit(t *testing.T) {
 // empty, so a stderr-only error message collapses a real diagnosis into
 // an opaque "exit status 1".
 func TestComplete_NonZeroExitFallsBackToStdout(t *testing.T) {
-	script := fakeClaude(t, "", fakeOpts{exitCode: 1, stdout: "Error: Reached max turns (1)"})
+	fake := fakeClaude(t, "", fakeOpts{ExitCode: 1, Stdout: "Error: Reached max turns (1)"})
 
-	p, _ := New(llm.ClaudeCLIConfig{Binary: script})
+	p, _ := New(llm.ClaudeCLIConfig{Binary: fake.binary})
 	defer p.Close()
 
 	_, err := p.Complete(context.Background(), llm.CompletionRequest{
@@ -428,9 +485,9 @@ func TestComplete_NonZeroExitFallsBackToStdout(t *testing.T) {
 }
 
 func TestComplete_EmptyResponseErrors(t *testing.T) {
-	script := fakeClaude(t, "", fakeOpts{stdout: ""})
+	fake := fakeClaude(t, "", fakeOpts{Stdout: ""})
 
-	p, _ := New(llm.ClaudeCLIConfig{Binary: script})
+	p, _ := New(llm.ClaudeCLIConfig{Binary: fake.binary})
 	defer p.Close()
 
 	if _, err := p.Complete(context.Background(), llm.CompletionRequest{
@@ -441,9 +498,9 @@ func TestComplete_EmptyResponseErrors(t *testing.T) {
 }
 
 func TestComplete_ContextCancellation(t *testing.T) {
-	script := fakeClaude(t, "", fakeOpts{stdout: "late", sleep: 2 * time.Second})
+	fake := fakeClaude(t, "", fakeOpts{Stdout: "late", Sleep: 2 * time.Second})
 
-	p, _ := New(llm.ClaudeCLIConfig{Binary: script, TimeoutSeconds: 1})
+	p, _ := New(llm.ClaudeCLIConfig{Binary: fake.binary, TimeoutSeconds: 1})
 	defer p.Close()
 
 	if _, err := p.Complete(context.Background(), llm.CompletionRequest{
@@ -454,9 +511,9 @@ func TestComplete_ContextCancellation(t *testing.T) {
 }
 
 func TestComplete_ExtraArgsForwarded(t *testing.T) {
-	script := fakeClaude(t, "", fakeOpts{stdout: "ok"})
+	fake := fakeClaude(t, "", fakeOpts{Stdout: "ok"})
 
-	p, _ := New(llm.ClaudeCLIConfig{Binary: script, Args: []string{"--permission-mode", "plan"}})
+	p, _ := New(llm.ClaudeCLIConfig{Binary: fake.binary, Args: []string{"--permission-mode", "plan"}})
 	defer p.Close()
 
 	if _, err := p.Complete(context.Background(), llm.CompletionRequest{
@@ -464,7 +521,7 @@ func TestComplete_ExtraArgsForwarded(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Complete: %v", err)
 	}
-	if got, ok := flagValue(argv(t, script), "--permission-mode"); !ok || got != "plan" {
+	if got, ok := flagValue(fake.argv(t), "--permission-mode"); !ok || got != "plan" {
 		t.Errorf("--permission-mode=%q present=%v, want plan", got, ok)
 	}
 }
@@ -488,20 +545,21 @@ func TestFlatten_Roles(t *testing.T) {
 	}
 }
 
-// Sanity check: the test helper itself can run a child process. If
-// this fails the environment doesn't support `/bin/sh` and every
-// other subprocess test in this file will skip cleanly.
-func TestHelper_FakeScriptIsExecutable(t *testing.T) {
-	script := fakeClaude(t, "", fakeOpts{stdout: "alive"})
-	cmd := exec.Command(script, "ping")
+// Sanity check on the harness itself: re-execing the test binary really does
+// impersonate the CLI, on every OS. If this fails, every other subprocess
+// test in this file is testing nothing.
+func TestHelper_FakeCLIIsExecutable(t *testing.T) {
+	fake := fakeClaude(t, "", fakeOpts{Stdout: "alive"})
+	cmd := exec.Command(fake.binary, "ping")
 	cmd.Stdin = strings.NewReader("")
 	out, err := cmd.Output()
 	if err != nil {
-		// On a CI runner without /bin/sh, surface as skip instead of
-		// fail so we don't paint subprocess CI red.
-		t.Skipf("cannot exec fake script: %v", err)
+		t.Fatalf("exec fake CLI: %v", err)
 	}
 	if !strings.Contains(string(out), "alive") {
 		t.Errorf("output=%q", out)
+	}
+	if args := fake.argv(t); len(args) != 1 || args[0] != "ping" {
+		t.Errorf("argv=%q, want [ping]", args)
 	}
 }

--- a/internal/llm/provider/codex/codex_test.go
+++ b/internal/llm/provider/codex/codex_test.go
@@ -2,10 +2,13 @@ package codex
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -13,69 +16,126 @@ import (
 	"github.com/zzet/gortex/internal/llm"
 )
 
-// fakeCodex writes a shell script that impersonates the `codex` CLI.
-// It logs args + stdin to sidecar files for assertions, writes
-// opts.lastMessage to whatever path follows --output-last-message
-// (mirroring real `codex exec`), echoes opts.stdout as progress noise,
-// and exits with opts.exitCode.
+// fakeCLIEnv carries the fake-CLI script to a re-exec'd copy of this test
+// binary. TestMain acts on it before the test framework starts, so the
+// provider can be pointed at this binary as if it were `codex`.
+const fakeCLIEnv = "GORTEX_FAKE_CODEX"
+
+// TestMain doubles as the fake `codex` CLI. The provider spawns its binary as
+// a subprocess, and the fake used to be a /bin/sh script — which is not
+// executable on Windows ("%1 is not a valid Win32 application"). Re-execing
+// the test binary is the portable equivalent: it impersonates the CLI on
+// every OS, exercising the same paths (argv construction, stdin piping, the
+// --output-last-message sidecar, the stdout fallback, exit status and stderr
+// handling) the script did.
+func TestMain(m *testing.M) {
+	if spec := os.Getenv(fakeCLIEnv); spec != "" {
+		os.Exit(runFakeCLI(spec))
+	}
+	os.Exit(m.Run())
+}
+
+// fakeOpts is the scripted behaviour of one fake-CLI invocation. It is
+// JSON-encoded into fakeCLIEnv, so every field has to be exported.
+type fakeOpts struct {
+	Dir         string        `json:"dir"`          // where args.txt / stdin.txt land
+	LastMessage string        `json:"last_message"` // written to the --output-last-message sidecar
+	Stdout      string        `json:"stdout"`       // emitted on stdout (progress logs)
+	Stderr      string        `json:"stderr"`
+	ExitCode    int           `json:"exit_code"`
+	Sleep       time.Duration `json:"sleep"`
+}
+
+// runFakeCLI is the child-process half: it records the argv and stdin it was
+// given, mirrors real `codex exec` by writing LastMessage to whatever path
+// follows --output-last-message, emits the scripted payloads, and returns the
+// scripted exit code.
+func runFakeCLI(spec string) int {
+	var opts fakeOpts
+	if err := json.Unmarshal([]byte(spec), &opts); err != nil {
+		fmt.Fprintf(os.Stderr, "fake codex: bad spec: %v\n", err)
+		return 111
+	}
+	args := os.Args[1:]
+	// One argument per line, matching the sidecar shape the assertions read.
+	if err := os.WriteFile(filepath.Join(opts.Dir, "args.txt"), []byte(strings.Join(args, "\n")+"\n"), 0o600); err != nil {
+		fmt.Fprintf(os.Stderr, "fake codex: record argv: %v\n", err)
+		return 111
+	}
+	stdin, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fake codex: read stdin: %v\n", err)
+		return 111
+	}
+	if err := os.WriteFile(filepath.Join(opts.Dir, "stdin.txt"), stdin, 0o600); err != nil {
+		fmt.Fprintf(os.Stderr, "fake codex: record stdin: %v\n", err)
+		return 111
+	}
+	if opts.Sleep > 0 {
+		time.Sleep(opts.Sleep + time.Second)
+	}
+	if opts.LastMessage != "" {
+		if out := flagValue(args, "--output-last-message"); out != "" {
+			if err := os.WriteFile(out, []byte(opts.LastMessage), 0o600); err != nil {
+				fmt.Fprintf(os.Stderr, "fake codex: write last message: %v\n", err)
+				return 111
+			}
+		}
+	}
+	if opts.Stderr != "" {
+		fmt.Fprint(os.Stderr, opts.Stderr)
+	}
+	if opts.Stdout != "" {
+		fmt.Fprint(os.Stdout, opts.Stdout)
+	}
+	return opts.ExitCode
+}
+
+// flagValue returns the argument following flag, or "" when the flag is
+// absent or trailing.
+func flagValue(args []string, flag string) string {
+	for i, a := range args {
+		if a == flag && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+// fakeCLI is the parent-process handle on one armed fake: the binary path to
+// hand the provider, plus the directory its sidecar recordings land in.
+type fakeCLI struct {
+	binary string
+	dir    string
+}
+
+// fakeCodex arms the fake `codex` CLI for one test and returns the handle.
+// The provider is pointed at this test binary; fakeCLIEnv (inherited by the
+// spawn) tells the child to impersonate the CLI instead of running tests.
 //
-// A shell-script fake exercises every provider code path — arg
-// construction, stdin piping, the --output-last-message sidecar, the
-// stdout fallback, exit-status and stderr handling — without a real
-// codex install.
-func fakeCodex(t *testing.T, dir string, opts fakeOpts) string {
+// Because it uses t.Setenv, a test that calls it must not run in parallel.
+func fakeCodex(t *testing.T, dir string, opts fakeOpts) fakeCLI {
 	t.Helper()
 	if dir == "" {
 		dir = t.TempDir()
 	}
-	script := filepath.Join(dir, "fake-codex.sh")
+	opts.Dir = dir
+	spec, err := json.Marshal(opts)
+	if err != nil {
+		t.Fatalf("encode fake spec: %v", err)
+	}
+	t.Setenv(fakeCLIEnv, string(spec))
 
-	argsLog := filepath.Join(dir, "args.txt")
-	stdinLog := filepath.Join(dir, "stdin.txt")
-	q := func(s string) string { return strings.ReplaceAll(s, "'", "'\\''") }
-
-	body := "#!/bin/sh\n" +
-		"printf '%s\\n' \"$@\" > '" + argsLog + "'\n" +
-		"cat > '" + stdinLog + "'\n" +
-		"prev=''\n" +
-		"outfile=''\n" +
-		"for a in \"$@\"; do\n" +
-		"  if [ \"$prev\" = '--output-last-message' ]; then outfile=\"$a\"; fi\n" +
-		"  prev=\"$a\"\n" +
-		"done\n"
-	if opts.sleep > 0 {
-		body += fmt.Sprintf("sleep %d\n", int(opts.sleep.Seconds()+1))
+	bin, err := os.Executable()
+	if err != nil {
+		bin = os.Args[0]
 	}
-	if opts.lastMessage != "" {
-		body += "if [ -n \"$outfile\" ]; then printf '%s' '" + q(opts.lastMessage) + "' > \"$outfile\"; fi\n"
-	}
-	if opts.stderr != "" {
-		body += "printf '%s' '" + q(opts.stderr) + "' >&2\n"
-	}
-	if opts.stdout != "" {
-		body += "printf '%s' '" + q(opts.stdout) + "'\n"
-	}
-	if opts.exitCode != 0 {
-		body += fmt.Sprintf("exit %d\n", opts.exitCode)
-	}
-
-	if err := os.WriteFile(script, []byte(body), 0o700); err != nil {
-		t.Fatalf("write fake script: %v", err)
-	}
-	return script
+	return fakeCLI{binary: bin, dir: dir}
 }
 
-type fakeOpts struct {
-	lastMessage string // written to the --output-last-message sidecar
-	stdout      string // emitted on stdout (progress logs)
-	stderr      string
-	exitCode    int
-	sleep       time.Duration
-}
-
-func readSidecar(t *testing.T, scriptPath, name string) string {
+func (f fakeCLI) sidecar(t *testing.T, name string) string {
 	t.Helper()
-	b, err := os.ReadFile(filepath.Join(filepath.Dir(scriptPath), name))
+	b, err := os.ReadFile(filepath.Join(f.dir, name))
 	if err != nil {
 		t.Fatalf("read %s: %v", name, err)
 	}
@@ -90,8 +150,14 @@ func TestNew_BinaryNotFound(t *testing.T) {
 
 func TestNew_DefaultsBinary(t *testing.T) {
 	dir := t.TempDir()
-	bin := filepath.Join(dir, "codex")
-	if err := os.WriteFile(bin, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+	// exec.LookPath only resolves a name that carries a PATHEXT extension on
+	// Windows — an extensionless `codex` file is invisible to it — so the
+	// stub is named for the host. It is never executed; New only resolves it.
+	name, body := "codex", "#!/bin/sh\nexit 0\n"
+	if runtime.GOOS == "windows" {
+		name, body = "codex.cmd", "@echo off\r\nexit /b 0\r\n"
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o700); err != nil {
 		t.Fatalf("write fake binary: %v", err)
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
@@ -107,9 +173,9 @@ func TestNew_DefaultsBinary(t *testing.T) {
 }
 
 func TestComplete_FreeformSuccess(t *testing.T) {
-	script := fakeCodex(t, "", fakeOpts{lastMessage: "hello world", stdout: "[progress] thinking…"})
+	fake := fakeCodex(t, "", fakeOpts{LastMessage: "hello world", Stdout: "[progress] thinking…"})
 
-	p, err := New(llm.CodexConfig{Binary: script})
+	p, err := New(llm.CodexConfig{Binary: fake.binary})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
@@ -128,13 +194,13 @@ func TestComplete_FreeformSuccess(t *testing.T) {
 		t.Errorf("text=%q want hello world (the sidecar must win over stdout noise)", resp.Text)
 	}
 
-	gotArgs := readSidecar(t, script, "args.txt")
+	gotArgs := fake.sidecar(t, "args.txt")
 	for _, want := range []string{"exec", "--skip-git-repo-check", "--sandbox", "read-only", "--output-last-message", "-"} {
 		if !strings.Contains(gotArgs, want) {
 			t.Errorf("args missing %q\nargs=\n%s", want, gotArgs)
 		}
 	}
-	stdin := readSidecar(t, script, "stdin.txt")
+	stdin := fake.sidecar(t, "stdin.txt")
 	if !strings.Contains(stdin, "User: hi") {
 		t.Errorf("stdin missing user turn:\n%s", stdin)
 	}
@@ -146,9 +212,9 @@ func TestComplete_FreeformSuccess(t *testing.T) {
 func TestComplete_StdoutFallback(t *testing.T) {
 	// No sidecar payload — the provider must fall back to stdout for
 	// an older codex build that does not honour --output-last-message.
-	script := fakeCodex(t, "", fakeOpts{stdout: "fallback answer"})
+	fake := fakeCodex(t, "", fakeOpts{Stdout: "fallback answer"})
 
-	p, _ := New(llm.CodexConfig{Binary: script})
+	p, _ := New(llm.CodexConfig{Binary: fake.binary})
 	defer p.Close()
 
 	resp, err := p.Complete(context.Background(), llm.CompletionRequest{
@@ -163,9 +229,9 @@ func TestComplete_StdoutFallback(t *testing.T) {
 }
 
 func TestComplete_PassesModel(t *testing.T) {
-	script := fakeCodex(t, "", fakeOpts{lastMessage: "ok"})
+	fake := fakeCodex(t, "", fakeOpts{LastMessage: "ok"})
 
-	p, _ := New(llm.CodexConfig{Binary: script, Model: "gpt-5-codex"})
+	p, _ := New(llm.CodexConfig{Binary: fake.binary, Model: "gpt-5-codex"})
 	defer p.Close()
 
 	if _, err := p.Complete(context.Background(), llm.CompletionRequest{
@@ -173,7 +239,7 @@ func TestComplete_PassesModel(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Complete: %v", err)
 	}
-	args := readSidecar(t, script, "args.txt")
+	args := fake.sidecar(t, "args.txt")
 	if !strings.Contains(args, "--model\ngpt-5-codex") {
 		t.Errorf("args missing --model gpt-5-codex:\n%s", args)
 	}
@@ -181,9 +247,9 @@ func TestComplete_PassesModel(t *testing.T) {
 
 func TestComplete_StructuredExtractsJSON(t *testing.T) {
 	wrapped := "```json\n{\"terms\":[\"bcrypt\",\"argon2\"]}\n```\n"
-	script := fakeCodex(t, "", fakeOpts{lastMessage: wrapped})
+	fake := fakeCodex(t, "", fakeOpts{LastMessage: wrapped})
 
-	p, _ := New(llm.CodexConfig{Binary: script})
+	p, _ := New(llm.CodexConfig{Binary: fake.binary})
 	defer p.Close()
 
 	resp, err := p.Complete(context.Background(), llm.CompletionRequest{
@@ -196,16 +262,16 @@ func TestComplete_StructuredExtractsJSON(t *testing.T) {
 	if resp.Text != `{"terms":["bcrypt","argon2"]}` {
 		t.Errorf("text=%q want the unwrapped JSON object", resp.Text)
 	}
-	stdin := readSidecar(t, script, "stdin.txt")
+	stdin := fake.sidecar(t, "stdin.txt")
 	if !strings.Contains(stdin, "JSON Schema") {
 		t.Errorf("structured request must inject a JSON Schema rider; stdin=\n%s", stdin)
 	}
 }
 
 func TestComplete_StructuredNoJSONErrors(t *testing.T) {
-	script := fakeCodex(t, "", fakeOpts{lastMessage: "I cannot help with that."})
+	fake := fakeCodex(t, "", fakeOpts{LastMessage: "I cannot help with that."})
 
-	p, _ := New(llm.CodexConfig{Binary: script})
+	p, _ := New(llm.CodexConfig{Binary: fake.binary})
 	defer p.Close()
 
 	if _, err := p.Complete(context.Background(), llm.CompletionRequest{
@@ -217,9 +283,9 @@ func TestComplete_StructuredNoJSONErrors(t *testing.T) {
 }
 
 func TestComplete_NonZeroExit(t *testing.T) {
-	script := fakeCodex(t, "", fakeOpts{exitCode: 2, stderr: "not signed in"})
+	fake := fakeCodex(t, "", fakeOpts{ExitCode: 2, Stderr: "not signed in"})
 
-	p, _ := New(llm.CodexConfig{Binary: script})
+	p, _ := New(llm.CodexConfig{Binary: fake.binary})
 	defer p.Close()
 
 	_, err := p.Complete(context.Background(), llm.CompletionRequest{
@@ -234,9 +300,9 @@ func TestComplete_NonZeroExit(t *testing.T) {
 }
 
 func TestComplete_EmptyResponseErrors(t *testing.T) {
-	script := fakeCodex(t, "", fakeOpts{})
+	fake := fakeCodex(t, "", fakeOpts{})
 
-	p, _ := New(llm.CodexConfig{Binary: script})
+	p, _ := New(llm.CodexConfig{Binary: fake.binary})
 	defer p.Close()
 
 	if _, err := p.Complete(context.Background(), llm.CompletionRequest{
@@ -247,9 +313,9 @@ func TestComplete_EmptyResponseErrors(t *testing.T) {
 }
 
 func TestComplete_ContextCancellation(t *testing.T) {
-	script := fakeCodex(t, "", fakeOpts{lastMessage: "late", sleep: 2 * time.Second})
+	fake := fakeCodex(t, "", fakeOpts{LastMessage: "late", Sleep: 2 * time.Second})
 
-	p, _ := New(llm.CodexConfig{Binary: script, TimeoutSeconds: 1})
+	p, _ := New(llm.CodexConfig{Binary: fake.binary, TimeoutSeconds: 1})
 	defer p.Close()
 
 	if _, err := p.Complete(context.Background(), llm.CompletionRequest{
@@ -260,9 +326,9 @@ func TestComplete_ContextCancellation(t *testing.T) {
 }
 
 func TestComplete_ExtraArgsForwarded(t *testing.T) {
-	script := fakeCodex(t, "", fakeOpts{lastMessage: "ok"})
+	fake := fakeCodex(t, "", fakeOpts{LastMessage: "ok"})
 
-	p, _ := New(llm.CodexConfig{Binary: script, Args: []string{"--sandbox", "workspace-write"}})
+	p, _ := New(llm.CodexConfig{Binary: fake.binary, Args: []string{"--sandbox", "workspace-write"}})
 	defer p.Close()
 
 	if _, err := p.Complete(context.Background(), llm.CompletionRequest{
@@ -270,7 +336,7 @@ func TestComplete_ExtraArgsForwarded(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Complete: %v", err)
 	}
-	args := readSidecar(t, script, "args.txt")
+	args := fake.sidecar(t, "args.txt")
 	if !strings.Contains(args, "workspace-write") {
 		t.Errorf("args missing forwarded extra arg:\n%s", args)
 	}
@@ -302,16 +368,21 @@ func TestBuildPrompt_NoSystem(t *testing.T) {
 	}
 }
 
-// Sanity check: the test helper itself can run a child process.
-func TestHelper_FakeScriptIsExecutable(t *testing.T) {
-	script := fakeCodex(t, "", fakeOpts{stdout: "alive"})
-	cmd := exec.Command(script, "ping")
+// Sanity check on the harness itself: re-execing the test binary really does
+// impersonate the CLI, on every OS. If this fails, every other subprocess
+// test in this file is testing nothing.
+func TestHelper_FakeCLIIsExecutable(t *testing.T) {
+	fake := fakeCodex(t, "", fakeOpts{Stdout: "alive"})
+	cmd := exec.Command(fake.binary, "ping")
 	cmd.Stdin = strings.NewReader("")
 	out, err := cmd.Output()
 	if err != nil {
-		t.Skipf("cannot exec fake script: %v", err)
+		t.Fatalf("exec fake CLI: %v", err)
 	}
 	if !strings.Contains(string(out), "alive") {
 		t.Errorf("output=%q", out)
+	}
+	if args := fake.sidecar(t, "args.txt"); args != "ping\n" {
+		t.Errorf("args=%q, want \"ping\\n\"", args)
 	}
 }

--- a/internal/localizationauth/receipt.go
+++ b/internal/localizationauth/receipt.go
@@ -122,7 +122,7 @@ func Publish(token string, receipt Receipt) bool {
 	if err := tmp.Close(); err != nil {
 		return false
 	}
-	if err := os.Rename(tmpPath, path); err != nil {
+	if err := platform.ReplaceFile(tmpPath, path); err != nil {
 		return false
 	}
 	committed = true
@@ -132,23 +132,19 @@ func Publish(token string, receipt Receipt) bool {
 
 // Consume atomically claims and removes one receipt. Concurrent or repeated
 // consumers cannot observe the same terminal result.
+//
+// The claim is an exclusive marker rather than a rename: POSIX rename(2)
+// hands a contended receipt to exactly one caller, but on Windows two racing
+// MoveFileEx calls on one source can both fail with a sharing violation and
+// leave the receipt claimed by nobody, which silently disarms the terminal
+// contract. platform.ConsumeFile arbitrates the race the same way everywhere.
 func Consume(token string) (Receipt, bool) {
 	path, digest, ok := receiptPath(token)
 	if !ok {
 		return Receipt{}, false
 	}
-	claimToken, ok := NewToken()
+	data, ok := platform.ConsumeFile(path)
 	if !ok {
-		return Receipt{}, false
-	}
-	claimPath := path + ".consume-" + claimToken + ".json"
-	if err := os.Rename(path, claimPath); err != nil {
-		return Receipt{}, false
-	}
-	defer os.Remove(claimPath) //nolint:errcheck // one-shot cleanup is best effort
-
-	data, err := os.ReadFile(claimPath)
-	if err != nil {
 		return Receipt{}, false
 	}
 	var envelope receiptEnvelope
@@ -218,16 +214,27 @@ func trimReceipts(dir, preserve string) {
 	}
 	files := make([]receiptFile, 0, len(entries))
 	for _, entry := range entries {
-		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+		if entry.IsDir() {
 			continue
 		}
-		path := filepath.Join(dir, entry.Name())
+		name := entry.Name()
+		receipt := strings.HasSuffix(name, ".json")
+		// A claim marker outlives its consumer only when that process died
+		// mid-claim; age it out with the receipts but never count it against
+		// the cap, so a marker cannot evict a live receipt.
+		if !receipt && !strings.HasSuffix(name, platform.ClaimMarkerSuffix) {
+			continue
+		}
+		path := filepath.Join(dir, name)
 		info, err := entry.Info()
 		if err != nil {
 			continue
 		}
 		if time.Since(info.ModTime()) > receiptTTL && path != preserve {
 			_ = os.Remove(path)
+			continue
+		}
+		if !receipt {
 			continue
 		}
 		files = append(files, receiptFile{path: path, modTime: info.ModTime()})

--- a/internal/mcp/diagnostics_test.go
+++ b/internal/mcp/diagnostics_test.go
@@ -1,6 +1,8 @@
 package mcp
 
 import (
+	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 
@@ -10,6 +12,25 @@ import (
 
 	"github.com/zzet/gortex/internal/semantic/lsp"
 )
+
+// wantFileURI is the file:// URI the broadcasters must publish for the
+// POSIX-shaped fixture path p.
+//
+// On POSIX p is already absolute and the URI is the literal "file://" + p.
+// On Windows the very same string is drive-RELATIVE — filepath.IsAbs
+// ("/work/main.go") is false there — so lspuri.PathToURI resolves it
+// against the current drive before building the URI and the result carries
+// that drive: "file:///D:/work/main.go". Deriving only the Windows
+// expectation keeps the POSIX assertion an exact literal.
+func wantFileURI(t *testing.T, p string) string {
+	t.Helper()
+	if runtime.GOOS != "windows" {
+		return "file://" + p
+	}
+	abs, err := filepath.Abs(p)
+	require.NoError(t, err)
+	return "file:///" + filepath.ToSlash(abs)
+}
 
 // fakeSpecificSender records every SendNotificationToSpecificClient
 // call so tests can assert delivery target + payload.
@@ -166,7 +187,7 @@ func TestDiagnosticsBroadcaster_PayloadShape(t *testing.T) {
 	require.Len(t, calls, 1)
 	assert.Equal(t, "session-A", calls[0].sessionID)
 	assert.Equal(t, "notifications/diagnostics", calls[0].method)
-	assert.Equal(t, "file:///work/main.go", calls[0].params["uri"])
+	assert.Equal(t, wantFileURI(t, "/work/main.go"), calls[0].params["uri"])
 	assert.Equal(t, "/work/main.go", calls[0].params["path"])
 	assert.Equal(t, "gopls", calls[0].params["server"])
 	wire, ok := calls[0].params["diagnostics"].([]map[string]any)
@@ -317,10 +338,10 @@ func TestServer_ReleaseSession_UnsubscribesDiagnostics(t *testing.T) {
 	assert.Equal(t, 0, b.subscriberCount(), "ReleaseSession should drop the subscriber")
 }
 
-// TestPathToFileURI_Absolute — POSIX path round-trips into the
+// TestPathToFileURI_Absolute — an absolute path round-trips into the
 // expected file:// URI.
 func TestPathToFileURI_Absolute(t *testing.T) {
-	assert.Equal(t, "file:///work/main.go", pathToFileURI("/work/main.go"))
+	assert.Equal(t, wantFileURI(t, "/work/main.go"), pathToFileURI("/work/main.go"))
 	assert.Equal(t, "", pathToFileURI(""))
 }
 

--- a/internal/mcp/id_resolve.go
+++ b/internal/mcp/id_resolve.go
@@ -99,10 +99,9 @@ func (s *Server) resolveSymbolID(ctx context.Context, id string) string {
 	// prefix; the graphRelID rung below does not. Returning early on a nil
 	// multiIndexer skipped both, which cost a server built without
 	// MultiRepoOptions (cmd/gortex eval_recall.go, eval_server.go) the
-	// separator normalization graphPathSpelling exists to provide: on Windows
-	// the stored id is `pkga\a.go::Foo` while every agent writes
-	// `pkga/a.go::Foo`, and the tool answered "symbol not found" for an
-	// indexed symbol.
+	// path anchoring graphRelID exists to provide: an absolute-path id
+	// never matches a stored (repo-relative) one, and the tool answered
+	// "symbol not found" for an indexed symbol.
 	if s.multiIndexer != nil {
 		cwd := SessionCWDFromContext(ctx)
 		if cwd != "" {

--- a/internal/mcp/id_resolve_test.go
+++ b/internal/mcp/id_resolve_test.go
@@ -32,10 +32,10 @@ func nameResolveServer(t *testing.T) *Server {
 //
 // The absolute-path spelling is deliberate: it exercises the rung on every
 // platform, so the linux/macos matrix protects this. On Windows the same rung
-// additionally reconciles the separator, which is what graphPathSpelling exists
-// for — the store holds `pkga\a.go::Foo` while every agent writes
-// `pkga/a.go::Foo`, and move_symbol answered "symbol not found" for an indexed
-// symbol.
+// additionally reconciles the separator, which is what graphPathKey exists
+// for — filepath.Rel hands back `pkga\a.go` while the store holds
+// `pkga/a.go::Foo`, and move_symbol answered "symbol not found" for an
+// indexed symbol.
 func TestResolveSymbolID_WithoutMultiIndexer_StillAnchorsThePath(t *testing.T) {
 	srv, dir := setupMoveInlineRepo(t, map[string]string{
 		"pkga/a.go": "package pkga\n\nfunc Foo() int { return 42 }\n",

--- a/internal/mcp/localization_member_demotion_test.go
+++ b/internal/mcp/localization_member_demotion_test.go
@@ -128,6 +128,34 @@ func TestLocalizationDemotionOrdersATierByDeclarationSite(t *testing.T) {
 	}
 }
 
+// TestLocalizationDemotionOrdersAPageWithNothingToDemote covers the window a
+// tight page produces: one file's type and two of its ordinary methods, every
+// row in the leading tier, nothing demotable anywhere. The declaration order
+// is the page's only cross-platform key, so it has to apply here too — while
+// the ordering was gated on the presence of a demotable member, this exact
+// page kept whichever permutation the sibling lift handed it, and paged
+// `[type, detect, reload]` on POSIX against `[type, reload, detect]` on
+// Windows.
+func TestLocalizationDemotionOrdersAPageWithNothingToDemote(t *testing.T) {
+	at := func(name string, line int) *rerank.Candidate {
+		cand := memberDemotionCandidate("config.swift", name, graph.KindMethod)
+		cand.Node.StartLine = line
+		return cand
+	}
+	typ := memberDemotionCandidate("config.swift", "DirectoryConfiguration", graph.KindType)
+	typ.Node.StartLine = 5
+	for _, arrival := range [][]*rerank.Candidate{
+		{at("detect", 25), at("reload", 29), typ},
+		{at("reload", 29), at("detect", 25), typ},
+		{typ, at("reload", 29), at("detect", 25)},
+	} {
+		require.Equal(t,
+			[]string{"DirectoryConfiguration", "detect", "reload"},
+			memberDemotionNames(demoteLocalizationFileMembers(arrival)),
+			"arrival order: %#v", memberDemotionNames(arrival))
+	}
+}
+
 func TestLocalizationDemotionKeepsTypesAndOrdinaryCallablesInOneLeadingTier(t *testing.T) {
 	in := []*rerank.Candidate{
 		memberDemotionCandidate("config.swift", "DirectoryConfiguration.<init>", graph.KindMethod),

--- a/internal/mcp/localization_member_demotion_test.go
+++ b/internal/mcp/localization_member_demotion_test.go
@@ -102,6 +102,32 @@ func TestLocalizationDemotionYieldsFrontSlotToSiblingMethodForDataMembers(t *tes
 	}
 }
 
+// TestLocalizationDemotionOrdersATierByDeclarationSite pins the tier's
+// internal order to a key every platform agrees on. The candidates reaching
+// this stage are already permuted by liftLocalizationSiblingCallables — each
+// traded-in sibling lands in the slot of whichever demoted member it replaced
+// — so their arrival order carries no ranking signal, and inheriting it made
+// the localization page depend on an upstream tie that resolved differently
+// on Windows than on POSIX. Whatever order the tier arrives in, it leaves in
+// declaration order.
+func TestLocalizationDemotionOrdersATierByDeclarationSite(t *testing.T) {
+	at := func(name string, kind graph.NodeKind, line int) *rerank.Candidate {
+		cand := memberDemotionCandidate("config.swift", name, kind)
+		cand.Node.StartLine = line
+		return cand
+	}
+	for _, arrival := range [][]*rerank.Candidate{
+		{at("shaderSlots", graph.KindField, 9), at("detect", graph.KindMethod, 25), at("reload", graph.KindMethod, 29), at("DirectoryConfiguration", graph.KindType, 5)},
+		{at("shaderSlots", graph.KindField, 9), at("reload", graph.KindMethod, 29), at("detect", graph.KindMethod, 25), at("DirectoryConfiguration", graph.KindType, 5)},
+		{at("shaderSlots", graph.KindField, 9), at("DirectoryConfiguration", graph.KindType, 5), at("reload", graph.KindMethod, 29), at("detect", graph.KindMethod, 25)},
+	} {
+		require.Equal(t,
+			[]string{"DirectoryConfiguration", "detect", "reload", "shaderSlots"},
+			memberDemotionNames(demoteLocalizationFileMembers(arrival)),
+			"arrival order: %#v", memberDemotionNames(arrival))
+	}
+}
+
 func TestLocalizationDemotionKeepsTypesAndOrdinaryCallablesInOneLeadingTier(t *testing.T) {
 	in := []*rerank.Candidate{
 		memberDemotionCandidate("config.swift", "DirectoryConfiguration.<init>", graph.KindMethod),

--- a/internal/mcp/localization_text_index_test.go
+++ b/internal/mcp/localization_text_index_test.go
@@ -109,18 +109,24 @@ func TestLocalizationTextMatchDirectSymbolIDSkipsFileIndex(t *testing.T) {
 	}
 }
 
-func TestLocalizationTextMatchUsesWindowsPathAlias(t *testing.T) {
+// TestLocalizationTextMatchNormalisesNativePathToGraphKey pins the one
+// spelling reconciliation that survives: the index is keyed the way the graph
+// keys nodes (forward slashes on every platform), so a natively-spelled match
+// path has to be folded onto that key before the owner lookup. Windows-only —
+// on POSIX a backslash is an ordinary filename byte and the two paths are
+// genuinely different files.
+func TestLocalizationTextMatchNormalisesNativePathToGraphKey(t *testing.T) {
 	if filepath.Separator == '/' {
-		t.Skip("Windows graph path spelling uses a distinct separator only on Windows")
+		t.Skip("a native path differs from the graph spelling only on Windows")
 	}
 	server := &Server{graph: graph.New()}
-	matchPath := "repo/dir/handler.go"
-	aliasPath := graphMatchPathKey(matchPath, true)
-	owner := &graph.Node{ID: aliasPath + "::owner", Name: "owner", Kind: graph.KindFunction, FilePath: aliasPath, StartLine: 1, EndLine: 20}
-	indexes := map[string]*fileSymbolIndex{aliasPath: {syms: []*graph.Node{owner}}}
-	got, provenance := server.localizationTextMatchNode(context.Background(), enrichedTextMatch{Path: matchPath, Line: 10}, indexes)
+	graphPath := "repo/dir/handler.go"
+	nativePath := filepath.FromSlash(graphPath)
+	owner := &graph.Node{ID: graphPath + "::owner", Name: "owner", Kind: graph.KindFunction, FilePath: graphPath, StartLine: 1, EndLine: 20}
+	indexes := map[string]*fileSymbolIndex{graphPath: {syms: []*graph.Node{owner}}}
+	got, provenance := server.localizationTextMatchNode(context.Background(), enrichedTextMatch{Path: nativePath, Line: 10}, indexes)
 	if got != owner || provenance != "permitted_search_text_owner" {
-		t.Fatalf("Windows path alias = (%#v, %q), want owner", got, provenance)
+		t.Fatalf("native path fold = (%#v, %q), want owner", got, provenance)
 	}
 }
 

--- a/internal/mcp/notes.go
+++ b/internal/mcp/notes.go
@@ -222,7 +222,15 @@ func (nm *notesManager) Query(f NoteQueryFilter) []persistence.NoteEntry {
 		out = append(out, e)
 	}
 
-	sort.Slice(out, func(i, j int) bool {
+	// Newest first. UpdatedAt alone is not a total order: two notes saved
+	// inside one wall-clock tick carry the same stamp, and the Windows
+	// clock is coarse enough that back-to-back Save calls routinely do —
+	// there sort.Slice's unstable pivot decided the tie arbitrarily and a
+	// caller reading out[0] got the older note. Entries only ever grows by
+	// append, so out is in save order; reversing it makes insertion order
+	// the newest-first tiebreak, and a stable sort then preserves it.
+	slices.Reverse(out)
+	sort.SliceStable(out, func(i, j int) bool {
 		return out[i].UpdatedAt.After(out[j].UpdatedAt)
 	})
 	if f.Limit > 0 && len(out) > f.Limit {

--- a/internal/mcp/overlay_e2e_test.go
+++ b/internal/mcp/overlay_e2e_test.go
@@ -446,7 +446,9 @@ func TestOverlay_MCP_RegisterPushList(t *testing.T) {
 
 	listRes := callToolByName(t, srv, ctx, "overlay_list", map[string]any{})
 	listText := toolText(listRes)
-	require.Contains(t, listText, targetFile)
+	// The listing is a JSON body: a Windows path reaches it with its
+	// backslashes escaped, so match the JSON spelling of the path.
+	require.Contains(t, listText, jsonEscape(targetFile))
 	require.Contains(t, listText, `"count":1`)
 
 	summary := callToolByName(t, srv, ctx, "get_file_summary", map[string]any{

--- a/internal/mcp/overlay_review_family_test.go
+++ b/internal/mcp/overlay_review_family_test.go
@@ -3,7 +3,6 @@ package mcp
 import (
 	"context"
 	"encoding/json"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,23 +21,18 @@ import (
 // that: reverting a site to s.graph serves the indexed payload and keeps
 // reporting a symbol the buffer deleted.
 
-// The fixture keeps the two path vocabularies apart, because the review
-// handlers are the seam between them: rf*File is the repo-relative,
-// '/'-spelled path a forge or `git diff` hands the caller, and rf*Key is the
-// key the store actually holds — the remainder in the indexing machine's
-// native separators (see internal/graphpath), with no repo prefix here. They
-// coincide on POSIX and diverge on Windows, where analysis.JoinFileNodes
-// converts the caller's path before the lookup. Keying the graph with the
-// '/'-joined form describes a file a Windows daemon never indexes, and the
-// converted query then misses it.
+// The fixture still names the two path vocabularies the review handlers sit
+// between — rf*File is the repo-relative path a forge or `git diff` hands the
+// caller, rf*Key the key the store holds — but the two spellings are one
+// string on every platform: the indexer folds every graph key through
+// filepath.ToSlash, so there is no separator for analysis.JoinFileNodes to
+// convert.
 const (
 	rfKeptFile = "repo/edit.go"
 	rfGoneFile = "repo/gone.go"
-)
 
-var (
-	rfKeptKey = filepath.FromSlash(rfKeptFile)
-	rfGoneKey = filepath.FromSlash(rfGoneFile)
+	rfKeptKey = rfKeptFile
+	rfGoneKey = rfGoneFile
 	rfKeptID  = rfKeptKey + "::Kept"
 	rfGoneID  = rfGoneKey + "::Gone"
 )

--- a/internal/mcp/rename_apply.go
+++ b/internal/mcp/rename_apply.go
@@ -45,7 +45,7 @@ func (s *Server) unindexedRenameRecovery(ctx context.Context, id, newName string
 		return nil
 	}
 
-	file := s.graphPathSpelling(relPath)
+	file := graphPathKey(relPath)
 	owner, relPath := s.indexerForRel(file)
 	if owner == nil || relPath == "" {
 		return nil

--- a/internal/mcp/savings_retrieval.go
+++ b/internal/mcp/savings_retrieval.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -239,7 +240,7 @@ func citedFilesFromResult(payload string) []string {
 	out := make([]string, 0, 8)
 	add := func(p string) {
 		p = strings.TrimSpace(p)
-		if p == "" || filepath.IsAbs(p) || seen[p] || len(out) >= maxRetrievalCitationScan {
+		if p == "" || citationIsAbsolute(p) || seen[p] || len(out) >= maxRetrievalCitationScan {
 			return
 		}
 		seen[p] = true
@@ -279,6 +280,18 @@ func citedFilesFromResult(payload string) []string {
 		}
 	}
 	return out
+}
+
+// citationIsAbsolute reports whether a cited path names an absolute location
+// in either spelling. filepath.IsAbs only understands the running platform's:
+// on Windows it answers false for the '/'-rooted form, which is exactly what
+// the path_abs columns carry — every wire format Gortex emits spells paths
+// with forward slashes regardless of who wrote them. So the absolute-path
+// filter passed `/abs/only.go` straight through and the ledger credited it as
+// a repo-relative citation. Treating a leading '/' as absolute costs nothing
+// on POSIX, where filepath.IsAbs already says the same thing.
+func citationIsAbsolute(p string) bool {
+	return filepath.IsAbs(p) || path.IsAbs(filepath.ToSlash(p))
 }
 
 // maxToonCitationBytes bounds the TOON decode attempt so a very large text

--- a/internal/mcp/savings_retrieval_test.go
+++ b/internal/mcp/savings_retrieval_test.go
@@ -191,9 +191,13 @@ func TestRetrievalBaselineCapsFilesPerCall(t *testing.T) {
 	srv, _, dir := newRetrievalSavingsServer(t, files)
 	ctx := WithSessionID(context.Background(), "session-cap")
 
+	// Graph paths are '/'-joined on every platform (the indexer folds every
+	// key through filepath.ToSlash), and so is every citation lifted off the
+	// wire — filepath.Join here would hand resolveGraphPath `myrepo\mod0.go`,
+	// which matches no repo prefix on Windows and credits nothing.
 	cited := make([]string, 0, files)
 	for i := range files {
-		cited = append(cited, filepath.Join("myrepo", fmt.Sprintf("mod%d.go", i)))
+		cited = append(cited, fmt.Sprintf("myrepo/mod%d.go", i))
 	}
 	srv.recordFileSetBaselineSavings(ctx, "search_symbols", cited, "a retrieval page")
 

--- a/internal/mcp/stale_refs_test.go
+++ b/internal/mcp/stale_refs_test.go
@@ -57,7 +57,7 @@ func TestStaleRefsBroadcaster_RemovedSymbol_InWorkingSet(t *testing.T) {
 	calls := fake.snapshot()
 	require.Len(t, calls, 1)
 	assert.Equal(t, "/x.go", calls[0].params["path"])
-	assert.Equal(t, "file:///x.go", calls[0].params["uri"])
+	assert.Equal(t, wantFileURI(t, "/x.go"), calls[0].params["uri"])
 	removed := calls[0].params["removed_symbols"].([]string)
 	require.Len(t, removed, 1)
 	assert.Equal(t, "x.go::Foo", removed[0])

--- a/internal/mcp/tools_conflicts_test.go
+++ b/internal/mcp/tools_conflicts_test.go
@@ -3,7 +3,6 @@ package mcp
 import (
 	"context"
 	"encoding/json"
-	"path/filepath"
 	"strconv"
 	"testing"
 
@@ -127,17 +126,14 @@ func TestCommunityConflicts_EmptyCommunityIDsIgnored(t *testing.T) {
 func conflictsTestServer(t *testing.T) (*Server, string, string) {
 	t.Helper()
 	g := graph.New()
-	// The returned names are the forge spelling a caller supplies; the graph
-	// keys use native separators, which is what the indexer writes even with
-	// no repo prefix.
+	// The forge spelling a caller supplies and the graph key are the same
+	// string: graph paths are '/'-joined on every platform.
 	fileA := "internal/a/svc.go"
 	fileB := "internal/b/svc.go"
-	storedA := filepath.FromSlash(fileA)
-	storedB := filepath.FromSlash(fileB)
-	idA := storedA + "::DoA"
-	idB := storedB + "::DoB"
-	g.AddNode(&graph.Node{ID: idA, Kind: graph.KindFunction, Name: "DoA", FilePath: storedA, StartLine: 1, EndLine: 5})
-	g.AddNode(&graph.Node{ID: idB, Kind: graph.KindFunction, Name: "DoB", FilePath: storedB, StartLine: 1, EndLine: 5})
+	idA := fileA + "::DoA"
+	idB := fileB + "::DoB"
+	g.AddNode(&graph.Node{ID: idA, Kind: graph.KindFunction, Name: "DoA", FilePath: fileA, StartLine: 1, EndLine: 5})
+	g.AddNode(&graph.Node{ID: idB, Kind: graph.KindFunction, Name: "DoB", FilePath: fileB, StartLine: 1, EndLine: 5})
 
 	srv := NewServer(query.NewEngine(g), g, nil, nil, zap.NewNop(), nil)
 	installCommunitiesForTest(srv, &analysis.CommunityResult{
@@ -264,11 +260,9 @@ func conflictsBudgetServer(t *testing.T) (*Server, map[string][]string, []forge.
 		for p := 0; p < 2; p++ {
 			prNum := c*2 + p + 1
 			file := "internal/x/" + comm + "_" + string(rune('a'+p)) + ".go"
-			// Same split as conflictsTestServer: supplied in the forge
-			// spelling, stored with native separators.
-			stored := filepath.FromSlash(file)
-			id := stored + "::F"
-			g.AddNode(&graph.Node{ID: id, Kind: graph.KindFunction, Name: "F", FilePath: stored, StartLine: 1, EndLine: 3})
+			// Same as conflictsTestServer: the forge spelling IS the graph key.
+			id := file + "::F"
+			g.AddNode(&graph.Node{ID: id, Kind: graph.KindFunction, Name: "F", FilePath: file, StartLine: 1, EndLine: 3})
 			nodeToComm[id] = comm
 			members3[c] = append(members3[c], id)
 			files[strconv.Itoa(prNum)] = []string{file}

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -5061,13 +5061,20 @@ func sortLocalizationMemberTier(tier []*rerank.Candidate) {
 // stable across platforms — the same Swift fixture paged
 // `[type, detect, reload]` on POSIX and `[type, reload, detect]` on Windows.
 // Declaration order is a total order on a key every platform agrees on.
+//
+// The declaration order applies to every file that holds more than one slot,
+// not only to one that happens to carry a demotable member. A tight window
+// can select a file's type and two of its ordinary methods and nothing else:
+// every row is then in the leading tier, there is no demotion to perform, and
+// gating the ordering on one made exactly that page — the one with the fewest
+// slots to disagree about — inherit the arrival permutation again.
 func demoteLocalizationFileMembers(cands []*rerank.Candidate) []*rerank.Candidate {
 	if len(cands) < 2 {
 		return cands
 	}
 	slots := make(map[string][]int, len(cands))
 	files := make([]string, 0, len(cands))
-	demotable := false
+	reorderable := false
 	for i, cand := range cands {
 		if cand == nil || cand.Node == nil || cand.Node.FilePath == "" {
 			continue
@@ -5077,11 +5084,11 @@ func demoteLocalizationFileMembers(cands []*rerank.Candidate) []*rerank.Candidat
 			files = append(files, key)
 		}
 		slots[key] = append(slots[key], i)
-		if localizationMemberTier(cand.Node) != localizationMemberTierBehavioral {
-			demotable = true
+		if len(slots[key]) > 1 {
+			reorderable = true
 		}
 	}
-	if !demotable {
+	if !reorderable {
 		return cands
 	}
 	out := append([]*rerank.Candidate(nil), cands...)

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -877,8 +877,12 @@ func exploreStructuralSignals(parent, child *graph.Node) (shared int, local bool
 			shared++
 		}
 	}
-	parentPath := nodeDisplayPath(parent)
-	childPath := nodeDisplayPath(child)
+	// An indexed path carries the indexing machine's separators, so the
+	// "same directory" test folds to '/' first — on Windows every
+	// LastIndex below would otherwise be -1 and no two files would ever
+	// read as local siblings.
+	parentPath := strings.ReplaceAll(nodeDisplayPath(parent), "\\", "/")
+	childPath := strings.ReplaceAll(nodeDisplayPath(child), "\\", "/")
 	parentSlash := strings.LastIndex(parentPath, "/")
 	childSlash := strings.LastIndex(childPath, "/")
 	if parentSlash >= 0 && childSlash >= 0 && parentPath != childPath {
@@ -1238,7 +1242,11 @@ func exploreDraftExactAnchor(query string, n *graph.Node) bool {
 			return true
 		}
 	}
-	path := nodeDisplayPath(n)
+	// Fold the indexed path's separators before taking the basename: on
+	// Windows a raw graph path has none of the '/' this LastIndex looks
+	// for, so the whole path would be matched against the query instead
+	// of the file's name and the anchor could never fire.
+	path := strings.ReplaceAll(nodeDisplayPath(n), "\\", "/")
 	if slash := strings.LastIndex(path, "/"); slash >= 0 {
 		path = path[slash+1:]
 	}
@@ -1585,6 +1593,9 @@ func exploreLocalizationExplicitAnchor(query string, n *graph.Node) bool {
 		// that would make same-name files in different packages terminal.
 		return false
 	}
+	// Same separator fold as above — the basename fallback must see a
+	// file name, not a whole backslash-joined Windows path.
+	path = strings.ReplaceAll(path, "\\", "/")
 	if slash := strings.LastIndex(path, "/"); slash >= 0 {
 		path = path[slash+1:]
 	}

--- a/internal/mcp/tools_explore.go
+++ b/internal/mcp/tools_explore.go
@@ -5028,6 +5028,20 @@ func localizationMemberTier(n *graph.Node) int {
 	}
 }
 
+// sortLocalizationMemberTier puts one file's tier rows in declaration order,
+// falling back to the node id when two rows share a start line (a fixture
+// without line numbers, or two declarations the extractor put on one line).
+// Both keys are the graph's own, so the result is identical on every platform.
+func sortLocalizationMemberTier(tier []*rerank.Candidate) {
+	sort.SliceStable(tier, func(i, j int) bool {
+		a, b := tier[i].Node, tier[j].Node
+		if a.StartLine != b.StartLine {
+			return a.StartLine < b.StartLine
+		}
+		return a.ID < b.ID
+	})
+}
+
 // demoteLocalizationFileMembers reorders localization candidates inside the
 // index positions each file already occupies. Nothing is dropped, added, or
 // moved across files: a file's tiered candidates are written back into that
@@ -5036,6 +5050,17 @@ func localizationMemberTier(n *graph.Node) int {
 // projection's field — survives. Relative order inside a tier is preserved, so
 // the reorder is stable and idempotent. Candidates without a node or a file
 // path cannot be attributed to a file and keep their position.
+//
+// Inside a tier the rows are ordered by their own declaration site — the
+// file's reading order — rather than by the order they happened to arrive
+// in. The arrival order carries no ranking signal at this point:
+// liftLocalizationSiblingCallables writes each traded-in sibling into the
+// slot of whichever demoted member it replaced, so a file's rows are already
+// permuted by something other than their rank. Leaving that permutation
+// visible made the page depend on an upstream tie whose resolution is not
+// stable across platforms — the same Swift fixture paged
+// `[type, detect, reload]` on POSIX and `[type, reload, detect]` on Windows.
+// Declaration order is a total order on a key every platform agrees on.
 func demoteLocalizationFileMembers(cands []*rerank.Candidate) []*rerank.Candidate {
 	if len(cands) < 2 {
 		return cands
@@ -5070,6 +5095,9 @@ func demoteLocalizationFileMembers(cands []*rerank.Candidate) []*rerank.Candidat
 			cand := cands[position]
 			tier := localizationMemberTier(cand.Node)
 			tiers[tier] = append(tiers[tier], cand)
+		}
+		for i := range tiers {
+			sortLocalizationMemberTier(tiers[i])
 		}
 		written := 0
 		for _, tier := range tiers {

--- a/internal/mcp/tools_fileops.go
+++ b/internal/mcp/tools_fileops.go
@@ -600,26 +600,17 @@ func (s *Server) resolveGraphPath(ctx context.Context, graphPath string) (string
 // behaviour callers had before, never worse. Use it before GetFileSymbols
 // / FileEditingContext so a repo-relative path doesn't silently miss the
 // prefixed nodes in multi-repo mode.
+//
+// The result is spelled the way graph keys are — forward slashes on every
+// platform (graphPathKey). resolveFilePath derives the relative form with
+// filepath.Rel / filepath.Join, so on Windows it hands back
+// `alpha/svc\a.go`, which matches no node: get_file_summary answered
+// file_not_indexed for an indexed file.
 func (s *Server) graphRelPath(ctx context.Context, fp string) string {
 	if _, rel, err := s.resolveFilePath(ctx, fp); err == nil && rel != "" {
-		return s.graphPathSpelling(rel)
+		return graphPathKey(rel)
 	}
 	return fp
-}
-
-// graphPathSpelling renders a repo-relative path the way graph node IDs
-// spell it: the repo prefix joined with "/", the repo-relative remainder in
-// the OS separator. resolveFilePath echoes a caller-supplied relative path
-// back verbatim, so without this a forward-slash path — the spelling every
-// agent writes — missed every node below the repo root on Windows and the
-// read tools answered file_not_indexed for an indexed file. Identity on
-// POSIX, where the two separators already agree.
-func (s *Server) graphPathSpelling(rel string) string {
-	prefixed := false
-	if s.multiIndexer != nil {
-		prefixed = matchedRepoPrefix(s.multiIndexer, rel) != ""
-	}
-	return graphMatchPathKey(rel, prefixed)
 }
 
 // fileAttributionNode synthesizes a node carrying just the repo prefix

--- a/internal/mcp/tools_fileops_test.go
+++ b/internal/mcp/tools_fileops_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	mcplib "github.com/mark3labs/mcp-go/mcp"
@@ -181,6 +182,9 @@ func TestEditFile_NonexistentFile(t *testing.T) {
 }
 
 func TestWriteFile_PreservesExistingMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits: Windows has no exec bit and reports every file as 0666 or 0444")
+	}
 	srv, dir := setupTestServer(t)
 	target := filepath.Join(dir, "exec.sh")
 	require.NoError(t, os.WriteFile(target, []byte("old"), 0o755))

--- a/internal/mcp/tools_overlay_branch_test.go
+++ b/internal/mcp/tools_overlay_branch_test.go
@@ -399,7 +399,9 @@ func TestOverlayBranch_BackwardCompat(t *testing.T) {
 	// 2. overlay_list shows the file.
 	_, listText := invokeTool(t, srv, ctx, "overlay_list", map[string]any{})
 	require.Contains(t, listText, `"count":1`)
-	require.Contains(t, listText, targetFile)
+	// The listing is a JSON body: a Windows path reaches it with its
+	// backslashes escaped, so match the JSON spelling of the path.
+	require.Contains(t, listText, jsonEscape(targetFile))
 
 	// 3. A query reflects the overlay (Compat is visible).
 	_, summary := invokeTool(t, srv, ctx, "get_file_summary", map[string]any{

--- a/internal/mcp/tools_prs_test.go
+++ b/internal/mcp/tools_prs_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 	"strconv"
 	"testing"
 
@@ -25,15 +24,12 @@ import (
 func prToolsTestServer(t *testing.T) (*Server, string) {
 	t.Helper()
 	g := graph.New()
-	// `file` is the forge/git spelling a caller supplies; `stored` is what the
-	// indexer writes, which uses native separators even with no repo prefix.
-	// Hard-coding the '/' form as the graph key describes an index a Windows
-	// daemon never produces, and the join contract then cannot be observed.
+	// The forge/git spelling a caller supplies and the key the indexer writes
+	// are the same string: graph paths are '/'-joined on every platform.
 	file := "internal/auth/login.go"
-	stored := filepath.FromSlash(file)
-	hubID := stored + "::ValidateToken"
-	g.AddNode(&graph.Node{ID: hubID, Kind: graph.KindFunction, Name: "ValidateToken", FilePath: stored, StartLine: 1, EndLine: 10})
-	callerFile := filepath.FromSlash("pkg/c.go")
+	hubID := file + "::ValidateToken"
+	g.AddNode(&graph.Node{ID: hubID, Kind: graph.KindFunction, Name: "ValidateToken", FilePath: file, StartLine: 1, EndLine: 10})
+	const callerFile = "pkg/c.go"
 	for i := 0; i < 12; i++ {
 		cid := callerFile + "::caller" + strconv.Itoa(i)
 		g.AddNode(&graph.Node{ID: cid, Kind: graph.KindFunction, Name: "caller" + strconv.Itoa(i), FilePath: callerFile})
@@ -189,11 +185,9 @@ func TestGetPRImpact_RequiresNumber(t *testing.T) {
 // stay raw-first for unprefixed graphs, and never double-prefix.
 func TestChangedSymbolsForFiles_RepoPrefixJoin(t *testing.T) {
 	g := graph.New()
-	// The graph keys a file as "<prefix>/" + the remainder in the indexing
-	// machine's native separators (see internal/graphpath), so the fixture is
-	// built that way. Hard-coding the '/'-joined form describes a key a
-	// Windows daemon never produces.
-	prefixedFile := "myrepo/" + filepath.FromSlash("internal/auth/login.go")
+	// The graph keys a file as "<prefix>/" + the remainder, forward-slashed
+	// throughout on every platform, so the fixture is built that way.
+	const prefixedFile = "myrepo/internal/auth/login.go"
 	prefixedID := prefixedFile + "::ValidateToken"
 	g.AddNode(&graph.Node{ID: prefixedID, Kind: graph.KindFunction, Name: "ValidateToken", FilePath: prefixedFile, StartLine: 1, EndLine: 10})
 	srv := NewServer(query.NewEngine(g), g, nil, nil, zap.NewNop(), nil)
@@ -213,7 +207,7 @@ func TestChangedSymbolsForFiles_RepoPrefixJoin(t *testing.T) {
 	// prefixed is still prefixed: it names the nested file, not the
 	// same-named top-level one. Treating it as already-keyed used to
 	// resolve the wrong file — or, with no shadow present, nothing at all.
-	shadowFile := "myrepo/" + filepath.FromSlash("myrepo/internal/auth/login.go")
+	const shadowFile = "myrepo/myrepo/internal/auth/login.go"
 	g.AddNode(&graph.Node{ID: shadowFile + "::Nested", Kind: graph.KindFunction, Name: "Nested", FilePath: shadowFile, StartLine: 1, EndLine: 10})
 	_, nodes = srv.changedSymbolsForFiles(context.Background(), "myrepo", []string{"myrepo/internal/auth/login.go"})
 	require.Len(t, nodes, 1)

--- a/internal/mcp/tools_review.go
+++ b/internal/mcp/tools_review.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -274,7 +275,7 @@ func (s *Server) handleSiblingDiffContext(ctx context.Context, req mcp.CallToolR
 	seen := map[string]bool{}
 	var siblings []siblingDiffRow
 	for _, f := range diff.ChangedFiles {
-		f = filepath.Clean(f)
+		f = cleanRepoRelPath(f)
 		if f == "" || f == "." || focus[f] || seen[f] {
 			continue
 		}
@@ -324,13 +325,30 @@ func siblingDiffScope(req mcp.CallToolRequest) (scope, baseRef string) {
 	return scope, baseRef
 }
 
+// cleanRepoRelPath is the one cleaner every repo-relative path in this file
+// goes through: the changed-file list, the focus set, and the node lookups
+// that join them. filepath.Clean would be wrong here — it re-spells the path
+// in the running platform's separators, and on Windows that leaves
+// `internal\alpha\a.go`, which is neither what MapGitDiff hands back (git
+// speaks '/' everywhere) nor what the graph keys its file nodes under (the
+// indexer folds every key through filepath.ToSlash). The sibling relation
+// silently degraded to "none" for every file below the repo root, because
+// GetFileNodes was handed a spelling no node carries.
+func cleanRepoRelPath(p string) string {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return ""
+	}
+	return path.Clean(filepath.ToSlash(p))
+}
+
 // resolveFocusFiles collects the focus file set from focus_files / focus_file
 // (paths) and focus_symbol_id (the symbol's file). Paths are cleaned so they
 // join the MapGitDiff ChangedFiles keys.
 func (s *Server) resolveFocusFiles(ctx context.Context, req mcp.CallToolRequest) map[string]bool {
 	focus := map[string]bool{}
 	add := func(p string) {
-		p = filepath.Clean(strings.TrimSpace(p))
+		p = cleanRepoRelPath(p)
 		if p != "" && p != "." {
 			focus[p] = true
 		}

--- a/internal/mcp/tools_review_pack_coverage_test.go
+++ b/internal/mcp/tools_review_pack_coverage_test.go
@@ -48,8 +48,10 @@ func vitestCoveredRepo(t *testing.T) string {
 	run("config", "diff.mnemonicPrefix", "false")
 	run("config", "diff.noprefix", "false")
 
-	prod := filepath.Join("src", "production.ts")
-	test := filepath.Join("tests", "production.ts")
+	// Repo-relative and therefore '/'-spelled on every platform — the graph
+	// keys its file nodes that way and so does the diff these paths join.
+	const prod = "src/production.ts"
+	const test = "tests/production.ts"
 	write(prod, `export function resolveEntityOrderBy(sort: string): string[] {
   return [sort];
 }

--- a/internal/mcp/tools_review_test.go
+++ b/internal/mcp/tools_review_test.go
@@ -45,9 +45,13 @@ func siblingDiffGitRepo(t *testing.T) (root, fileA, fileB, fileC string) {
 	run("config", "diff.mnemonicPrefix", "false")
 	run("config", "diff.noprefix", "false")
 
-	fileA = filepath.Join("internal", "alpha", "a.go")
-	fileB = filepath.Join("internal", "alpha", "b.go")
-	fileC = filepath.Join("internal", "beta", "c.go")
+	// '/'-spelled on every platform: these are repo-relative paths, which is
+	// what git prints, what the graph keys file nodes under, and what the
+	// review handlers compare. filepath.Join here would build a third
+	// spelling that matches neither on Windows.
+	fileA = "internal/alpha/a.go"
+	fileB = "internal/alpha/b.go"
+	fileC = "internal/beta/c.go"
 	write := func(rel, src string) {
 		abs := filepath.Join(dir, rel)
 		require.NoError(t, os.MkdirAll(filepath.Dir(abs), 0o755))
@@ -276,7 +280,7 @@ func reviewGitRepo(t *testing.T) (root, file string) {
 	run("config", "user.name", "t")
 	run("config", "diff.noprefix", "false")
 
-	file = filepath.Join("internal", "svc", "handler.go")
+	file = "internal/svc/handler.go"
 	write := func(rel, src string) {
 		abs := filepath.Join(dir, rel)
 		require.NoError(t, os.MkdirAll(filepath.Dir(abs), 0o755))

--- a/internal/mcp/tools_search_text.go
+++ b/internal/mcp/tools_search_text.go
@@ -198,12 +198,11 @@ func (s *Server) filterTextMatchesByResolvedScope(ctx context.Context, matches [
 		}
 		n := reader.GetNode(m.Path)
 		if n == nil {
-			// A trigram match path is always forward-slash, but node IDs
-			// keep the repo-relative remainder in the OS separator. The two
-			// spellings agree only for a file at the repo root, so on
-			// Windows every match below the root failed attribution here and
-			// the fail-closed drop below emptied the entire result set.
-			if key := graphMatchPathKey(m.Path, knownRepo); key != m.Path {
+			// Both spellings are forward-slash — a trigram match path by
+			// construction, a graph node ID because the indexer folds every
+			// key through filepath.ToSlash — so this retry only catches a
+			// natively-spelled path that reached the batch from elsewhere.
+			if key := graphPathKey(m.Path); key != m.Path {
 				n = reader.GetNode(key)
 			}
 		}
@@ -221,23 +220,16 @@ func (s *Server) filterTextMatchesByResolvedScope(ctx context.Context, matches [
 	return out
 }
 
-// graphMatchPathKey spells a trigram match path the way graph node IDs
-// spell it. Match paths are always forward-slash; a node ID joins the repo
-// prefix with "/" but keeps the repo-relative remainder in the OS separator,
-// so the two forms diverge on Windows for every file below the repo root.
-// repoPrefixed says whether the first segment names a tracked repo rather
-// than an ordinary directory. Returns path unchanged where the separators
-// already agree, so POSIX callers pay nothing.
-func graphMatchPathKey(path string, repoPrefixed bool) string {
-	if filepath.Separator == '/' {
-		return path
-	}
-	if repoPrefixed {
-		if repo, rest, ok := strings.Cut(path, "/"); ok {
-			return repo + "/" + filepath.FromSlash(rest)
-		}
-	}
-	return filepath.FromSlash(path)
+// graphPathKey spells a repo-relative path the way graph node IDs spell it:
+// forward slashes on every platform, because the indexer folds every key it
+// mints through filepath.ToSlash (Indexer.relKey). The repo prefix and the
+// remainder therefore share one separator, so no prefix-aware split is
+// needed. Identity on POSIX, where a backslash is an ordinary filename byte
+// and must survive; on Windows it converts a natively-spelled path
+// (filepath.Rel / filepath.Join output) into the graph's spelling, which is
+// where the two vocabularies actually meet.
+func graphPathKey(path string) string {
+	return filepath.ToSlash(path)
 }
 
 // enrichTextMatchesContext decorates every trigram match with its enclosing
@@ -260,7 +252,7 @@ func (s *Server) enrichTextMatchesContext(
 			exactSeen[match.Path] = struct{}{}
 			exactPaths = append(exactPaths, match.Path)
 		}
-		if alias := graphMatchPathKey(match.Path, true); alias != match.Path {
+		if alias := graphPathKey(match.Path); alias != match.Path {
 			if _, duplicate := aliasSeen[alias]; !duplicate {
 				aliasSeen[alias] = struct{}{}
 				aliasPaths = append(aliasPaths, alias)
@@ -290,7 +282,7 @@ func fileSymbolIndexForPath(indexes map[string]*fileSymbolIndex, path string) *f
 	if index := indexes[path]; index != nil {
 		return index
 	}
-	if key := graphMatchPathKey(path, true); key != path {
+	if key := graphPathKey(path); key != path {
 		return indexes[key]
 	}
 	return nil

--- a/internal/mcp/tools_search_text_pathsep_test.go
+++ b/internal/mcp/tools_search_text_pathsep_test.go
@@ -20,17 +20,19 @@ import (
 	"github.com/zzet/gortex/internal/search/trigram"
 )
 
-// TestGraphMatchPathKey pins the two spellings apart: a trigram match path
-// is always forward-slash, while a graph node ID joins the repo prefix with
-// "/" and keeps the repo-relative remainder in the OS separator.
-func TestGraphMatchPathKey(t *testing.T) {
-	require.Equal(t, "beta/"+filepath.FromSlash("pkg/sub/main.go"),
-		graphMatchPathKey("beta/pkg/sub/main.go", true),
-		"a repo-prefixed match keeps the prefix separator and OS-spells the remainder")
-	require.Equal(t, filepath.FromSlash("pkg/sub/main.go"),
-		graphMatchPathKey("pkg/sub/main.go", false),
-		"an unprefixed match is OS-spelled whole")
-	require.Equal(t, "beta/main.go", graphMatchPathKey("beta/main.go", true),
+// TestGraphPathKey pins the one graph spelling: forward slashes on every
+// platform, prefix and remainder alike. A trigram match path already arrives
+// that way, so it passes through untouched; a natively-spelled path — what
+// filepath.Rel / filepath.Join produce on Windows — is converted.
+func TestGraphPathKey(t *testing.T) {
+	require.Equal(t, "beta/pkg/sub/main.go", graphPathKey("beta/pkg/sub/main.go"),
+		"a forward-slash path is already the graph spelling")
+	require.Equal(t, "beta/pkg/sub/main.go",
+		graphPathKey("beta/"+filepath.FromSlash("pkg/sub/main.go")),
+		"a natively-spelled remainder is folded onto the graph spelling")
+	require.Equal(t, "pkg/sub/main.go", graphPathKey(filepath.FromSlash("pkg/sub/main.go")),
+		"an unprefixed native path is folded whole")
+	require.Equal(t, "beta/main.go", graphPathKey("beta/main.go"),
 		"a repo-root file has one spelling on every platform")
 }
 
@@ -72,22 +74,22 @@ func nestedRepoServer(t *testing.T, entries []config.RepoEntry) (*Server, *graph
 }
 
 // TestGraphRelPath_LoneRepoForwardSlash covers the read side of the same
-// separator gap. resolveFilePath echoes a caller-supplied relative path back
-// verbatim, so a forward-slash path — what agents write, and what every tool
-// description shows — reached the graph unchanged and missed the node below
-// the repo root on Windows: get_file_summary answered file_not_indexed for a
-// file that was indexed.
+// separator question. resolveFilePath derives its relative form with
+// filepath.Rel / filepath.Join, so on Windows it hands back `solo/pkg\sub\main.go`
+// while the graph keys the node `solo/pkg/sub/main.go` — the path missed
+// every node below the repo root and get_file_summary answered
+// file_not_indexed for a file that was indexed.
 func TestGraphRelPath_LoneRepoForwardSlash(t *testing.T) {
 	solo := setupNestedRepo(t, "solo", "shared", "package sub\n\nfunc SoloHandler() {}\n")
 	srv, g := nestedRepoServer(t, []config.RepoEntry{{Path: solo, Name: "solo", Project: "backend"}})
 
-	nodeKey := "solo/" + filepath.FromSlash("pkg/sub/main.go")
+	const nodeKey = "solo/pkg/sub/main.go"
 	require.NotNil(t, g.GetNode(nodeKey), "fixture invariant: a lone repo's node ids carry its prefix")
 
 	require.Equal(t, nodeKey, srv.graphRelPath(context.Background(), "solo/pkg/sub/main.go"),
 		"a forward-slash path must be normalised to the graph's spelling")
 	require.Equal(t, nodeKey, srv.graphRelPath(context.Background(), nodeKey),
-		"an already OS-spelled path is unchanged (idempotent)")
+		"the graph spelling is unchanged (idempotent)")
 
 	res := callTool(t, srv, "get_file_summary", map[string]any{"path": "pkg/sub/main.go"})
 	require.False(t, res.IsError, "a forward-slash repo-relative path must resolve")
@@ -96,15 +98,16 @@ func TestGraphRelPath_LoneRepoForwardSlash(t *testing.T) {
 
 // TestFilterTextMatchesByResolvedScope_BelowRepoRoot is the regression for
 // search_text returning zero results on Windows. Scope narrowing attributes
-// every match to a graph node and fails closed when it cannot. The lookup
-// key was the raw forward-slash match path, which equals the node ID only
-// for a file at the repo root — so on Windows every match below the root was
-// silently dropped and a repo-wide search reported no hits at all.
+// every match to a graph node and fails closed when it cannot, so any
+// disagreement between the match-path spelling and the node-ID spelling
+// silently drops every hit and a repo-wide search reports nothing at all.
+// Both are forward-slash — trigram emits them, and the indexer folds every
+// key through filepath.ToSlash — and this pins that agreement.
 //
-// The existing fail-closed fixture uses a root-level file, where the two
-// spellings coincide on every platform; these put the file in a
-// subdirectory, and cover both node-ID shapes: prefixed (several tracked
-// repos) and a lone repo, whose ids carry its prefix too.
+// The existing fail-closed fixture uses a root-level file, where any
+// separator question is moot; these put the file in a subdirectory, and
+// cover both node-ID shapes: prefixed (several tracked repos) and a lone
+// repo, whose ids carry its prefix too.
 func TestFilterTextMatchesByResolvedScope_BelowRepoRoot(t *testing.T) {
 	t.Run("prefixed node ids", func(t *testing.T) {
 		alpha := setupNestedRepo(t, "alpha", "shared", "package sub\n\n// marker\nfunc A() {}\n")
@@ -114,7 +117,7 @@ func TestFilterTextMatchesByResolvedScope_BelowRepoRoot(t *testing.T) {
 			{Path: beta, Name: "beta", Project: "backend"},
 		})
 
-		nodeKey := "beta/" + filepath.FromSlash("pkg/sub/main.go")
+		const nodeKey = "beta/pkg/sub/main.go"
 		require.NotNil(t, g.GetNode(nodeKey),
 			"fixture invariant: several tracked repos mint prefixed node ids")
 
@@ -133,7 +136,7 @@ func TestFilterTextMatchesByResolvedScope_BelowRepoRoot(t *testing.T) {
 			{Path: solo, Name: "solo", Project: "backend"},
 		})
 
-		require.NotNil(t, g.GetNode("solo/"+filepath.FromSlash("pkg/sub/main.go")),
+		require.NotNil(t, g.GetNode("solo/pkg/sub/main.go"),
 			"fixture invariant: a lone repo's node ids carry its prefix")
 
 		got := srv.filterTextMatchesByResolvedScope(
@@ -142,6 +145,6 @@ func TestFilterTextMatchesByResolvedScope_BelowRepoRoot(t *testing.T) {
 			ResolvedScope{WorkspaceID: "shared", RepoAllow: map[string]bool{"solo": true}},
 		)
 		require.Len(t, got, 1,
-			"the unprefixed retry must also cross the separator gap")
+			"a lone repo's prefixed node id must attribute the match too")
 	})
 }

--- a/internal/mcp/tools_search_text_test.go
+++ b/internal/mcp/tools_search_text_test.go
@@ -378,9 +378,9 @@ func TestGetFileSummary_MultiRepoRelativePath(t *testing.T) {
 	})
 
 	// A repo-relative path unique to one repo anchors to that repo's prefix,
-	// spelled the way node IDs are: prefix by "/", remainder by the OS
-	// separator. On POSIX the two are the same string.
-	require.Equal(t, "alpha/"+filepath.FromSlash("svc/a.go"), srv.graphRelPath(context.Background(), "svc/a.go"))
+	// spelled the way node IDs are: forward slashes throughout, on every
+	// platform.
+	require.Equal(t, "alpha/svc/a.go", srv.graphRelPath(context.Background(), "svc/a.go"))
 
 	// get_file_summary with the repo-relative path now finds the symbols
 	// rather than returning a file_not_indexed miss.
@@ -389,7 +389,7 @@ func TestGetFileSummary_MultiRepoRelativePath(t *testing.T) {
 	require.Contains(t, res.Content[0].(mcplib.TextContent).Text, "AlphaHandler")
 
 	// An already-prefixed path keeps working (idempotent normalisation).
-	require.Equal(t, "beta/"+filepath.FromSlash("other/b.go"), srv.graphRelPath(context.Background(), "beta/other/b.go"))
+	require.Equal(t, "beta/other/b.go", srv.graphRelPath(context.Background(), "beta/other/b.go"))
 }
 
 // TestFilterTextMatchesByPath_RepoPrefixed pins the multi-repo path

--- a/internal/modelhint/modelhint_test.go
+++ b/internal/modelhint/modelhint_test.go
@@ -53,10 +53,17 @@ func TestRead_StaleIgnored(t *testing.T) {
 	Write("/work/repo", "claude-opus-4-8", "claude-code")
 
 	// Backdate the per-cwd file beyond the trust window by rewriting it
-	// through the same path with a stale Updated stamp.
-	stale := Hint{CWD: "/work/repo", Model: "claude-opus-4-8", Updated: time.Now().Add(-2 * ttl).UnixNano()}
+	// through the same path with a stale Updated stamp. Write and Read both
+	// key the file on filepath.Abs(cwd), which on Windows turns "/work/repo"
+	// into "<drive>:\work\repo" — hashing the raw spelling here would target a
+	// different file and leave the fresh hint in place.
+	abs, err := filepath.Abs("/work/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale := Hint{CWD: abs, Model: "claude-opus-4-8", Updated: time.Now().Add(-2 * ttl).UnixNano()}
 	data, _ := json.Marshal(stale)
-	writeFileAtomic(cwdFile(dir, "/work/repo"), data)
+	writeFileAtomic(cwdFile(dir, abs), data)
 	writeFileAtomic(filepath.Join(dir, lastFile), data)
 
 	if h, ok := Read("/work/repo"); ok {

--- a/internal/parser/crashpool/quarantine.go
+++ b/internal/parser/crashpool/quarantine.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/zzet/gortex/internal/platform"
 )
 
 // QuarantineEntry records one file that crashed, hung, or panicked the
@@ -31,7 +33,12 @@ type QuarantineEntry struct {
 // *Quarantine is safe for every method (no-op / not-quarantined), so
 // callers can keep crash isolation optional without nil checks.
 type Quarantine struct {
-	mu      sync.Mutex
+	mu sync.Mutex
+	// saveMu serialises the temp-file-plus-replace commit. It is separate
+	// from mu — Save snapshots the entries under mu and must not hold it
+	// across the write — and it is what keeps two Saves from replacing the
+	// backing file at the same instant, which Windows refuses.
+	saveMu  sync.Mutex
 	path    string
 	entries map[string]*QuarantineEntry
 }
@@ -150,9 +157,14 @@ func (q *Quarantine) Save() error {
 	if err := os.MkdirAll(filepath.Dir(q.path), 0o755); err != nil {
 		return err
 	}
-	// Unique temp name so concurrent Saves — the indexer re-indexes
-	// files in parallel through one shared quarantine — never clobber
-	// each other's in-flight write before the rename.
+	// The indexer re-indexes files in parallel through one shared
+	// quarantine, so Saves overlap. Two of them commit here: the
+	// unique temp name keeps their in-flight writes apart, saveMu
+	// keeps their commits apart (Windows refuses to replace a file a
+	// second replace is already moving onto), and platform.ReplaceFile
+	// absorbs the same refusal from another process.
+	q.saveMu.Lock()
+	defer q.saveMu.Unlock()
 	f, err := os.CreateTemp(filepath.Dir(q.path), ".quarantine-*.tmp")
 	if err != nil {
 		return err
@@ -167,5 +179,5 @@ func (q *Quarantine) Save() error {
 		_ = os.Remove(tmp)
 		return err
 	}
-	return os.Rename(tmp, q.path)
+	return platform.ReplaceFile(tmp, q.path)
 }

--- a/internal/pathkey/canonical_test.go
+++ b/internal/pathkey/canonical_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/zzet/gortex/internal/testenv"
 )
 
 func TestCanonicalHasPathPrefixResolvesRootAndCWDAliases(t *testing.T) {
@@ -110,11 +112,7 @@ func TestCanonicalExistingRootDarwinTmpAlias(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("macOS /tmp alias regression")
 	}
-	root, err := os.MkdirTemp("/tmp", "gortex-pathkey-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.RemoveAll(root) })
+	root := testenv.ShortTempDir(t)
 	want, err := filepath.EvalSymlinks(root)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/pathkey/identity_test.go
+++ b/internal/pathkey/identity_test.go
@@ -47,8 +47,12 @@ func TestFoldPath_UppercasesDriveLetter(t *testing.T) {
 }
 
 func TestFoldPath_CleansRedundantSegments(t *testing.T) {
-	got := foldPath("/Users/me/./project/../project", false)
-	want := "/Users/me/project"
+	// foldPath canonicalizes with filepath.Clean, which also rewrites
+	// separators to the host's native ones — so both the input and the
+	// expectation are spelled natively (on Windows "/Users/me/project"
+	// folds to `\Users\me\project`).
+	got := foldPath(filepath.FromSlash("/Users/me/./project/../project"), false)
+	want := filepath.FromSlash("/Users/me/project")
 	if got != want {
 		t.Fatalf("foldPath did not clean: got %q want %q", got, want)
 	}

--- a/internal/platform/atomicfile.go
+++ b/internal/platform/atomicfile.go
@@ -18,6 +18,19 @@ const (
 	transientDelay    = 3 * time.Millisecond
 )
 
+const (
+	// The delete a won claim still owes runs on a much longer budget than the
+	// 60ms above, because it is no longer racing anybody: the claim is already
+	// decided and only the file name is outstanding, while the readers that
+	// refuse the delete on Windows hold the file for as long as their own read
+	// takes. Go's own testing.TempDir cleanup waits about this long for the
+	// same refusal to clear. The backoff starts short so an uncontended delete
+	// still lands on the first retry.
+	claimRemoveBudget   = 2 * time.Second
+	claimRemoveDelay    = time.Millisecond
+	claimRemoveMaxDelay = 64 * time.Millisecond
+)
+
 // ReplaceFile moves oldpath onto newpath, replacing an existing newpath.
 //
 // POSIX rename(2) is atomic: it never fails because somebody holds either end
@@ -33,7 +46,7 @@ func ReplaceFile(oldpath, newpath string) error {
 	return retryTransient(func() error { return os.Rename(oldpath, newpath) })
 }
 
-// ClaimFile grants exactly one caller the right to consume path and deletes it
+// ClaimFile grants exactly one caller the right to consume path and retires it
 // as the claim. It reports true for that single winner, and false for every
 // loser of a concurrent race, for a repeat claim, and for a path that is not
 // there.
@@ -44,18 +57,46 @@ func ReplaceFile(oldpath, newpath string) error {
 // reports success to several callers, so it is claimed by everybody. Exclusive
 // creation is atomic everywhere, so the marker — not the delete — decides the
 // winner, and the delete it guards then runs against no other claimer.
+//
+// Retiring the payload is where the two platforms part company. POSIX
+// unlink(2) always succeeds for the winner: an open reader keeps its handle,
+// the name goes immediately. Windows refuses the delete outright while a
+// reader holds the payload open, because Go opens files with FILE_SHARE_READ
+// and FILE_SHARE_WRITE but never FILE_SHARE_DELETE, and the delete has to open
+// the file for DELETE access first. A winner that reported failure just
+// because a reader was mid-read would leave a contended payload claimed by
+// nobody, so instead it empties the payload — a write the reader's own share
+// mode does permit — and then retries the delete on the longer budget above.
+// A delete that still does not land leaves an empty file behind and the claim
+// stands. An emptied payload is a consumed payload: a later ClaimFile or
+// ConsumeFile refuses it and collects the leftover once the readers are gone,
+// so the emptying can never hand a second caller the claim.
+//
+// The cost of that is visible only to a racing reader on Windows, which can
+// now read an empty or truncated payload where it used to read either the
+// whole one or nothing. Every consumer of a claimed payload already has to
+// validate what it read — on POSIX the delete can land mid-read too — so a
+// short read is rejected rather than misread.
 func ClaimFile(path string) bool {
 	release, ok := claimMarker(path)
 	if !ok {
 		return false
 	}
 	defer release()
-	return removeFile(path) == nil
+	if payloadConsumed(path) {
+		collectConsumedPayload(path)
+		return false
+	}
+	return retirePayload(path)
 }
 
 // ConsumeFile reads path and claims it, handing the content to exactly one
 // caller. ok is false for every loser of a concurrent race, for an
 // already-consumed path, and for a file that cannot be read.
+//
+// An empty payload is an already-consumed one, as it is for ClaimFile: the
+// content is read before the claim retires the file, so a caller that finds
+// nothing to hand over is looking at a payload some earlier winner emptied.
 func ConsumeFile(path string) ([]byte, bool) {
 	release, ok := claimMarker(path)
 	if !ok {
@@ -68,10 +109,87 @@ func ConsumeFile(path string) ([]byte, bool) {
 		data, readErr = os.ReadFile(path) //nolint:gosec // the caller owns the path
 		return readErr
 	})
-	if removeFile(path) != nil || err != nil {
+	if err != nil {
+		return nil, false
+	}
+	if len(data) == 0 {
+		collectConsumedPayload(path)
+		return nil, false
+	}
+	if !retirePayload(path) {
 		return nil, false
 	}
 	return data, true
+}
+
+// retirePayload deletes the payload on behalf of the caller that holds its
+// claim marker, and reports whether that caller comes away owning it. A plain
+// delete settles it everywhere but Windows, where a reader can refuse it; the
+// winner then empties the payload, which no reader can refuse, and keeps
+// retrying the delete on the claim budget. Only a payload that was not there
+// to take, or that could not even be emptied, leaves the caller empty-handed.
+func retirePayload(path string) bool {
+	err := removeFile(path)
+	if err == nil {
+		return true
+	}
+	if !transientSharingError(err) {
+		return false
+	}
+	if emptyPayload(path) != nil {
+		return false
+	}
+	_ = removeWithin(path, claimRemoveBudget)
+	return true
+}
+
+// payloadConsumed reports whether path is the empty file an earlier claim left
+// behind when a reader outlasted its delete. A path that is not there is not a
+// consumed payload — it is nothing at all, which retirePayload reports on its
+// own.
+func payloadConsumed(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular() && info.Size() == 0
+}
+
+// collectConsumedPayload clears an emptied payload once nothing holds it open,
+// so the leftover of a delete that lost its race does not outlive the readers
+// that caused it. Best effort: a still-held payload stays for the next caller.
+func collectConsumedPayload(path string) {
+	_ = removeFile(path)
+}
+
+// emptyPayload truncates the payload the caller has claimed but cannot yet
+// delete. Opening for writing is allowed while a reader holds the file open —
+// Go opens files with FILE_SHARE_WRITE — so the content goes away even when
+// the name cannot yet.
+func emptyPayload(path string) error {
+	return retryTransient(func() error {
+		f, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0o600) //nolint:gosec // the caller owns the path
+		if err != nil {
+			return err
+		}
+		return f.Close()
+	})
+}
+
+// removeWithin deletes path, retrying a transient sharing refusal with an
+// exponential backoff until the budget is spent. On POSIX no error is
+// transient, so the delete runs exactly once.
+func removeWithin(path string, budget time.Duration) error {
+	deadline := time.Now().Add(budget)
+	err := os.Remove(path)
+	for delay := claimRemoveDelay; err != nil && transientSharingError(err); {
+		if time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(delay)
+		if delay < claimRemoveMaxDelay {
+			delay *= 2
+		}
+		err = os.Remove(path)
+	}
+	return err
 }
 
 // claimMarker exclusively creates path's claim marker, returning the release

--- a/internal/platform/atomicfile.go
+++ b/internal/platform/atomicfile.go
@@ -1,0 +1,115 @@
+package platform
+
+import (
+	"os"
+	"time"
+)
+
+// ClaimMarkerSuffix is appended to a path to name the exclusive marker
+// ClaimFile and ConsumeFile create while they claim it. A directory sweeper
+// recognises a marker abandoned by a process that died mid-claim by this
+// suffix; a live marker exists only for the microseconds of the claim.
+const ClaimMarkerSuffix = ".claim"
+
+const (
+	// A rename, a read or a delete can lose a race with a concurrent holder
+	// on Windows; 20 attempts 3ms apart bound the wait at 60ms.
+	transientAttempts = 20
+	transientDelay    = 3 * time.Millisecond
+)
+
+// ReplaceFile moves oldpath onto newpath, replacing an existing newpath.
+//
+// POSIX rename(2) is atomic: it never fails because somebody holds either end
+// open, and concurrent renames onto one destination all report success.
+// Windows MoveFileEx(REPLACE_EXISTING) instead fails with a sharing violation
+// or "Access is denied" while any handle to either end is open — including one
+// held for microseconds by another goroutine that is reading the destination
+// or replacing it at the same instant — so on Windows those transient failures
+// are retried briefly. A vanished source is never retried: it reports
+// ERROR_FILE_NOT_FOUND, which means another caller already moved it and no
+// amount of waiting brings it back.
+func ReplaceFile(oldpath, newpath string) error {
+	return retryTransient(func() error { return os.Rename(oldpath, newpath) })
+}
+
+// ClaimFile grants exactly one caller the right to consume path and deletes it
+// as the claim. It reports true for that single winner, and false for every
+// loser of a concurrent race, for a repeat claim, and for a path that is not
+// there.
+//
+// Neither a rename nor an unlink is a portable single-winner claim. On Windows
+// two racers moving one source can both fail with a sharing violation, so the
+// resource is claimed by nobody; on macOS concurrent unlink(2) of one path
+// reports success to several callers, so it is claimed by everybody. Exclusive
+// creation is atomic everywhere, so the marker — not the delete — decides the
+// winner, and the delete it guards then runs against no other claimer.
+func ClaimFile(path string) bool {
+	release, ok := claimMarker(path)
+	if !ok {
+		return false
+	}
+	defer release()
+	return removeFile(path) == nil
+}
+
+// ConsumeFile reads path and claims it, handing the content to exactly one
+// caller. ok is false for every loser of a concurrent race, for an
+// already-consumed path, and for a file that cannot be read.
+func ConsumeFile(path string) ([]byte, bool) {
+	release, ok := claimMarker(path)
+	if !ok {
+		return nil, false
+	}
+	defer release()
+	var data []byte
+	err := retryTransient(func() error {
+		var readErr error
+		data, readErr = os.ReadFile(path) //nolint:gosec // the caller owns the path
+		return readErr
+	})
+	if removeFile(path) != nil || err != nil {
+		return nil, false
+	}
+	return data, true
+}
+
+// claimMarker exclusively creates path's claim marker, returning the release
+// that removes it again. A caller that dies before releasing leaves the marker
+// behind and the claimed file unclaimable, which keeps the at-most-once
+// guarantee the claim exists for.
+func claimMarker(path string) (func(), bool) {
+	if path == "" {
+		return nil, false
+	}
+	markerPath := path + ClaimMarkerSuffix
+	marker, err := os.OpenFile(markerPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600) //nolint:gosec // the caller owns the path
+	if err != nil {
+		return nil, false
+	}
+	_ = marker.Close()
+	return func() { _ = removeFile(markerPath) }, true
+}
+
+// removeFile deletes path, absorbing the transient Windows refusals. Go opens
+// files without FILE_SHARE_DELETE, so a reader that has the file open for the
+// microseconds of its read makes DeleteFile fail with "Access is denied" —
+// which on POSIX cannot happen at all, since unlink(2) only detaches the name.
+func removeFile(path string) error {
+	return retryTransient(func() error { return os.Remove(path) })
+}
+
+// retryTransient runs op, repeating it while it fails with a sharing failure
+// another holder will shortly release. On POSIX no error is transient, so op
+// runs exactly once.
+func retryTransient(op func() error) error {
+	err := op()
+	for attempt := 1; err != nil && attempt < transientAttempts; attempt++ {
+		if !transientSharingError(err) {
+			break
+		}
+		time.Sleep(transientDelay)
+		err = op()
+	}
+	return err
+}

--- a/internal/platform/atomicfile_test.go
+++ b/internal/platform/atomicfile_test.go
@@ -1,0 +1,215 @@
+package platform
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestReplaceFileReplacesAnExistingDestination(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+	if err := os.WriteFile(src, []byte("new"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dst, []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ReplaceFile(src, dst); err != nil {
+		t.Fatalf("ReplaceFile: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("destination = %q, want %q", got, "new")
+	}
+	if _, err := os.Stat(src); !os.IsNotExist(err) {
+		t.Fatalf("source survived the replace: %v", err)
+	}
+	if err := ReplaceFile(src, dst); err == nil {
+		t.Fatal("replacing from a missing source succeeded")
+	}
+}
+
+// TestReplaceFileSurvivesConcurrentReplacers commits the same destination from
+// many goroutines at once. On Windows a replace whose destination another
+// goroutine is replacing or reading fails with a sharing violation, so every
+// caller has to get its write in.
+func TestReplaceFileSurvivesConcurrentReplacers(t *testing.T) {
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "dst")
+
+	var wg sync.WaitGroup
+	for i := range 16 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			src, err := os.CreateTemp(dir, "src-*")
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			if _, err := src.Write([]byte{byte('a' + i)}); err != nil {
+				t.Error(err)
+				return
+			}
+			if err := src.Close(); err != nil {
+				t.Error(err)
+				return
+			}
+			if err := ReplaceFile(src.Name(), dst); err != nil {
+				t.Errorf("ReplaceFile: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("destination = %q, want one committed write", got)
+	}
+}
+
+func TestClaimFileHasSingleWinner(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "claimed")
+	if err := os.WriteFile(path, []byte("payload"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var winners atomic.Int32
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if ClaimFile(path) {
+				winners.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := winners.Load(); got != 1 {
+		t.Fatalf("claim winners = %d, want 1", got)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("claimed file survived: %v", err)
+	}
+	if ClaimFile(path) {
+		t.Fatal("a consumed path was claimed twice")
+	}
+	if ClaimFile("") {
+		t.Fatal("an empty path was claimed")
+	}
+	if _, err := os.Stat(path + ClaimMarkerSuffix); !os.IsNotExist(err) {
+		t.Fatalf("claim marker survived: %v", err)
+	}
+}
+
+func TestConsumeFileHandsTheContentToASingleWinner(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "consumed")
+	if err := os.WriteFile(path, []byte("payload"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var winners atomic.Int32
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if data, ok := ConsumeFile(path); ok && string(data) == "payload" {
+				winners.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := winners.Load(); got != 1 {
+		t.Fatalf("consume winners = %d, want 1", got)
+	}
+	if _, ok := ConsumeFile(path); ok {
+		t.Fatal("a consumed path was consumed twice")
+	}
+	if _, ok := ConsumeFile(""); ok {
+		t.Fatal("an empty path was consumed")
+	}
+}
+
+// TestClaimFileSurvivesConcurrentReaders reads the claimed file from other
+// goroutines while it is being claimed. Windows opens files without
+// FILE_SHARE_DELETE, so a reader holding the file blocks the winner's delete;
+// the winner must still come away with the claim.
+func TestClaimFileSurvivesConcurrentReaders(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "read-while-claimed")
+	if err := os.WriteFile(path, []byte("payload"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+	var readers sync.WaitGroup
+	for range 8 {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					_, _ = os.ReadFile(path) //nolint:gosec // test-owned path
+				}
+			}
+		}()
+	}
+
+	var winners atomic.Int32
+	var claimers sync.WaitGroup
+	for range 16 {
+		claimers.Add(1)
+		go func() {
+			defer claimers.Done()
+			if ClaimFile(path) {
+				winners.Add(1)
+			}
+		}()
+	}
+	claimers.Wait()
+	close(done)
+	readers.Wait()
+
+	if got := winners.Load(); got != 1 {
+		t.Fatalf("claim winners = %d, want 1", got)
+	}
+}
+
+// TestClaimFileRefusesAHeldClaim pins the marker as the arbiter: while one
+// claim is outstanding nobody else may consume the file, on every platform.
+func TestClaimFileRefusesAHeldClaim(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "held")
+	if err := os.WriteFile(path, []byte("payload"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	release, ok := claimMarker(path)
+	if !ok {
+		t.Fatal("claimMarker failed")
+	}
+	if ClaimFile(path) {
+		t.Fatal("claimed a file whose claim is held")
+	}
+	if _, ok := ConsumeFile(path); ok {
+		t.Fatal("consumed a file whose claim is held")
+	}
+	release()
+	if !ClaimFile(path) {
+		t.Fatal("a released claim was not reclaimable")
+	}
+}

--- a/internal/platform/atomicfile_test.go
+++ b/internal/platform/atomicfile_test.go
@@ -146,8 +146,10 @@ func TestConsumeFileHandsTheContentToASingleWinner(t *testing.T) {
 
 // TestClaimFileSurvivesConcurrentReaders reads the claimed file from other
 // goroutines while it is being claimed. Windows opens files without
-// FILE_SHARE_DELETE, so a reader holding the file blocks the winner's delete;
-// the winner must still come away with the claim.
+// FILE_SHARE_DELETE, so a reader holding the file refuses the winner's delete
+// for as long as the read takes; the winner must still come away with the
+// claim, the payload must be consumed either way — deleted, or emptied and
+// therefore unclaimable — and nobody may claim it a second time.
 func TestClaimFileSurvivesConcurrentReaders(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "read-while-claimed")
 	if err := os.WriteFile(path, []byte("payload"), 0o600); err != nil {
@@ -188,6 +190,52 @@ func TestClaimFileSurvivesConcurrentReaders(t *testing.T) {
 
 	if got := winners.Load(); got != 1 {
 		t.Fatalf("claim winners = %d, want 1", got)
+	}
+	// The payload is consumed whether or not the delete landed: it is either
+	// gone, or empty because the winner neutralised it past a reader that
+	// refused the delete. A surviving byte would mean a claim that consumed
+	// nothing.
+	if info, err := os.Stat(path); err == nil && info.Size() != 0 {
+		t.Fatalf("claimed payload survived with %d bytes", info.Size())
+	}
+	// Nothing holds the file now, so a second claim must both refuse — the
+	// payload was already consumed — and collect whatever the winner left.
+	if ClaimFile(path) {
+		t.Fatal("a consumed payload was claimed a second time")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("consumed payload was not collected: %v", err)
+	}
+	if _, err := os.Stat(path + ClaimMarkerSuffix); !os.IsNotExist(err) {
+		t.Fatalf("claim marker survived: %v", err)
+	}
+}
+
+// TestClaimRefusesAnEmptiedPayload pins the rule the Windows delete fallback
+// rests on: a payload an earlier winner emptied but could not yet delete is
+// already consumed, so neither ClaimFile nor ConsumeFile may hand it to a
+// second caller — and each collects the leftover on its way out.
+func TestClaimRefusesAnEmptiedPayload(t *testing.T) {
+	dir := t.TempDir()
+	for _, tc := range []struct {
+		name  string
+		claim func(string) bool
+	}{
+		{"ClaimFile", ClaimFile},
+		{"ConsumeFile", func(path string) bool { _, ok := ConsumeFile(path); return ok }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(dir, "emptied-"+tc.name)
+			if err := os.WriteFile(path, nil, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if tc.claim(path) {
+				t.Fatal("an emptied payload was claimed")
+			}
+			if _, err := os.Stat(path); !os.IsNotExist(err) {
+				t.Fatalf("emptied payload was not collected: %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/platform/atomicfile_unix.go
+++ b/internal/platform/atomicfile_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package platform
+
+// transientSharingError reports whether a failed rename, read or delete can
+// succeed on a retry. It never can on POSIX: rename(2) and unlink(2) are
+// atomic and no open handle can refuse them, so every error they return is a
+// real one.
+func transientSharingError(error) bool { return false }

--- a/internal/platform/atomicfile_windows.go
+++ b/internal/platform/atomicfile_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package platform
+
+import (
+	"errors"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// transientSharingError reports whether a failed rename, read or delete is the
+// sharing failure another holder of the file causes, rather than a real one.
+// Windows refuses to move, replace or delete a file while another handle to it
+// is open unless that handle asked for FILE_SHARE_DELETE, which os.Open does
+// not; the refusal surfaces as one of these codes and clears as soon as the
+// other holder is done. ERROR_FILE_NOT_FOUND is deliberately absent: a
+// vanished file means somebody else already claimed it, and waiting cannot
+// bring it back.
+func transientSharingError(err error) bool {
+	for _, code := range [...]syscall.Errno{
+		windows.ERROR_ACCESS_DENIED,
+		windows.ERROR_SHARING_VIOLATION,
+		windows.ERROR_LOCK_VIOLATION,
+		windows.ERROR_USER_MAPPED_FILE,
+	} {
+		if errors.Is(err, code) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/resolver/cross_pkg_guard.go
+++ b/internal/resolver/cross_pkg_guard.go
@@ -1,7 +1,6 @@
 package resolver
 
 import (
-	"path/filepath"
 	"sort"
 	"strings"
 
@@ -237,8 +236,8 @@ func (r *Resolver) targetImportReachable(callerFile string, callerNode, target *
 		// shown unreachable — leave the edge alone.
 		return true
 	}
-	callerDir := filepath.Dir(callerFile)
-	targetDir := filepath.Dir(target.FilePath)
+	callerDir := filePathDir(callerFile)
+	targetDir := filePathDir(target.FilePath)
 	if targetDir == callerDir {
 		return true
 	}
@@ -450,7 +449,7 @@ func (r *Resolver) buildImportClosureFiltered(repos map[string]struct{}) map[str
 	}
 	for file := range graph.FileNodeIdentitiesSeq(r.graph, repoPrefixes) {
 		if file.FilePath != "" && inScope(file.ID) {
-			add(file.FilePath, filepath.Dir(file.FilePath))
+			add(file.FilePath, filePathDir(file.FilePath))
 		}
 	}
 	// Materialise metadata-free import projections and batch-load only the
@@ -537,7 +536,7 @@ func (r *Resolver) buildImportClosureFiltered(repos map[string]struct{}) map[str
 		seen[file] = true
 		var dirs []string
 		for _, tf := range reexpTargets[file] {
-			dirs = append(dirs, filepath.Dir(tf))
+			dirs = append(dirs, filePathDir(tf))
 			dirs = append(dirs, barrelDirs(tf, seen)...)
 		}
 		barrelDirCache[file] = dirs
@@ -550,7 +549,7 @@ func (r *Resolver) buildImportClosureFiltered(repos map[string]struct{}) map[str
 			callerFile = from.FilePath
 		}
 		if target, ok := placements[e.To]; ok && target.FilePath != "" {
-			add(callerFile, filepath.Dir(target.FilePath))
+			add(callerFile, filePathDir(target.FilePath))
 			for _, d := range barrelDirs(target.FilePath, map[string]bool{}) {
 				add(callerFile, d)
 			}

--- a/internal/resolver/cross_repo.go
+++ b/internal/resolver/cross_repo.go
@@ -3,7 +3,6 @@ package resolver
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"runtime"
 	"sort"
 	"strconv"
@@ -699,7 +698,7 @@ func (cr *CrossRepoResolver) resolveScopedLocked(edges []*graph.Edge) *CrossRepo
 // used by resolveImport — the only resolution path that previously
 // scanned every node per edge.
 //
-//   - dirIndex     keys on filepath.Dir(file.FilePath) for exact matches
+//   - dirIndex     keys on filePathDir(file.FilePath) for exact matches
 //     (importPath equal to the file's directory).
 //   - lastDirIndex keys on the last path component of that directory,
 //     covering the common case where an import path is a single name
@@ -711,7 +710,7 @@ func (cr *CrossRepoResolver) buildDirIndexes() {
 	cr.dirIndex = make(map[string][]graph.FileNodeIdentity, 128)
 	cr.lastDirIndex = make(map[string][]graph.FileNodeIdentity, 128)
 	for file := range graph.FileNodeIdentitiesSeq(cr.graph, nil) {
-		dir := filepath.Dir(file.FilePath)
+		dir := filePathDir(file.FilePath)
 		cr.dirIndex[dir] = append(cr.dirIndex[dir], file)
 		last := lastPathComponent(dir)
 		if last != "" && last != dir {
@@ -1412,7 +1411,7 @@ func (cr *CrossRepoResolver) resolveImport(e *graph.Edge, importPath string, sta
 		// `*/bindings/go` directory sorts first. Collect every match so
 		// the workspace-aware pick below can prefer the importer's own
 		// workspace instead of the first one encountered.
-		if dirMatchesImport(filepath.Dir(file.FilePath), importPath) {
+		if dirMatchesImport(filePathDir(file.FilePath), importPath) {
 			crossRepoAll = append(crossRepoAll, file)
 		}
 	}
@@ -1436,7 +1435,7 @@ func (cr *CrossRepoResolver) resolveImport(e *graph.Edge, importPath string, sta
 		}
 	} else {
 		for file := range graph.FileNodeIdentitiesSeq(cr.graph, nil) {
-			dir := filepath.Dir(file.FilePath)
+			dir := filePathDir(file.FilePath)
 			if strings.HasSuffix(dir, lastPathComponent(importPath)) || dir == importPath {
 				consider(file)
 				if stop() {

--- a/internal/resolver/dataflow_callee_bind.go
+++ b/internal/resolver/dataflow_callee_bind.go
@@ -1,7 +1,6 @@
 package resolver
 
 import (
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -66,7 +65,7 @@ func (r *Resolver) buildCalleeIndex() *calleeIndex {
 		}
 		indexName(idx.byFile, node.FilePath, node.Name, node.ID)
 		if node.Kind == graph.KindFunction {
-			indexName(idx.byDir, filepath.Dir(node.FilePath), node.Name, node.ID)
+			indexName(idx.byDir, filePathDir(node.FilePath), node.Name, node.ID)
 		}
 	}
 	return idx
@@ -109,7 +108,7 @@ func (r *Resolver) bindDataflowCalleeRefsForFile(filePath string) {
 	}
 	// Same-package functions: r.dirIndex[dir] carries one KindFile node per
 	// file in the directory, so each package file is visited exactly once.
-	dir := filepath.Dir(filePath)
+	dir := filePathDir(filePath)
 	for _, fileNode := range r.dirIndex[dir] {
 		for _, n := range r.incrementalFileNodes(fileNode.FilePath) {
 			if n != nil && n.Kind == graph.KindFunction && n.Name != "" && n.FilePath != "" {
@@ -199,7 +198,7 @@ func bindDataflowCalleeEdge(e *graph.Edge, idx *calleeIndex) string {
 		if ids := idx.byFile[e.FilePath][name]; len(ids) == 1 {
 			chosen = ids[0]
 		} else if len(ids) == 0 {
-			if ids := idx.byDir[filepath.Dir(e.FilePath)][name]; len(ids) == 1 {
+			if ids := idx.byDir[filePathDir(e.FilePath)][name]; len(ids) == 1 {
 				chosen = ids[0]
 			}
 		}

--- a/internal/resolver/incremental_attribution_cache.go
+++ b/internal/resolver/incremental_attribution_cache.go
@@ -1,8 +1,6 @@
 package resolver
 
 import (
-	"path/filepath"
-
 	"go.uber.org/zap"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -22,7 +20,7 @@ func (r *Resolver) prepareIncrementalAttributionCache(frontier incrementalFileFr
 
 	missingSet := make(map[string]struct{})
 	for _, path := range frontier.paths {
-		for _, fileNode := range r.dirIndex[filepath.Dir(path)] {
+		for _, fileNode := range r.dirIndex[filePathDir(path)] {
 			if fileNode.FilePath == "" {
 				continue
 			}

--- a/internal/resolver/method_receiver_rebind.go
+++ b/internal/resolver/method_receiver_rebind.go
@@ -1,7 +1,6 @@
 package resolver
 
 import (
-	"path/filepath"
 	"strings"
 
 	"go.uber.org/zap"
@@ -29,7 +28,7 @@ import (
 //     method types (which is most of any non-trivial Go codebase).
 //
 // Algorithm: index every Go KindType / KindInterface node by
-// (filepath.Dir(file), name); walk EdgeMemberOf; for each Go method
+// (filePathDir(file), name); walk EdgeMemberOf; for each Go method
 // whose To doesn't resolve, look up (its file's dir, type name); if
 // exactly one match, rewrite edge.To to the canonical type ID via
 // ReindexEdges (one batched commit instead of per-edge round-trips).
@@ -104,7 +103,7 @@ func (r *Resolver) rebindGoMethodReceiversForFile(filePath string) {
 			break
 		}
 	}
-	dir := filepath.Dir(filePath)
+	dir := filePathDir(filePath)
 	cacheKey := repoPrefix + "\x00" + dir
 	typesIdx, ok := r.receiverTypeIdxByDir[cacheKey]
 	if !ok {
@@ -130,7 +129,7 @@ func (r *Resolver) rebindGoMethodReceiversForFile(filePath string) {
 			// two-pass fallback; there is still no per-file query loop.
 			for _, kind := range []graph.NodeKind{graph.KindType, graph.KindInterface} {
 				for n := range r.nodesByKindLang(kind, "go") {
-					if n != nil && n.RepoPrefix == repoPrefix && filepath.Dir(n.FilePath) == dir {
+					if n != nil && n.RepoPrefix == repoPrefix && filePathDir(n.FilePath) == dir {
 						addGoTypeToIndex(typesIdx, n)
 					}
 				}
@@ -171,7 +170,7 @@ func addGoTypeToIndex(idx map[pkgKey]string, n *graph.Node) {
 	if n == nil || n.Name == "" || n.FilePath == "" {
 		return
 	}
-	k := pkgKey{n.RepoPrefix, filepath.Dir(n.FilePath), n.Name}
+	k := pkgKey{n.RepoPrefix, filePathDir(n.FilePath), n.Name}
 	if existing, ok := idx[k]; ok && existing != n.ID {
 		idx[k] = ""
 		return
@@ -225,7 +224,7 @@ func (r *Resolver) rebindMemberOf(typesIdx map[pkgKey]string, memberOf []*graph.
 		if file == "" || typeName == "" {
 			continue
 		}
-		canonicalID, ok := typesIdx[pkgKey{method.RepoPrefix, filepath.Dir(file), typeName}]
+		canonicalID, ok := typesIdx[pkgKey{method.RepoPrefix, filePathDir(file), typeName}]
 		if !ok || canonicalID == "" || canonicalID == e.To {
 			continue
 		}

--- a/internal/resolver/pascal_form.go
+++ b/internal/resolver/pascal_form.go
@@ -76,7 +76,7 @@ func ResolvePascalForms(g graph.Store) int {
 // pascalFormKey is the directory plus lowercased extension-less basename that a
 // paired unit and form share.
 func pascalFormKey(path string) string {
-	dir := filepath.ToSlash(filepath.Dir(path))
+	dir := filePathDir(path)
 	base := filepath.Base(path)
 	base = strings.TrimSuffix(base, filepath.Ext(base))
 	return dir + "/" + strings.ToLower(base)

--- a/internal/resolver/resolve_all_pending.go
+++ b/internal/resolver/resolve_all_pending.go
@@ -2,7 +2,6 @@ package resolver
 
 import (
 	"context"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -343,7 +342,7 @@ func (p *resolveAllPassIndexes) ensureDir(prefixes []string) {
 		p.resolver.lastDirIndex = make(map[string][]graph.FileNodeIdentity, 128)
 	}
 	for file := range graph.FileNodeIdentitiesSeq(p.resolver.graph, missing) {
-		dir := filepath.Dir(file.FilePath)
+		dir := filePathDir(file.FilePath)
 		p.resolver.dirIndex[dir] = append(p.resolver.dirIndex[dir], file)
 		last := lastPathComponent(dir)
 		if last != "" && last != dir {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -211,9 +211,9 @@ type Resolver struct {
 	// `RegisterAll` resolving to `OverlayManager.Register` simply
 	// because "OverlayManager" sorts before "Registry".
 	reachableDirsByFile map[string]map[string]struct{}
-	// dirByFilePath memoises filepath.Dir(path) for every indexed file,
+	// dirByFilePath memoises filePathDir(path) for every indexed file,
 	// built once alongside reachableDirsByFile. filterByReachability runs in
-	// the parallel resolver workers and otherwise recomputes filepath.Dir
+	// the parallel resolver workers and otherwise recomputes filePathDir
 	// per candidate per edge — ~20% of resolution CPU on a large TS monorepo
 	// (filepathlite.Dir/Clean dominate). Read-only after build, so the
 	// workers share it lock-free.
@@ -1905,7 +1905,7 @@ func (r *Resolver) scopedFiles() []string {
 // buildDirIndexes builds two lookup maps for resolveImport. Populated
 // once per ResolveAll / ResolveFile pass and torn down after.
 //
-//   - dirIndex     keys on filepath.Dir(file.FilePath) for exact
+//   - dirIndex     keys on filePathDir(file.FilePath) for exact
 //     importPath == dir matches.
 //   - lastDirIndex keys on the last path component of that directory
 //     so an import of "logger" matches any file under .../logger/.
@@ -1913,7 +1913,7 @@ func (r *Resolver) buildDirIndexes() {
 	r.dirIndex = make(map[string][]graph.FileNodeIdentity, 128)
 	r.lastDirIndex = make(map[string][]graph.FileNodeIdentity, 128)
 	for file := range graph.FileNodeIdentitiesSeq(r.graph, nil) {
-		dir := filepath.Dir(file.FilePath)
+		dir := filePathDir(file.FilePath)
 		r.dirIndex[dir] = append(r.dirIndex[dir], file)
 		last := lastPathComponent(dir)
 		if last != "" && last != dir {
@@ -3607,7 +3607,7 @@ func (r *Resolver) resolveImport(e *graph.Edge, importPath string, stats *Resolv
 		// the last path component only, so without this gate an import
 		// of `.../tree-sitter-c/bindings/go` would resolve to whichever
 		// `*/bindings/go` directory sorts first.
-		if !crossRepoFound && dirMatchesImport(filepath.Dir(file.FilePath), importPath) {
+		if !crossRepoFound && dirMatchesImport(filePathDir(file.FilePath), importPath) {
 			crossRepoFile, crossRepoFound = file, true
 		}
 	}
@@ -3634,7 +3634,7 @@ func (r *Resolver) resolveImport(e *graph.Edge, importPath string, stats *Resolv
 		}
 	} else {
 		for file := range graph.FileNodeIdentitiesSeq(r.graph, nil) {
-			dir := filepath.Dir(file.FilePath)
+			dir := filePathDir(file.FilePath)
 			if strings.HasSuffix(dir, lastPathComponent(importPath)) || dir == importPath {
 				consider(file)
 				if stop() {
@@ -4663,10 +4663,10 @@ func (r *Resolver) buildReachabilityIndex() {
 	}
 
 	// Seed with each indexed file's own directory, and memoise the per-file
-	// dir so filterByReachability never recomputes filepath.Dir per edge.
+	// dir so filterByReachability never recomputes filePathDir per edge.
 	dirByPath := make(map[string]string)
 	seedFile := func(file graph.FileNodeIdentity) {
-		dir := filepath.Dir(file.FilePath)
+		dir := filePathDir(file.FilePath)
 		dirByPath[file.FilePath] = dir
 		addDir(file.ID, dir)
 	}
@@ -4717,7 +4717,7 @@ func (r *Resolver) buildReachabilityIndex() {
 			// External / unindexed package — nothing to add.
 		default:
 			if placement, ok := placements[e.To]; ok && placement.Kind == graph.KindFile {
-				importedDir = filepath.Dir(placement.FilePath)
+				importedDir = filePathDir(placement.FilePath)
 			}
 		}
 		if importedDir != "" {
@@ -4841,7 +4841,7 @@ func (r *Resolver) buildReachabilityIndexForPendingCached(
 	dirs := make(map[string]string, len(filePaths))
 	missingFiles := make([]string, 0, len(filePaths))
 	for _, filePath := range filePaths {
-		dir := filepath.Dir(filePath)
+		dir := filePathDir(filePath)
 		dirs[filePath] = dir
 		if cached, ok := stableByFile[filePath]; ok {
 			reachable[filePath] = cached
@@ -4928,7 +4928,7 @@ func (r *Resolver) buildReachabilityIndexForPendingCached(
 			case strings.HasPrefix(targetID, "external::"):
 			default:
 				if target, ok := targets[targetID]; ok && target.FilePath != "" {
-					importedDir = filepath.Dir(target.FilePath)
+					importedDir = filePathDir(target.FilePath)
 					dirs[target.FilePath] = importedDir
 				}
 			}
@@ -5120,7 +5120,7 @@ func (r *Resolver) importedDirForSpec(callerFile, spec string) string {
 			if bare && !isJSTSDirEntryPoint(f.FilePath) {
 				continue
 			}
-			return filepath.Dir(f.FilePath)
+			return filePathDir(f.FilePath)
 		}
 		return ""
 	}
@@ -5133,16 +5133,16 @@ func (r *Resolver) importedDirForSpec(callerFile, spec string) string {
 	return ""
 }
 
-// dirFor returns filepath.Dir(path), served from the per-file memo built in
+// dirFor returns filePathDir(path), served from the per-file memo built in
 // buildReachabilityIndex (every indexed file is keyed) and falling back to a
 // live computation for paths not in the index. The memo turns the per-edge
-// filepath.Dir in filterByReachability — ~20% of resolution CPU on a large
+// filePathDir in filterByReachability — ~20% of resolution CPU on a large
 // monorepo — into a map lookup.
 func (r *Resolver) dirFor(path string) string {
 	if d, ok := r.dirByFilePath[path]; ok {
 		return d
 	}
-	return filepath.Dir(path)
+	return filePathDir(path)
 }
 
 // filterByReachability narrows candidates to those whose defining file
@@ -5354,7 +5354,7 @@ func bestTypeCandidate(candidates []*graph.Node, callerDir string) *graph.Node {
 			continue
 		}
 		rank := typeCandidateRank(c)
-		sameDir := filepath.Dir(c.FilePath) == callerDir
+		sameDir := filePathDir(c.FilePath) == callerDir
 		if best == nil || candidateBeats(rank, sameDir, c.ID, bestRank, bestSameDir, best.ID) {
 			best, bestRank, bestSameDir = c, rank, sameDir
 		}

--- a/internal/resolver/storepath.go
+++ b/internal/resolver/storepath.go
@@ -1,0 +1,32 @@
+package resolver
+
+import (
+	"path"
+	"path/filepath"
+)
+
+// filePathDir returns the parent directory of a graph file path, always
+// '/'-joined.
+//
+// PURPOSE: every directory key this package builds or consults is
+// slash-separated — dirIndex / lastDirIndex, the import closure in
+// buildImportClosureFiltered, dirMatchesImport's `strings.HasSuffix(
+// importPath, "/"+dir)` test, the byDir name index. filepath.Dir cannot
+// derive such a key: on Windows it re-Cleans its result with the native
+// separator, so "packages/logger/index.ts" yields "packages\logger", a
+// spelling no slash-keyed index and no import-path suffix test can match.
+// The whole cascade then silently misses and imports fall through to
+// `external::`/`stdlib::` stubs.
+//
+// RATIONALE: path.Dir over the slash-folded path is byte-identical to
+// filepath.Dir on POSIX — including the "." it returns for a bare
+// filename and for the empty string — so this is a no-op there, and it
+// produces the same slash key on Windows. ToSlash first because an
+// indexed path is repoPrefix + '/' + the indexing machine's native
+// relative path (see internal/graphpath), i.e. mixed `repo/dir\file` on
+// Windows.
+//
+// KEYWORDS: windows, separator, dir-key, slash-contract, import-closure
+func filePathDir(p string) string {
+	return path.Dir(filepath.ToSlash(p))
+}

--- a/internal/review/anchor.go
+++ b/internal/review/anchor.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -376,9 +377,18 @@ func parseLineAnswer(out string) (int, bool) {
 
 // cleanPath normalises a path the same way the diff parser keys files, so a
 // caller-supplied path joins the ChangeView map.
+//
+// Review paths are a '/'-separated contract end to end: they come out of a
+// git diff header, they key the ChangeView, and they are rendered verbatim
+// into finding rows, the verification command and forge comment APIs. The
+// clean is therefore path.Clean over the slash spelling — filepath.Clean
+// would rewrite "internal/svc/handler.go" to "internal\svc\handler.go" on
+// Windows and both split the map keys and leak backslashes into the report.
+// filepath.ToSlash is the identity on POSIX, where a backslash is an
+// ordinary filename byte.
 func cleanPath(p string) string {
 	p = strings.TrimPrefix(p, "./")
-	return filepath.Clean(p)
+	return path.Clean(filepath.ToSlash(p))
 }
 
 // --- diff parsing (local, covers both sides) ---

--- a/internal/review/classify.go
+++ b/internal/review/classify.go
@@ -1,6 +1,7 @@
 package review
 
 import (
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -224,7 +225,10 @@ func goVerificationCommand(testTargets []string) string {
 		if t == "" {
 			continue
 		}
-		dir := filepath.ToSlash(filepath.Dir(t))
+		// cleanPath already returned the '/' spelling, so the directory
+		// split is path.Dir — the `go test ./pkg/...` argument must be
+		// slash-separated whatever host renders it.
+		dir := path.Dir(t)
 		if dir == "" || dir == "." {
 			dirs["."] = true
 			continue

--- a/internal/review/report.go
+++ b/internal/review/report.go
@@ -138,10 +138,12 @@ func rankFileRisk(diff *analysis.DiffResult, impact map[string]*analysis.ImpactR
 	// risk to that unchanged shadow.
 	fromGraphKey := func(file string) string {
 		// Normalize to the '/' comparison form BEFORE removing the prefix.
-		// cleanPath ends in filepath.Clean, so on Windows the graph key
-		// "repo-a/repo-a\widget.go" becomes "repo-a\repo-a\widget.go" and the
-		// '/'-joined prefix no longer matches: the row keeps its prefix while
-		// the repo-relative side produces a second row for the same file.
+		// A Windows graph key is "repo-a/repo-a\widget.go" (one '/' after the
+		// repo prefix, native separators below it), so a '/'-joined prefix
+		// only matches once the whole key is normalized: without it the row
+		// keeps its prefix while the repo-relative side produces a second
+		// row for the same file. cleanPath already returns the '/' spelling;
+		// graphpath.Norm keeps that guarantee local to this strip.
 		file = graphpath.Norm(cleanPath(file))
 		if repoPrefix != "" {
 			file = strings.TrimPrefix(file, repoPrefix+"/")

--- a/internal/savings/events_test.go
+++ b/internal/savings/events_test.go
@@ -28,15 +28,19 @@ func appendLegacyEventLine(t *testing.T, path string, ev Event) {
 	}
 }
 
+// TestEventsPathFor asserts the sibling-path derivation. EventsPathFor
+// names a file on disk (never a '/'-separated graph key), so it builds
+// with filepath.Join and returns the host's native separators — the
+// fixtures are therefore spelled natively too.
 func TestEventsPathFor(t *testing.T) {
 	cases := []struct {
 		in   string
 		want string
 	}{
 		{"", ""},
-		{"/tmp/savings.json", "/tmp/savings.jsonl"},
-		{"/tmp/whatever.foo", "/tmp/whatever.jsonl"},
-		{"./bare", "bare.jsonl"},
+		{filepath.FromSlash("/cache/savings.json"), filepath.FromSlash("/cache/savings.jsonl")},
+		{filepath.FromSlash("/cache/whatever.foo"), filepath.FromSlash("/cache/whatever.jsonl")},
+		{filepath.FromSlash("./bare"), "bare.jsonl"},
 	}
 	for _, c := range cases {
 		got := EventsPathFor(c.in)

--- a/internal/savings/store_test.go
+++ b/internal/savings/store_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -563,6 +564,9 @@ func TestImportLegacy_FlushLaggedTotalsFlooredByEvents(t *testing.T) {
 // renaming, so the next open retries instead of permanently losing the
 // unread tail.
 func TestImportLegacy_UnreadableEventsAborts(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("windows has no POSIX mode bits: a 0000 file is still readable, so the read cannot be made to fail")
+	}
 	if os.Getuid() == 0 {
 		t.Skip("permission bits don't bind as root")
 	}

--- a/internal/semantic/checkout_workspace_weight_test.go
+++ b/internal/semantic/checkout_workspace_weight_test.go
@@ -39,16 +39,16 @@ func TestCheckoutWorkspacesChargesAHeavyServerSeveralSlots(t *testing.T) {
 	t.Run("two heavy pairs spend the whole default budget", func(t *testing.T) {
 		w := NewCheckoutWorkspaces(0, zap.NewNop())
 
-		holdFirst := acquire(t, w, "java", "/family/first")
-		holdSecond := acquire(t, w, "java", "/family/second")
+		holdFirst := acquire(t, w, "java", famRoot("first"))
+		holdSecond := acquire(t, w, "java", famRoot("second"))
 
-		if _, ok := w.Acquire("java", "/family/third"); ok {
+		if _, ok := w.Acquire("java", famRoot("third")); ok {
 			t.Error("a third heavy workspace was admitted over a budget two of them spend")
 		}
 		// Nor does an ordinary server fit behind them: the budget is spent and
 		// every pair holding it is mid-pass, so this is the refusal that skips
 		// a stage rather than an eviction.
-		if _, ok := w.Acquire("go", "/family/third"); ok {
+		if _, ok := w.Acquire("go", famRoot("third")); ok {
 			t.Error("an ordinary workspace was admitted over a spent budget")
 		}
 
@@ -60,12 +60,12 @@ func TestCheckoutWorkspacesChargesAHeavyServerSeveralSlots(t *testing.T) {
 		w := NewCheckoutWorkspaces(0, zap.NewNop())
 
 		holds := []func(){
-			acquire(t, w, "go", "/family/first"),
-			acquire(t, w, "go", "/family/second"),
-			acquire(t, w, "go", "/family/third"),
-			acquire(t, w, "go", "/family/fourth"),
+			acquire(t, w, "go", famRoot("first")),
+			acquire(t, w, "go", famRoot("second")),
+			acquire(t, w, "go", famRoot("third")),
+			acquire(t, w, "go", famRoot("fourth")),
 		}
-		if _, ok := w.Acquire("go", "/family/fifth"); ok {
+		if _, ok := w.Acquire("go", famRoot("fifth")); ok {
 			t.Error("a fifth ordinary workspace was admitted over a budget of four slots")
 		}
 
@@ -86,26 +86,26 @@ func TestCheckoutWorkspacesEvictionFreesTheWholeHeavyWeight(t *testing.T) {
 		w := NewCheckoutWorkspaces(4, zap.NewNop())
 		w.SetStopper(stopper)
 
-		acquire(t, w, "java", "/family/first")()
-		acquire(t, w, "java", "/family/second")()
+		acquire(t, w, "java", famRoot("first"))()
+		acquire(t, w, "java", famRoot("second"))()
 		// The budget is spent, so the ordinary pair displaces the heavy one
 		// used longest ago — and the two slots that pair held are more than
 		// this admission needs.
-		acquire(t, w, "go", "/family/third")()
+		acquire(t, w, "go", famRoot("third"))()
 
 		wantLive := []CheckoutWorkspaceRef{
-			{Language: "java", Root: "/family/second"},
-			{Language: "go", Root: "/family/third"},
+			{Language: "java", Root: famRoot("second")},
+			{Language: "go", Root: famRoot("third")},
 		}
 		if live := w.Live(); !reflect.DeepEqual(live, wantLive) {
 			t.Errorf("live = %v, want %v", live, wantLive)
 		}
 		// The leftover slot is real: a second ordinary pair fits without
 		// costing the surviving heavy one its server.
-		acquire(t, w, "go", "/family/fourth")()
+		acquire(t, w, "go", famRoot("fourth"))()
 
 		synctest.Wait()
-		want := []CheckoutWorkspaceRef{{Language: "java", Root: "/family/first"}}
+		want := []CheckoutWorkspaceRef{{Language: "java", Root: famRoot("first")}}
 		if got := stopper.calls(); !reflect.DeepEqual(got, want) {
 			t.Errorf("stopped %v, want %v", got, want)
 		}
@@ -128,10 +128,10 @@ func TestCheckoutWorkspacesEvictRootFreesTheWholeHeavyWeight(t *testing.T) {
 		// Two of the four slots go to the checkout that is about to depart,
 		// and the third to one that stays — held, so nothing below can reach
 		// its slot by evicting it.
-		acquire(t, w, "java", "/family/departing")()
-		staying := acquire(t, w, "go", "/family/staying")
+		acquire(t, w, "java", famRoot("departing"))()
+		staying := acquire(t, w, "go", famRoot("staying"))
 
-		if got := w.EvictRoot("/family/departing"); got != 1 {
+		if got := w.EvictRoot(famRoot("departing")); got != 1 {
 			t.Fatalf("EvictRoot dropped %d pairs, want the departed checkout's one", got)
 		}
 
@@ -140,9 +140,9 @@ func TestCheckoutWorkspacesEvictRootFreesTheWholeHeavyWeight(t *testing.T) {
 		// departed pair — or none — leaves the last of them nothing to be
 		// admitted into.
 		holds := []func(){
-			acquire(t, w, "go", "/family/first"),
-			acquire(t, w, "go", "/family/second"),
-			acquire(t, w, "go", "/family/third"),
+			acquire(t, w, "go", famRoot("first")),
+			acquire(t, w, "go", famRoot("second")),
+			acquire(t, w, "go", famRoot("third")),
 		}
 		if got := w.Live(); len(got) != 4 {
 			t.Errorf("live = %v, want the held pair and three admitted beside it", got)
@@ -151,7 +151,7 @@ func TestCheckoutWorkspacesEvictRootFreesTheWholeHeavyWeight(t *testing.T) {
 		synctest.Wait()
 		// The readmissions came out of the freed budget, so none of them cost
 		// a surviving workspace its server.
-		want := []CheckoutWorkspaceRef{{Language: "java", Root: "/family/departing"}}
+		want := []CheckoutWorkspaceRef{{Language: "java", Root: famRoot("departing")}}
 		if got := stopper.calls(); !reflect.DeepEqual(got, want) {
 			t.Errorf("stopped %v, want %v", got, want)
 		}
@@ -172,11 +172,11 @@ func TestCheckoutWorkspaceCapRaiseWidensTheWeightedBudget(t *testing.T) {
 	w := NewManager(Config{CheckoutLSPMaxWorkspaces: 6}, zap.NewNop()).CheckoutWorkspaces()
 
 	holds := []func(){
-		acquire(t, w, "java", "/family/first"),
-		acquire(t, w, "java", "/family/second"),
-		acquire(t, w, "java", "/family/third"),
+		acquire(t, w, "java", famRoot("first")),
+		acquire(t, w, "java", famRoot("second")),
+		acquire(t, w, "java", famRoot("third")),
 	}
-	if _, ok := w.Acquire("java", "/family/fourth"); ok {
+	if _, ok := w.Acquire("java", famRoot("fourth")); ok {
 		t.Error("a fourth heavy workspace was admitted over a raised budget three of them spend")
 	}
 
@@ -201,13 +201,13 @@ func TestCheckoutWorkspacesStarveWithoutStoppingWhatCannotHelp(t *testing.T) {
 		// Three slots are held by in-flight passes and out of reach; the
 		// fourth is a warm pair, so eviction can free one slot and no more.
 		holds := []func(){
-			acquire(t, w, "go", "/family/first"),
-			acquire(t, w, "go", "/family/second"),
-			acquire(t, w, "go", "/family/third"),
+			acquire(t, w, "go", famRoot("first")),
+			acquire(t, w, "go", famRoot("second")),
+			acquire(t, w, "go", famRoot("third")),
 		}
-		acquire(t, w, "go", "/family/fourth")()
+		acquire(t, w, "go", famRoot("fourth"))()
 
-		if _, ok := w.Acquire("java", "/family/fifth"); ok {
+		if _, ok := w.Acquire("java", famRoot("fifth")); ok {
 			t.Fatal("a heavy workspace was admitted into a single reachable slot")
 		}
 
@@ -236,9 +236,9 @@ func TestCheckoutWorkspacesRefuseAServerHeavierThanTheWholeBudget(t *testing.T) 
 		w := NewCheckoutWorkspaces(1, zap.NewNop())
 		w.SetStopper(stopper)
 
-		acquire(t, w, "go", "/family/first")()
+		acquire(t, w, "go", famRoot("first"))()
 
-		if _, ok := w.Acquire("java", "/family/second"); ok {
+		if _, ok := w.Acquire("java", famRoot("second")); ok {
 			t.Error("a heavy workspace was admitted into a budget smaller than its weight")
 		}
 

--- a/internal/semantic/checkout_workspaces_test.go
+++ b/internal/semantic/checkout_workspaces_test.go
@@ -1,6 +1,8 @@
 package semantic
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"sync"
@@ -9,6 +11,32 @@ import (
 
 	"go.uber.org/zap"
 )
+
+// fixtureVolume is the volume name filepath.Abs would prepend to a rooted but
+// volume-less path — "" on POSIX, the current drive (e.g. "D:") on Windows.
+// Computed once, off any synctest bubble.
+var fixtureVolume = func() string {
+	wd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	return filepath.VolumeName(wd)
+}()
+
+// famRoot spells a synthetic checkout root of one family the way the running
+// platform spells an absolute path, so a fixture and the assertion that reads
+// it back stay in one spelling.
+//
+// The registry keys by cleanCheckoutRoot, which is filepath.Abs + Clean: on
+// Windows the POSIX-spelled "/family/first" comes back drive-prefixed and
+// backslashed as `D:\family\first`, and a literal "/family/first" in a want
+// list would never match it again. Building the fixture the same way — the
+// current volume plus a natively joined "\family\<name>" — makes both sides
+// agree on both platforms; on POSIX the volume is empty and this is
+// "/family/<name>" verbatim.
+func famRoot(name string) string {
+	return fixtureVolume + filepath.Join(string(filepath.Separator), "family", name)
+}
 
 // recordingStopper stands in for the LSP router: it records what the registry
 // asked it to stop, which is the only observable an eviction has when no real
@@ -61,26 +89,26 @@ func TestCheckoutWorkspacesEvictsTheLeastRecentlyUsedPair(t *testing.T) {
 		w := NewCheckoutWorkspaces(2, zap.NewNop())
 		w.SetStopper(stopper)
 
-		acquire(t, w, "go", "/family/first")()
-		acquire(t, w, "go", "/family/second")()
+		acquire(t, w, "go", famRoot("first"))()
+		acquire(t, w, "go", famRoot("second"))()
 		// Touching the first pair again makes the second the oldest.
-		acquire(t, w, "go", "/family/first")()
+		acquire(t, w, "go", famRoot("first"))()
 
-		acquire(t, w, "go", "/family/third")()
+		acquire(t, w, "go", famRoot("third"))()
 
 		// The slot is free the moment the bookkeeping says so; the subprocess
 		// behind it is stopped off the admitting caller's goroutine.
 		live := w.Live()
 		wantLive := []CheckoutWorkspaceRef{
-			{Language: "go", Root: "/family/first"},
-			{Language: "go", Root: "/family/third"},
+			{Language: "go", Root: famRoot("first")},
+			{Language: "go", Root: famRoot("third")},
 		}
 		if !reflect.DeepEqual(live, wantLive) {
 			t.Errorf("live = %v, want %v", live, wantLive)
 		}
 
 		synctest.Wait()
-		want := []CheckoutWorkspaceRef{{Language: "go", Root: "/family/second"}}
+		want := []CheckoutWorkspaceRef{{Language: "go", Root: famRoot("second")}}
 		if got := stopper.calls(); !reflect.DeepEqual(got, want) {
 			t.Errorf("stopped %v, want %v", got, want)
 		}
@@ -93,21 +121,26 @@ func TestCheckoutWorkspacesEvictsTheLeastRecentlyUsedPair(t *testing.T) {
 func TestCheckoutWorkspacesEvictionDoesNotHoldTheRegistryLock(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		blocked := make(chan struct{})
+		// Deferred, not closed at the end of the body: a failing assertion
+		// below leaves the bubble through runtime.Goexit, and a bubble whose
+		// main goroutine exits while a wedged stopper is still parked on this
+		// channel panics with "blocked goroutines remain" — burying the real
+		// failure. A defer runs on Goexit too, so the stoppers always drain.
+		defer close(blocked)
 		w := NewCheckoutWorkspaces(1, zap.NewNop())
 		w.SetStopper(blockingStopper{until: blocked})
 
-		acquire(t, w, "go", "/family/first")()
+		acquire(t, w, "go", famRoot("first"))()
 		// Evicts the first pair, whose stopper is wedged until this test says
 		// otherwise.
-		acquire(t, w, "go", "/family/second")()
+		acquire(t, w, "go", famRoot("second"))()
 		synctest.Wait()
 
 		// The registry answers while the stop is still in flight.
-		if got := w.Live(); len(got) != 1 || got[0].Root != "/family/second" {
+		if got := w.Live(); len(got) != 1 || got[0].Root != famRoot("second") {
 			t.Fatalf("live = %v, want the second pair alone", got)
 		}
-		acquire(t, w, "go", "/family/third")()
-		close(blocked)
+		acquire(t, w, "go", famRoot("third"))()
 	})
 }
 
@@ -120,27 +153,27 @@ func TestCheckoutWorkspacesEvictRootStopsADepartedCheckout(t *testing.T) {
 		w := NewCheckoutWorkspaces(4, zap.NewNop())
 		w.SetStopper(stopper)
 
-		acquire(t, w, "go", "/family/first")()
-		acquire(t, w, "typescript", "/family/first")()
-		held := acquire(t, w, "go", "/family/second")
+		acquire(t, w, "go", famRoot("first"))()
+		acquire(t, w, "typescript", famRoot("first"))()
+		held := acquire(t, w, "go", famRoot("second"))
 
-		if got := w.EvictRoot("/family/first"); got != 2 {
+		if got := w.EvictRoot(famRoot("first")); got != 2 {
 			t.Errorf("EvictRoot dropped %d pairs, want both of the checkout's", got)
 		}
 		// A pair a pass still holds survives its checkout's departure, the way
 		// it survives the cap: the pass is reading that very server.
-		if got := w.EvictRoot("/family/second"); got != 0 {
+		if got := w.EvictRoot(famRoot("second")); got != 0 {
 			t.Errorf("EvictRoot dropped %d held pairs, want none", got)
 		}
-		if got := w.Live(); len(got) != 1 || got[0].Root != "/family/second" {
+		if got := w.Live(); len(got) != 1 || got[0].Root != famRoot("second") {
 			t.Errorf("live = %v, want the held pair alone", got)
 		}
 		held()
 
 		synctest.Wait()
 		want := []CheckoutWorkspaceRef{
-			{Language: "go", Root: "/family/first"},
-			{Language: "typescript", Root: "/family/first"},
+			{Language: "go", Root: famRoot("first")},
+			{Language: "typescript", Root: famRoot("first")},
 		}
 		got := stopper.calls()
 		sort.Slice(got, func(i, j int) bool { return got[i].Language < got[j].Language })
@@ -160,10 +193,10 @@ func TestCheckoutWorkspacesRefusesWhenEveryPairIsHeld(t *testing.T) {
 		w := NewCheckoutWorkspaces(2, zap.NewNop())
 		w.SetStopper(stopper)
 
-		holdOne := acquire(t, w, "go", "/family/first")
-		holdTwo := acquire(t, w, "go", "/family/second")
+		holdOne := acquire(t, w, "go", famRoot("first"))
+		holdTwo := acquire(t, w, "go", famRoot("second"))
 
-		if _, ok := w.Acquire("go", "/family/third"); ok {
+		if _, ok := w.Acquire("go", famRoot("third")); ok {
 			t.Fatal("the cap admitted a third pair while both slots were held")
 		}
 		synctest.Wait()
@@ -173,12 +206,12 @@ func TestCheckoutWorkspacesRefusesWhenEveryPairIsHeld(t *testing.T) {
 
 		// Releasing one makes it evictable, and the refused pair gets in.
 		holdOne()
-		release := acquire(t, w, "go", "/family/third")
+		release := acquire(t, w, "go", famRoot("third"))
 		release()
 		holdTwo()
 
 		synctest.Wait()
-		want := []CheckoutWorkspaceRef{{Language: "go", Root: "/family/first"}}
+		want := []CheckoutWorkspaceRef{{Language: "go", Root: famRoot("first")}}
 		if got := stopper.calls(); !reflect.DeepEqual(got, want) {
 			t.Errorf("stopped %v, want %v", got, want)
 		}
@@ -191,17 +224,17 @@ func TestCheckoutWorkspacesRefusesWhenEveryPairIsHeld(t *testing.T) {
 func TestCheckoutWorkspacesKeysByLanguageAndRoot(t *testing.T) {
 	w := NewCheckoutWorkspaces(4, zap.NewNop())
 
-	acquire(t, w, "go", "/family/first")()
-	acquire(t, w, "typescript", "/family/first")()
-	acquire(t, w, "go", "/family/second")()
+	acquire(t, w, "go", famRoot("first"))()
+	acquire(t, w, "typescript", famRoot("first"))()
+	acquire(t, w, "go", famRoot("second"))()
 	// The same pair spelled with a trailing separator is the same working
 	// copy, so it must not take a second slot.
-	acquire(t, w, "go", "/family/second/")()
+	acquire(t, w, "go", famRoot("second")+string(filepath.Separator))()
 
 	want := []CheckoutWorkspaceRef{
-		{Language: "go", Root: "/family/first"},
-		{Language: "typescript", Root: "/family/first"},
-		{Language: "go", Root: "/family/second"},
+		{Language: "go", Root: famRoot("first")},
+		{Language: "typescript", Root: famRoot("first")},
+		{Language: "go", Root: famRoot("second")},
 	}
 	if got := w.Live(); !reflect.DeepEqual(got, want) {
 		t.Errorf("live = %v, want %v", got, want)

--- a/internal/semantic/lsp/actions_test.go
+++ b/internal/semantic/lsp/actions_test.go
@@ -84,9 +84,13 @@ func TestWriteWorkspaceEdit_DocumentChanges(t *testing.T) {
 	p := filepath.Join(dir, "x.txt")
 	require.NoError(t, os.WriteFile(p, []byte("old\n"), 0o644))
 
+	// pathToURI, not `"file://" + p`: the naive concatenation puts a Windows
+	// drive letter in the URI authority ("file://C:\dir\x.txt"), which
+	// uriToAbsPath rejects — WriteWorkspaceEdit would then write nothing and
+	// report no files.
 	edit := WorkspaceEdit{
 		DocumentChanges: []TextDocumentEdit{{
-			TextDocument: VersionedTextDocumentIdentifier{URI: "file://" + p, Version: 1},
+			TextDocument: VersionedTextDocumentIdentifier{URI: pathToURI(p), Version: 1},
 			Edits: []TextEdit{{
 				Range:   Range{Start: Position{Line: 0, Character: 0}, End: Position{Line: 0, Character: 3}},
 				NewText: "new",
@@ -108,9 +112,11 @@ func TestWriteWorkspaceEdit_LegacyChanges(t *testing.T) {
 	p := filepath.Join(dir, "y.txt")
 	require.NoError(t, os.WriteFile(p, []byte("a b c\n"), 0o644))
 
+	// Same reason as the documentChanges case: the URI has to be built by
+	// pathToURI so a Windows drive letter lands inside the path.
 	edit := WorkspaceEdit{
 		Changes: map[string][]TextEdit{
-			"file://" + p: {{
+			pathToURI(p): {{
 				Range:   Range{Start: Position{Line: 0, Character: 2}, End: Position{Line: 0, Character: 3}},
 				NewText: "X",
 			}},
@@ -164,12 +170,17 @@ func TestCodeActionOrCommand_AsCodeAction(t *testing.T) {
 }
 
 // TestUriToAbsPath rejects non-file URIs and parses well-formed ones.
+// uriToAbsPath returns an OS-NATIVE path, so the expectation is spelled
+// natively too (on Windows "file:///abs/path.go" is `\abs\path.go`). The
+// per-platform URI literals — including the drive-letter shapes — are
+// table-tested in internal/lspuri; here the wrapper's delegation plus a
+// lossless round trip through a real native absolute path is what matters.
 func TestUriToAbsPath(t *testing.T) {
 	cases := []struct {
 		uri  string
 		want string
 	}{
-		{"file:///abs/path.go", "/abs/path.go"},
+		{"file:///abs/path.go", filepath.FromSlash("/abs/path.go")},
 		{"http://example.com/x", ""},
 		{"", ""},
 	}
@@ -177,6 +188,11 @@ func TestUriToAbsPath(t *testing.T) {
 		if got := uriToAbsPath(c.uri); got != c.want {
 			t.Errorf("uriToAbsPath(%q) = %q, want %q", c.uri, got, c.want)
 		}
+	}
+
+	native := filepath.Join(t.TempDir(), "round trip.go")
+	if got := uriToAbsPath(pathToURI(native)); got != native {
+		t.Errorf("round trip of %q = %q", native, got)
 	}
 }
 

--- a/internal/semantic/lsp/helper_process_test.go
+++ b/internal/semantic/lsp/helper_process_test.go
@@ -1,0 +1,95 @@
+package lsp
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+// The transport tests need a subprocess with scripted stdout/stderr
+// behaviour. They used to spawn /bin/sh and /bin/cat, which do not exist on
+// Windows (and a `.sh` fixture is not executable there either), so the stand-
+// in is this test binary re-exec'd against TestSubprocessHelper — the same
+// helper-process pattern internal/semantic/scip and internal/indexer use.
+//
+// The behaviour selector travels in the environment rather than in argv so a
+// transport's Command / Args stay exactly what the test wants to assert on.
+const (
+	helperModeEnv  = "GORTEX_LSP_SUBPROCESS_HELPER"
+	helperLinesEnv = "GORTEX_LSP_SUBPROCESS_HELPER_LINES"
+
+	// helperCat copies stdin to stdout and exits when stdin closes — the
+	// blocking, well-behaved child /bin/cat used to provide.
+	helperCat = "cat"
+	// helperStderrLines writes helperLinesEnv "err<N>" lines to stderr and
+	// then one line to stdout.
+	helperStderrLines = "stderr-lines"
+)
+
+// helperArgs is the argv that re-runs this binary as the helper process.
+// The trailing "--" keeps any further arguments away from the test flags.
+var helperArgs = []string{"-test.run=^TestSubprocessHelper$", "--"}
+
+// helperCommand returns the path to this test binary, the command every
+// helper-process spawn uses.
+func helperCommand(t *testing.T) string {
+	t.Helper()
+	exe, err := os.Executable()
+	if err != nil {
+		return os.Args[0]
+	}
+	return exe
+}
+
+// useHelper arms the environment the re-exec'd child reads. It must be called
+// from the test goroutine (t.Setenv), so no test using it may run in parallel.
+func useHelper(t *testing.T, mode string, lines int) {
+	t.Helper()
+	t.Setenv(helperModeEnv, mode)
+	t.Setenv(helperLinesEnv, strconv.Itoa(lines))
+}
+
+// helperTransport builds a SpawnTransport whose subprocess is this test
+// binary running the scripted helper behaviour.
+func helperTransport(t *testing.T, mode string, lines int, logger *zap.Logger) *SpawnTransport {
+	t.Helper()
+	useHelper(t, mode, lines)
+	return &SpawnTransport{
+		Command: helperCommand(t),
+		Args:    helperArgs,
+		Logger:  logger,
+	}
+}
+
+// TestSubprocessHelper is not a test. It is the child process the transport
+// tests spawn; with helperModeEnv unset (an ordinary suite run) it returns
+// immediately and passes. It exits the process itself so the test framework's
+// own "PASS" summary never lands on the stdout pipe the parent is reading.
+func TestSubprocessHelper(t *testing.T) {
+	mode := os.Getenv(helperModeEnv)
+	if mode == "" {
+		return
+	}
+	switch mode {
+	case helperCat:
+		_, _ = io.Copy(os.Stdout, os.Stdin)
+	case helperStderrLines:
+		n, err := strconv.Atoi(os.Getenv(helperLinesEnv))
+		if err != nil || n < 0 {
+			fmt.Fprintf(os.Stderr, "helper: bad line count %q\n", os.Getenv(helperLinesEnv))
+			os.Exit(2)
+		}
+		for i := 1; i <= n; i++ {
+			fmt.Fprintf(os.Stderr, "err%d\n", i)
+		}
+		fmt.Fprintln(os.Stdout, "stdout-line")
+	default:
+		fmt.Fprintf(os.Stderr, "helper: unknown mode %q\n", mode)
+		os.Exit(2)
+	}
+	os.Exit(0)
+}

--- a/internal/semantic/lsp/lsp_test.go
+++ b/internal/semantic/lsp/lsp_test.go
@@ -16,9 +16,23 @@ import (
 	"go.uber.org/zap"
 )
 
+// TestLSP_PathToURI checks the shape every LSP server requires — the
+// `file://` scheme with three slashes, forward slashes throughout, and a
+// lossless round trip back to the native path. The expectation is derived
+// from a native absolute path because "/repo/main.go" is NOT absolute on
+// Windows: pathToURI absolutizes first, so it would pick up the current
+// drive and produce "file:///D:/repo/main.go". The exact per-platform
+// literals (drive letter inside the path, percent-encoding) are
+// table-tested in internal/lspuri.
 func TestLSP_PathToURI(t *testing.T) {
-	uri := pathToURI("/repo/main.go")
-	assert.Equal(t, "file:///repo/main.go", uri)
+	abs, err := filepath.Abs(filepath.FromSlash("/repo/main.go"))
+	require.NoError(t, err)
+
+	uri := pathToURI(abs)
+	assert.True(t, strings.HasPrefix(uri, "file:///"), "uri = %q", uri)
+	assert.NotContains(t, uri, `\`, "a file URI never carries a backslash")
+	assert.True(t, strings.HasSuffix(uri, "/repo/main.go"), "uri = %q", uri)
+	assert.Equal(t, abs, uriToAbsPath(uri))
 }
 
 func TestLSP_URIToPath(t *testing.T) {
@@ -78,12 +92,24 @@ func TestLSP_NewClient_FailsForBadCommand(t *testing.T) {
 }
 
 func TestBuildWorkspaceFolders(t *testing.T) {
+	// The roots are native absolute paths: on Windows a "/repo" fixture has
+	// no volume, so buildWorkspaceFolders would absolutize it against the
+	// current drive and the URI literal would not be predictable.
+	abs := func(slash string) string {
+		t.Helper()
+		p, err := filepath.Abs(filepath.FromSlash(slash))
+		require.NoError(t, err)
+		return p
+	}
+	repo := abs("/repo")
+
 	// Always include the primary root. Pyright relies on this to build
 	// workspace context for textDocument/definition even when rootUri is set.
-	require.Equal(t, []WorkspaceFolder{{URI: "file:///repo", Name: "repo"}}, buildWorkspaceFolders("/repo", nil))
-	require.Equal(t, []WorkspaceFolder{{URI: "file:///repo", Name: "repo"}}, buildWorkspaceFolders("/repo", []string{}))
+	want := []WorkspaceFolder{{URI: pathToURI(repo), Name: "repo"}}
+	require.Equal(t, want, buildWorkspaceFolders(repo, nil))
+	require.Equal(t, want, buildWorkspaceFolders(repo, []string{}))
 
-	folders := buildWorkspaceFolders("/repo/app", []string{"/repo/shared", "/repo/types"})
+	folders := buildWorkspaceFolders(abs("/repo/app"), []string{abs("/repo/shared"), abs("/repo/types")})
 	require.Len(t, folders, 3) // primary + 2 additional
 	require.Equal(t, "app", folders[0].Name)
 	require.Equal(t, "shared", folders[1].Name)

--- a/internal/semantic/lsp/passive_test.go
+++ b/internal/semantic/lsp/passive_test.go
@@ -389,16 +389,18 @@ func TestPassiveProvider_DialFailsSpawnFallback(t *testing.T) {
 	deadAddr := ln.Addr().String()
 	require.NoError(t, ln.Close())
 
-	// /bin/cat with no args blocks on stdin without writing anything,
-	// so the spawn succeeds but the (immediate) initialize Call we
-	// don't make would have blocked indefinitely. We don't invoke
-	// initialize here — dialOrSpawn just constructs the Client.
-	// /bin/cat exits cleanly when we close stdin during Shutdown,
-	// so the deferred Close is fast.
+	// The helper's cat mode blocks on stdin without writing anything, so
+	// the spawn succeeds but the (immediate) initialize Call we don't make
+	// would have blocked indefinitely. We don't invoke initialize here —
+	// dialOrSpawn just constructs the Client. It exits cleanly when we
+	// close stdin during Shutdown, so the deferred Close is fast. This is
+	// the test binary rather than /bin/cat because Windows has neither
+	// /bin/cat nor a shell at a fixed path.
+	useHelper(t, helperCat, 0)
 	spec := &ServerSpec{
 		Name:      "fake-passive-spawn-fallback",
-		Command:   "/bin/cat",
-		Args:      nil,
+		Command:   helperCommand(t),
+		Args:      helperArgs,
 		Languages: []string{"go"},
 		Connect: &ConnectSpec{
 			Network:       "tcp",
@@ -409,7 +411,7 @@ func TestPassiveProvider_DialFailsSpawnFallback(t *testing.T) {
 	p := NewProviderFromSpec(spec, zap.NewNop())
 	defer p.Close()
 
-	// We don't await initialize success — /bin/sleep is not a real
+	// We don't await initialize success — the helper is not a real
 	// LSP server, so the handshake will eventually time out. The
 	// dialOrSpawn helper is what we're verifying: it must succeed
 	// on the spawn fallback. Run it directly to keep the test fast.

--- a/internal/semantic/lsp/spawn_stderr_test.go
+++ b/internal/semantic/lsp/spawn_stderr_test.go
@@ -34,11 +34,7 @@ func TestSpawnTransport_RoutesStderrThroughLogger(t *testing.T) {
 	core, obs := observer.New(zapcore.DebugLevel)
 	logger := zap.New(core)
 
-	tr := &SpawnTransport{
-		Command: "/bin/sh",
-		Args:    []string{"-c", "echo err1 >&2; echo err2 >&2; echo stdout-line"},
-		Logger:  logger,
-	}
+	tr := helperTransport(t, helperStderrLines, 2, logger)
 	_, stdout, err := tr.Start()
 	require.NoError(t, err)
 
@@ -56,7 +52,7 @@ func TestSpawnTransport_RoutesStderrThroughLogger(t *testing.T) {
 	var lines []string
 	for _, e := range entries {
 		require.Equal(t, "subprocess stderr", e.Message)
-		require.Equal(t, "/bin/sh", e.ContextMap()["tag"])
+		require.Equal(t, tr.Command, e.ContextMap()["tag"])
 		line, _ := e.ContextMap()["line"].(string)
 		lines = append(lines, line)
 	}
@@ -68,10 +64,7 @@ func TestSpawnTransport_RoutesStderrThroughLogger(t *testing.T) {
 // with no Logger still drains stderr (rather than leaving the pipe
 // buffer to fill and the child to block on writing to it).
 func TestSpawnTransport_NilLoggerDoesNotBlock(t *testing.T) {
-	tr := &SpawnTransport{
-		Command: "/bin/sh",
-		Args:    []string{"-c", "for i in $(seq 1 500); do echo spam line $i >&2; done; echo done"},
-	}
+	tr := helperTransport(t, helperStderrLines, 500, nil)
 	_, stdout, err := tr.Start()
 	require.NoError(t, err)
 
@@ -98,11 +91,7 @@ func TestSpawnTransport_StderrBurstIsSuppressed(t *testing.T) {
 	core, obs := observer.New(zapcore.DebugLevel)
 	logger := zap.New(core)
 
-	tr := &SpawnTransport{
-		Command: "/bin/sh",
-		Args:    []string{"-c", "for i in $(seq 1 300); do echo boom $i >&2; done"},
-		Logger:  logger,
-	}
+	tr := helperTransport(t, helperStderrLines, 300, logger)
 	_, stdout, err := tr.Start()
 	require.NoError(t, err)
 	_, _ = io.Copy(io.Discard, stdout)

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -329,6 +329,15 @@ func (h *Handler) SetReadOnly(ro bool) { h.readOnly = ro }
 // SetCapabilities overrides the advertised federation capability set.
 func (h *Handler) SetCapabilities(caps []string) { h.capabilities = caps }
 
+// SetStartTimeForTest overrides the instant /v1/health reports uptime
+// from. It exists so a test in a package that embeds this handler (see
+// internal/eval) can backdate the start rather than race the clock for a
+// positive reading: Windows advances the runtime's monotonic clock in
+// ~0.5-15.6 ms ticks, so a handler built microseconds before the request
+// still lands inside the tick it started in and time.Since returns
+// exactly 0 there. Production code has no reason to move the start.
+func (h *Handler) SetStartTimeForTest(start time.Time) { h.startTime = start }
+
 // --- /tools ---
 
 type toolInfo struct {

--- a/internal/server/handler_test.go
+++ b/internal/server/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	mcpserver "github.com/mark3labs/mcp-go/server"
@@ -53,6 +54,14 @@ func newTestHandler(t *testing.T) *Handler {
 
 func TestHealthEndpoint(t *testing.T) {
 	h := newTestHandler(t)
+	// Uptime is reported from the handler's start instant, so backdate it
+	// rather than race the clock for a positive reading. Windows advances
+	// the runtime's monotonic clock in ~0.5-15.6 ms ticks, and a handler
+	// this test builds microseconds before the request still lands inside
+	// the tick it started in: time.Since returns exactly 0 there and the
+	// old "> 0" assertion failed on a correct handler.
+	const uptime = 3 * time.Second
+	h.startTime = time.Now().Add(-uptime)
 	req := httptest.NewRequest(http.MethodGet, "/v1/health", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
@@ -65,7 +74,7 @@ func TestHealthEndpoint(t *testing.T) {
 	assert.True(t, resp.Indexed)
 	assert.Equal(t, 2, resp.Nodes)
 	assert.Equal(t, "0.0.1-test", resp.Version)
-	assert.Greater(t, resp.UptimeSeconds, float64(0))
+	assert.GreaterOrEqual(t, resp.UptimeSeconds, uptime.Seconds())
 }
 
 func TestListToolsEndpoint(t *testing.T) {

--- a/internal/serverstack/shared_server.go
+++ b/internal/serverstack/shared_server.go
@@ -759,6 +759,12 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 	// prior sessions (demoting the ones that fell out of use). Runs after
 	// the NewServer register sweep, so the cold tools are already deferred.
 	srv.InitLearnedTools(sideCfg.NotesDir, sideCfg.NotesRepo)
+	// InitMemories opens a second store the SideStores dirs do not name: the
+	// user-level global memories, always mounted at platform.MemoriesDir()
+	// even when this stack configured no side-store dirs at all. Its sidecar
+	// handle is as durable as the others, so record it here or a stack whose
+	// SideStores are empty still leaves one file open at Close.
+	s.sidecarPaths = append(s.sidecarPaths, persistence.DefaultSidecarPath(platform.MemoriesDir()))
 	srv.InitMemories(sideCfg.NotesDir, sideCfg.NotesRepo)
 	srv.InitSuppressions(sideCfg.NotesDir, sideCfg.NotesRepo)
 	srv.InitNotebook(sideCfg.NotebookPath)

--- a/internal/serverstack/shared_server.go
+++ b/internal/serverstack/shared_server.go
@@ -24,6 +24,7 @@ import (
 	gortexmcp "github.com/zzet/gortex/internal/mcp"
 	"github.com/zzet/gortex/internal/parser"
 	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/persistence"
 	"github.com/zzet/gortex/internal/platform"
 	"github.com/zzet/gortex/internal/query"
 	"github.com/zzet/gortex/internal/savings"
@@ -158,13 +159,30 @@ type SharedServer struct {
 	LSPRouter           *lsp.Router
 
 	cleanup []func() // run LIFO by Close (backend close, savings flush).
+	// sidecarPaths are the sidecar databases this stack caused to be
+	// opened — the side stores and the savings ledger. They are released
+	// after the teardown chain, not inside it.
+	sidecarPaths []string
 }
 
-// Close runs the teardown chain LIFO.
+// Close runs the teardown chain LIFO, then releases every sidecar database
+// the stack opened.
+//
+// The sidecar handles go last, outside the chain: every cleanup step that
+// might still write a note, a memory or a saving has finished by then.
+// Leaving them open pins the sidecar files for the life of the process,
+// which the daemon can afford and a one-shot stack cannot — on Windows an
+// open file cannot be deleted, so the directory holding it survives
+// teardown. persistence.CloseSidecar is a no-op for a path nothing opened,
+// so listing a store that stayed in memory costs nothing.
 func (s *SharedServer) Close() error {
 	for i := len(s.cleanup) - 1; i >= 0; i-- {
 		s.cleanup[i]()
 	}
+	for _, path := range s.sidecarPaths {
+		_ = persistence.CloseSidecar(path)
+	}
+	s.sidecarPaths = nil
 	return nil
 }
 
@@ -728,6 +746,13 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 	// Side-stores. The HTTP path previously wired NONE of these; routing it
 	// through the shared constructor adds notes/memories/savings to it.
 	sideCfg := cfg.SideStores
+	// Every side store resolves its dir to <dir>/sidecar.sqlite and holds
+	// that handle open; record the files so Close can release them.
+	for _, dir := range []string{sideCfg.NotesDir, sideCfg.FeedbackDir} {
+		if dir != "" {
+			s.sidecarPaths = append(s.sidecarPaths, persistence.DefaultSidecarPath(dir))
+		}
+	}
 	srv.InitFeedback(sideCfg.FeedbackDir, sideCfg.FeedbackRepo)
 	srv.InitNotes(sideCfg.NotesDir, sideCfg.NotesRepo)
 	// Learned tool surface: re-promote tools this workspace promoted in
@@ -757,6 +782,7 @@ func NewSharedServer(cfg SharedServerConfig) (*SharedServer, error) {
 			logger.Warn("serverstack: legacy savings import failed", zap.Error(ierr))
 		}
 		srv.InitSavings(savingsStore, cfg.SavingsRepo)
+		s.sidecarPaths = append(s.sidecarPaths, savingsPath)
 		s.cleanup = append(s.cleanup, func() { _ = srv.FlushSavings() })
 	} else {
 		logger.Warn("serverstack: savings persistence disabled", zap.Error(err))

--- a/internal/serverstack/sidecar_close_test.go
+++ b/internal/serverstack/sidecar_close_test.go
@@ -1,0 +1,78 @@
+package serverstack
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/persistence"
+	"github.com/zzet/gortex/internal/platform"
+	"github.com/zzet/gortex/internal/testenv"
+)
+
+// TestCloseReleasesTheGlobalMemoriesSidecar pins that Close releases the
+// user-level memories store too. InitMemories mounts it unconditionally at
+// platform.MemoriesDir(), under no directory the SideStores config names, so
+// a stack that configured no side stores at all still opened one sidecar —
+// and Close only knew about the ones it had been handed.
+//
+// The consequence is platform-specific: POSIX deletes a file with an open
+// handle, Windows refuses. A test whose home lives under t.TempDir() there
+// fails its own cleanup with "TempDir RemoveAll cleanup: ... The process
+// cannot access the file because it is being used by another process", which
+// is how internal/serverstack's lease test failed on the Windows shard.
+func TestCloseReleasesTheGlobalMemoriesSidecar(t *testing.T) {
+	testenv.Sandbox(t)
+
+	base := t.TempDir()
+	repo := filepath.Join(base, "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	conf := config.Default()
+	conf.Semantic.Enabled = false
+
+	stack, err := NewSharedServer(SharedServerConfig{
+		Lifecycle:   LifecycleOneshot,
+		Index:       repo,
+		BackendPath: filepath.Join(base, "store.sqlite"),
+		Config:      conf,
+		Logger:      zap.NewNop(),
+		// Pin the ledger to temp paths: with both empty the constructor
+		// reaches the machine-global savings sidecar.
+		SavingsPath:       filepath.Join(base, "savings.sqlite"),
+		SavingsLegacyJSON: filepath.Join(base, "savings.json"),
+	})
+	if err != nil {
+		t.Fatalf("NewSharedServer: %v", err)
+	}
+
+	sidecar := persistence.DefaultSidecarPath(platform.MemoriesDir())
+	if _, err := os.Stat(sidecar); err != nil {
+		t.Fatalf("the stack opened no global memories sidecar, so this test proves nothing: %v", err)
+	}
+	// OpenSidecar hands back the cached handle, so this is the instance the
+	// stack is holding — not a second one.
+	held, err := persistence.OpenSidecar(sidecar)
+	if err != nil {
+		t.Fatalf("OpenSidecar: %v", err)
+	}
+
+	if err := stack.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Close must have evicted it from the shared cache, so asking again
+	// builds a fresh handle. Same pointer means the old one is still open.
+	reopened, err := persistence.OpenSidecar(sidecar)
+	if err != nil {
+		t.Fatalf("OpenSidecar after Close: %v", err)
+	}
+	t.Cleanup(func() { _ = reopened.Close() })
+	if reopened == held {
+		t.Fatal("Close left the global memories sidecar open: on Windows its handle pins the file and the test's own TempDir cleanup fails")
+	}
+}

--- a/internal/testenv/tmpdir.go
+++ b/internal/testenv/tmpdir.go
@@ -1,0 +1,29 @@
+package testenv
+
+import (
+	"os"
+	"runtime"
+	"testing"
+)
+
+// ShortTempDir returns a fresh temporary directory whose absolute path is
+// short enough to hold an AF_UNIX socket. t.TempDir() nests the test name
+// under the platform temp root, which on macOS ("/var/folders/…/T/") and
+// under long test names overruns the 104/108-byte sun_path limit, so Unix
+// hosts create the directory under /tmp directly. Windows has no /tmp; its
+// %TEMP% ("C:\\Users\\<user>\\AppData\\Local\\Temp") is short enough on its own
+// and AF_UNIX has the same 108-byte limit there. The directory is removed
+// when the test ends.
+func ShortTempDir(tb testing.TB) string {
+	tb.Helper()
+	parent := "/tmp"
+	if runtime.GOOS == "windows" {
+		parent = os.TempDir()
+	}
+	dir, err := os.MkdirTemp(parent, "gx")
+	if err != nil {
+		tb.Fatalf("ShortTempDir: %v", err)
+	}
+	tb.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}


### PR DESCRIPTION
## Summary

- add `windows-latest` to the full test matrix (`fail-fast: false`) and drop the selector-based `build-windows` job
- run the Windows shard without the race detector (Linux and macOS keep `-race`): with it the shard overran the 60-minute job cap before half the packages had reported; the platform contract is what Windows is here to check
- port the suite to Windows: the last complete Windows run had 184 failing tests in 19 packages; every one is fixed below

## What was wrong on Windows, and what changed

**Production fixes** (behaviour on Windows only, byte-identical on POSIX):
- `indexer` / `store_sqlite`: graph paths are keyed with forward slashes on every platform. The indexer kept OS-native separators in graph keys while symbol IDs, URIs and cross-repo lookups assumed `/`, so on Windows the same file existed under two spellings and dozens of lookups (find_import_path, barrel re-exports, localization anchors, contract edges, TS path aliases, GDScript resolution) missed.
- `resolver`: directory keys derived with `/`, so import resolution binds on Windows (bare specifiers, workspace membership, cross-package guard, extern edges).
- `review`, `analysis`, `forge`, `audit`: repo-relative paths in findings, diff headers, hunks, verification commands and discovered config files stay slash-separated (`path.Clean`, not `filepath.Clean`).
- `cmd/gortex`: `reapStaleEmbeddedStores` released the store lock before `RemoveAll` (Windows refuses to delete an open file, so the reap was a silent no-op); `loadHistory` / `runSavings` and `serverstack.SharedServer.Close` release their sidecar SQLite handles; `isAmbiguousLaunchCWD` recognises a drive root; the short-name repo match and the uninstall preview agree on separators.
- `daemon`: a dial to a missing socket is classified as "daemon unavailable" on Windows too — Winsock reports `WSAECONNREFUSED` (10061), which is not Go's `syscall.ECONNREFUSED` there — so hooks, the proxy's restart retry and embedded fallback behave as on POSIX.
- `platform`: one file-claim / file-replace policy (`ClaimFile`, `ReplaceFile`) used by the localization receipt, the hooks tool snapshot and the crash-pool quarantine: POSIX `rename(2)` hands a contended file to exactly one caller, Windows `MoveFileEx` can fail every caller, so exclusive claims go through an `O_EXCL` marker and replaces retry sharing violations.
- `mcp`: graph paths are looked up in the graph's forward-slash spelling everywhere (review pack, PR review context, PR risk, sibling diff, find_import_path, file summary, symbol-ID anchoring), an absolute citation is rejected in either spelling, note ordering is total, and every localization file tier is ordered by declaration site — the sort used to run only when the page had a member to demote, so a tight window kept whatever arrival order the ranked tail produced (which differs between POSIX and Windows).
- `serverstack`: the global memories sidecar opened by `InitMemories` is released on `Close`.

**Test fixes**:
- `testenv.ShortTempDir` replaces every `os.MkdirTemp("/tmp", …)` used for short AF_UNIX socket paths (33 daemon/cmd/hooks failures were `GetFileAttributesEx /tmp`).
- Shell-script stubs (`fake-claude.sh`, `/bin/sh`, `/bin/cat`) became helper-process re-execs of the test binary; PATH stubs carry a PATHEXT extension on Windows.
- POSIX absolute fixtures (`/work/alpha`, `/repo`, `/abs/config`) are built natively; URI expectations derive from native absolute paths; JSON and quoted-path expectations account for `\`.
- Assertions on POSIX-only semantics — mode bits, exec bits, chmod-denied access, self-signalling — are skipped on Windows with a stated reason; nothing is weakened on POSIX.
- The embedding provider test downloads its model from Hugging Face on every run; a stalled download used to hang the package until the 45-minute test timeout, so the download is bounded and a stall skips with a stated reason instead of killing the shard. The `platform.ClaimFile` winner no longer loses its claim when concurrent readers keep the payload open on Windows (Go opens files without `FILE_SHARE_DELETE`, so removal fails while any reader holds the file).
- Three timing assertions measured the runner instead of the behaviour: two health endpoints' `uptime > 0` raced Windows' ~15 ms clock tick (now backdated and asserted `>= 3 s`), and the PASSIVE WAL-checkpoint test timed the CI disk back-filling 408 frames rather than lock contention (PASSIVE never consults the busy handler; the test now times the pass after the back-fill).
- The hooks suite's stdout capture drains the pipe while the hook writes: Windows pipes buffer 4 KiB (POSIX 64 KiB) and the SessionStart briefing is larger, so the first test past that size deadlocked and the whole package hit the go-test timeout — the single reason the shard used to run out its 60-minute cap. `TestRouter_ReloadConfig_ConcurrentNoRace` no longer resolves a real hostname per iteration (183 s on Windows DNS).

## Validation

- macOS: full suite green (the `cmd/gortex` write-through guard trips only when a live daemon on the developer machine appends to the real query log; identical on unmodified `main`).
- Windows: every package and test file cross-compiles (`GOOS=windows CGO_ENABLED=1` with mingw); the CI shard is the behavioural oracle — 153/153 packages pass, in about half an hour. The shard writes no coverage profile: nothing uploads it there, and the runner's PowerShell tokenised `-coverprofile=coverage.out` into an extra `.out` package argument, which was the last thing failing the step.
- `go vet`, `golangci-lint`, `actionlint` clean.

## Follow-ups noted, not in this PR

- `internal/graphpath` still documents the native-separator premise its callers no longer need; `PrefixForms`' native arm only folds graphs indexed by older versions.
- `hostPhysicalMemory()` returns 0 on Windows, so cold-index GC tuning is inert there.
- `-v` on the Windows shard is temporary, to expose per-test timings until the shard is reliably green.
