### PR TITLE
fix(cpp): index .hxx headers

### DIFF
--- a/internal/indexer/extractor_version.go
+++ b/internal/indexer/extractor_version.go
@@ -66,6 +66,7 @@ var extractorSaltExtLang = map[string]string{
 	".cxx":  "cpp",
 	".hpp":  "cpp",
 	".hh":   "cpp",
+	".hxx":  "cpp",
 	".cs":   "csharp",
 	// Razor templates are extracted by the C# extractor over their
 	// embedded code blocks, so a C# extraction fix has to re-flag them

--- a/internal/indexer/extractor_version_test.go
+++ b/internal/indexer/extractor_version_test.go
@@ -70,11 +70,17 @@ func TestStaleLangsDetection(t *testing.T) {
 		if got := merkleSaltFor("src/Handler.php"); got != "php@2" {
 			t.Errorf("PHP extractor salt = %q, want php@2", got)
 		}
+		if got := merkleSaltFor("include/widget.hxx"); got != "cpp@2" {
+			t.Errorf("C++ extractor salt for .hxx = %q, want cpp@2", got)
+		}
 	})
 
 	t.Run("lang_for_file", func(t *testing.T) {
 		if got := ExtractorLangForFile("internal/auth/token.go"); got != "go" {
 			t.Errorf("ExtractorLangForFile(.go) = %q, want go", got)
+		}
+		if got := ExtractorLangForFile("include/widget.hxx"); got != "cpp" {
+			t.Errorf("ExtractorLangForFile(.hxx) = %q, want cpp", got)
 		}
 		if got := ExtractorLangForFile("README.zzz"); got != "" {
 			t.Errorf("ExtractorLangForFile(unknown) = %q, want \"\"", got)

--- a/internal/parser/languages/cpp.go
+++ b/internal/parser/languages/cpp.go
@@ -118,7 +118,7 @@ func NewCppExtractor() *CppExtractor {
 }
 
 func (e *CppExtractor) Language() string     { return "cpp" }
-func (e *CppExtractor) Extensions() []string { return []string{".cpp", ".cc", ".cxx", ".hpp"} }
+func (e *CppExtractor) Extensions() []string { return []string{".cpp", ".cc", ".cxx", ".hpp", ".hxx"} }
 
 // --- Deferred call buffer ----------------------------------------
 

--- a/internal/parser/languages/cpp_test.go
+++ b/internal/parser/languages/cpp_test.go
@@ -136,6 +136,7 @@ func TestCppExtractor_Extensions(t *testing.T) {
 	assert.Contains(t, exts, ".cc")
 	assert.Contains(t, exts, ".cxx")
 	assert.Contains(t, exts, ".hpp")
+	assert.Contains(t, exts, ".hxx")
 	assert.NotContains(t, exts, ".h")
 }
 


### PR DESCRIPTION
## Summary

- register `.hxx` files with the C++ extractor so they reach tree-sitter indexing
- map `.hxx` to the C++ extractor salt for incremental freshness and cache invalidation
- add focused regression coverage for extractor admission, language lookup, and Merkle salting

## Root cause

The parser registry is populated from each extractor's declared extensions. `CppExtractor.Extensions()` included `.cxx` and `.hpp`, but not `.hxx`, so `.hxx` headers were discarded before C++ extraction and produced no graph nodes or edges. The incremental extractor-version map had the same omission. The optional clangd/LSP path already recognized `.hxx`.

The ambiguous `.h` extension remains on its existing content-sniffing path.

## Verification

- `GOWORK=off go test ./internal/parser/languages ./internal/indexer`
- `GOWORK=off go build ./internal/indexer/... ./internal/parser/languages/...`
- `GOWORK=off go test -race ./internal/indexer/... ./internal/parser/languages/...`
- `GOWORK=off go test ./...` — all packages passed except the documented `cmd/gortex` live-daemon state guard, because the running daemon updated `~/.gortex/cache/query-log.jsonl` during the test

Closes #648
