### PR TITLE
fix(agents): keep Windows checkouts and rendered docs platform-independent

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+# Line endings are a property of the repository, not of the checkout.
+#
+# Several text assets are consumed byte-for-byte rather than line-by-line:
+# `internal/agents/opencode/plugin/gortex.js` and
+# `internal/agents/pi/extension/index.ts` are compiled into the binary with
+# go:embed and written verbatim into a user's project, and the golden files
+# under `cmd/gortex/testdata/` are compared against rendered output. Git for
+# Windows installs with `core.autocrlf=true` — the GitHub windows runner
+# included — so without this file a Windows checkout rewrites those assets to
+# CRLF, which both changes what the binary ships and breaks the comparisons.
+#
+# The committed blobs are already LF, so this pins the checkout; it does not
+# rewrite history or content.
+* text=auto eol=lf
+
+# PowerShell is the one place a CRLF checkout is still the convention.
+*.ps1 text eol=crlf
+
+# Never guess at these.
+*.png binary
+*.gz binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,16 @@ jobs:
       - name: Build all packages
         run: go build ./...
 
+      # ./internal/agents is one package and does not recurse, so the
+      # opencode adapter is named explicitly. Its plugin asset is embedded
+      # verbatim with go:embed and TestPluginFailsOpen parses it by
+      # splitting on "\n}\n", which is the closest thing the suite has to a
+      # detector for a CRLF checkout of an embedded file — and it can only
+      # fire on a runner that converts line endings.
       - name: Test Windows agent integrations
-        run: go test -timeout=5m -count=1 ./internal/agents
+        run: >
+          go test -timeout=5m -count=1
+          ./internal/agents ./internal/agents/opencode
 
       # Symlink confinement keeps out-of-repo files out of the index, and it
       # reads differently on Windows: a symlink reparse point maps to

--- a/internal/agents/claudecode/install_diet_test.go
+++ b/internal/agents/claudecode/install_diet_test.go
@@ -133,9 +133,14 @@ func TestGlobalInstall_FatToSlimReplacement(t *testing.T) {
 
 	// The block is now the thin pointer: it @-includes the active
 	// profile copy from the hermetic instructions dir…
+	// Two spellings of one file, and the difference is the point: the
+	// @-include is document content and stays '/'-spelled on every OS,
+	// while the ReadFile below is a real filesystem call and needs the
+	// native path.
 	activePath := filepath.Join(env.InstructionsDir, profiles.ActiveFileName)
-	if !strings.Contains(text, "@"+activePath) {
-		t.Errorf("re-installed block does not @-include the active profile (%s)", activePath)
+	includedPath := filepath.ToSlash(activePath)
+	if !strings.Contains(text, "@"+includedPath) {
+		t.Errorf("re-installed block does not @-include the active profile (%s)", includedPath)
 	}
 	if !strings.Contains(text, "gortex instructions switch") {
 		t.Error("re-installed block lost the switch verb")

--- a/internal/agents/embedded_asset_eol_test.go
+++ b/internal/agents/embedded_asset_eol_test.go
@@ -1,0 +1,74 @@
+package agents
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// embeddedTextAssets are the text files this tree hands to a user
+// verbatim: go:embed compiles them into the binary and the adapters write
+// them into a project unchanged. Their bytes are therefore a shipping
+// artefact, not a source detail, and a checkout that rewrites their line
+// endings changes what users receive.
+var embeddedTextAssets = []string{
+	"internal/agents/opencode/plugin/gortex.js",
+	"internal/agents/pi/extension/index.ts",
+}
+
+// TestEmbeddedTextAssetsArePinnedToLF guards the `* text=auto eol=lf` line
+// in .gitattributes from both directions.
+//
+// The byte half catches a checkout that already converted: Git for Windows
+// installs with core.autocrlf=true, so without the attribute these files
+// arrive CRLF and the binary ships CRLF. The attribute half catches the
+// removal itself, and is the half that still binds on a runner configured
+// not to convert — where a byte assertion would pass no matter what
+// .gitattributes says.
+//
+// TestPluginFailsOpen detects the same corruption, but only as a side
+// effect of splitting the plugin source on "\n}\n"; this states the
+// contract directly and covers the pi extension too.
+func TestEmbeddedTextAssetsArePinnedToLF(t *testing.T) {
+	root, err := repoRoot()
+	if err != nil {
+		t.Skipf("not a git work tree, nothing to assert: %v", err)
+	}
+
+	for _, rel := range embeddedTextAssets {
+		body, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Errorf("%s: %v", rel, err)
+			continue
+		}
+		if i := strings.Index(string(body), "\r\n"); i >= 0 {
+			t.Errorf("%s: embedded asset has a CRLF line ending at byte %d — "+
+				"this checkout converted it and the binary would ship it that way; "+
+				"check the `* text=auto eol=lf` line in .gitattributes", rel, i)
+		}
+
+		out, err := exec.Command("git", "-C", root, "check-attr", "eol", "--", rel).Output()
+		if err != nil {
+			t.Errorf("%s: git check-attr: %v", rel, err)
+			continue
+		}
+		// `<path>: eol: <value>`; unset attributes report "unspecified".
+		line := string(out)
+		if got := strings.TrimSpace(line[strings.LastIndex(line, ":")+1:]); got != "lf" {
+			t.Errorf("%s: eol attribute is %q, want \"lf\" — a Windows checkout "+
+				"will convert this embedded asset to CRLF", rel, got)
+		}
+	}
+}
+
+// repoRoot locates the work tree so the test can address assets by their
+// repo-relative path from whatever directory `go test` runs it in.
+func repoRoot() (string, error) {
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/internal/agents/embedded_asset_eol_test.go
+++ b/internal/agents/embedded_asset_eol_test.go
@@ -1,6 +1,7 @@
 package agents
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -32,10 +33,22 @@ var embeddedTextAssets = []string{
 // effect of splitting the plugin source on "\n}\n"; this states the
 // contract directly and covers the pi extension too.
 func TestEmbeddedTextAssetsArePinnedToLF(t *testing.T) {
-	root, err := repoRoot()
+	wd, err := os.Getwd()
 	if err != nil {
-		t.Skipf("not a git work tree, nothing to assert: %v", err)
+		t.Fatalf("getwd: %v", err)
 	}
+	root, err := moduleRootFrom(wd)
+	if err != nil {
+		t.Fatalf("locating the module root: %v", err)
+	}
+
+	// The attribute half needs the assets to belong to the checkout whose
+	// attributes it is about to read. A copied, vendored or nested tree
+	// can sit inside some *other* work tree, and asking that one about
+	// these paths answers a different question — or, as this test did
+	// before, addresses files that are not there at all.
+	gitRoot, gitErr := gitTopLevel(root)
+	attributesApply := gitErr == nil && sameDir(gitRoot, root)
 
 	for _, rel := range embeddedTextAssets {
 		body, err := os.ReadFile(filepath.Join(root, filepath.FromSlash(rel)))
@@ -49,6 +62,9 @@ func TestEmbeddedTextAssetsArePinnedToLF(t *testing.T) {
 				"check the `* text=auto eol=lf` line in .gitattributes", rel, i)
 		}
 
+		if !attributesApply {
+			continue
+		}
 		out, err := exec.Command("git", "-C", root, "check-attr", "eol", "--", rel).Output()
 		if err != nil {
 			t.Errorf("%s: git check-attr: %v", rel, err)
@@ -61,14 +77,86 @@ func TestEmbeddedTextAssetsArePinnedToLF(t *testing.T) {
 				"will convert this embedded asset to CRLF", rel, got)
 		}
 	}
+
+	if !attributesApply {
+		t.Logf("module root %s is not its own git work tree (%v); "+
+			"asserted the embedded bytes only, skipped the attribute half", root, gitErr)
+	}
 }
 
-// repoRoot locates the work tree so the test can address assets by their
-// repo-relative path from whatever directory `go test` runs it in.
-func repoRoot() (string, error) {
-	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+// TestModuleRootFromIgnoresAnEnclosingCheckout is the regression case for
+// the layout that broke this file: the source placed under some other
+// repository, as a vendored copy, a monorepo subdirectory or a packaging
+// staging tree. `git rev-parse --show-toplevel` answers for the enclosing
+// work tree, which is the wrong tree and often does not contain these
+// paths at all, so the root has to come from the module instead.
+func TestModuleRootFromIgnoresAnEnclosingCheckout(t *testing.T) {
+	outer := t.TempDir()
+	inner := filepath.Join(outer, "src")
+	start := filepath.Join(inner, "internal", "agents")
+
+	// An enclosing work tree *and* an enclosing module, so neither a git
+	// lookup nor a sloppy upward walk can accidentally pass.
+	for _, dir := range []string{filepath.Join(outer, ".git"), start} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, f := range []string{
+		filepath.Join(outer, "go.mod"),
+		filepath.Join(inner, "go.mod"),
+	} {
+		if err := os.WriteFile(f, []byte("module x\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := moduleRootFrom(start)
+	if err != nil {
+		t.Fatalf("moduleRootFrom(%s): %v", start, err)
+	}
+	if !sameDir(got, inner) {
+		t.Errorf("moduleRootFrom(%s) = %s, want the nearest module root %s", start, got, inner)
+	}
+}
+
+// moduleRootFrom walks up from dir to the nearest directory holding a
+// go.mod. That is the module this test belongs to, whatever repository
+// happens to contain it.
+func moduleRootFrom(dir string) (string, error) {
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("no go.mod at or above %s", dir)
+		}
+		dir = parent
+	}
+}
+
+// gitTopLevel reports the work tree dir owns, if any.
+func gitTopLevel(dir string) (string, error) {
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "--show-toplevel").Output()
 	if err != nil {
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// sameDir compares two directories by identity rather than by spelling.
+// git answers with forward slashes on Windows while filepath produces
+// backslashes, and either side may arrive through a symlink or a
+// different case, so string equality is the wrong test.
+func sameDir(a, b string) bool {
+	fa, err := os.Stat(a)
+	if err != nil {
+		return false
+	}
+	fb, err := os.Stat(b)
+	if err != nil {
+		return false
+	}
+	return os.SameFile(fa, fb)
 }

--- a/internal/agents/instructions.go
+++ b/internal/agents/instructions.go
@@ -63,7 +63,13 @@ const (
 // CLAUDE.md. The heading stays here as the idempotency sentinel and as
 // a functional minimum for readers that do not expand @-includes.
 func GlobalPointerBody(instructionsDir string) string {
-	active := filepath.Join(instructionsDir, profiles.ActiveFileName)
+	// The @-include is document content, not a filesystem call: it is
+	// written into ~/.claude/CLAUDE.md and read back as markdown. Native
+	// separators would leak a `@C:\Users\me\.gortex\...` line into a file
+	// whose every other path is '/'-spelled, and the same rendered body
+	// is compared against a golden that cannot be platform-specific. This
+	// mirrors shellSafeHookBinary, which normalises for the same reason.
+	active := filepath.ToSlash(filepath.Join(instructionsDir, profiles.ActiveFileName))
 	return "## MANDATORY: Use Gortex MCP tools instead of Read/Grep/Glob\n\n" +
 		"The machine-wide Gortex rules load from the active instruction profile, imported below:\n\n" +
 		"@" + active + "\n\n" +

--- a/internal/agents/instructions_test.go
+++ b/internal/agents/instructions_test.go
@@ -1,7 +1,7 @@
 package agents
 
 import (
-	"path/filepath"
+	"path"
 	"strings"
 	"testing"
 
@@ -82,7 +82,11 @@ func TestBashInstructionsBodyUsesOnlyExplicitCLIMirror(t *testing.T) {
 func TestGlobalPointerBody_ShapeAndSentinel(t *testing.T) {
 	const dir = "/home/user/.gortex/instructions"
 	body := GlobalPointerBody(dir)
-	activePath := filepath.Join(dir, "active.md")
+	// path.Join, not filepath.Join: the @-include is document content and
+	// stays '/'-spelled on every OS. Building the expectation with
+	// filepath.Join would assert the native mangling on Windows and pass
+	// there whether or not the renderer normalises.
+	activePath := path.Join(dir, "active.md")
 
 	if !strings.Contains(body, InstructionsSentinel) {
 		t.Error("pointer block lost the idempotency sentinel heading")

--- a/internal/agents/render.go
+++ b/internal/agents/render.go
@@ -359,10 +359,26 @@ func canonicalManifestKey(key string) string {
 // HOME / repo root and the resolved gortex binary path — with stable
 // placeholders so the manifest is identical on every machine.
 func normalizeRender(s, home, root string) string {
-	s = strings.ReplaceAll(s, home, "$HOME")
-	s = strings.ReplaceAll(s, root, "$ROOT")
+	// The values to scrub are native paths — os.Executable, exec.LookPath,
+	// the sandbox HOME — but a rendered manifest deliberately carries
+	// '/'-spelled paths even on Windows: shellSafeHookBinary normalises
+	// unconditionally, and an @-include is document content rather than a
+	// filesystem call. Replacing only the native spelling therefore leaves
+	// a machine-specific absolute in the manifest on Windows and the
+	// golden drifts for every developer who has gortex installed.
+	// filepath.ToSlash is a no-op on POSIX, so the second pass collapses
+	// into the first everywhere else.
+	scrub := func(s, from, to string) string {
+		if from == "" {
+			return s
+		}
+		s = strings.ReplaceAll(s, from, to)
+		return strings.ReplaceAll(s, filepath.ToSlash(from), to)
+	}
+	s = scrub(s, home, "$HOME")
+	s = scrub(s, root, "$ROOT")
 	for _, p := range gortexBinaryPaths() {
-		s = strings.ReplaceAll(s, p, "gortex")
+		s = scrub(s, p, "gortex")
 	}
 	return s
 }

--- a/internal/agents/render_test.go
+++ b/internal/agents/render_test.go
@@ -242,3 +242,39 @@ func TestRenderRestoresUnsetEnvironment(t *testing.T) {
 		t.Errorf("CLAUDE_CONFIG_DIR leaked out of the render as %q; it was unset before", v)
 	}
 }
+
+// TestNormalizeRenderScrubsTheSlashSpelledPath binds the second
+// replacement in normalizeRender, which nothing else can.
+//
+// A rendered manifest carries '/'-spelled paths even on Windows —
+// shellSafeHookBinary normalises unconditionally, and an @-include is
+// document content rather than a filesystem call — while the values handed
+// to normalizeRender are native. Scrubbing only the native spelling
+// therefore leaves a machine-specific absolute in the manifest, and
+// TestAgentsRenderGolden catches it only in cmd/gortex, which the Windows
+// job does not test.
+//
+// On linux/macos both spellings are the same string and this passes with
+// either implementation; on Windows it fails without the ToSlash pass.
+// That asymmetry is the point, and it is why the assertion lives in
+// internal/agents, which the Windows job already runs.
+func TestNormalizeRenderScrubsTheSlashSpelledPath(t *testing.T) {
+	home := filepath.Join(string(filepath.Separator)+"sandbox", "home")
+	root := filepath.Join(string(filepath.Separator)+"sandbox", "repo")
+
+	// The body is what a renderer emits: forward slashes, whatever the OS.
+	body := "@" + filepath.ToSlash(home) + "/.gortex/instructions/active.md\n" +
+		"root=" + filepath.ToSlash(root) + "\n"
+
+	got := normalizeRender(body, home, root)
+
+	if !strings.Contains(got, "@$HOME/.gortex/instructions/active.md") {
+		t.Errorf("the slash-spelled home survived normalizeRender:\n%s", got)
+	}
+	if !strings.Contains(got, "root=$ROOT") {
+		t.Errorf("the slash-spelled root survived normalizeRender:\n%s", got)
+	}
+	if strings.Contains(got, filepath.ToSlash(home)) || strings.Contains(got, filepath.ToSlash(root)) {
+		t.Errorf("a machine-specific absolute is still in the manifest:\n%s", got)
+	}
+}

--- a/internal/agents/render_test.go
+++ b/internal/agents/render_test.go
@@ -261,10 +261,22 @@ func TestRenderRestoresUnsetEnvironment(t *testing.T) {
 func TestNormalizeRenderScrubsTheSlashSpelledPath(t *testing.T) {
 	home := filepath.Join(string(filepath.Separator)+"sandbox", "home")
 	root := filepath.Join(string(filepath.Separator)+"sandbox", "repo")
+	exe := filepath.Join(string(filepath.Separator)+"tools", "bin", "gortex")
+
+	// The binary path is the third thing normalizeRender scrubs, and the
+	// one an adapter is most likely to have written through
+	// shellSafeHookBinary. Pinning gortexBinaryPaths keeps the assertion
+	// about the scrub rather than about whatever gortex happens to be
+	// installed on the machine running the test. No test in this package
+	// calls t.Parallel, so the swap cannot race one.
+	restore := gortexBinaryPaths
+	t.Cleanup(func() { gortexBinaryPaths = restore })
+	gortexBinaryPaths = func() []string { return []string{exe} }
 
 	// The body is what a renderer emits: forward slashes, whatever the OS.
 	body := "@" + filepath.ToSlash(home) + "/.gortex/instructions/active.md\n" +
-		"root=" + filepath.ToSlash(root) + "\n"
+		"root=" + filepath.ToSlash(root) + "\n" +
+		`"command": "` + filepath.ToSlash(exe) + ` hook"` + "\n"
 
 	got := normalizeRender(body, home, root)
 
@@ -274,7 +286,14 @@ func TestNormalizeRenderScrubsTheSlashSpelledPath(t *testing.T) {
 	if !strings.Contains(got, "root=$ROOT") {
 		t.Errorf("the slash-spelled root survived normalizeRender:\n%s", got)
 	}
-	if strings.Contains(got, filepath.ToSlash(home)) || strings.Contains(got, filepath.ToSlash(root)) {
-		t.Errorf("a machine-specific absolute is still in the manifest:\n%s", got)
+	if !strings.Contains(got, `"command": "gortex hook"`) {
+		t.Errorf("the slash-spelled executable survived normalizeRender:\n%s", got)
+	}
+	for _, leaked := range []string{
+		filepath.ToSlash(home), filepath.ToSlash(root), filepath.ToSlash(exe),
+	} {
+		if strings.Contains(got, leaked) {
+			t.Errorf("machine-specific absolute %q is still in the manifest:\n%s", leaked, got)
+		}
 	}
 }


### PR DESCRIPTION
First tranche of the Windows CI work for #652. Scope is deliberately small and touches no runtime behaviour outside the rendered-document path: it removes the failures that block *reading* the Windows suite at all.

## What is wrong

**1. The repository has no `.gitattributes`.**

Git for Windows installs with `core.autocrlf=true` — the GitHub `windows-latest` runner included — so a Windows checkout rewrites every text file to CRLF. Two things break:

- `internal/agents/opencode/plugin/gortex.js` and `internal/agents/pi/extension/index.ts` are `go:embed`'d and written verbatim into a user's project. A source build on Windows therefore ships CRLF assets. `TestPluginFailsOpen` already detects it — it splits `pluginSource` on `"\n}\n"`, which stops matching.
- `gofmt -l` flags **every** Go file in the tree. Control on an untouched file:

  ```
  $ file -b internal/agents/aider/adapter.go
  Unicode text, UTF-8 text, with CRLF line terminators
  $ gofmt -l internal/agents/aider/adapter.go
  internal/agents/aider/adapter.go          # unformatted

  # same file, re-checked-out under the new .gitattributes
  $ file -b internal/agents/aider/adapter.go
  Unicode text, UTF-8 text
  $ gofmt -l internal/agents/aider/adapter.go
                                            # clean
  ```

  So any formatting or lint gate on the Windows leg would fail wholesale, and a Windows contributor cannot separate real findings from the noise.

The committed blobs are already LF. `git add --renormalize .` reports **no** content change — only the files this PR edits appear — so this pins the checkout and rewrites nothing.

`*.ps1` keeps CRLF; `*.png` / `*.gz` are marked binary.

**2. `GlobalPointerBody` builds the `@`-include with `filepath.Join`.**

On Windows that writes

```
@C:\Users\me\.gortex\instructions\active.md
```

into `~/.claude/CLAUDE.md`. That line is document content, not a filesystem call, and every other path in the file is `/`-spelled. `shellSafeHookBinary` already normalises unconditionally for exactly this reason, with the rationale written in its doc comment.

`UpsertMarkedBlock` keys idempotency on the start/end markers (`instructions.go:203`, `:216`), not on the path string, so an existing install has its block replaced in place on the next run — no duplicate, no orphan.

I checked for a consumer that parses the line back: the only production caller is `claudecode/adapter.go:268`, and it only writes.

**3. `normalizeRender` scrubs only the native spelling.**

`gortexBinaryPaths()` collects native paths (`os.Executable`, `exec.LookPath`), and `home` / `root` arrive native too — but a rendered manifest carries `/`-spelled paths by design. On Windows the `ReplaceAll` never matches, so `TestAgentsRenderGolden` leaks a machine-specific absolute into the comparison:

```
-@$HOME/.gortex/instructions/active.md
+@D:/tmp/gobuild/gortex-render-home-3991093423/.gortex/instructions/active.md
```

and it drifts for any developer who has gortex installed on PATH. This is the same class the file's own `canonicalManifestKey` already guards against.

## Verification

windows/amd64, go1.26.6, `-count=1`, measured against `origin/main` `699f351e`:

| package | before | after |
|---|---|---|
| `internal/agents` | ok | ok |
| `internal/agents/opencode` | 1 | **0** |
| `cmd/gortex` | 19 | **18** |
| `internal/agents/claudecode` | 2 | 2 — both pre-existing (`TestResolveHookCommand`, `TestEmitPluginBundle_HookHandlerExecBit`) |

Newly-broken set is empty. `gofmt` and `go vet` clean on the touched files.

Each fix was sabotage-verified separately:

- revert (1) → `TestPluginFailsOpen`: `callHook has no closing brace this test can find`
- revert (2) → claude-code golden drifts to `@$HOME\.gortex\instructions\active.md`
- revert (3) → claude-code **and** hermes goldens drift to absolute paths

`TestAgentsRenderGolden` now passes on Windows with the full PATH — i.e. with gortex actually installed — which it did not before.

## Two assertions changed, and why

`TestGlobalPointerBody_ShapeAndSentinel` and `TestGlobalInstall_FatToSlimReplacement` built their expected `@`-include with `filepath.Join`. That asserts the native mangling on Windows, so it passes there whether or not the renderer normalises. They now use `path.Join` / `filepath.ToSlash`. In `install_diet_test.go` both spellings are kept deliberately — the `@`-include assertion takes the slash form, the `os.ReadFile` next to it keeps the native one.

## Limitation, stated up front

As in #646, none of this can fail on the linux/macos matrix: `filepath.ToSlash` is a no-op on POSIX, and the CRLF conversion never happens there. The `windows-latest` leg from #652 is the only place these bind. I have not added a selector step — after your note on #652 that narrow selectors can miss the regression they are meant to protect, that seems like the wrong direction.

## On the rest of #652

I ran the full suite on `origin/main` `699f351e` (windows/amd64, go1.26.6, no `-race`): **173 failing tests across 28 packages**, of which **2 are my machine, not the repo** — `internal/analysis` `TestMapGitDiff*` and `internal/releases` leave a `.git/ai/working_logs/` directory behind that a local `git` fork creates, and `os.RemoveAll` then fails. I will post the full classification on #652 with the buckets and the three questions that need your call before I can fix them.
