### PR TITLE
feat(localize): corroboration-gated terminality and an answer page that leads with its shape

### DIFF
--- a/internal/mcp/localization_current_capture_test.go
+++ b/internal/mcp/localization_current_capture_test.go
@@ -198,30 +198,31 @@ func TestFinishReservedReadWithDigestMergesOnlyOnAnswerReady(t *testing.T) {
 	}
 }
 
-func TestFinishReservedReadWithDigestEmptySuccessReleasesAdvisoryAndPreservesCurrentTaskDigest(t *testing.T) {
+func TestFinishReservedReadWithDigestEmptySuccessSpendsOneAllowanceAndPreservesCurrentTaskDigest(t *testing.T) {
 	retained := mergeLocalizationEvidenceDigest([]localizationDigestRow{
 		captureTestRow("repo/storage/base.go::Storage.Load", "repo/storage/base.go"),
 	}, nil)
 	state := &localizationTerminalState{
-		state:                    localizationStateRecoveryInFlight,
-		generation:               5,
-		readReservationToken:     21,
-		readReservationGen:       5,
-		recoveryRetriesRemaining: 1,
-		digest:                   retained,
+		state:                       localizationStateRecoveryInFlight,
+		generation:                  5,
+		readReservationToken:        21,
+		readReservationGen:          5,
+		recoveryRetriesRemaining:    1,
+		recoveryAllowancesRemaining: localizationRecoveryAllowanceCap,
+		digest:                      retained,
 	}
 	completion := state.finishReservedReadTokenWithDigest(21, true, nil, true)
-	if completion.State != localizationStateLocalized || completion.AllowedToolCalls != 0 || completion.Enforceable {
-		t.Fatalf("empty accepted recovery did not release an advisory result: %#v", completion)
+	if completion.State != localizationStateNeedsRecovery || completion.AllowedToolCalls != 1 || completion.Enforceable {
+		t.Fatalf("empty accepted recovery did not keep one further allowance: %#v", completion)
 	}
-	if state.state != localizationStateInactive {
-		t.Fatalf("empty accepted recovery left state restricted: %q", state.state)
+	if state.recoveryAllowancesRemaining != localizationRecoveryAllowanceCap-1 {
+		t.Fatalf("empty accepted recovery spent %d allowances", localizationRecoveryAllowanceCap-state.recoveryAllowancesRemaining)
 	}
-	if state.digest != nil || completion.digest != retained {
-		t.Fatalf("advisory release did not return retained evidence and clear internal authorization: state=%#v completion=%#v", state.digest, completion.digest)
+	if state.digest != retained || completion.digest != retained {
+		t.Fatalf("uncorroborated recovery dropped retained evidence: state=%#v completion=%#v", state.digest, completion.digest)
 	}
 	if got := completion.digest.Evidence[0].ID; got != "repo/storage/base.go::Storage.Load" {
-		t.Fatalf("same-task advisory release changed retained identity: %q", got)
+		t.Fatalf("same-task recovery changed retained identity: %q", got)
 	}
 }
 

--- a/internal/mcp/localization_digest.go
+++ b/internal/mcp/localization_digest.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -1335,9 +1336,73 @@ func localizationFinalResponseSymbolLabel(row localizationDigestRow, qualify boo
 	id := localizationFinalResponseField(row.ID)
 	file := localizationFinalResponseField(row.File)
 	if !qualify || id == "" || file == "" || strings.Contains(id, file) {
-		return id
+		return localizationDisplayIdentity(id, row.Line)
 	}
-	return file + "::" + id
+	return file + "::" + localizationDisplayIdentity(id, row.Line)
+}
+
+// localizationDisplayIdentity renders one retained identity for prose. A graph
+// ID carries two spellings no answer can say: the keyword a constructor is
+// indexed under, and the positional suffix that separates same-named
+// declarations. Both are presentation-only. The row's ID, the graph, and every
+// machine field keep their exact spelling — only this label changes.
+func localizationDisplayIdentity(identity string, line int) string {
+	identity = strings.TrimSpace(identity)
+	if identity == "" {
+		return identity
+	}
+	prefix := ""
+	member := identity
+	if cut := strings.LastIndex(identity, "::"); cut >= 0 {
+		prefix, member = identity[:cut+2], identity[cut+2:]
+	}
+	member = localizationConstructorProse(localizationTrimPositionalSuffix(member, line))
+	if member == "" {
+		return identity
+	}
+	return prefix + member
+}
+
+// localizationTrimPositionalSuffix drops the `_L<line>` / `@<line>` tie-break
+// extractors append when one file declares the same name twice. The rendered
+// row already carries the line in its own column. The trailing number must be
+// that line: a declaration genuinely named `CACHE_L2` cannot satisfy it, and
+// emitters disagree by one on where a declaration starts.
+func localizationTrimPositionalSuffix(member string, line int) string {
+	digits := len(member)
+	for digits > 0 && member[digits-1] >= '0' && member[digits-1] <= '9' {
+		digits--
+	}
+	if digits == len(member) {
+		return member
+	}
+	suffix, err := strconv.Atoi(member[digits:])
+	if err != nil || (line > 0 && suffix != line && suffix != line-1 && suffix != line+1) {
+		return member
+	}
+	switch {
+	case digits >= 2 && member[digits-2] == '_' && member[digits-1] == 'L':
+		return member[:digits-2]
+	case digits >= 1 && member[digits-1] == '@':
+		return member[:digits-1]
+	}
+	return member
+}
+
+// localizationConstructorProse spells a keyword-indexed constructor the way an
+// answer has to say it. The extractor names it `<Type>.<init>` across Java, C#
+// and Swift; a caller repeating that back is naming a symbol no reader
+// recognizes.
+func localizationConstructorProse(member string) string {
+	const keyword = "<init>"
+	switch {
+	case member == keyword:
+		return "constructor"
+	case strings.HasSuffix(member, "."+keyword):
+		return strings.TrimSuffix(member, "."+keyword) + " constructor"
+	default:
+		return member
+	}
 }
 
 func renderLocalizationAnswerPage(
@@ -1352,6 +1417,8 @@ func renderLocalizationAnswerPage(
 	}
 	var response strings.Builder
 	response.WriteString(heading)
+	response.WriteString("\n")
+	response.WriteString(localizationAnswerShapeDirective)
 	response.WriteString("\n")
 	excerpted := 0
 	for _, item := range presented {
@@ -1421,6 +1488,20 @@ const localizationAnswerClaimDiscipline = "Name only symbols this page lists or 
 // name what the answer should carry, and leave the caller free to disagree —
 // its disagreement is right more often than not.
 const localizationAnswerReadyDirective = "Localization for this task is complete. Answer now from this evidence, naming the files and symbols you rely on. If it does not fit the request, say so and name what does — your judgement about the code is welcome, another navigation call is not. " + localizationAnswerClaimDiscipline
+
+// The same instruction as a closing line is read after the answer is already
+// shaped, which is why it is obeyed at a rate indistinguishable from absence.
+// It leads the page instead, and it names the shape rather than describing it:
+// how many candidates, what each row must carry, and the one thing a caller
+// must not leave out when nothing corroborated the match. Two lines is the
+// budget — every byte here is a byte the evidence rows do not get.
+const localizationAnswerShapeDirective = "ANSWER WITH: the 2-3 strongest candidates below, each as its file plus a bare qualified identifier (Class.method), nothing trailing it.\n" +
+	"If the match is unconfirmed, say so in the answer."
+
+// localizationUnconfirmedAnswerDirective closes a page that terminates without
+// corroboration. It must not read as the proven directive: the caller has to
+// know the bounded allowance ran out and the candidates were never confirmed.
+const localizationUnconfirmedAnswerDirective = "The bounded localization allowance is spent and nothing corroborated these candidates. Answer now from them, naming the files and symbols you rely on, and say plainly that the match is unconfirmed. " + localizationAnswerClaimDiscipline
 
 const (
 	localizationAnswerHeading      = "LOCALIZATION:"
@@ -1649,12 +1730,36 @@ func localizationCompletionWithDigest(completion localizationCompletion, digest 
 		}
 		return completion
 	}
+	if completion.provisionalAnswer {
+		// A terminal state reached without corroboration keeps the unconfirmed
+		// heading it earned — including when it retained nothing at all, which is
+		// the one case a proven page would be furthest from true. Only the closing
+		// line changes: no step remains to prefer, so the page says the allowance
+		// is spent.
+		var rows []localizationDigestRow
+		page := ""
+		if digest != nil {
+			rows, page = digest.Evidence, digest.provisionalResponse
+		}
+		if page == "" {
+			page = renderLocalizationProvisionalResponseForTask("", nil, rows)
+		}
+		completion.FinalResponse = localizationUnconfirmedTerminalPage(page)
+		return completion
+	}
 	if digest != nil && digest.finalResponse != "" {
 		completion.FinalResponse = digest.finalResponse
 	} else if completion.FinalResponse == "" {
 		completion.FinalResponse = renderLocalizationFinalResponse(nil)
 	}
 	return completion
+}
+
+func localizationUnconfirmedTerminalPage(page string) string {
+	if !strings.HasSuffix(page, localizationProvisionalDirective) {
+		return page
+	}
+	return strings.TrimSuffix(page, localizationProvisionalDirective) + localizationUnconfirmedAnswerDirective
 }
 
 func localizationTerminalStructuredContent(payload any, contract localizationTerminalContract) map[string]any {
@@ -1678,6 +1783,9 @@ func localizationTerminalStructuredContent(payload any, contract localizationTer
 		// cache-write rate, which is the most expensive place to repeat oneself:
 		// point at it instead.
 		structured["directive"] = localizationAnswerReadyDirective
+		if contract.Completion.provisionalAnswer {
+			structured["directive"] = localizationUnconfirmedAnswerDirective
+		}
 	}
 	return structured
 }
@@ -1751,7 +1859,8 @@ func localizationAnswerReadyResult(completion localizationCompletion) *mcpgo.Cal
 	// Older retained completions may predate the in-response convergence cue.
 	// Preserve their successful replay shape without duplicating the directive
 	// for newly rendered terminal evidence.
-	if !strings.HasSuffix(visible, localizationAnswerReadyDirective) {
+	if !strings.HasSuffix(visible, localizationAnswerReadyDirective) &&
+		!strings.HasSuffix(visible, localizationUnconfirmedAnswerDirective) {
 		visible += "\n\n" + localizationAnswerReadyDirective
 	}
 	result := mcpgo.NewToolResultText(visible)

--- a/internal/mcp/localization_digest_test.go
+++ b/internal/mcp/localization_digest_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -24,19 +25,37 @@ func testEvidenceDigest() *localizationEvidenceDigest {
 
 func requireLocalizationTerminalReplay(t *testing.T, result *mcpgo.CallToolResult, _, _ string) localizationTerminalContract {
 	t.Helper()
-	if result == nil || result.IsError {
-		t.Fatalf("terminal replay = %#v, want successful MCP result", result)
-	}
-	text, ok := singleTextContent(result)
-	if !ok || !strings.Contains(text, localizationAnswerReadyDirective) {
-		t.Fatalf("terminal replay content = %#v", result.Content)
-	}
-	for _, required := range []string{
+	return requireLocalizationReplayClosing(t, result, localizationAnswerReadyDirective, []string{
 		"Localization for this task is complete",
 		"Answer now",
 		"naming the files and symbols you rely on",
 		"another navigation call is not",
-	} {
+	})
+}
+
+// A localization that spent its recovery allowances without corroborating
+// anything replays the same structure under the closing line that says so.
+func requireLocalizationUnconfirmedReplay(t *testing.T, result *mcpgo.CallToolResult) localizationTerminalContract {
+	t.Helper()
+	return requireLocalizationReplayClosing(t, result, localizationUnconfirmedAnswerDirective, []string{
+		"bounded localization allowance is spent",
+		"Answer now",
+		"say plainly that the match is unconfirmed",
+	})
+}
+
+func requireLocalizationReplayClosing(
+	t *testing.T, result *mcpgo.CallToolResult, directive string, required []string,
+) localizationTerminalContract {
+	t.Helper()
+	if result == nil || result.IsError {
+		t.Fatalf("terminal replay = %#v, want successful MCP result", result)
+	}
+	text, ok := singleTextContent(result)
+	if !ok || !strings.Contains(text, directive) {
+		t.Fatalf("terminal replay content = %#v", result.Content)
+	}
+	for _, required := range required {
 		if !strings.Contains(text, required) {
 			t.Fatalf("terminal replay text %q does not contain %q", text, required)
 		}
@@ -61,14 +80,14 @@ func requireLocalizationTerminalReplay(t *testing.T, result *mcpgo.CallToolResul
 	// The answer rides the completion once; the top level carries only the
 	// pointer to it, so the same block is never billed twice on the wire.
 	if _, duplicated := structured["final_response"]; duplicated ||
-		structured["directive"] != localizationAnswerReadyDirective ||
+		structured["directive"] != directive ||
 		contract.Completion.FinalResponse == "" {
 		t.Fatalf("terminal replay stable keys = %#v", structured)
 	}
 	if text != contract.Completion.FinalResponse {
 		t.Fatalf("terminal replay text diverged from final_response: %q", text)
 	}
-	if !strings.HasSuffix(contract.Completion.FinalResponse, localizationAnswerReadyDirective) {
+	if !strings.HasSuffix(contract.Completion.FinalResponse, directive) {
 		t.Fatalf("terminal convergence directive is outside final_response: %q", contract.Completion.FinalResponse)
 	}
 	return contract
@@ -174,9 +193,17 @@ func TestRefinementAllowsOneAlternateRankedCandidateRead(t *testing.T) {
 		testEvidenceDigest(),
 	)
 
-	if completion := state.completionLocked(); !strings.Contains(completion.RequiredAction, "recommended") ||
+	completion := state.completionLocked()
+	if !strings.Contains(completion.RequiredAction, preferred) ||
+		!strings.Contains(completion.RequiredAction, alternate) ||
 		!strings.Contains(completion.RequiredAction, "any returned candidate") {
-		t.Fatalf("required action does not explain alternate candidate authorization: %q", completion.RequiredAction)
+		t.Fatalf("required action does not name the ranked alternates it authorizes: %q", completion.RequiredAction)
+	}
+	// Obeying the directive has to stay productive when the top candidate is
+	// wrong, so it names what to do next instead of ending at one read.
+	if !strings.Contains(completion.RequiredAction, "does not match the task's anchor terms") ||
+		!strings.Contains(completion.RequiredAction, "one bounded search") {
+		t.Fatalf("required action ends at the first candidate: %q", completion.RequiredAction)
 	}
 	args := map[string]any{"target": map[string]any{"symbol": alternate}}
 	if blocked, reserved := state.authorize("read", "source", args); blocked != nil || !reserved {
@@ -1660,5 +1687,107 @@ func TestAnswerReadyNavigationDispatchNeverInvokesLegacyHandler(t *testing.T) {
 	}
 	if text, _ := singleTextContent(called.Result); strings.Contains(text, localizationAnswerReadyDirective) {
 		t.Fatalf("capabilities was incorrectly intercepted: %q", text)
+	}
+}
+
+// The instruction that says what an answer must look like is the one
+// instruction a closing line cannot deliver: by the time it is read, the
+// answer is already shaped. It leads every page instead.
+func TestAnswerPagesLeadWithTheAnswerShapeDirective(t *testing.T) {
+	digest := provisionalTestDigest(t, provisionalTestRow())
+	pages := map[string]string{
+		"proven":      digest.finalResponse,
+		"provisional": digest.provisionalResponse,
+	}
+	for name, page := range pages {
+		lines := strings.Split(page, "\n")
+		if len(lines) < 3 {
+			t.Fatalf("%s page is too short to carry a leading directive: %q", name, page)
+		}
+		if got := lines[1] + "\n" + lines[2]; got != localizationAnswerShapeDirective {
+			t.Fatalf("%s page does not lead with the answer shape: %q", name, got)
+		}
+		if strings.Index(page, localizationAnswerShapeDirective) > strings.Index(page, "- PRIMARY") {
+			t.Fatalf("%s page buried the answer shape below its rows: %q", name, page)
+		}
+	}
+	// Two lines is the whole budget: every byte here is a byte the rows lose.
+	if strings.Count(localizationAnswerShapeDirective, "\n") != 1 {
+		t.Fatalf("answer shape directive is not two lines: %q", localizationAnswerShapeDirective)
+	}
+	for _, required := range []string{"2-3 strongest candidates", "Class.method", "unconfirmed"} {
+		if !strings.Contains(localizationAnswerShapeDirective, required) {
+			t.Fatalf("answer shape directive is missing %q: %q", required, localizationAnswerShapeDirective)
+		}
+	}
+}
+
+// A caller repeating a keyword-indexed constructor or a positional tie-break
+// suffix is naming a symbol no reader recognizes. Presentation drops both; the
+// identities the graph and the host envelope carry keep their exact spelling.
+func TestPresentedIdentitiesDropSyntheticSpellings(t *testing.T) {
+	constructor := localizationDigestRow{
+		Rank: 1, ID: "src/Foo.java::Foo.<init>_L42", Name: "Foo.<init>",
+		QualName: "Foo.<init>", Kind: "method", File: "src/Foo.java", Line: 42,
+	}
+	positional := localizationDigestRow{
+		Rank: 2, ID: "src/app.ts::handleRequest@17", Name: "handleRequest",
+		Kind: "function", File: "src/app.ts", Line: 17,
+	}
+	digest := provisionalTestDigest(t, constructor, positional)
+
+	for _, page := range []string{digest.finalResponse, digest.provisionalResponse} {
+		for _, synthetic := range []string{"<init>", "_L42", "handleRequest@17"} {
+			if strings.Contains(page, synthetic) {
+				t.Fatalf("page presented the synthetic spelling %q: %q", synthetic, page)
+			}
+		}
+		for _, presented := range []string{"src/Foo.java::Foo constructor", "src/app.ts::handleRequest"} {
+			if !strings.Contains(page, presented) {
+				t.Fatalf("page does not present %q: %q", presented, page)
+			}
+		}
+	}
+	if digest.Evidence[0].ID != constructor.ID || digest.Evidence[1].ID != positional.ID {
+		t.Fatalf("presentation changed retained identities: %#v", digest.Evidence)
+	}
+	for _, id := range []string{constructor.ID, positional.ID} {
+		if !slices.Contains(digest.Symbols, id) {
+			t.Fatalf("machine symbol list lost %q: %#v", id, digest.Symbols)
+		}
+	}
+}
+
+// The suffix is stripped because it repeats the row's own line column. A name
+// that merely ends in a number is a different declaration and keeps it.
+func TestPositionalSuffixTrimRequiresTheRowsOwnLine(t *testing.T) {
+	tests := []struct {
+		name string
+		row  localizationDigestRow
+		want string
+	}{
+		{
+			name: "declaration named for a cache level",
+			row: localizationDigestRow{
+				Rank: 1, ID: "src/cache.go::CACHE_L2", Name: "CACHE_L2",
+				Kind: "field", File: "src/cache.go", Line: 87,
+			},
+			want: "src/cache.go::CACHE_L2",
+		},
+		{
+			name: "overload disambiguated by its line",
+			row: localizationDigestRow{
+				Rank: 1, ID: "src/Cache.java::Cache.get_L87", Name: "Cache.get",
+				Kind: "method", File: "src/Cache.java", Line: 87,
+			},
+			want: "src/Cache.java::Cache.get",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := localizationFinalResponseSymbolLabel(test.row, false); got != test.want {
+				t.Fatalf("presented identity = %q, want %q", got, test.want)
+			}
+		})
 	}
 }

--- a/internal/mcp/localization_generic_invariants_test.go
+++ b/internal/mcp/localization_generic_invariants_test.go
@@ -279,7 +279,7 @@ func TestAdvisoryReleaseCannotInvalidateConcurrentLocalizeReservation(t *testing
 	}
 }
 
-func TestAcceptedEmptyRecoveryReleasesAdvisorySession(t *testing.T) {
+func TestAcceptedEmptyRecoveryKeepsOneAllowanceThenTerminatesUnconfirmed(t *testing.T) {
 	state := newLocalizationTerminalState()
 	completion := newLocalizationRecoveryCompletion()
 	completion.digest = &localizationEvidenceDigest{Evidence: []localizationDigestRow{{
@@ -291,13 +291,26 @@ func TestAcceptedEmptyRecoveryReleasesAdvisorySession(t *testing.T) {
 	if blocked != nil || token == 0 {
 		t.Fatalf("recovery authorization = (%#v, %d)", blocked, token)
 	}
-	advisory := state.finishReservedReadTokenWithDigest(token, true, nil, true)
-	if advisory.State != localizationStateLocalized || advisory.AllowedToolCalls != 0 || advisory.Enforceable {
-		t.Fatalf("empty accepted recovery did not return advisory completion: %#v", advisory)
+	retry := state.finishReservedReadTokenWithDigest(token, true, nil, true)
+	if retry.State != localizationStateNeedsRecovery || retry.AllowedToolCalls != 1 || retry.Enforceable {
+		t.Fatalf("empty accepted recovery did not keep one further allowance: %#v", retry)
+	}
+
+	blocked, token = state.authorizeWithToken("search", "symbols", map[string]any{"query": "storage"})
+	if blocked != nil || token == 0 {
+		t.Fatalf("second recovery authorization = (%#v, %d)", blocked, token)
+	}
+	spent := state.finishReservedReadTokenWithDigest(token, true, nil, true)
+	if spent.State != localizationStateAnswerReady || spent.AllowedToolCalls != 0 || spent.Enforceable {
+		t.Fatalf("spent recovery allowance did not terminate the session: %#v", spent)
+	}
+	if !strings.HasPrefix(spent.FinalResponse, localizationProvisionalHeading) ||
+		!strings.HasSuffix(spent.FinalResponse, localizationUnconfirmedAnswerDirective) {
+		t.Fatalf("uncorroborated terminal page claimed proof: %q", spent.FinalResponse)
 	}
 	state.mu.Lock()
 	defer state.mu.Unlock()
-	if state.state != localizationStateInactive {
-		t.Fatalf("advisory wire completion left session restricted: %q", state.state)
+	if state.state != localizationStateAnswerReady {
+		t.Fatalf("terminal recovery left session navigable: %q", state.state)
 	}
 }

--- a/internal/mcp/localization_provisional_page_test.go
+++ b/internal/mcp/localization_provisional_page_test.go
@@ -62,7 +62,9 @@ func TestAProvisionalPageCostsLittleBeyondItsIdentities(t *testing.T) {
 	digest := provisionalTestDigest(t, provisionalTestRow())
 	overhead := len(digest.provisionalResponse) -
 		len(provisionalTestRow().File) - len(provisionalTestRow().ID)
-	require.Less(t, overhead, 220,
+	// The leading answer-shape directive is fixed cost on every page: it is the
+	// only instruction placed where it is read before the answer is formed.
+	require.Less(t, overhead, 400,
 		"fixed page cost must stay a small fraction of the %d-byte envelope budget",
 		exploreDefaultBudgetTokens*localizationEnvelopeBytesPerToken)
 }

--- a/internal/mcp/localization_recovery_test.go
+++ b/internal/mcp/localization_recovery_test.go
@@ -701,25 +701,29 @@ func TestPlannedRecoveryEmptyResultReAllowsThenTerminatesUnconfirmed(t *testing.
 }
 
 // A recovery page whose identities say nothing about the request can still be
-// the right location — when it lands on evidence the ranked page already
-// carried. Nothing else in the row corroborates, so the file overlap is what
-// separates the two outcomes.
-func TestRecoveryTerminalizesOnlyWhenItLandsOnRetainedEvidence(t *testing.T) {
-	retained := mergeLocalizationEvidenceDigest([]localizationDigestRow{
-		captureTestRow("fixture/storage/flush.go::Storage.Flush", "fixture/storage/flush.go"),
-	}, nil)
+// the right location — when it contributes a declaration the page did not have
+// in a file the page already located. A row the page already ranked contributes
+// nothing: re-returning it is the recovery agreeing with itself.
+func TestRecoveryTerminalizesOnlyWhenItContributesAlignedNovelEvidence(t *testing.T) {
+	ranked := captureTestRow("fixture/storage/flush.go::Storage.Flush", "fixture/storage/flush.go")
+	retained := mergeLocalizationEvidenceDigest([]localizationDigestRow{ranked}, nil)
 	tests := []struct {
 		name  string
 		row   localizationDigestRow
 		state string
 	}{
 		{
-			name: "retained file",
+			name: "novel declaration in a retained file",
 			row: localizationDigestRow{
 				ID: "fixture/storage/flush.go::Storage.helper", Name: "helper",
 				Kind: "method", File: "fixture/storage/flush.go",
 			},
 			state: localizationStateAnswerReady,
+		},
+		{
+			name:  "row the page already ranked",
+			row:   ranked,
+			state: localizationStateNeedsRecovery,
 		},
 		{
 			name: "unrelated file",
@@ -748,6 +752,52 @@ func TestRecoveryTerminalizesOnlyWhenItLandsOnRetainedEvidence(t *testing.T) {
 			if test.state == localizationStateAnswerReady &&
 				!strings.HasPrefix(result.FinalResponse, localizationAnswerHeading) {
 				t.Fatalf("corroborated terminal did not emit the proven page: %q", result.FinalResponse)
+			}
+		})
+	}
+}
+
+// The page ranks several declarations from one file. A recovery that returns
+// those same siblings has narrowed nothing, and terminalizing on them stops a
+// session on a candidate the ranking had already offered and the caller had
+// already passed over.
+func TestRecoveryReturningOnlyRankedSiblingsDoesNotTerminalize(t *testing.T) {
+	siblings := []localizationDigestRow{
+		captureTestRow("fixture/storage/flush.go::Storage.Flush", "fixture/storage/flush.go"),
+		captureTestRow("fixture/storage/flush.go::Storage.Sync", "fixture/storage/flush.go"),
+	}
+	baseline := mergeLocalizationEvidenceDigest(siblings, nil)
+	newcomer := localizationDigestRow{
+		ID: "fixture/storage/flush.go::Storage.drain", Name: "drain",
+		Kind: "method", File: "fixture/storage/flush.go",
+	}
+	tests := []struct {
+		name  string
+		rows  []localizationDigestRow
+		state string
+	}{
+		{name: "ranked siblings only", rows: siblings, state: localizationStateNeedsRecovery},
+		{name: "one ranked sibling", rows: siblings[1:], state: localizationStateNeedsRecovery},
+		{
+			name:  "ranked siblings plus a novel declaration",
+			rows:  append(append([]localizationDigestRow(nil), siblings...), newcomer),
+			state: localizationStateAnswerReady,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			state := newLocalizationTerminalState()
+			completion := newLocalizationRecoveryCompletion()
+			completion.digest = baseline
+			state.armForTask(completion, "Storage writes stall during commit")
+
+			blocked, token := state.authorizeWithToken("search", "symbols", map[string]any{"query": "storage"})
+			if blocked != nil || token == 0 {
+				t.Fatalf("recovery authorization = (%#v, %d)", blocked, token)
+			}
+			result := state.finishReservedReadTokenWithDigest(token, true, test.rows, true)
+			if result.State != test.state {
+				t.Fatalf("recovery completion = %#v, want state %q", result, test.state)
 			}
 		})
 	}

--- a/internal/mcp/localization_recovery_test.go
+++ b/internal/mcp/localization_recovery_test.go
@@ -10,7 +10,7 @@ import (
 	mcpgo "github.com/mark3labs/mcp-go/mcp"
 )
 
-func TestWeakReadAllowsOneBoundedSearchRecoveryThenTerminates(t *testing.T) {
+func TestWeakReadAllowsBoundedSearchRecoveriesThenTerminates(t *testing.T) {
 	server := setupPresetServer(t, ToolPolicyConfig{Preset: "core", Mode: "defer"})
 	ctx := WithSessionID(context.Background(), "weak_read_search_recovery")
 	terminal := server.localizationFor(ctx)
@@ -44,13 +44,23 @@ func TestWeakReadAllowsOneBoundedSearchRecoveryThenTerminates(t *testing.T) {
 	}
 	requireLocalizationResultStateEqual(t, terminal, readResult, localizationStateNeedsRecovery, false, 1)
 
+	// The stub search returns a page with no graph-backed identity, so it
+	// corroborates nothing. One further allowance follows; the second spends it.
 	searchResult, err := server.handleFacade(ctx, "search", localizationRecoveryRequest("search", "text", map[string]any{
 		"query": "resolveCandidate",
 	}))
 	if err != nil || searchResult == nil || searchResult.IsError || searchCalls != 1 {
 		t.Fatalf("bounded recovery search = (%#v, %v), calls=%d", searchResult, err, searchCalls)
 	}
-	requireLocalizationResultStateEqual(t, terminal, searchResult, localizationStateAnswerReady, true, 0)
+	requireLocalizationResultStateEqual(t, terminal, searchResult, localizationStateNeedsRecovery, false, 1)
+
+	secondResult, err := server.handleFacade(ctx, "search", localizationRecoveryRequest("search", "text", map[string]any{
+		"query": "findCandidate",
+	}))
+	if err != nil || secondResult == nil || secondResult.IsError || searchCalls != 2 {
+		t.Fatalf("second bounded recovery search = (%#v, %v), calls=%d", secondResult, err, searchCalls)
+	}
+	requireLocalizationResultStateEqual(t, terminal, secondResult, localizationStateAnswerReady, true, 0)
 
 	extra, err := server.handleFacade(ctx, "search", localizationRecoveryRequest("search", "text", map[string]any{
 		"query": "another anchor",
@@ -58,8 +68,8 @@ func TestWeakReadAllowsOneBoundedSearchRecoveryThenTerminates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("post-recovery call returned transport error: %v", err)
 	}
-	requireLocalizationTerminalReplay(t, extra, "search", "text")
-	if searchCalls != 1 {
+	requireLocalizationUnconfirmedReplay(t, extra)
+	if searchCalls != 2 {
 		t.Fatalf("post-recovery search reached handler: calls=%d", searchCalls)
 	}
 }
@@ -124,7 +134,17 @@ func TestRecoveryRejectsUnrelatedAnchorWithoutConsumingAllowance(t *testing.T) {
 	if err != nil || retry == nil || retry.IsError || calls != 1 {
 		t.Fatalf("corrected recovery = (%#v, %v), calls=%d", retry, err, calls)
 	}
-	requireLocalizationResultStateEqual(t, terminal, retry, localizationStateAnswerReady, true, 0)
+	// Accepted, so the allowance the rejection preserved was spent here. The
+	// stub page corroborates nothing, so one further allowance remains.
+	requireLocalizationResultStateEqual(t, terminal, retry, localizationStateNeedsRecovery, false, 1)
+
+	last, err := server.handleFacade(ctx, "search", localizationRecoveryRequest("search", "text", map[string]any{
+		"query": "--multiline",
+	}))
+	if err != nil || last == nil || last.IsError || calls != 2 {
+		t.Fatalf("final recovery = (%#v, %v), calls=%d", last, err, calls)
+	}
+	requireLocalizationResultStateEqual(t, terminal, last, localizationStateAnswerReady, true, 0)
 }
 
 func TestRecoveryAcceptsTaskAlignedIdentifierAndCompactLiteralAnchors(t *testing.T) {
@@ -403,7 +423,7 @@ func TestRecoveryEvidenceRejectsGenericCallableWithSignatureOnlyOverlap(t *testi
 	}
 }
 
-func TestRecoveryWeakResultReleasesAdvisoryForEveryOperation(t *testing.T) {
+func TestRecoveryWeakResultReAllowsThenTerminatesUnconfirmedForEveryOperation(t *testing.T) {
 	longSink := localizationDigestRow{
 		ID:        "fixture/storage/report.go::Reporter.ReportStorageFailureAsPending",
 		Name:      "ReportStorageFailureAsPending",
@@ -432,14 +452,20 @@ func TestRecoveryWeakResultReleasesAdvisoryForEveryOperation(t *testing.T) {
 				t.Fatalf("recovery authorization = (%#v, %d)", blocked, token)
 			}
 			completion := state.finishReservedReadTokenWithDigest(token, true, []localizationDigestRow{longSink}, true)
-			if completion.State != localizationStateLocalized || completion.AllowedToolCalls != 0 || completion.Enforceable {
-				t.Fatalf("weak accepted recovery did not release advisory completion: %#v", completion)
+			if completion.State != localizationStateNeedsRecovery || completion.AllowedToolCalls != 1 || completion.Enforceable {
+				t.Fatalf("weak accepted recovery did not keep one further allowance: %#v", completion)
 			}
-			state.mu.Lock()
-			storedState := state.state
-			state.mu.Unlock()
-			if storedState != localizationStateInactive {
-				t.Fatalf("weak accepted recovery left session restricted: %q", storedState)
+
+			blocked, token = state.authorizeWithToken(test.facade, test.operation, test.arguments)
+			if blocked != nil || token == 0 {
+				t.Fatalf("second recovery authorization = (%#v, %d)", blocked, token)
+			}
+			completion = state.finishReservedReadTokenWithDigest(token, true, []localizationDigestRow{longSink}, true)
+			if completion.State != localizationStateAnswerReady || completion.Enforceable {
+				t.Fatalf("spent recovery allowance did not terminate: %#v", completion)
+			}
+			if !strings.HasPrefix(completion.FinalResponse, localizationProvisionalHeading) {
+				t.Fatalf("uncorroborated terminal page claimed proof: %q", completion.FinalResponse)
 			}
 		})
 	}
@@ -560,7 +586,7 @@ func TestPlannedRecoveryReplaceFamilyRegression(t *testing.T) {
 	}
 }
 
-func TestPlannedRecoveryIsExactRetriableAndWeakResultReleasesAdvisory(t *testing.T) {
+func TestPlannedRecoveryIsExactRetriableAndWeakResultReAllowsRecovery(t *testing.T) {
 	task := "Printed records are duplicated unexpectedly\ncombining --multiline with --replace while --only-matching spans lines"
 	preferred := "crates/searcher/src/sink.rs::sink_slow_multi_line_only_matching"
 	current := []localizationDigestRow{{
@@ -635,18 +661,21 @@ func TestPlannedRecoveryIsExactRetriableAndWeakResultReleasesAdvisory(t *testing
 	if blocked != nil || token == 0 {
 		t.Fatalf("exact planned recovery authorization = (%#v, %d)", blocked, token)
 	}
+	// The planned anchor was derived from evidence the page already retained, so
+	// a hit on it corroborates and terminalizes. A weak page that agrees with
+	// nothing keeps the second allowance instead.
 	weak := []localizationDigestRow{{
-		ID:   "crates/searcher/src/glue.rs::Matcher.replace_with_captures",
-		Name: "replace_with_captures", Kind: "method", File: "crates/searcher/src/glue.rs",
+		ID:   "crates/other/src/unrelated.rs::Unrelated.run",
+		Name: "run", Kind: "method", File: "crates/other/src/unrelated.rs",
 	}}
 	completion = state.finishReservedReadTokenWithDigest(token, true, weak, true)
-	if completion.State != localizationStateLocalized || completion.RequiredAction != "continue_task" ||
-		completion.AllowedToolCalls != 0 || completion.Enforceable {
-		t.Fatalf("weak planned result did not release an advisory completion: %#v", completion)
+	if completion.State != localizationStateNeedsRecovery || completion.RequiredAction != "recover_once" ||
+		completion.AllowedToolCalls != 1 || completion.Enforceable {
+		t.Fatalf("weak planned result did not keep one further allowance: %#v", completion)
 	}
 }
 
-func TestPlannedRecoveryEmptyResultReleasesAdvisory(t *testing.T) {
+func TestPlannedRecoveryEmptyResultReAllowsThenTerminatesUnconfirmed(t *testing.T) {
 	state := newLocalizationTerminalState()
 	state.armForTask(newLocalizationPlannedRecoveryCompletion("search.symbols", "transform_with"), "--multi-line with --transform duplicates output")
 	blocked, token := state.authorizeWithToken("search", "symbols", map[string]any{"query": "transform_with"})
@@ -654,10 +683,144 @@ func TestPlannedRecoveryEmptyResultReleasesAdvisory(t *testing.T) {
 		t.Fatalf("planned recovery authorization = (%#v, %d)", blocked, token)
 	}
 	completion := state.finishReservedReadTokenWithDigest(token, true, nil, true)
-	if completion.State != localizationStateLocalized || completion.RequiredAction != "continue_task" ||
-		completion.AllowedToolCalls != 0 || completion.Enforceable {
-		t.Fatalf("empty planned result did not release an advisory completion: %#v", completion)
+	// An exact plan that returns nothing has disproved the plan, not the task:
+	// the next allowance is unplanned so the caller can pick its own anchor.
+	if completion.State != localizationStateNeedsRecovery || completion.RequiredAction != "recover_once" ||
+		completion.AllowedToolCalls != 1 || completion.Enforceable {
+		t.Fatalf("empty planned result did not keep one further allowance: %#v", completion)
 	}
+
+	blocked, token = state.authorizeWithToken("search", "symbols", map[string]any{"query": "--transform"})
+	if blocked != nil || token == 0 {
+		t.Fatalf("second recovery authorization = (%#v, %d)", blocked, token)
+	}
+	completion = state.finishReservedReadTokenWithDigest(token, true, nil, true)
+	if completion.State != localizationStateAnswerReady || completion.Enforceable {
+		t.Fatalf("spent recovery allowance did not terminate: %#v", completion)
+	}
+}
+
+// A recovery page whose identities say nothing about the request can still be
+// the right location — when it lands on evidence the ranked page already
+// carried. Nothing else in the row corroborates, so the file overlap is what
+// separates the two outcomes.
+func TestRecoveryTerminalizesOnlyWhenItLandsOnRetainedEvidence(t *testing.T) {
+	retained := mergeLocalizationEvidenceDigest([]localizationDigestRow{
+		captureTestRow("fixture/storage/flush.go::Storage.Flush", "fixture/storage/flush.go"),
+	}, nil)
+	tests := []struct {
+		name  string
+		row   localizationDigestRow
+		state string
+	}{
+		{
+			name: "retained file",
+			row: localizationDigestRow{
+				ID: "fixture/storage/flush.go::Storage.helper", Name: "helper",
+				Kind: "method", File: "fixture/storage/flush.go",
+			},
+			state: localizationStateAnswerReady,
+		},
+		{
+			name: "unrelated file",
+			row: localizationDigestRow{
+				ID: "fixture/other/pool.go::Pool.helper", Name: "helper",
+				Kind: "method", File: "fixture/other/pool.go",
+			},
+			state: localizationStateNeedsRecovery,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			state := newLocalizationTerminalState()
+			completion := newLocalizationRecoveryCompletion()
+			completion.digest = retained
+			state.armForTask(completion, "Storage writes stall during commit")
+
+			blocked, token := state.authorizeWithToken("search", "symbols", map[string]any{"query": "storage"})
+			if blocked != nil || token == 0 {
+				t.Fatalf("recovery authorization = (%#v, %d)", blocked, token)
+			}
+			result := state.finishReservedReadTokenWithDigest(token, true, []localizationDigestRow{test.row}, true)
+			if result.State != test.state {
+				t.Fatalf("recovery completion = %#v, want state %q", result, test.state)
+			}
+			if test.state == localizationStateAnswerReady &&
+				!strings.HasPrefix(result.FinalResponse, localizationAnswerHeading) {
+				t.Fatalf("corroborated terminal did not emit the proven page: %q", result.FinalResponse)
+			}
+		})
+	}
+}
+
+// Rows an uncorroborated recovery surfaced are kept for the caller, but they
+// must never become the evidence the next recovery corroborates against.
+func TestASecondRecoveryCannotCorroborateItselfWithTheFirstResult(t *testing.T) {
+	retained := mergeLocalizationEvidenceDigest([]localizationDigestRow{
+		captureTestRow("fixture/storage/flush.go::Storage.Flush", "fixture/storage/flush.go"),
+	}, nil)
+	state := newLocalizationTerminalState()
+	completion := newLocalizationRecoveryCompletion()
+	completion.digest = retained
+	state.armForTask(completion, "Storage writes stall during commit")
+
+	unrelated := []localizationDigestRow{{
+		ID: "fixture/other/pool.go::Pool.helper", Name: "helper",
+		Kind: "method", File: "fixture/other/pool.go",
+	}}
+	for attempt, want := range []string{localizationStateNeedsRecovery, localizationStateAnswerReady} {
+		blocked, token := state.authorizeWithToken("search", "symbols", map[string]any{"query": "storage"})
+		if blocked != nil || token == 0 {
+			t.Fatalf("recovery %d authorization = (%#v, %d)", attempt+1, blocked, token)
+		}
+		result := state.finishReservedReadTokenWithDigest(token, true, unrelated, true)
+		if result.State != want {
+			t.Fatalf("recovery %d completion = %#v, want state %q", attempt+1, result, want)
+		}
+		if want == localizationStateAnswerReady {
+			if result.Enforceable || !strings.HasPrefix(result.FinalResponse, localizationProvisionalHeading) {
+				t.Fatalf("self-corroborated recovery claimed proof: %#v", result)
+			}
+		}
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if !localizationDigestHasRow(state.digest, unrelated[0].ID) {
+		t.Fatalf("uncorroborated recovery discarded what it surfaced: %#v", state.digest)
+	}
+}
+
+// The two limits are different axes: a handler that never ran proves nothing
+// about the evidence, so it must not cost a corroboration allowance.
+func TestFailedRecoveryHandlerDoesNotSpendACorroborationAllowance(t *testing.T) {
+	state := newLocalizationTerminalState()
+	state.armForTask(newLocalizationRecoveryCompletion(), "Storage writes stall during commit")
+
+	blocked, token := state.authorizeWithToken("search", "symbols", map[string]any{"query": "storage"})
+	if blocked != nil || token == 0 {
+		t.Fatalf("recovery authorization = (%#v, %d)", blocked, token)
+	}
+	if failed := state.finishReservedReadTokenWithDigest(token, false, nil, false); failed.State != localizationStateNeedsRecovery {
+		t.Fatalf("failed recovery handler = %#v, want restored allowance", failed)
+	}
+	state.mu.Lock()
+	remaining := state.recoveryAllowancesRemaining
+	state.mu.Unlock()
+	if remaining != localizationRecoveryAllowanceCap {
+		t.Fatalf("failed handler spent %d corroboration allowances", localizationRecoveryAllowanceCap-remaining)
+	}
+}
+
+func localizationDigestHasRow(digest *localizationEvidenceDigest, id string) bool {
+	if digest == nil {
+		return false
+	}
+	for _, row := range digest.Evidence {
+		if row.ID == id {
+			return true
+		}
+	}
+	return false
 }
 
 func localizationRecoveryRequest(facade, operation string, arguments map[string]any) mcpgo.CallToolRequest {

--- a/internal/mcp/localization_refinement_contract.go
+++ b/internal/mcp/localization_refinement_contract.go
@@ -1,6 +1,84 @@
 package mcp
 
+import (
+	"fmt"
+	"strings"
+)
+
 // The refinement page is byte-budgeted (see the tight-budget builder test), so
 // this stays the happy-path instruction only. The release that unsticks a wrong
 // ranking is named on the refusals, which is where a blocked caller reads.
 const localizationRefinementRequiredActionFormat = `Call Gortex MCP read(operation:"source", target:{symbol:%q}); the named symbol is recommended; any returned candidate is permitted only when its ID appears in completion.allowed_symbols; do not call a host file-read tool.`
+
+// A directive naming one symbol is obeyed whether or not that symbol is the
+// answer, and the ranked alternate that was the answer is never opened. Naming
+// the ranked set — and saying in the same sentence what to do when the first
+// candidate does not match — keeps obedience productive when the ranking is
+// wrong, which is the case this contract exists for.
+const localizationRefinementRequiredActionSetFormat = `Call Gortex MCP read(operation:"source", target:{symbol:%q}); if it does not match the task's anchor terms, try %s, or run one bounded search before answering;`
+
+const (
+	localizationRefinementAllowanceClause = ` any returned candidate is permitted only when its ID appears in completion.allowed_symbols;`
+	localizationRefinementHostToolClause  = ` do not call a host file-read tool.`
+	// localizationRefinementNamedCandidateCap names the preferred symbol plus
+	// two ranked alternates. A longer list costs page bytes the evidence rows
+	// need and stops reading as a decision.
+	localizationRefinementNamedCandidateCap = 3
+	// localizationRefinementRequiredActionMaxBytes bounds the directive so a
+	// widened candidate set cannot push the refinement envelope over budget.
+	localizationRefinementRequiredActionMaxBytes = 512
+)
+
+// localizationRefinementRequiredAction renders the directive for the ranked
+// candidate set. The trailing clauses are dropped before a named candidate is:
+// both restate machine fields the completion already carries, while a dropped
+// candidate is a symbol the caller can no longer reach.
+func localizationRefinementRequiredAction(preferred string, allowed []string) string {
+	preferred = strings.TrimSpace(preferred)
+	alternates := localizationRefinementAlternates(preferred, allowed)
+	for count := len(alternates); count > 0; count-- {
+		lead := fmt.Sprintf(localizationRefinementRequiredActionSetFormat, preferred,
+			localizationRefinementAlternateList(alternates[:count]))
+		for _, tail := range []string{
+			localizationRefinementAllowanceClause + localizationRefinementHostToolClause,
+			localizationRefinementHostToolClause,
+			"",
+		} {
+			if action := lead + tail; len(action) <= localizationRefinementRequiredActionMaxBytes {
+				return action
+			}
+		}
+	}
+	return fmt.Sprintf(localizationRefinementRequiredActionFormat, preferred)
+}
+
+func localizationRefinementAlternates(preferred string, allowed []string) []string {
+	alternates := make([]string, 0, localizationRefinementNamedCandidateCap-1)
+	seen := map[string]struct{}{preferred: {}}
+	for _, symbol := range allowed {
+		symbol = strings.TrimSpace(symbol)
+		if symbol == "" {
+			continue
+		}
+		if _, duplicate := seen[symbol]; duplicate {
+			continue
+		}
+		seen[symbol] = struct{}{}
+		alternates = append(alternates, symbol)
+		if len(alternates) == localizationRefinementNamedCandidateCap-1 {
+			break
+		}
+	}
+	return alternates
+}
+
+func localizationRefinementAlternateList(alternates []string) string {
+	quoted := make([]string, 0, len(alternates))
+	for _, symbol := range alternates {
+		quoted = append(quoted, fmt.Sprintf("%q", symbol))
+	}
+	if len(quoted) < 2 {
+		return strings.Join(quoted, "")
+	}
+	return strings.Join(quoted[:len(quoted)-1], ", ") + " or " + quoted[len(quoted)-1]
+}

--- a/internal/mcp/localization_refinement_contract_test.go
+++ b/internal/mcp/localization_refinement_contract_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -36,5 +37,62 @@ func TestLocalizationRefinementRequiredActionNamesFacadeReadSelector(t *testing.
 	}
 	if _, exists := payload["exact_symbol"]; exists {
 		t.Fatalf("uncertain refinement serialized exact_symbol: %#v", payload)
+	}
+}
+
+// A directive naming one symbol is obeyed whether or not that symbol is the
+// answer. The ranked set is named instead, and the instruction says what to do
+// when the first candidate misses, so obeying it stays productive.
+func TestRefinementDirectiveNamesTheRankedCandidateSetAndItsFallback(t *testing.T) {
+	symbols := []string{
+		"repo/pkg/resolve.go::Resolver.Run",
+		"repo/pkg/dispatch.go::Dispatcher.Run",
+		"repo/pkg/worker.go::Worker.Run",
+		"repo/pkg/legacy.go::Legacy.Run",
+	}
+	completion := newLocalizationRefinementCompletionForSymbols(symbols[0], symbols)
+
+	authorized := make(map[string]struct{}, len(completion.AllowedSymbols))
+	for _, symbol := range completion.AllowedSymbols {
+		authorized[symbol] = struct{}{}
+	}
+	for _, named := range symbols[:localizationRefinementNamedCandidateCap] {
+		if !strings.Contains(completion.RequiredAction, named) {
+			t.Fatalf("required action omits ranked candidate %q: %q", named, completion.RequiredAction)
+		}
+		if _, permitted := authorized[named]; !permitted {
+			t.Fatalf("required action named %q outside allowed_symbols %v", named, completion.AllowedSymbols)
+		}
+	}
+	if strings.Contains(completion.RequiredAction, symbols[localizationRefinementNamedCandidateCap]) {
+		t.Fatalf("required action named more than the ranked head: %q", completion.RequiredAction)
+	}
+	for _, required := range []string{
+		"does not match the task's anchor terms",
+		"one bounded search before answering",
+		"completion.allowed_symbols",
+	} {
+		if !strings.Contains(completion.RequiredAction, required) {
+			t.Fatalf("required action is missing %q: %q", required, completion.RequiredAction)
+		}
+	}
+}
+
+// The refinement page is byte-budgeted. Widening the directive to a set may
+// cost clauses that restate machine fields, never a candidate the caller would
+// otherwise be unable to reach.
+func TestRefinementDirectiveHoldsItsByteBoundOnLongIdentities(t *testing.T) {
+	nested := strings.Repeat("deeply/nested/", 8)
+	symbols := make([]string, 0, 3)
+	for index := 0; index < 3; index++ {
+		symbols = append(symbols, fmt.Sprintf("repo/%sservice%d.go::Service.HandleRequest%d", nested, index, index))
+	}
+	action := localizationRefinementRequiredAction(symbols[0], symbols)
+	if len(action) > localizationRefinementRequiredActionMaxBytes {
+		t.Fatalf("refinement directive = %d bytes, want <= %d: %q",
+			len(action), localizationRefinementRequiredActionMaxBytes, action)
+	}
+	if !strings.Contains(action, symbols[0]) || !strings.Contains(action, symbols[1]) {
+		t.Fatalf("byte trimming dropped a reachable candidate: %q", action)
 	}
 }

--- a/internal/mcp/localization_terminal.go
+++ b/internal/mcp/localization_terminal.go
@@ -23,6 +23,11 @@ const (
 	localizationTerminalContractV2     = 2
 )
 
+// localizationRecoveryAllowanceCap bounds how many accepted recovery calls one
+// contract may spend. The first uncorroborated recovery buys one more attempt;
+// the second must terminate, so a session can never loop on recovery.
+const localizationRecoveryAllowanceCap = 2
+
 var localizationRecoveryOperations = []string{"search.text", "search.symbols", "read.source"}
 
 // localizationDirectedReadRelease names the exit on every refusal that would
@@ -66,6 +71,10 @@ type localizationCompletion struct {
 	// authorized read without claiming that the current response is terminal.
 	// It defaults false until the evidence policy explicitly opts in.
 	enforceableOnAnswerReady bool
+	// provisionalAnswer marks a terminal completion whose retained candidates
+	// were never corroborated. It is session-only: the wire carries the
+	// difference as the unconfirmed page and a false enforceable flag.
+	provisionalAnswer bool
 	// taskLead is the bounded, normalized first issue line used only to check
 	// whether an advisory read covers the task's primary claim. The full prompt
 	// is never retained here.
@@ -241,7 +250,7 @@ func newLocalizationRefinementCompletionForSymbols(preferredSymbol string, allow
 	return localizationCompletion{
 		State:             localizationStateNeedsRefinement,
 		Scope:             "localization",
-		RequiredAction:    fmt.Sprintf(localizationRefinementRequiredActionFormat, preferredSymbol),
+		RequiredAction:    localizationRefinementRequiredAction(preferredSymbol, allowedSymbols),
 		AllowedToolCalls:  1,
 		ContractVersion:   localizationTerminalContractV2,
 		AllowedSymbols:    allowedSymbols,
@@ -298,6 +307,18 @@ type localizationTerminalState struct {
 	correctionRetriesRemaining uint8
 	refinementRetriesRemaining uint8
 	recoveryRetriesRemaining   uint8
+	// recoveryAllowancesRemaining counts accepted recovery calls, not handler
+	// failures: an uncorroborated result spends one allowance, a failed handler
+	// spends none.
+	recoveryAllowancesRemaining uint8
+	// answerProvisional keeps an uncorroborated terminal state honest across
+	// every later replay.
+	answerProvisional bool
+	// recoveryBaseline is the evidence a recovery has to agree with. It is the
+	// page the localization ranked, frozen when the recovery contract is armed:
+	// rows an uncorroborated recovery contributed are retained for the caller
+	// but must never become the thing the next recovery corroborates against.
+	recoveryBaseline *localizationEvidenceDigest
 	// Read reservations are tokenized independently of localization calls. A
 	// reset or newly armed task invalidates an old token, so a late read cannot
 	// finish (or decorate itself with) a newer task's contract.
@@ -356,6 +377,9 @@ func (s *localizationTerminalState) reset() {
 	s.correctionRetriesRemaining = 0
 	s.refinementRetriesRemaining = 0
 	s.recoveryRetriesRemaining = 0
+	s.recoveryAllowancesRemaining = 0
+	s.answerProvisional = false
+	s.recoveryBaseline = nil
 	s.readReservationToken = 0
 	s.readReservationGen = 0
 	s.enforceableOnAnswerReady = false
@@ -490,6 +514,9 @@ func (s *localizationTerminalState) commitLocalizationLocked(completion localiza
 	s.correctionRetriesRemaining = 0
 	s.refinementRetriesRemaining = 0
 	s.recoveryRetriesRemaining = 0
+	s.recoveryAllowancesRemaining = 0
+	s.answerProvisional = completion.provisionalAnswer
+	s.recoveryBaseline = nil
 	s.readReservationToken = 0
 	s.readReservationGen = 0
 	s.enforceableOnAnswerReady = completion.enforceableOnAnswerReady
@@ -509,6 +536,8 @@ func (s *localizationTerminalState) commitLocalizationLocked(completion localiza
 	}
 	if completion.State == localizationStateNeedsRecovery {
 		s.recoveryRetriesRemaining = 1
+		s.recoveryAllowancesRemaining = localizationRecoveryAllowanceCap
+		s.recoveryBaseline = completion.digest
 	}
 	if completion.State == localizationStateNeedsExactRead {
 		// A handler failure may be transient, but the exact-read contract must
@@ -549,6 +578,7 @@ func (s *localizationTerminalState) completionLocked() localizationCompletion {
 		completion = newLocalizationOpenCompletion()
 	default:
 		completion = newLocalizationCompletion(true, "")
+		completion.provisionalAnswer = s.answerProvisional
 	}
 	completion.enforceableOnAnswerReady = s.enforceableOnAnswerReady
 	completion.taskLead = s.taskLead
@@ -878,6 +908,58 @@ func localizationRecoveryEvidenceAlignedWithLead(task, lead, requested, operatio
 		}
 		if localizationReservedReadEvidenceAlignedWithLead(task, lead, "", []localizationDigestRow{row}) {
 			return true
+		}
+	}
+	return false
+}
+
+// localizationRecoveryCorroborated is the terminality gate for an accepted
+// recovery call. A recovery may land anywhere in the repository, so its result
+// has to agree with something before it can be called an answer: either it
+// returns evidence the retained page already ranked, or its own identities
+// carry the request's anchor terms. A page that agrees with neither is a new
+// unrelated location, and stamping it terminal converts a miss into a
+// confident wrong answer.
+func localizationRecoveryCorroborated(
+	task, lead, requested, operation string,
+	rows []localizationDigestRow,
+	retained *localizationEvidenceDigest,
+) bool {
+	if len(rows) == 0 {
+		return false
+	}
+	if localizationRowsIntersectRetained(rows, retained) {
+		return true
+	}
+	return localizationRecoveryEvidenceAlignedWithLead(task, lead, requested, operation, rows)
+}
+
+// localizationRowsIntersectRetained reports whether a permitted call returned a
+// symbol or a file the contract had already retained.
+func localizationRowsIntersectRetained(rows []localizationDigestRow, retained *localizationEvidenceDigest) bool {
+	if len(rows) == 0 || retained == nil || len(retained.Evidence) == 0 {
+		return false
+	}
+	ids := make(map[string]struct{}, len(retained.Evidence))
+	files := make(map[string]struct{}, len(retained.Evidence))
+	for _, row := range retained.Evidence {
+		if id := strings.TrimSpace(row.ID); id != "" {
+			ids[id] = struct{}{}
+		}
+		if file := strings.TrimSpace(row.File); file != "" {
+			files[strings.ToLower(file)] = struct{}{}
+		}
+	}
+	for _, row := range rows {
+		if id := strings.TrimSpace(row.ID); id != "" {
+			if _, exists := ids[id]; exists {
+				return true
+			}
+		}
+		if file := strings.TrimSpace(row.File); file != "" {
+			if _, exists := files[strings.ToLower(file)]; exists {
+				return true
+			}
 		}
 	}
 	return false
@@ -1647,25 +1729,47 @@ func (s *localizationTerminalState) finishReservedReadTokenInternal(
 	case localizationStateRecoveryInFlight:
 		requested := s.inFlightRecoveryAnchor
 		operation := s.inFlightRecoveryOperation
+		baseline := s.recoveryBaseline
 		s.inFlightRecoveryAnchor = ""
 		s.inFlightRecoveryOperation = ""
-		legacyRecovery := !captureRequired || (wireSuccess && !evidenceRecorded) ||
-			(operation == "" && strings.TrimSpace(s.taskFingerprint) == "")
+		// A synthetic finisher carries no capture record and no task, so it
+		// cannot be judged on evidence. Every production recovery is.
+		legacyRecovery := !captureRequired || (operation == "" && strings.TrimSpace(s.taskFingerprint) == "")
 		confidentRecovery := legacyRecovery || (capturedResult && mergedDigest != nil && len(mergedDigest.Evidence) > 0 &&
-			localizationRecoveryEvidenceAlignedWithLead(s.taskFingerprint, s.taskLead, requested, operation, currentEvidence))
+			localizationRecoveryCorroborated(s.taskFingerprint, s.taskLead, requested, operation, currentEvidence, baseline))
 		if success && confidentRecovery {
 			s.recoveryOperation = ""
 			s.recoveryAnchor = ""
 			s.state = localizationStateAnswerReady
 			s.recoveryRetriesRemaining = 0
+			s.recoveryAllowancesRemaining = 0
+			s.recoveryBaseline = nil
 			return s.completionLocked()
 		}
 		if wireSuccess {
-			// The one accepted recovery call completed but did not prove a
-			// declaration aligned with the task. Preserve everything it surfaced,
-			// then release the contract as advisory instead of opening a loop or
-			// manufacturing terminal confidence.
-			return s.releaseLocalizationAdvisoryLocked(mergedDigest)
+			// The accepted recovery call completed without corroborating anything.
+			// Keep what it surfaced and spend one allowance: a second attempt is
+			// cheap next to an uncorroborated answer, and the cap keeps it bounded.
+			if capturedResult {
+				s.digest = mergedDigest
+			}
+			s.recoveryOperation = ""
+			s.recoveryAnchor = ""
+			if s.recoveryAllowancesRemaining > 1 {
+				s.recoveryAllowancesRemaining--
+				s.recoveryRetriesRemaining = 1
+				s.state = localizationStateNeedsRecovery
+				return s.completionLocked()
+			}
+			// The allowance is spent. Terminate rather than loop, under the
+			// unconfirmed heading the evidence actually earned.
+			s.recoveryAllowancesRemaining = 0
+			s.recoveryRetriesRemaining = 0
+			s.recoveryBaseline = nil
+			s.enforceableOnAnswerReady = false
+			s.answerProvisional = true
+			s.state = localizationStateAnswerReady
+			return s.completionLocked()
 		}
 		if s.recoveryRetriesRemaining > 0 {
 			s.recoveryRetriesRemaining--
@@ -1701,6 +1805,8 @@ func (s *localizationTerminalState) finishReservedReadTokenInternal(
 			if !wasCorrection && !s.enforceableOnAnswerReady && !confidentRead {
 				s.state = localizationStateNeedsRecovery
 				s.recoveryRetriesRemaining = 1
+				s.recoveryAllowancesRemaining = localizationRecoveryAllowanceCap
+				s.recoveryBaseline = s.digest
 				return s.completionLocked()
 			}
 			s.state = localizationStateAnswerReady
@@ -1756,6 +1862,8 @@ func (s *localizationTerminalState) finishReservedReadTokenInternal(
 				}
 				s.state = localizationStateNeedsRecovery
 				s.recoveryRetriesRemaining = 1
+				s.recoveryAllowancesRemaining = localizationRecoveryAllowanceCap
+				s.recoveryBaseline = s.digest
 				return s.completionLocked()
 			}
 			s.state = localizationStateAnswerReady

--- a/internal/mcp/localization_terminal.go
+++ b/internal/mcp/localization_terminal.go
@@ -914,52 +914,78 @@ func localizationRecoveryEvidenceAlignedWithLead(task, lead, requested, operatio
 }
 
 // localizationRecoveryCorroborated is the terminality gate for an accepted
-// recovery call. A recovery may land anywhere in the repository, so its result
-// has to agree with something before it can be called an answer: either it
-// returns evidence the retained page already ranked, or its own identities
-// carry the request's anchor terms. A page that agrees with neither is a new
-// unrelated location, and stamping it terminal converts a miss into a
-// confident wrong answer.
+// recovery call. Corroboration requires the recovery to have taught the page
+// something: at least one row the frozen baseline did not already hold by
+// symbol ID, and that novel row must land in a baseline file or carry the
+// request's anchor terms. A result that is a subset of the retained rows adds
+// no information whatever its overlap looks like — treating a same-page
+// sibling as proof stops a session on a candidate the page had already ranked
+// and rejected.
 func localizationRecoveryCorroborated(
 	task, lead, requested, operation string,
 	rows []localizationDigestRow,
-	retained *localizationEvidenceDigest,
+	baseline *localizationEvidenceDigest,
 ) bool {
-	if len(rows) == 0 {
+	novel := localizationNovelRecoveryRows(rows, baseline)
+	if len(novel) == 0 {
 		return false
 	}
-	if localizationRowsIntersectRetained(rows, retained) {
+	if localizationRowsShareBaselineFile(novel, baseline) {
 		return true
 	}
-	return localizationRecoveryEvidenceAlignedWithLead(task, lead, requested, operation, rows)
+	return localizationRecoveryEvidenceAlignedWithLead(task, lead, requested, operation, novel)
 }
 
-// localizationRowsIntersectRetained reports whether a permitted call returned a
-// symbol or a file the contract had already retained.
-func localizationRowsIntersectRetained(rows []localizationDigestRow, retained *localizationEvidenceDigest) bool {
-	if len(rows) == 0 || retained == nil || len(retained.Evidence) == 0 {
+// localizationNovelRecoveryRows keeps the rows the frozen baseline did not
+// already carry. Identity is the symbol ID: a row the page already ranked is
+// not evidence the recovery produced.
+func localizationNovelRecoveryRows(
+	rows []localizationDigestRow, baseline *localizationEvidenceDigest,
+) []localizationDigestRow {
+	if len(rows) == 0 {
+		return nil
+	}
+	if baseline == nil || len(baseline.Evidence) == 0 {
+		return rows
+	}
+	retained := make(map[string]struct{}, len(baseline.Evidence))
+	for _, row := range baseline.Evidence {
+		if id := strings.TrimSpace(row.ID); id != "" {
+			retained[id] = struct{}{}
+		}
+	}
+	novel := make([]localizationDigestRow, 0, len(rows))
+	for _, row := range rows {
+		if _, alreadyRanked := retained[strings.TrimSpace(row.ID)]; alreadyRanked {
+			continue
+		}
+		novel = append(novel, row)
+	}
+	return novel
+}
+
+// localizationRowsShareBaselineFile reports whether a novel row landed in a
+// file the ranked page already carried. The page located the file; the recovery
+// located a declaration in it that the page did not have.
+func localizationRowsShareBaselineFile(
+	rows []localizationDigestRow, baseline *localizationEvidenceDigest,
+) bool {
+	if len(rows) == 0 || baseline == nil || len(baseline.Evidence) == 0 {
 		return false
 	}
-	ids := make(map[string]struct{}, len(retained.Evidence))
-	files := make(map[string]struct{}, len(retained.Evidence))
-	for _, row := range retained.Evidence {
-		if id := strings.TrimSpace(row.ID); id != "" {
-			ids[id] = struct{}{}
-		}
+	files := make(map[string]struct{}, len(baseline.Evidence))
+	for _, row := range baseline.Evidence {
 		if file := strings.TrimSpace(row.File); file != "" {
 			files[strings.ToLower(file)] = struct{}{}
 		}
 	}
 	for _, row := range rows {
-		if id := strings.TrimSpace(row.ID); id != "" {
-			if _, exists := ids[id]; exists {
-				return true
-			}
+		file := strings.TrimSpace(row.File)
+		if file == "" {
+			continue
 		}
-		if file := strings.TrimSpace(row.File); file != "" {
-			if _, exists := files[strings.ToLower(file)]; exists {
-				return true
-			}
+		if _, exists := files[strings.ToLower(file)]; exists {
+			return true
 		}
 	}
 	return false

--- a/internal/mcp/localization_terminal_evidence_v8_test.go
+++ b/internal/mcp/localization_terminal_evidence_v8_test.go
@@ -254,8 +254,8 @@ func TestRecoveryAllowsInferredConcreteIdentifierOnlyForScopedSymbolEvidence(t *
 		t.Fatalf("inferred exact identifier authorization = (%#v, %d)", blocked, firstToken)
 	}
 	zero := state.finishReservedReadTokenWithDigest(firstToken, true, nil, true)
-	if zero.State != localizationStateLocalized || zero.AllowedToolCalls != 0 || zero.Enforceable {
-		t.Fatalf("empty typed page did not release an advisory completion: %#v", zero)
+	if zero.State != localizationStateNeedsRecovery || zero.AllowedToolCalls != 1 || zero.Enforceable {
+		t.Fatalf("empty typed page did not keep one further allowance: %#v", zero)
 	}
 
 	positiveState := newLocalizationTerminalState()

--- a/internal/mcp/localization_terminal_test.go
+++ b/internal/mcp/localization_terminal_test.go
@@ -796,15 +796,21 @@ func TestHandleFacadeExactReadCommitsOnlyOnSuccess(t *testing.T) {
 		!strings.Contains(body, `"required_action":"recover_once"`) || !strings.Contains(body, `"terminal":false`) {
 		t.Fatalf("successful unproven exact-read retry omitted recovery completion: %q", body)
 	}
+	// The capture-free legacy handler corroborates nothing, so each accepted
+	// recovery spends one allowance and the second one terminalizes.
 	third, err := server.handleFacade(ctx, "read", req)
 	if err != nil || third == nil || third.IsError || calls != 3 {
 		t.Fatalf("bounded exact-read recovery = result=%#v err=%v calls=%d", third, err, calls)
 	}
 	fourth, err := server.handleFacade(ctx, "read", req)
-	if err != nil || calls != 3 {
-		t.Fatalf("post-recovery exact read = result=%#v err=%v calls=%d", fourth, err, calls)
+	if err != nil || fourth == nil || fourth.IsError || calls != 4 {
+		t.Fatalf("second bounded exact-read recovery = result=%#v err=%v calls=%d", fourth, err, calls)
 	}
-	requireLocalizationTerminalReplay(t, fourth, "read", "source")
+	fifth, err := server.handleFacade(ctx, "read", req)
+	if err != nil || calls != 4 {
+		t.Fatalf("post-recovery exact read = result=%#v err=%v calls=%d", fifth, err, calls)
+	}
+	requireLocalizationUnconfirmedReplay(t, fifth)
 }
 
 func TestHandleFacadeExhaustedCorrectionFailureCarriesAdvisoryCompletion(t *testing.T) {
@@ -1149,13 +1155,19 @@ func TestHandleFacadeExactReadPanicRestoresReservation(t *testing.T) {
 	if err != nil || third == nil || third.IsError {
 		t.Fatalf("third exact read recovery = (%v, %v), want success", third, err)
 	}
+	// Two recovery allowances, neither corroborated by the capture-free legacy
+	// handler: the second spends the last one and terminalizes.
 	fourth, err := server.handleFacade(ctx, "read", req)
-	if err != nil {
-		t.Fatalf("fourth exact read = (%v, %v), want terminal block", fourth, err)
+	if err != nil || fourth == nil || fourth.IsError {
+		t.Fatalf("fourth exact read recovery = (%v, %v), want success", fourth, err)
 	}
-	requireLocalizationTerminalReplay(t, fourth, "read", "source")
-	if calls != 3 {
-		t.Fatalf("legacy source calls = %d, want 3", calls)
+	fifth, err := server.handleFacade(ctx, "read", req)
+	if err != nil {
+		t.Fatalf("fifth exact read = (%v, %v), want terminal block", fifth, err)
+	}
+	requireLocalizationUnconfirmedReplay(t, fifth)
+	if calls != 4 {
+		t.Fatalf("legacy source calls = %d, want 4", calls)
 	}
 }
 
@@ -1227,7 +1239,9 @@ func TestLocalizationEnvelopeOmitsOversizedSource(t *testing.T) {
 	if len(envelope.Evidence) != 1 || envelope.Evidence[0].Source != "" {
 		t.Fatalf("oversized source leaked into compact envelope: %#v", envelope.Evidence)
 	}
-	if len(text) > 1500 {
+	// The guard proves the 32 KB source stayed out; the page's fixed cost now
+	// includes the leading answer-shape directive.
+	if len(text) > 1700 {
 		t.Fatalf("compact envelope exceeded size guard: %d bytes", len(text))
 	}
 }


### PR DESCRIPTION
## What

Four changes to the localization contract and answer page, motivated by transcript forensics across 960 agent sessions showing that fully obedient agents were stopped by an `answer_ready` stamp on unproven pages and steered by a single-symbol directive that is frequently off-target.

1. **Corroboration-gated terminality.** A recovery call terminalizes only when its result contributes at least one novel declaration that lands on the retained page by file or by the task's anchor terms. An uninformative recovery (empty, or a pure subset of what the page already ranked) keeps what it surfaced, spends one of two bounded allowances, and re-arms recovery; the spent ledger closes with the honest provisional page. First-call terminal authority (strong literal proof) is unchanged.
2. **Refinement directive as a set.** Instead of prescribing one symbol to read, the directive names up to three ranked candidates and phrases the miss as non-terminal — obeying a wrong lead no longer ends the session.
3. **Leading answer-shape directive.** The answer instruction moves from a trailing sentence to two lines at the top of the page: bare qualified identifiers, 2–3 strongest candidates, say so when unconfirmed.
4. **Notation hygiene.** Displayed identities drop synthetic spellings (constructor rows render as prose; positional suffixes trimmed only when they match the row's own line). IDs and machine fields stay exact.

## Validation — stated in full

- Suites: 4,840 internal/mcp tests, hooks, race detector, lint — all green. 14 tests that encoded the old always-terminalize policy rewritten deliberately (listed per-commit).
- First-call sealed replay (318 tasks): no stronghold change vs base, gold-in-PRIMARY +3, page presence +1.
- Billed agent subset (118 tasks, codex): 18/58 previously-lost tasks converted — the trap mechanism is real; 4/60 sampled wins regressed, which motivated the novel-evidence tightening in the final commit.
- **Billed full-corpus codex run (320 tasks): null.** 65.9% vs 67.2% symbol paired against the pre-change binary (−1.2pp, p=0.64, 19 wins / 23 losses): the gate converts trap-shaped sessions and loses a similar number to the longer recovery loop. Per-task outcomes are stochastic (single-session sampling cannot resolve marginal tasks); the aggregate is the reliable number.
- The claude agent has not been billed-validated on this branch.

## Reviewer guidance

The contract changes (commits 1 and 3) carry the measured risk trade; the presentation changes (commit 2 — answer shape, notation) are low-risk and independently valuable. If the null on the contract side argues against merging whole, the presentation commit can be cherry-picked.