### PR TITLE
fix: preserve ambiguous method-call evidence

### DIFF
--- a/internal/analysis/deadcode.go
+++ b/internal/analysis/deadcode.go
@@ -393,6 +393,12 @@ func FindDeadCode(g graph.Store, processes *ProcessResult, excludePatterns []str
 			continue
 		}
 
+		// An unresolved same-name call is direct evidence of incomplete
+		// resolution, so zero concrete incoming edges is not proof of dead code.
+		if graph.ClassifyZeroEdge(g, n.ID) == graph.ZeroEdgeCoverageIncomplete {
+			continue
+		}
+
 		// For methods with zero incoming edges, check if they exist to satisfy
 		// an interface contract.  Look up the receiver type via member_of edges
 		// and check if any implemented interface requires this method name.

--- a/internal/analysis/deadcode.go
+++ b/internal/analysis/deadcode.go
@@ -280,6 +280,7 @@ func FindDeadCode(g graph.Store, processes *ProcessResult, excludePatterns []str
 	}
 
 	var result []DeadCodeEntry
+	var resultNodes []*graph.Node
 	for _, n := range candidates {
 		// Skip kinds the analyzer never reports — structural,
 		// extracted metadata, infra, function-shape, and value-only
@@ -393,12 +394,6 @@ func FindDeadCode(g graph.Store, processes *ProcessResult, excludePatterns []str
 			continue
 		}
 
-		// An unresolved same-name call is direct evidence of incomplete
-		// resolution, so zero concrete incoming edges is not proof of dead code.
-		if graph.ClassifyZeroEdge(g, n.ID) == graph.ZeroEdgeCoverageIncomplete {
-			continue
-		}
-
 		// For methods with zero incoming edges, check if they exist to satisfy
 		// an interface contract.  Look up the receiver type via member_of edges
 		// and check if any implemented interface requires this method name.
@@ -484,7 +479,58 @@ func FindDeadCode(g graph.Store, processes *ProcessResult, excludePatterns []str
 			FilePath: n.FilePath,
 			Line:     n.StartLine,
 		})
+		resultNodes = append(resultNodes, n)
 	}
+
+	// Resolve unresolved same-name evidence in one batched store query. These
+	// edges mean resolution coverage is incomplete, so zero concrete incoming
+	// edges is not proof that a same-named callable is dead.
+	placeholderSeen := make(map[string]struct{})
+	placeholderIDs := make([]string, 0, len(resultNodes)*4)
+	for _, n := range resultNodes {
+		if n.Kind != graph.KindFunction && n.Kind != graph.KindMethod {
+			continue
+		}
+		for _, id := range graph.UnresolvedNameCandidateIDs(n) {
+			if id == "" {
+				continue
+			}
+			if _, seen := placeholderSeen[id]; seen {
+				continue
+			}
+			placeholderSeen[id] = struct{}{}
+			placeholderIDs = append(placeholderIDs, id)
+		}
+	}
+
+	unresolvedInDegree := make(map[string]int)
+	if counter, ok := g.(graph.InDegreeForNodes); ok {
+		unresolvedInDegree = counter.InDegreeForNodes(placeholderIDs)
+	} else {
+		for _, id := range placeholderIDs {
+			if count := len(g.GetInEdges(id)); count > 0 {
+				unresolvedInDegree[id] = count
+			}
+		}
+	}
+
+	filtered := result[:0]
+	for i, entry := range result {
+		n := resultNodes[i]
+		incomplete := false
+		if n.Kind == graph.KindFunction || n.Kind == graph.KindMethod {
+			for _, id := range graph.UnresolvedNameCandidateIDs(n) {
+				if unresolvedInDegree[id] > 0 {
+					incomplete = true
+					break
+				}
+			}
+		}
+		if !incomplete {
+			filtered = append(filtered, entry)
+		}
+	}
+	result = filtered
 
 	// Sort by file path then line for deterministic output
 	sort.Slice(result, func(i, j int) bool {

--- a/internal/analysis/deadcode_ambiguous_method_test.go
+++ b/internal/analysis/deadcode_ambiguous_method_test.go
@@ -1,0 +1,67 @@
+package analysis
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestDeadCode_UnresolvedSameNameCandidatesAreCoverageGaps(t *testing.T) {
+	g := graph.New()
+	file := "pkg/prov.go"
+	g.AddNode(&graph.Node{ID: file, Kind: graph.KindFile, Name: "prov.go", FilePath: file, Language: "go"})
+
+	var ambiguousMethodIDs []string
+	for _, typ := range []string{"ScriptedDomainProvider", "ScriptedEmailProvider", "ScriptedDNSProvider"} {
+		typeID := file + "::" + typ
+		g.AddNode(&graph.Node{ID: typeID, Kind: graph.KindType, Name: typ, FilePath: file, Language: "go"})
+		g.AddEdge(&graph.Edge{From: file, To: typeID, Kind: graph.EdgeDefines, FilePath: file})
+
+		methodID := file + "::" + typ + ".recordSubmit"
+		g.AddNode(&graph.Node{
+			ID: methodID, Kind: graph.KindMethod, Name: "recordSubmit",
+			FilePath: file, StartLine: 10, EndLine: 12, Language: "go",
+			Meta: map[string]any{"receiver": typ},
+		})
+		g.AddEdge(&graph.Edge{From: file, To: methodID, Kind: graph.EdgeDefines, FilePath: file})
+		g.AddEdge(&graph.Edge{From: methodID, To: typeID, Kind: graph.EdgeMemberOf, FilePath: file})
+		ambiguousMethodIDs = append(ambiguousMethodIDs, methodID)
+	}
+
+	callerID := file + "::scriptedSubmission.submit"
+	g.AddNode(&graph.Node{
+		ID: callerID, Kind: graph.KindMethod, Name: "submit",
+		FilePath: file, StartLine: 30, EndLine: 34, Language: "go",
+		Meta: map[string]any{"receiver": "scriptedSubmission"},
+	})
+	g.AddEdge(&graph.Edge{From: file, To: callerID, Kind: graph.EdgeDefines, FilePath: file})
+	g.AddEdge(&graph.Edge{
+		From: callerID, To: "unresolved::*.recordSubmit",
+		Kind: graph.EdgeCalls, FilePath: file, Line: 32,
+	})
+
+	uniqueTypeID := file + "::UniqueProvider"
+	uniqueMethodID := uniqueTypeID + ".uniqueUnused"
+	g.AddNode(&graph.Node{ID: uniqueTypeID, Kind: graph.KindType, Name: "UniqueProvider", FilePath: file, Language: "go"})
+	g.AddNode(&graph.Node{
+		ID: uniqueMethodID, Kind: graph.KindMethod, Name: "uniqueUnused",
+		FilePath: file, StartLine: 40, EndLine: 42, Language: "go",
+		Meta: map[string]any{"receiver": "UniqueProvider"},
+	})
+	g.AddEdge(&graph.Edge{From: file, To: uniqueTypeID, Kind: graph.EdgeDefines, FilePath: file})
+	g.AddEdge(&graph.Edge{From: file, To: uniqueMethodID, Kind: graph.EdgeDefines, FilePath: file})
+	g.AddEdge(&graph.Edge{From: uniqueMethodID, To: uniqueTypeID, Kind: graph.EdgeMemberOf, FilePath: file})
+
+	result := FindDeadCode(g, nil, nil)
+	reported := make(map[string]bool, len(result))
+	for _, entry := range result {
+		reported[entry.ID] = true
+	}
+
+	for _, methodID := range ambiguousMethodIDs {
+		assert.False(t, reported[methodID], "unresolved same-name evidence must suppress %s", methodID)
+	}
+	assert.True(t, reported[uniqueMethodID], "a uniquely named unused method must remain reportable")
+}

--- a/internal/resolver/ambiguous_method_call_test.go
+++ b/internal/resolver/ambiguous_method_call_test.go
@@ -61,3 +61,32 @@ func TestResolveMethodCall_AmbiguousCandidatesPreserveEvidence(t *testing.T) {
 		assert.Equal(t, graph.ZeroEdgeCoverageIncomplete, graph.ClassifyZeroEdge(g, methodID))
 	}
 }
+
+func TestResolveMethodCall_AmbiguousMethodsWithFunctionStayUnresolved(t *testing.T) {
+	g := graph.New()
+	file := "pkg/call.go"
+	g.AddNode(&graph.Node{ID: file, Kind: graph.KindFile, Name: "call.go", FilePath: file, Language: "go"})
+	g.AddNode(&graph.Node{ID: file + "::caller", Kind: graph.KindFunction, Name: "caller", FilePath: file, Language: "go"})
+
+	for _, typ := range []string{"First", "Second"} {
+		g.AddNode(&graph.Node{
+			ID: file + "::" + typ + ".run", Kind: graph.KindMethod, Name: "run",
+			FilePath: file, Language: "go", Meta: map[string]any{"receiver": typ},
+		})
+	}
+	g.AddNode(&graph.Node{ID: file + "::run", Kind: graph.KindFunction, Name: "run", FilePath: file, Language: "go"})
+
+	const placeholderID = "unresolved::*.run"
+	callEdge := &graph.Edge{
+		From: file + "::caller", To: placeholderID,
+		Kind: graph.EdgeCalls, FilePath: file, Line: 10,
+	}
+	g.AddEdge(callEdge)
+
+	stats := New(g).ResolveAll()
+
+	assert.Equal(t, 0, stats.Resolved)
+	assert.Equal(t, 1, stats.Unresolved)
+	assert.Equal(t, placeholderID, callEdge.To,
+		"a same-named function is not receiver evidence for choosing either method")
+}

--- a/internal/resolver/ambiguous_method_call_test.go
+++ b/internal/resolver/ambiguous_method_call_test.go
@@ -1,0 +1,63 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestResolveMethodCall_AmbiguousCandidatesPreserveEvidence(t *testing.T) {
+	g := graph.New()
+	file := "pkg/prov.go"
+	g.AddNode(&graph.Node{ID: file, Kind: graph.KindFile, Name: "prov.go", FilePath: file, Language: "go"})
+
+	var methodIDs []string
+	for _, typ := range []string{"ScriptedDomainProvider", "ScriptedEmailProvider", "ScriptedDNSProvider"} {
+		typeID := file + "::" + typ
+		g.AddNode(&graph.Node{ID: typeID, Kind: graph.KindType, Name: typ, FilePath: file, Language: "go"})
+		g.AddEdge(&graph.Edge{From: file, To: typeID, Kind: graph.EdgeDefines, FilePath: file})
+
+		methodID := file + "::" + typ + ".recordSubmit"
+		g.AddNode(&graph.Node{
+			ID: methodID, Kind: graph.KindMethod, Name: "recordSubmit",
+			FilePath: file, StartLine: 10, EndLine: 12, Language: "go",
+			Meta: map[string]any{"receiver": typ},
+		})
+		g.AddEdge(&graph.Edge{From: file, To: methodID, Kind: graph.EdgeDefines, FilePath: file})
+		g.AddEdge(&graph.Edge{From: methodID, To: typeID, Kind: graph.EdgeMemberOf, FilePath: file})
+		methodIDs = append(methodIDs, methodID)
+	}
+
+	callerID := file + "::scriptedSubmission.submit"
+	g.AddNode(&graph.Node{
+		ID: callerID, Kind: graph.KindMethod, Name: "submit",
+		FilePath: file, StartLine: 30, EndLine: 34, Language: "go",
+		Meta: map[string]any{"receiver": "scriptedSubmission"},
+	})
+	g.AddEdge(&graph.Edge{From: file, To: callerID, Kind: graph.EdgeDefines, FilePath: file})
+
+	const placeholderID = "unresolved::*.recordSubmit"
+	callEdge := &graph.Edge{
+		From: callerID, To: placeholderID,
+		Kind: graph.EdgeCalls, FilePath: file, Line: 32,
+	}
+	g.AddEdge(callEdge)
+
+	stats := New(g).ResolveAll()
+
+	assert.Equal(t, 0, stats.Resolved)
+	assert.Equal(t, 1, stats.Unresolved)
+	assert.Equal(t, placeholderID, callEdge.To)
+	assert.Empty(t, callEdge.Origin)
+	assert.Nil(t, callEdge.Meta["dispatch"])
+	assert.Len(t, g.GetInEdges(placeholderID), 1)
+
+	for _, methodID := range methodIDs {
+		for _, edge := range g.GetInEdges(methodID) {
+			assert.NotEqual(t, graph.EdgeCalls, edge.Kind, "ambiguous call must not pick %s", methodID)
+		}
+		assert.Equal(t, graph.ZeroEdgeCoverageIncomplete, graph.ClassifyZeroEdge(g, methodID))
+	}
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -4299,6 +4299,14 @@ func (r *Resolver) resolveMethodCall(e *graph.Edge, methodName string, stats *Re
 		}
 	}
 
+	// Without receiver evidence, more than one reachable method is ambiguous.
+	// Preserve the unresolved placeholder instead of inventing a caller for an
+	// arbitrary same-named method.
+	if receiverType == "" && methodCount > 1 {
+		stats.Unresolved++
+		return
+	}
+
 	// Interface-dispatch annotation: when the receiver type names a
 	// graph interface and multiple reachable methods of this name
 	// exist, every candidate is a legal runtime target. Mark the edge

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -762,11 +762,10 @@ func TestResolveMethodCall_ImportReachabilityFilter(t *testing.T) {
 		"reachability filter should pick the imported package's method")
 }
 
-// TestResolveMethodCall_LocalityPrefersSamePackage covers the locality
-// fallback: when two methods named "Do" survive Pass 0 (both packages
-// imported), the same-package method beats any cross-package candidate
-// regardless of name order.
-func TestResolveMethodCall_LocalityPrefersSamePackage(t *testing.T) {
+// TestResolveMethodCall_AmbiguousUntypedStaysUnresolved covers the locality
+// fallback boundary: when multiple reachable methods survive but the call has
+// no receiver-type evidence, locality is not enough to invent a concrete edge.
+func TestResolveMethodCall_AmbiguousUntypedStaysUnresolved(t *testing.T) {
 	g := graph.New()
 
 	g.AddNode(&graph.Node{ID: "pkg/a/main.go", Kind: graph.KindFile, FilePath: "pkg/a/main.go", Language: "go"})
@@ -809,9 +808,10 @@ func TestResolveMethodCall_LocalityPrefersSamePackage(t *testing.T) {
 	r := New(g)
 	stats := r.ResolveAll()
 
-	assert.Equal(t, 1, stats.Resolved)
-	assert.Equal(t, "pkg/a/helpers.go::Helper.Do", callEdge.To,
-		"same-package candidate should win the locality fallback")
+	assert.Equal(t, 0, stats.Resolved)
+	assert.Equal(t, 1, stats.Unresolved)
+	assert.Equal(t, "unresolved::*.Do", callEdge.To,
+		"an untyped call with multiple viable methods must remain unresolved")
 }
 
 // TestResolveMethodCall_InterfaceDispatchFanOut verifies that when the


### PR DESCRIPTION
Closes #638

## Root cause

When an untyped member call had several reachable same-name methods, the locality fallback rewrote the unresolved call edge to one arbitrary method. That invented a caller for the winner and removed the unresolved evidence that should protect the losing candidates from dead-code reports.

## Summary

- keep untyped multi-candidate method calls unresolved instead of selecting a guessed target
- preserve same-name unresolved evidence for zero-edge classification and caller caveats
- suppress only callable dead-code candidates covered by unresolved same-name evidence
- batch and deduplicate placeholder in-degree checks to avoid per-candidate store queries
- add regressions for the production-shaped three-method case, mixed method/function candidates, existing locality behavior, and a uniquely unused dead-code control

Typed receivers, known interface dispatch, and unique method candidates keep their existing resolution paths.

## Verification

- go test ./internal/resolver ./internal/analysis ./internal/graph -count=1
- go test ./... -count=1: all test bodies passed; the cmd/gortex user-state guard reported its documented false positive because the running daemon updated cache/query-log.jsonl during the run
- BenchmarkFindDeadCode_100k, one iteration: about 80 ms after batching versus about 891 ms for the per-symbol draft