### PR TITLE
fix(resolver): resolve relative, alias and component imports from SFC <script> blocks

### DIFF
--- a/internal/mcp/find_usages_sfc_test.go
+++ b/internal/mcp/find_usages_sfc_test.go
@@ -1,0 +1,61 @@
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/query"
+	"go.uber.org/zap"
+)
+
+// A .vue <script setup> that imports a .ts composable and calls it must show
+// up in find_usages on the .ts symbol, and a component-to-component
+// `import Foo from './Foo.vue'` must bind to the SFC file, not an external
+// stub. End-to-end through the real indexer + resolver + handler.
+func setupSFCServer(t *testing.T) *Server {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(name, body string) {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644))
+	}
+	write("useX.ts", "export function useX() { return 1 }\n")
+	write("Foo.vue", "<script setup lang=\"ts\">\nimport { useX } from './useX'\nconst x = useX()\n</script>\n<template><div>{{ x }}</div></template>\n")
+	write("Bar.vue", "<script setup lang=\"ts\">\nimport Foo from './Foo.vue'\n</script>\n<template><Foo/></template>\n")
+
+	g := graph.New()
+	cfg := config.Default()
+	idx := indexer.New(g, testRegistry(), cfg.Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	return NewServer(query.NewEngine(g), g, idx, nil, zap.NewNop(), nil)
+}
+
+func TestFindUsages_TSSymbolCalledFromVueScript(t *testing.T) {
+	srv := setupSFCServer(t)
+	res := callTool(t, srv, "find_usages", map[string]any{"id": "useX.ts::useX", "group_by": "file"})
+	require.False(t, res.IsError, resultText(res))
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal([]byte(resultText(res)), &resp))
+	files := map[string]bool{}
+	for _, grp := range resp["groups"].([]any) {
+		files[grp.(map[string]any)["file"].(string)] = true
+	}
+	require.True(t, files["Foo.vue"], "find_usages useX.ts::useX should list the Foo.vue call site; got %v", resp)
+}
+
+func TestVueImportsVueBindsToFile(t *testing.T) {
+	srv := setupSFCServer(t)
+	var resolved bool
+	for _, e := range srv.graph.GetOutEdges("Bar.vue") {
+		if e.Kind == graph.EdgeImports && e.To == "Foo.vue" {
+			resolved = true
+		}
+	}
+	require.True(t, resolved, "Bar.vue -> Foo.vue import edge should bind to the Foo.vue file node")
+}

--- a/internal/resolver/jsts_imports.go
+++ b/internal/resolver/jsts_imports.go
@@ -165,6 +165,13 @@ func probeJSTSFile(getNode func(string) *graph.Node, stem string) string {
 	// verbatim first, then — when it names an emitted JavaScript file —
 	// against the TypeScript sources that compile to it.
 	switch ext := jsTSExt(stem); ext {
+	case ".vue", ".svelte", ".astro":
+		// A single-file component is only ever imported by its full name
+		// (`./Foo.vue`); there is no extension probing on top of it.
+		if isFile(stem) {
+			return stem
+		}
+		return ""
 	case ".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs":
 		if isFile(stem) {
 			return stem
@@ -218,10 +225,17 @@ func jsTSExt(p string) string {
 }
 
 // isJSTSPath reports whether a file path is a JavaScript / TypeScript
-// source file — the only importers whose specifiers this resolver expands.
+// source file - the only importers whose specifiers this resolver expands.
+//
+// Single-file components (.vue / .svelte / .astro) count too: their <script>
+// block is carved out and parsed by the JS/TS extractor, so the import edges
+// it emits carry the host .vue path as FilePath. Rejecting them here left
+// every relative import from a .vue script as an external stub, and calls
+// into the imported .ts symbol lost reachability and got reverted.
 func isJSTSPath(p string) bool {
 	switch jsTSExt(p) {
-	case ".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs":
+	case ".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs",
+		".vue", ".svelte", ".astro":
 		return true
 	}
 	return false

--- a/internal/resolver/jsts_imports_sfc_test.go
+++ b/internal/resolver/jsts_imports_sfc_test.go
@@ -1,0 +1,59 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// A .vue/.svelte/.astro <script> is parsed by the JS/TS extractor and its
+// import edges carry the host file path, so the SFC must count as a JS/TS
+// importer or its relative imports never bind to in-repo .ts files.
+func TestIsJSTSPathAcceptsSFC(t *testing.T) {
+	for _, p := range []string{"src/A.vue", "src/B.svelte", "src/C.astro", "src/d.ts"} {
+		if !isJSTSPath(p) {
+			t.Errorf("isJSTSPath(%q) = false, want true", p)
+		}
+	}
+	for _, p := range []string{"src/x.go", "src/y.html", "README"} {
+		if isJSTSPath(p) {
+			t.Errorf("isJSTSPath(%q) = true, want false", p)
+		}
+	}
+}
+
+func TestResolveJSTSImportTargetFromVueScript(t *testing.T) {
+	getNode := func(id string) *graph.Node {
+		if id == "src/features/useGetAvailableThemes.ts" {
+			return &graph.Node{ID: id, Kind: graph.KindFile}
+		}
+		return nil
+	}
+	got := resolveJSTSImportTarget(getNode, nil, "src/components/Foo.vue", "../features/useGetAvailableThemes")
+	if got != "src/features/useGetAvailableThemes.ts" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+// `import Foo from './Foo.vue'` names the SFC verbatim. probeJSTSFile must
+// accept the explicit .vue/.svelte/.astro extension as-is (no extension
+// probing on top of it) or every component-to-component import stays an
+// external stub.
+func TestProbeJSTSFileAcceptsExplicitSFC(t *testing.T) {
+	files := map[string]bool{"src/Foo.vue": true, "src/Bar.svelte": true, "src/Baz.astro": true}
+	getNode := func(id string) *graph.Node {
+		if files[id] {
+			return &graph.Node{ID: id, Kind: graph.KindFile}
+		}
+		return nil
+	}
+	for _, stem := range []string{"src/Foo.vue", "src/Bar.svelte", "src/Baz.astro"} {
+		if got := probeJSTSFile(getNode, stem); got != stem {
+			t.Errorf("probeJSTSFile(%q) = %q, want verbatim", stem, got)
+		}
+	}
+	// No probing: `./Foo` never picks up Foo.vue.
+	if got := probeJSTSFile(getNode, "src/Foo"); got != "" {
+		t.Errorf("probeJSTSFile(src/Foo) = %q, want \"\"", got)
+	}
+}


### PR DESCRIPTION
## Summary

Verified on a real project: [mutoe/vue3-realworld-example-app](https://github.com/mutoe/vue3-realworld-example-app), indexed with the daemon (123 files, 1328 nodes, 4264 edges).

`src/components/ArticlesList.vue` imports one composable through a tsconfig alias and three sibling components:

import { useArticles } from 'src/composable/use-articles'
import AppPagination from './AppPagination.vue'
import ArticlesListArticlePreview from './ArticlesListArticlePreview.vue'
import ArticlesListNavigation from './ArticlesListNavigation.vue'

Before: all four were external stubs, `find_usages useArticles` returned nothing.

After: the same file's import edges in the graph:

src/components/ArticlesList.vue -> src/composable/use-articles.ts
src/components/ArticlesList.vue -> src/composable/use-articles.ts::useArticles
src/components/ArticlesList.vue -> src/components/AppPagination.vue
src/components/ArticlesList.vue -> src/components/ArticlesListArticlePreview.vue
src/components/ArticlesList.vue -> src/components/ArticlesListNavigation.vue

and `find_usages useArticles` lists `ArticlesList.vue:39`.

## Changes

- `isJSTSPath` accepts `.vue` / `.svelte` / `.astro`. The predicate gates six sites (`resolveJSTSImportTarget`, `isJSTSBareSpecifier`, `pickImportEvidenceCallee`, the top-level value-callee pick, `importedDirForSpec` and the cross-repo `resolveImport` mirror); all of them reason about "the importing file has JS/TS module semantics", which an SFC script does. Deliberate side effect: bare specifiers from an SFC (`'vue'`, `'pinia'`) now pass the entry-point gate of #450 instead of `bare=false` letting the directory cascade bind them to an arbitrary same-named local directory.
- `probeJSTSFile` accepts an explicit `.vue` / `.svelte` / `.astro` specifier verbatim, so `import Foo from './Foo.vue'` binds to the SFC file node. No extension probing on top of it: `./Foo` never picks up `Foo.vue`.
- Tests: `TestIsJSTSPathAcceptsSFC`, `TestResolveJSTSImportTargetFromVueScript`, `TestProbeJSTSFileAcceptsExplicitSFC` (unit), and `internal/mcp/find_usages_sfc_test.go` end to end through the real indexer and the `find_usages` handler (`.vue` calling a `.ts` composable, `.vue` importing `.vue`).

## Testing

- [x] All tests pass (`go test -race ./...`)
- [x] New tests added for new functionality
- [ ] Benchmarks run if performance-relevant (not relevant: one extra `case` in two `switch` statements)

## Checklist

- [x] Code follows existing patterns in the codebase
- [x] No unnecessary abstractions added
- [ ] Language extractor includes `Meta["methods"]` for interfaces (n/a, resolver-only change)
- [ ] Methods have `EdgeMemberOf` edges to their containing type (n/a)

Follow-up in a stacked PR: cross-directory single-candidate calls from JS/TS (including SFC scripts) still land at `text_matched` and are hidden by `find_usages` by default; that is a separate resolver bug, fixed on `fix/jsts-single-candidate-import-evidence`.