### PR TITLE
resolver: never fan interface dispatch back onto the caller

### DIFF
--- a/internal/resolver/csharp_iface_dispatch.go
+++ b/internal/resolver/csharp_iface_dispatch.go
@@ -362,7 +362,13 @@ func ResolveCSharpInterfaceDispatchScoped(g graph.Store, scope map[string]bool) 
 			}
 			f := families[fi]
 			for _, member := range f.members {
-				if member == e.To {
+				// Skip the member the call already reaches — and the CALLER
+				// itself: a family member forwarding through its own
+				// interface (decorator/facade shape) must not gain a
+				// synthesized from==to edge that find_usages consumers read
+				// as "the symbol is its own caller". Real recursion is the
+				// binder's edge to mint, never this synthesizer's.
+				if member == e.To || member == e.From {
 					continue
 				}
 				k := csharpCallSiteKey(e.From, member, e.FilePath, e.Line)

--- a/internal/resolver/csharp_iface_dispatch_test.go
+++ b/internal/resolver/csharp_iface_dispatch_test.go
@@ -402,3 +402,56 @@ func TestResolveCSharpInterfaceDispatch_FanoutTierAndCap(t *testing.T) {
 			"a fan-out wider than the cap is dropped as noise")
 	})
 }
+
+// TestResolveCSharpInterfaceDispatch_DecoratorForwardingNeverSelfEdges pins
+// the decorator/facade shape: a class that implements the SAME interface it
+// wraps and forwards the same-named member through an injected inner
+// instance. The forwarding call binds to the interface member, and the
+// caller is itself a family member — the fan-out must reach the sibling
+// implementation but must NEVER fan back onto the caller: a synthesized
+// from==to edge reads as "the symbol is its own caller" in find_usages
+// consumers. Real recursion is the binder's edge to mint, never this
+// synthesizer's.
+func TestResolveCSharpInterfaceDispatch_DecoratorForwardingNeverSelfEdges(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"IConverter.cs": `namespace App {
+    public interface IConverter {
+        string Convert(int n);
+    }
+}`,
+		"English.cs": `namespace App {
+    public class EnglishConverter : IConverter {
+        public string Convert(int n) { return "en"; }
+    }
+}`,
+		"Caching.cs": `namespace App {
+    public class CachingConverter : IConverter {
+        private readonly IConverter _inner;
+        public CachingConverter(IConverter inner) { _inner = inner; }
+        public string Convert(int n) {
+            IConverter inner = _inner;
+            return inner.Convert(n);
+        }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	callerID := "Caching.cs::CachingConverter.Convert"
+	require.Contains(t, callTargetsFrom(g, callerID), "IConverter.cs::IConverter.Convert",
+		"the forwarding call should bind to the interface member")
+
+	ResolveCSharpInterfaceDispatch(g)
+
+	var fanoutTargets []string
+	for _, e := range g.GetOutEdges(callerID) {
+		if !isIfaceDispatchEdge(e) {
+			continue
+		}
+		require.NotEqual(t, callerID, e.To,
+			"a dispatch fan-out must never claim the caller dispatches to itself (from==to)")
+		fanoutTargets = append(fanoutTargets, e.To)
+	}
+	assert.Contains(t, fanoutTargets, "English.cs::EnglishConverter.Convert",
+		"the legitimate fan-out to the sibling implementation must survive the self guard")
+}


### PR DESCRIPTION
The csharp-iface-dispatch fan-out skips the member a call already reaches
(member == e.To) but never the caller itself. When the caller is a member
of the same dispatch family, the fan-out mints a synthesized from == to
call edge. The decorator/facade shape triggers it: a class implements an
interface, holds an injected instance of that same interface, and forwards
the same-named member through it. find_usages then reports the symbol as
its own caller, at the same origin and confidence as the legitimate
sibling edges. Found through a programmatic consumer of the edge list on
my production C# codebase. The binder-layer variant of this class was
fixed earlier by the facade-self-steal change; this closes the
synthesizer-layer one.

Fix: skip member == e.From alongside member == e.To. Real recursion is
unaffected, since a genuine self-call is the binder's own edge, never this
synthesizer's. The new test pins the decorator shape end to end: the
forwarding call binds the interface member, the fan-out still reaches the
sibling implementation, and no from == to edge survives. Existing dispatch
tests stay green, including the family cascade.
