### PR TITLE
parser: emit read/write edges for C# field identifiers

### DIFF
--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -141,6 +141,9 @@ const qCSharpAll = `
       (variable_declarator
         (identifier) @lvar.name))) @lvar.def
 
+  (assignment_expression
+    left: (identifier) @fassign.name) @fassign.expr
+
   (member_access_expression
     name: [
       (identifier) @maccess.name
@@ -317,6 +320,7 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 	var locals []csharpDeferredLocal
 	var typeUses []csharpTypeUse
 	var accesses []csharpDeferredAccess
+	var fieldAssigns []csharpDeferredFieldAssign
 
 	parser.EachMatch(e.qAll, root, src, func(m parser.QueryResult) {
 		switch {
@@ -400,6 +404,12 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 				line:        expr.StartLine + 1,
 				returnUsage: classifyReturnUsage(expr.Node, src, csharpReturnUsageSpec),
 			}, expr.Node))
+
+		case m.Captures["fassign.name"] != nil:
+			fieldAssigns = append(fieldAssigns, csharpDeferredFieldAssign{
+				name: m.Captures["fassign.name"].Text,
+				line: m.Captures["fassign.expr"].StartLine + 1,
+			})
 
 		case m.Captures["maccess.expr"] != nil:
 			accesses = append(accesses, csharpDeferredAccess{
@@ -740,6 +750,25 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 	// receiver-typing ladder needs the finished tenv.
 	emitCSharpMemberAccesses(accesses, src, filePath, funcRanges,
 		tenvByOwner, builtinsByOwner, result)
+
+	// Field-identifier uses need the shadow indexes: every DECLARED
+	// local by name (typed or not — tenv alone holds only the typed
+	// ones), parameters, and builtin-typed locals.
+	localNamesByOwner := map[string]map[string]bool{}
+	for _, l := range locals {
+		owner := localOwner(l)
+		if owner == "" {
+			continue
+		}
+		m := localNamesByOwner[owner]
+		if m == nil {
+			m = map[string]bool{}
+			localNamesByOwner[owner] = m
+		}
+		m[l.name] = true
+	}
+	emitCSharpFieldIdentifierUses(calls, accesses, fieldAssigns, src,
+		filePath, funcRanges, localNamesByOwner, builtinsByOwner, result)
 
 	// .NET surfaces a symbol walk misses: DI registrations + COM
 	// interop. Stamped onto the file node.

--- a/internal/parser/languages/csharp_field_identifier.go
+++ b/internal/parser/languages/csharp_field_identifier.go
@@ -1,0 +1,176 @@
+package languages
+
+import (
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+)
+
+// C# field-identifier usage edges.
+//
+// Fields are read through bare identifiers, not dotted access: an
+// injected field is a call receiver (`_store.Add(1)`), an access
+// receiver (`_store.Count`), or an assignment target (`_store = store`).
+// The member-access emitter records the accessed MEMBER and the call
+// path records the called METHOD, but neither position emitted any edge
+// naming the field itself — so find_usages on a field answered empty no
+// matter how often the class used it, and only the unidiomatic
+// `this._store` spelling left a trace. This emitter closes that gap for
+// the enclosing type's own fields: the one case where the implicit
+// receiver is known at extraction time (it is `this`), so the edge can
+// carry receiver_type evidence and ride the exact resolution path
+// this.-qualified accesses already use.
+//
+// Shadowing: a declared local, a parameter, or a builtin-typed local
+// with the field's name owns the identifier inside that method — no
+// field edge is minted there. Deliberately deferred (named remainder):
+// bare identifiers in argument/return position (`Frob(_store)`), which
+// need a wider capture surface than the receiver/assignment positions
+// covered here.
+
+// csharpDeferredFieldAssign buffers one bare-identifier assignment
+// target (`_store = ...`) until the shadow indexes exist.
+type csharpDeferredFieldAssign struct {
+	name string
+	line int
+}
+
+// csharpFieldNamesByType indexes the file's declared field names per
+// enclosing type name, from the field nodes the extractor already
+// minted (ID form `<file>::<Type>.<field>`).
+func csharpFieldNamesByType(result *parser.ExtractionResult) map[string]map[string]bool {
+	out := map[string]map[string]bool{}
+	for _, n := range result.Nodes {
+		if n == nil || n.Kind != graph.KindField {
+			continue
+		}
+		_, symbolPart, ok := strings.Cut(n.ID, "::")
+		if !ok {
+			continue
+		}
+		dot := strings.LastIndex(symbolPart, ".")
+		if dot <= 0 {
+			continue
+		}
+		typeName := symbolPart[:dot]
+		// Nested/namespaced owners keep only the innermost type name —
+		// csharpOwnerTypeName applies the same trim to method owners, so
+		// the two lookups meet on the same key.
+		if inner := strings.LastIndex(typeName, "."); inner >= 0 {
+			typeName = typeName[inner+1:]
+		}
+		m := out[typeName]
+		if m == nil {
+			m = map[string]bool{}
+			out[typeName] = m
+		}
+		m[n.Name] = true
+	}
+	return out
+}
+
+// csharpBareIdentifier reports whether a captured receiver text is a
+// single bare identifier — no chain, no call, no keyword.
+func csharpBareIdentifier(text string) bool {
+	if text == "" || text == "this" || text == "base" {
+		return false
+	}
+	return !strings.ContainsAny(text, ".()?[] \t\n")
+}
+
+// emitCSharpFieldIdentifierUses emits EdgeReads/EdgeWrites for bare
+// identifiers that name a field of the enclosing type, from the three
+// covered positions: call receivers, member-access receivers, and
+// assignment targets.
+func emitCSharpFieldIdentifierUses(
+	calls []csharpDeferredCall, accesses []csharpDeferredAccess,
+	fieldAssigns []csharpDeferredFieldAssign,
+	src []byte, filePath string, funcRanges *csharpFuncLookup,
+	localNamesByOwner map[string]map[string]bool,
+	builtinsByOwner map[string]map[string]string,
+	result *parser.ExtractionResult,
+) {
+	fieldsByType := csharpFieldNamesByType(result)
+	if len(fieldsByType) == 0 {
+		return
+	}
+	paramsByOwner := csharpParamNamesByOwner(result)
+
+	// eligible resolves the enclosing owner and reports whether name is
+	// an unshadowed field of the owner's type.
+	eligible := func(line int, name string) (owner, ownerType string, ok bool) {
+		owner = funcRanges.enclosing(line)
+		if owner == "" {
+			return "", "", false
+		}
+		ownerType = csharpOwnerTypeName(owner)
+		if ownerType == "" || !fieldsByType[ownerType][name] {
+			return "", "", false
+		}
+		if paramsByOwner[owner][name] || localNamesByOwner[owner][name] ||
+			builtinsByOwner[owner][name] != "" {
+			return "", "", false
+		}
+		return owner, ownerType, true
+	}
+
+	// One edge per (owner, name, line, kind): a site seen through two
+	// buffers (a call's receiver and the same node's member access) must
+	// not double-emit.
+	type siteKey struct {
+		owner string
+		name  string
+		line  int
+		kind  graph.EdgeKind
+	}
+	seen := map[siteKey]bool{}
+	emit := func(line int, name string, kind graph.EdgeKind) {
+		owner, ownerType, ok := eligible(line, name)
+		if !ok {
+			return
+		}
+		k := siteKey{owner, name, line, kind}
+		if seen[k] {
+			return
+		}
+		seen[k] = true
+		result.Edges = append(result.Edges, &graph.Edge{
+			From: owner, To: "unresolved::*." + name,
+			Kind: kind, FilePath: filePath, Line: line,
+			Meta: map[string]any{"receiver_type": ownerType},
+		})
+	}
+
+	for _, c := range calls {
+		// this./base.-qualified calls carry recvType and no bare
+		// receiver; member calls through a field carry the identifier.
+		if !c.isMember || c.recvType != "" || !csharpBareIdentifier(c.receiver) {
+			continue
+		}
+		emit(c.line, c.receiver, graph.EdgeReads)
+	}
+
+	for _, a := range accesses {
+		if a.node == nil {
+			continue
+		}
+		recv := a.node.ChildByFieldName("expression")
+		if a.conditional {
+			recv = a.node.ChildByFieldName("condition")
+		}
+		if recv == nil || recv.Type() != "identifier" {
+			continue
+		}
+		// Call-position accesses are covered through the calls buffer;
+		// skipping them here keeps one read per site.
+		if csharpAccessInCallPosition(a.node) {
+			continue
+		}
+		emit(a.line, recv.Content(src), graph.EdgeReads)
+	}
+
+	for _, fa := range fieldAssigns {
+		emit(fa.line, fa.name, graph.EdgeWrites)
+	}
+}

--- a/internal/parser/languages/csharp_field_identifier_test.go
+++ b/internal/parser/languages/csharp_field_identifier_test.go
@@ -1,0 +1,86 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// C# fields are read through bare identifiers, not dotted access: an
+// injected field is used as a call receiver (`_store.Add(1)`), an access
+// receiver (`_store.Count`), or an assignment target (`_store = store`).
+// None of those positions previously emitted any edge naming the FIELD
+// itself, so find_usages on a field answered empty no matter how often
+// the class used it. Only the unidiomatic `this._store` spelling left a
+// trace. These tests pin the field-identifier emission: reads/writes of
+// the enclosing type's own fields, with declared locals, parameters, and
+// builtin-typed locals shadowing the field name.
+func TestCSharpExtractor_FieldIdentifierUses(t *testing.T) {
+	src := []byte(`namespace App {
+    public class Store {
+        public void Add(int n) { }
+        public int Count { get; set; }
+    }
+    public class Ledger {
+        private readonly Store _store;
+        private int _total;
+        private int _unused;
+
+        public Ledger(Store store) { _store = store; }
+
+        public void Post() { _store.Add(1); }
+        public int Peek() { return _store.Count; }
+        public void Tally() { _total = 5; }
+        public void Shadowed() { var _store = new Store(); _store.Add(2); }
+        public void ShadowParam(Store _store) { _store.Add(3); }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("Ledger.cs", src)
+	require.NoError(t, err)
+
+	// Call-receiver read: `_store.Add(1)` reads the field _store.
+	post := accessEdges(result.Edges, "Ledger.cs::Ledger.Post", "_store")
+	require.Len(t, post, 1, "a field used as a call receiver is one read of the field")
+	assert.Equal(t, graph.EdgeReads, post[0].Kind)
+	require.NotNil(t, post[0].Meta)
+	assert.Equal(t, "Ledger", post[0].Meta["receiver_type"],
+		"the field's implicit receiver is the enclosing type")
+
+	// Access-receiver read: `_store.Count` reads the field too (the Count
+	// read is the access emitter's existing edge, asserted separately).
+	peek := accessEdges(result.Edges, "Ledger.cs::Ledger.Peek", "_store")
+	require.Len(t, peek, 1, "a field used as an access receiver is one read of the field")
+	assert.Equal(t, graph.EdgeReads, peek[0].Kind)
+	count := accessEdges(result.Edges, "Ledger.cs::Ledger.Peek", "Count")
+	require.Len(t, count, 1, "the member access itself still emits its own read")
+
+	// Constructor assignment: `_store = store` writes the field.
+	ctor := accessEdges(result.Edges, "Ledger.cs::Ledger.<init>", "_store")
+	require.Len(t, ctor, 1, "bare assignment lhs is one write of the field")
+	assert.Equal(t, graph.EdgeWrites, ctor[0].Kind)
+	assert.Equal(t, "Ledger", ctor[0].Meta["receiver_type"])
+
+	// Bare-identifier assignment beyond the ctor: `_total = 5`.
+	tally := accessEdges(result.Edges, "Ledger.cs::Ledger.Tally", "_total")
+	require.Len(t, tally, 1)
+	assert.Equal(t, graph.EdgeWrites, tally[0].Kind)
+
+	// Shadowing: a declared local or parameter with the field's name owns
+	// the identifier — no field edge may be minted from those methods.
+	assert.Empty(t, accessEdges(result.Edges, "Ledger.cs::Ledger.Shadowed", "_store"),
+		"a local named like the field shadows it")
+	assert.Empty(t, accessEdges(result.Edges, "Ledger.cs::Ledger.ShadowParam", "_store"),
+		"a parameter named like the field shadows it")
+
+	// Control: the untouched field keeps its honest empty.
+	for _, ed := range result.Edges {
+		if ed.To == "unresolved::*._unused" {
+			t.Fatalf("unused field gained an edge from %s", ed.From)
+		}
+	}
+}

--- a/internal/resolver/csharp_member_access_spec_test.go
+++ b/internal/resolver/csharp_member_access_spec_test.go
@@ -61,3 +61,54 @@ func TestResolveCSharp_MemberAccessBindsReceiverField(t *testing.T) {
 	assert.True(t, strings.Contains(write.To, "Plaque.Title"),
 		"write binds the same way, got %q", write.To)
 }
+
+// A field used as a bare identifier — a call receiver or an assignment
+// target, the idiomatic forms — must land on the ENCLOSING type's own
+// field node through the same cascade, with a same-named field on an
+// unrelated class never stealing the bind. This is what turns
+// find_usages on a field from structurally empty into the read/write
+// story of the field's actual life.
+func TestResolveCSharp_FieldIdentifierUsesBindOwnField(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Lib.cs": `namespace App {
+    public class Store { public void Add(int n) { } }
+    public class Decoy { private Store _store; }
+    public class Ledger {
+        private Store _store;
+        public Ledger(Store store) { _store = store; }
+        public void Post() { _store.Add(1); }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	read := accessEdge(g, "Lib.cs::Ledger.Post", "_store")
+	require.NotNil(t, read, "_store.Add(1) must produce a read edge of the field")
+	assert.Equal(t, graph.EdgeReads, read.Kind)
+	assert.True(t, strings.Contains(read.To, "Ledger._store"),
+		"binds the enclosing type's own field, got %q", read.To)
+	assert.False(t, strings.Contains(read.To, "Decoy"),
+		"the same-named field on an unrelated class must not win, got %q", read.To)
+	assert.GreaterOrEqual(t, read.Confidence, 0.9,
+		"enclosing-type receiver evidence binds confidently")
+
+	write := accessEdge(g, "Lib.cs::Ledger.<init>", "_store")
+	require.NotNil(t, write, "_store = store in the ctor must produce a write edge")
+	assert.Equal(t, graph.EdgeWrites, write.Kind)
+	assert.True(t, strings.Contains(write.To, "Ledger._store"),
+		"the write binds the same field, got %q", write.To)
+
+	// The find_usages shape: the field node's incoming edges now carry
+	// the field's life story — one read, one write, nothing phantom.
+	reads, writes := 0, 0
+	for _, e := range g.GetInEdges("Lib.cs::Ledger._store") {
+		switch e.Kind {
+		case graph.EdgeReads:
+			reads++
+		case graph.EdgeWrites:
+			writes++
+		}
+	}
+	assert.Equal(t, 1, reads, "exactly the one authored read site")
+	assert.Equal(t, 1, writes, "exactly the one authored write site")
+}


### PR DESCRIPTION
C# fields are used through bare identifiers, not dotted access: an
injected field is a call receiver (_store.Add(1)), an access receiver
(_store.Count), or an assignment target (_store = store). None of those
positions emitted any edge naming the field itself, so find_usages on a
field answered empty no matter how often its class used it. Only the
unidiomatic this._store spelling left a trace. Found through a
programmatic consumer of find_usages on my production C# codebase, where
a provably-read field answered empty and would have steered a dead-code
sweep wrong (the dead-code analyzer's own IncludeFields comment already
names this hazard).

The new emitter covers the enclosing type's own fields, the one case
where the implicit receiver is known at extraction time: bare-identifier
call receivers and member-access receivers emit EdgeReads, assignment
targets emit EdgeWrites, all to unresolved::*.<field> with receiver_type
set to the enclosing type. That is the exact shape resolveFieldRef
already binds, so no resolver changes are needed. Declared locals,
parameters, and builtin-typed locals shadow the field name and suppress
the edge; one edge per site even when a position is visible through two
capture buffers. Bare identifiers in argument or return position are a
named remainder, not covered here.

Tests: the extractor test pins all seven shapes (call receiver, access
receiver, ctor write, bare assignment write, local shadow, parameter
shadow, untouched-field control); the resolver test proves the edges
land on the enclosing type's own field node past a same-named decoy at
0.9 or higher, and that the field's incoming edges tell exactly the
authored story, one read and one write.
