### PR TITLE
query: find_usages serves value-side reads/writes of variables and fields

### DIFF
--- a/internal/parser/languages/csharp_field_identifier_test.go
+++ b/internal/parser/languages/csharp_field_identifier_test.go
@@ -84,3 +84,132 @@ func TestCSharpExtractor_FieldIdentifierUses(t *testing.T) {
 		}
 	}
 }
+
+// Field reads INSIDE lambda bodies. The original production miss that
+// motivated the field-identifier emitter reproduced with the field read
+// sitting inside a `() => { ... }` block lambda in a dictionary
+// initializer assigned in the constructor — post-fix, that exact shape
+// still answered zero edges. Pin both lambda positions: a block lambda
+// inside a collection-initializer entry (the production shape) and a
+// plain expression lambda in an ordinary method. The edge's owner is the
+// enclosing DECLARED member (ctor/method) — lambdas don't mint owners of
+// their own.
+func TestCSharpExtractor_FieldIdentifierUsesInsideLambdas(t *testing.T) {
+	src := []byte(`namespace App {
+    public class Store {
+        public int Read(Func<int, bool> f) { return 1; }
+    }
+    public class Reporter {
+        private readonly Store _lookup;
+        private readonly Dictionary<string, Func<string>> _tags;
+
+        public Reporter(Store lookup) {
+            _lookup = lookup;
+            _tags = new Dictionary<string, Func<string>>
+            {
+                { "A", () =>
+                    {
+                        var item = _lookup.Read(x => x > 0);
+                        return item.ToString();
+                    }
+                },
+            };
+        }
+
+        public int Direct() {
+            return _lookup.Read(x => x > 2);
+        }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("Reporter.cs", src)
+	require.NoError(t, err)
+
+	// The ctor owns two _lookup edges: the assignment write and the read
+	// from inside the initializer entry's block lambda.
+	ctor := accessEdges(result.Edges, "Reporter.cs::Reporter.<init>", "_lookup")
+	require.Len(t, ctor, 2, "ctor: assignment write + block-lambda call-receiver read")
+	kinds := map[graph.EdgeKind]int{}
+	for _, ed := range ctor {
+		kinds[ed.Kind]++
+	}
+	assert.Equal(t, 1, kinds[graph.EdgeWrites], "the `_lookup = lookup` assignment")
+	assert.Equal(t, 1, kinds[graph.EdgeReads], "the read inside the block lambda")
+
+	// An expression lambda argument does not swallow the receiving
+	// field's read in an ordinary method either.
+	direct := accessEdges(result.Edges, "Reporter.cs::Reporter.Direct", "_lookup")
+	require.Len(t, direct, 1, "expression-lambda argument: the field is still the call receiver")
+	assert.Equal(t, graph.EdgeReads, direct[0].Kind)
+}
+
+// fieldEdgesTo filters a result's EdgeReads/EdgeWrites by the unresolved
+// field name alone, owner-agnostic — for constructor shapes whose owner
+// IDs are the variable under test.
+func fieldEdgesTo(edges []*graph.Edge, name string) []*graph.Edge {
+	var out []*graph.Edge
+	for _, ed := range edges {
+		if ed.Kind != graph.EdgeReads && ed.Kind != graph.EdgeWrites {
+			continue
+		}
+		if ed.To == "unresolved::*."+name {
+			out = append(out, ed)
+		}
+	}
+	return out
+}
+
+// Constructor-shape coverage beyond the classic block-bodied instance
+// ctor: expression-bodied ctors, static ctors, and C# 12 primary
+// constructors all put field writes/reads in positions the emitter must
+// still own. Each class isolates one shape with its own field name so a
+// miss identifies itself.
+func TestCSharpExtractor_FieldIdentifierUsesAcrossCtorShapes(t *testing.T) {
+	src := []byte(`namespace App {
+    public class Store {
+        public void Add(int n) { }
+    }
+
+    public class ExprCtor {
+        private Store _expr;
+        public ExprCtor(Store s) => _expr = s;
+    }
+
+    public class StaticCtor {
+        private static Store _shared;
+        static StaticCtor() { _shared = new Store(); }
+        public void Use() { _shared.Add(1); }
+    }
+
+    public class Primary(Store s) {
+        private readonly Store _prim = s;
+        public void Use() { _prim.Add(2); }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("Ctors.cs", src)
+	require.NoError(t, err)
+
+	// Expression-bodied ctor: `=> _expr = s` writes the field.
+	expr := fieldEdgesTo(result.Edges, "_expr")
+	require.Len(t, expr, 1, "expression-bodied ctor assignment is one write")
+	assert.Equal(t, graph.EdgeWrites, expr[0].Kind)
+
+	// Static ctor write + ordinary static-field read.
+	shared := fieldEdgesTo(result.Edges, "_shared")
+	require.Len(t, shared, 2, "static-ctor write + Use() call-receiver read")
+	sharedKinds := map[graph.EdgeKind]int{}
+	for _, ed := range shared {
+		sharedKinds[ed.Kind]++
+	}
+	assert.Equal(t, 1, sharedKinds[graph.EdgeWrites])
+	assert.Equal(t, 1, sharedKinds[graph.EdgeReads])
+
+	// Primary-ctor class: the field is still usable from methods (the
+	// `= s` initializer itself is the declaration, not a tracked write).
+	prim := fieldEdgesTo(result.Edges, "_prim")
+	require.Len(t, prim, 1, "primary-ctor class: method call-receiver read")
+	assert.Equal(t, graph.EdgeReads, prim[0].Kind)
+}

--- a/internal/query/engine.go
+++ b/internal/query/engine.go
@@ -1794,6 +1794,13 @@ func isUsageEdgeKind(k graph.EdgeKind) bool {
 		// nodes only where extractors bind them (Python, JS/TS); Go
 		// imports target package nodes, so Go results are unaffected.
 		graph.EdgeImports, graph.EdgeReExports,
+		// Value-side uses of variables and fields ARE usages: a field
+		// provably read inside its own class answered find_usages empty
+		// while the store held its resolved reads/writes edges (the C#
+		// field-identifier emitter's whole point). EdgeAccessesField is
+		// deliberately absent — it is the synthesized union of these two
+		// riding the same sites and would double-count every one.
+		graph.EdgeReads, graph.EdgeWrites,
 		graph.EdgeProvides, graph.EdgeConsumes,
 		graph.EdgeReadsConfig, graph.EdgeWritesConfig,
 		graph.EdgeUsesEnv, graph.EdgeConfigures,

--- a/internal/query/find_usages_field_reads_test.go
+++ b/internal/query/find_usages_field_reads_test.go
@@ -1,0 +1,51 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// The C# field-identifier emitter (parser: read/write edges for C# field
+// identifiers) lands resolved EdgeReads/EdgeWrites on field nodes — but
+// find_usages filtered both kinds out, so a field provably read inside
+// its own class still answered empty: the store told the authored story
+// (one read, one write) while the usages view served zero rows. The
+// production repro was a repository field read as a call receiver inside
+// a ctor-initializer lambda, resolved `reads` edge present, usages 0.
+// reads/writes ARE the value-side usage story for variables and fields
+// (edge.go's own EdgeReads doc); EdgeAccessesField stays excluded — it
+// is the synthesized union of the two riding the same sites and would
+// double-count every one of them.
+func TestFindUsages_IncludesFieldReadsAndWrites(t *testing.T) {
+	g := graph.New()
+	field := "Svc.cs::Svc._lookup"
+	ctor := "Svc.cs::Svc.<init>"
+	reader := "Svc.cs::Svc.Report"
+
+	g.AddNode(&graph.Node{ID: "Svc.cs", Kind: graph.KindFile, Name: "Svc.cs", Language: "csharp"})
+	g.AddNode(&graph.Node{ID: field, Kind: graph.KindField, Name: "_lookup", FilePath: "Svc.cs", Language: "csharp"})
+	g.AddNode(&graph.Node{ID: ctor, Kind: graph.KindMethod, Name: "<init>", FilePath: "Svc.cs", Language: "csharp"})
+	g.AddNode(&graph.Node{ID: reader, Kind: graph.KindMethod, Name: "Report", FilePath: "Svc.cs", Language: "csharp"})
+
+	g.AddEdge(&graph.Edge{From: ctor, To: field, Kind: graph.EdgeWrites, FilePath: "Svc.cs", Line: 10})
+	g.AddEdge(&graph.Edge{From: reader, To: field, Kind: graph.EdgeReads, FilePath: "Svc.cs", Line: 40})
+	// The synthesized union rides alongside the split edges at the SAME
+	// sites — it must not add duplicate usage rows.
+	g.AddEdge(&graph.Edge{From: ctor, To: field, Kind: graph.EdgeAccessesField, FilePath: "Svc.cs", Line: 10})
+	g.AddEdge(&graph.Edge{From: reader, To: field, Kind: graph.EdgeAccessesField, FilePath: "Svc.cs", Line: 40})
+
+	e := NewEngine(g)
+	usages := e.FindUsages(field)
+
+	require.Len(t, usages.Edges, 2, "one write + one read, no accesses_field duplicates")
+	kinds := map[graph.EdgeKind]int{}
+	for _, ed := range usages.Edges {
+		kinds[ed.Kind]++
+	}
+	assert.Equal(t, 1, kinds[graph.EdgeWrites], "the ctor assignment is a usage")
+	assert.Equal(t, 1, kinds[graph.EdgeReads], "the lambda-body read is a usage")
+}


### PR DESCRIPTION
find_usages on a C# field still answered empty after #668, even though the
store held the field's resolved read and write edges. The edges were fine
end to end: extraction emitted them, the resolver bound them to the
enclosing type's own field, and a direct store query showed the authored
story (one constructor write, reads at the real use sites). The gap was
the view layer: isUsageEdgeKind never admitted EdgeReads or EdgeWrites,
so find_usages filtered the rows out and served an empty set over a
correct graph.

Found by re-probing the original false-empty case from my production C#
codebase on a freshly rebuilt store: a repository field read as a call
receiver inside a constructor-initializer lambda had its resolved reads
edge in the store while find_usages returned zero usages. A programmatic
consumer branching on that empty (a dead-code sweep, for example) still
reached the wrong conclusion the #668 fix was meant to prevent.

The change adds EdgeReads and EdgeWrites to isUsageEdgeKind. They are the
value-side usage story for variables and fields by edge.go's own
definition (LHS of assignment emits writes, every other identifier or
selector use emits reads). EdgeAccessesField stays excluded on purpose:
it is the synthesized union of the two riding the same sites, and
admitting it would double-count every usage.

Tests:

- internal/query/find_usages_field_reads_test.go pins the view: a field
  with one write, one read, and both accesses_field siblings answers
  exactly two usage rows, one of each kind, no duplicates. Written first
  and watched fail with zero rows against the old filter.
- internal/parser/languages/csharp_field_identifier_test.go grows two
  regression pins for the positions the re-probe went through, all
  already emitting correctly today: field reads inside a
  constructor-initializer block lambda and behind an expression-lambda
  argument, and writes from expression-bodied and static constructors
  plus a read in a C# 12 primary-constructor class. They pin that the
  emitter half stays correct while the view half changes.

Behavior note: find_usages results for variables and fields grow, since
readers and writers are now listed. That is the intent. Symbols of other
kinds are unaffected: reads/writes edges only ever target value symbols.

Full test suite on Windows matches my recorded baseline exactly, no new
failures.
