### PR TITLE
Replace regex extractor with tree-sitter for Julia

### DIFF
--- a/docs/languages.md
+++ b/docs/languages.md
@@ -11,7 +11,7 @@ Three engine tiers are used, in order of decreasing extraction depth:
   symbols, resolved call edges, ORM/contract/dataflow extraction, and accurate
   node ranges. Languages: Go, TypeScript, JavaScript, Python, Rust, Java, C#,
   Kotlin, Swift, Scala, PHP, Ruby, Elixir, C, C++, Dart, OCaml, Lua, Bash, SQL,
-  HTML, CSS, Markdown, OrgMode, Protobuf, YAML, TOML, HCL, Dockerfile.
+  HTML, CSS, Markdown, OrgMode, Protobuf, YAML, TOML, HCL, Dockerfile, Julia.
 - **regex** (~60 languages) — pattern-matched line scanning with indent / brace /
   keyword block heuristics. Captures top-level symbols and imports; call edges
   vary per language. Used where no upstream tree-sitter grammar is available
@@ -84,6 +84,7 @@ on interface nodes stores the expected method set for implementation matching.
 | Dart | Full | Full | Classes/Enums/Mixins/Extensions | Abstract interface | Full | Full | Full |
 | OCaml | Full | Full (class) | Types/Modules | Module types | open | Full | Full |
 | Lua | Full | Full (M.func/M:method) | - | - | require() | Full | Full |
+| Julia | Full (long + short form, `where` syntax) | Full (qualified `Base.show`, operators) | Structs/abstract/primitive + fields | - | Full (`using`/`import`/`include`, selective lists) | Full (incl. broadcast, macro calls) | `const` |
 
 ### Rust specifics
 
@@ -107,6 +108,27 @@ exports (`#[no_mangle]`, `#[wasm_bindgen]`, pyo3, napi). Declarations inside an
 language, so a missing definition is not a missing implementation.
 
 Recent extraction refinements (each covered by a per-feature CI golden): Java `@interface` annotation types index as interfaces and participate in implementation matching; Java `new T(){…}` and C# `new { … }` anonymous classes/types become synthetic type nodes with an `extends` edge (to the instantiated type, or to `object` for C#); JS/TS arrow-valued class fields (`x = () => {…}`) are emitted as callable methods; JS/TS named imports emit one `imports` edge per binding (alias-aware via `Edge.Alias`) and barrel re-exports emit `re_exports` edges; JS/TS cross-file imports resolve onto the target file/symbol for relative specifiers (`./x`, `../x`) and for `tsconfig.json` / `jsconfig.json` `compilerOptions.paths` / `baseUrl` path aliases (`@/lib/x`), so callers / usages / blast-radius span aliased imports the same as relative ones; chained / factory-call receivers (`New().Build()`) carry an inferred `receiver_type`. See [features.md](features.md) and [architecture.md](architecture.md) for the edge semantics.
+
+### Julia specifics
+
+`module` / `baremodule` index as `KindType` nodes (the graph's `KindModule`
+is reserved for ecosystem packages) and carry the module's `export` list in
+`Meta["exports"]`; definitions inside a module get `member_of` edges to it.
+Qualified method definitions (`function Base.show(...)`, `function Base.:+`)
+become `KindMethod` with `Meta["receiver"]`, mirroring the Lua `M.func`
+convention. Struct fields are `KindField` nodes with `member_of` into the
+struct; supertypes (`struct X <: Y`) emit `extends` edges with the full
+right-hand path in `Meta["base_path"]` (python extractor convention).
+
+`using M: a, b` / `import M as Alias` keep the module as the import target
+with the selected names / alias in the edge `Meta` for the resolver; all
+imports including `include("file.jl")` target `unresolved::import::<path>`.
+Calls attribute to the enclosing function-like definition (long form, short
+form, macro, or nested closure) and cover qualified (`Mod.f`) and broadcast
+(`f.(x)`, `Meta["broadcast"]`) callees plus macro invocations
+(`Meta["macro"]`). Operator calls (`a + b`) are not emitted — dispatch on
+operators is not statically attributable. Docstrings (preceding string
+literal or first body statement) attach as `Meta["doc"]`.
 
 ## Data, config, build
 
@@ -188,7 +210,6 @@ What is **not** covered:
 
 | Language | Extensions | What it extracts |
 |----------|------------|------------------|
-| Julia | `.jl` | `function`, `struct`, `module`, `using` / `import` |
 | R | `.r`, `.R` | Function defs; `library` / `require` / `source` |
 | MATLAB | `.mlx` | `function` (end-terminated), `classdef`, `import a.b.c` |
 | Mathematica | `.wl`, `.wls`, `.nb` | `name[args_] := body`, `SetDelayed`, `Get[…]` / `Needs[…]` |

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -120,9 +120,17 @@ convention. Struct fields are `KindField` nodes with `member_of` into the
 struct; supertypes (`struct X <: Y`) emit `extends` edges with the full
 right-hand path in `Meta["base_path"]` (python extractor convention).
 
-`using M: a, b` / `import M as Alias` keep the module as the import target
-with the selected names / alias in the edge `Meta` for the resolver; all
-imports including `include("file.jl")` target `unresolved::import::<path>`.
+`using M: a, b` / `import M as Alias` keep the module as the import target,
+including when the path is dotted or relative (`using A.B: x`, `import
+..Up: q`). A selective list additionally emits one edge per binding to
+`unresolved::import::<module>::<name>` — the per-binding shape JS/TS
+already uses — and a rename rides on `Edge.Alias`, with the module edge
+keeping it in `Meta` too because the SQLite edges table has no alias
+column. A module alias is applied at extraction time, so `import Foo as F`
+followed by `F.process(x)` records a call to `Foo.process`: the same target
+the unaliased spelling produces. Nothing in the resolver reads the import
+`Meta` — the edge targets are the consumable surface. All imports including
+`include("file.jl")` target `unresolved::import::<path>`.
 Calls attribute to the enclosing function-like definition (long form, short
 form, macro, or nested closure) and cover qualified (`Mod.f`) and broadcast
 (`f.(x)`, `Meta["broadcast"]`) callees plus macro invocations

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -114,10 +114,16 @@ Recent extraction refinements (each covered by a per-feature CI golden): Java `@
 `module` / `baremodule` index as `KindType` nodes (the graph's `KindModule`
 is reserved for ecosystem packages) and carry the module's `export` list in
 `Meta["exports"]`; definitions inside a module get `member_of` edges to it.
-Qualified method definitions (`function Base.show(...)`, `function Base.:+`)
-become `KindMethod` with `Meta["receiver"]`, mirroring the Lua `M.func`
-convention. Struct fields are `KindField` nodes with `member_of` into the
-struct; supertypes (`struct X <: Y`) emit `extends` edges with the full
+Node ids stay flat — the enclosing module rides on `Meta["scope_mod"]`, the
+Rust `mod` convention — and two definitions that would collide on one id
+(`f` in module `A` and `f` in module `B`) separate through the shared
+line-suffix helper. Qualified method definitions (`function Base.show(...)`,
+`function Base.:+`) become `KindMethod` with `Meta["receiver"]`, mirroring
+the Lua `M.func` convention. Julia has no constructor keyword, so a callable
+named after a type is that type's constructor and takes the cross-language
+`<Type>.<init>` spelling Java, C# and Swift already emit — outer, short and
+inner forms alike. Struct fields are `KindField` nodes with `member_of` into
+the struct; supertypes (`struct X <: Y`) emit `extends` edges with the full
 right-hand path in `Meta["base_path"]` (python extractor convention).
 
 `using M: a, b` / `import M as Alias` keep the module as the import target,

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -130,9 +130,10 @@ right-hand path in `Meta["base_path"]` (python extractor convention).
 including when the path is dotted or relative (`using A.B: x`, `import
 ..Up: q`). A selective list additionally emits one edge per binding to
 `unresolved::import::<module>::<name>` — the per-binding shape JS/TS
-already uses — and a rename rides on `Edge.Alias`, with the module edge
-keeping it in `Meta` too because the SQLite edges table has no alias
-column. A module alias is applied at extraction time, so `import Foo as F`
+already uses, bounded by the same cap so one statement cannot dwarf a
+file's graph — and a rename rides on `Edge.Alias` plus `Meta["alias"]`,
+because the SQLite edges table has no alias column and Meta is the half
+that survives the round-trip. A module alias is applied at extraction time, so `import Foo as F`
 followed by `F.process(x)` records a call to `Foo.process`: the same target
 the unaliased spelling produces. Nothing in the resolver reads the import
 `Meta` — the edge targets are the consumable surface. All imports including

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -141,8 +141,14 @@ Calls attribute to the enclosing function-like definition (long form, short
 form, macro, or nested closure) and cover qualified (`Mod.f`) and broadcast
 (`f.(x)`, `Meta["broadcast"]`) callees plus macro invocations
 (`Meta["macro"]`). Operator calls (`a + b`) are not emitted — dispatch on
-operators is not statically attributable. Docstrings (preceding string
-literal or first body statement) attach as `Meta["doc"]`.
+operators is not statically attributable. Docstrings attach as
+`Meta["doc"]` to long and short definitions, types, modules and constants,
+but only when the string sits immediately above the documented object —
+the adjacency Julia itself enforces, where a blank line or an own-line
+comment detaches the string and leaves the definition undocumented. A
+string at the top of a function body is executable code, not
+documentation. The stored text is the first PROSE paragraph, skipping the
+indented signature block Julia's convention opens a docstring with.
 
 ## Data, config, build
 

--- a/internal/indexer/extractor_version.go
+++ b/internal/indexer/extractor_version.go
@@ -164,6 +164,14 @@ func ExtractorVersionStaleLangs(storedJSON string) []string {
 // A language present in stored but absent from current is dropped: its
 // extension is no longer version-tracked, so there is nothing to compare.
 func staleLangsBetween(stored, current map[string]int) []string {
+	// No baseline at all is "we do not know what produced this graph",
+	// not "everything is behind". Guarding here as well as at the JSON
+	// layer keeps the helper fail-inert on its own terms, so a future
+	// caller that decodes the snapshot itself cannot turn an absent row
+	// into a whole-repository restage.
+	if len(stored) == 0 {
+		return nil
+	}
 	var stale []string
 	for lang, cur := range current {
 		storedV, recorded := stored[lang]

--- a/internal/indexer/extractor_version.go
+++ b/internal/indexer/extractor_version.go
@@ -148,12 +148,35 @@ func ExtractorVersionStaleLangs(storedJSON string) []string {
 }
 
 // staleLangsBetween returns the languages whose stored version is behind the
-// current version — only languages present in BOTH maps are compared, so a
-// language the stored snapshot never recorded is not spuriously flagged.
+// current version. Iteration is over CURRENT, not stored: a language the
+// stored snapshot never recorded is compared against the implicit baseline
+// version 1 that every untracked language carries, and flagged only when the
+// running binary has raised it above that baseline.
+//
+// Iterating stored instead would make a language that gains its FIRST tracked
+// version after the snapshot was written permanently invisible here — the
+// snapshot cannot name a language whose extension the older binary did not map
+// yet, so `julia@2` (shipped together with the `.jl` mapping) would never be
+// reported stale and every already-indexed repository would keep serving the
+// graph the previous Julia extractor produced. The Merkle path catches such a
+// bump through the changed leaf salt, but Merkle is not the default.
+//
+// A language present in stored but absent from current is dropped: its
+// extension is no longer version-tracked, so there is nothing to compare.
 func staleLangsBetween(stored, current map[string]int) []string {
 	var stale []string
-	for lang, storedV := range stored {
-		if cur, ok := current[lang]; ok && storedV < cur {
+	for lang, cur := range current {
+		storedV, recorded := stored[lang]
+		if !recorded {
+			// Never recorded: the snapshot's binary tracked no version
+			// for this language, which is the baseline 1. Only a
+			// deliberate raise above the baseline is a bump.
+			if cur > 1 {
+				stale = append(stale, lang)
+			}
+			continue
+		}
+		if storedV < cur {
 			stale = append(stale, lang)
 		}
 	}

--- a/internal/indexer/extractor_version.go
+++ b/internal/indexer/extractor_version.go
@@ -36,7 +36,8 @@ var extractorVersions = map[string]int{
 	"scala":  2,                                      // explicitly instantiated generic calls emit call edges
 	"go":     3,                                      // generic instantiations are marked so indexing a func value cannot bind (was: generic calls emit call edges)
 	"cpp":    2,                                      // templated and namespace-qualified calls emit call edges
-	"swift":  2,                                      // generic calls and ordinary member calls emit call edges
+	"swift":  2, // generic calls and ordinary member calls emit call edges
+	"julia":  2, // bespoke tree-sitter extractor replaces the regex extractor (fields, exports, qualified methods, broadcast/macro calls)
 }
 
 // extractorSaltExtLang maps a lower-case file extension to the language
@@ -87,6 +88,7 @@ var extractorSaltExtLang = map[string]string{
 	".exs":    "elixir",
 	".sh":     "bash",
 	".bash":   "bash",
+	".jl":     "julia",
 }
 
 // ExtractorLangForFile returns the extractor-staleness language key for a

--- a/internal/indexer/extractor_version_restage_test.go
+++ b/internal/indexer/extractor_version_restage_test.go
@@ -136,7 +136,10 @@ func TestIncrementalReindex_NonMerkleNewlyTrackedLanguageRestages(t *testing.T) 
 
 	res, err := idx.incrementalReindexPathsMode(dir, nil, incrementalPathMode{detectDeletions: true})
 	require.NoError(t, err)
-	assert.GreaterOrEqual(t, res.StaleFileCount, 1,
+	// Exactly one: the repository holds a single .jl file and nothing
+	// else, so a count above one would mean the restage stopped being
+	// per-language — the whole point of the design.
+	assert.Equal(t, 1, res.StaleFileCount,
 		"a language whose first tracked version postdates the stored snapshot must restage")
 
 	var restamped map[string]int

--- a/internal/indexer/extractor_version_restage_test.go
+++ b/internal/indexer/extractor_version_restage_test.go
@@ -104,3 +104,48 @@ func TestIncrementalReindex_NonMerkleVersionCurrentNoRestage(t *testing.T) {
 		t.Fatalf("stored row lost: %q", store.st.ExtractorVersions)
 	}
 }
+
+// TestIncrementalReindex_NonMerkleNewlyTrackedLanguageRestages is the Julia
+// shape: `.jl` entered extractorSaltExtLang in the same change that set
+// julia@2, so a repository indexed by the PREVIOUS release carries a snapshot
+// with no julia key at all. Comparing only the keys that snapshot happens to
+// hold leaves every such repository serving the regex-era Julia graph forever
+// — no content change re-triggers extraction. Merkle mode catches this through
+// the changed leaf salt; this is the default non-Merkle path.
+func TestIncrementalReindex_NonMerkleNewlyTrackedLanguageRestages(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "geom.jl"), "module Geom\nradius(c) = c.r\nend\n")
+
+	store := &indexStateStore{Store: graph.New()}
+	reg := parser.NewRegistry()
+	reg.Register(languages.NewJuliaExtractor())
+	idx := New(store, reg, config.IndexConfig{Workers: 1}, zap.NewNop())
+	idx.search = search.NewNull()
+	idx.SetRootPath(dir)
+	_, err := idx.IndexCtx(testCtx(), dir)
+	require.NoError(t, err)
+
+	// The previous release's snapshot: every language it tracked, at the
+	// versions it shipped — but no julia key, because it had no .jl mapping.
+	previous := extractorVersionsSnapshot()
+	delete(previous, "julia")
+	encoded, err := json.Marshal(previous)
+	require.NoError(t, err)
+	store.st = graph.RepoIndexState{ExtractorVersions: string(encoded)}
+	store.found = true
+
+	res, err := idx.incrementalReindexPathsMode(dir, nil, incrementalPathMode{detectDeletions: true})
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, res.StaleFileCount, 1,
+		"a language whose first tracked version postdates the stored snapshot must restage")
+
+	var restamped map[string]int
+	require.NoError(t, json.Unmarshal([]byte(store.st.ExtractorVersions), &restamped))
+	assert.Equal(t, extractorVersionForLang("julia"), restamped["julia"],
+		"the clean restage must record julia so it does not repeat forever")
+
+	res, err = idx.incrementalReindexPathsMode(dir, nil, incrementalPathMode{detectDeletions: true})
+	require.NoError(t, err)
+	assert.Zero(t, res.StaleFileCount,
+		"after the re-stamp an unchanged tree must be a no-op again")
+}

--- a/internal/indexer/extractor_version_test.go
+++ b/internal/indexer/extractor_version_test.go
@@ -48,6 +48,26 @@ func TestStaleLangsDetection(t *testing.T) {
 		}
 	})
 
+	t.Run("no_baseline_reports_nothing", func(t *testing.T) {
+		// Absent provenance means "unknown", not "everything is behind".
+		if got := staleLangsBetween(nil, extractorVersionsSnapshot()); got != nil {
+			t.Errorf("nil baseline = %v, want nil", got)
+		}
+		if got := staleLangsBetween(map[string]int{}, extractorVersionsSnapshot()); got != nil {
+			t.Errorf("empty baseline = %v, want nil", got)
+		}
+	})
+
+	t.Run("retired_language_is_not_compared", func(t *testing.T) {
+		// A language the salt map no longer tracks has no current
+		// version to compare against, so it is dropped rather than
+		// flagged forever.
+		stored := map[string]int{"go": 3, "retired": 9}
+		if got := staleLangsBetween(stored, map[string]int{"go": 3}); got != nil {
+			t.Errorf("retired language = %v, want nil", got)
+		}
+	})
+
 	t.Run("newly_tracked_language_is_stale", func(t *testing.T) {
 		// A language whose extension mapping ships in the SAME change that
 		// raises its version cannot appear in the previous release's
@@ -126,6 +146,12 @@ func TestStaleLangsDetection(t *testing.T) {
 		}
 		if got := merkleSaltFor("include/widget.hxx"); got != "cpp@2" {
 			t.Errorf("C++ extractor salt for .hxx = %q, want cpp@2", got)
+		}
+		// The Merkle half of the Julia bump: without the .jl → julia
+		// mapping the leaf salt stays empty and Merkle mode misses the
+		// bump the same way the mtime path did.
+		if got := merkleSaltFor("src/model.jl"); got != "julia@2" {
+			t.Errorf("Julia extractor salt = %q, want julia@2", got)
 		}
 	})
 

--- a/internal/indexer/extractor_version_test.go
+++ b/internal/indexer/extractor_version_test.go
@@ -1,24 +1,71 @@
 package indexer
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 )
 
+// snapshotJSON renders the shape a real previous release persisted — the FULL
+// per-language snapshot extractorVersionsSnapshot() writes — with the given
+// overrides applied and the named languages removed. A stored row is never
+// partial in production (persistRepoIndexState marshals the whole map and
+// persistExtractorVersion only adds to it), so a test that feeds a two-key map
+// is testing a shape the field never produces.
+func snapshotJSON(t *testing.T, overrides map[string]int, drop ...string) string {
+	t.Helper()
+	m := extractorVersionsSnapshot()
+	for _, lang := range drop {
+		delete(m, lang)
+	}
+	for lang, v := range overrides {
+		m[lang] = v
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal snapshot: %v", err)
+	}
+	return string(b)
+}
+
 // TestStaleLangsDetection proves the per-language extractor-staleness signal:
 // only languages whose stored version is behind the current one are flagged
 // (so the advisory names the exact languages to reindex — a scoped reindex
-// rather than a full cold rebuild), a language the snapshot never recorded is
-// never spuriously flagged, and an empty baseline reports nothing.
+// rather than a full cold rebuild), a language the snapshot recorded at the
+// current version is left alone, and an empty baseline reports nothing.
 func TestStaleLangsDetection(t *testing.T) {
 	t.Run("only_behind_langs", func(t *testing.T) {
 		stored := map[string]int{"go": 1, "python": 2, "ruby": 1}
-		current := map[string]int{"go": 2, "python": 2, "ruby": 1, "rust": 3}
+		current := map[string]int{"go": 2, "python": 2, "ruby": 1, "rust": 3, "lua": 1}
 		got := staleLangsBetween(stored, current)
-		// go is behind (1<2); python/ruby are current; rust is absent from
-		// stored (no baseline) so it is NOT flagged.
-		if want := []string{"go"}; !reflect.DeepEqual(got, want) {
+		// go is behind (1<2); python/ruby are current. rust is absent from
+		// stored, which means the snapshot's binary tracked no version for
+		// it — the implicit baseline 1 — so a current version of 3 IS a
+		// bump and must be flagged. lua is absent too but sits at the
+		// baseline itself, so there is nothing to re-extract.
+		if want := []string{"go", "rust"}; !reflect.DeepEqual(got, want) {
 			t.Errorf("staleLangsBetween = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("newly_tracked_language_is_stale", func(t *testing.T) {
+		// A language whose extension mapping ships in the SAME change that
+		// raises its version cannot appear in the previous release's
+		// snapshot. Comparing only the keys the snapshot happens to carry
+		// would leave every already-indexed repository on the old
+		// extraction forever, because no content change re-triggers it.
+		previous := extractorVersionsSnapshot()
+		delete(previous, "julia")
+
+		stale := staleLangsBetween(previous, extractorVersionsSnapshot())
+		var found bool
+		for _, lang := range stale {
+			if lang == "julia" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("staleLangsBetween = %v, want it to contain julia", stale)
 		}
 	})
 
@@ -39,28 +86,35 @@ func TestStaleLangsDetection(t *testing.T) {
 		if got := ExtractorVersionStaleLangs("not json"); got != nil {
 			t.Errorf("bad json = %v, want nil", got)
 		}
-		// Against the live extractor versions, an unchanged baseline language
-		// is not stale. Java is the exemplar because its extractor has never
-		// been bumped — a language whose version this suite also asserts
-		// would make the check tautological.
-		if got := ExtractorVersionStaleLangs(`{"java":1}`); len(got) != 0 {
+		// A snapshot written by THIS binary is current in every language.
+		if got := ExtractorVersionStaleLangs(snapshotJSON(t, nil)); len(got) != 0 {
 			t.Errorf("stored at current = %v, want empty", got)
 		}
-		if got := ExtractorVersionStaleLangs(`{"java":1,"php":1}`); !reflect.DeepEqual(got, []string{"php"}) {
+		if got := ExtractorVersionStaleLangs(
+			snapshotJSON(t, map[string]int{"php": 1})); !reflect.DeepEqual(got, []string{"php"}) {
 			t.Errorf("stored PHP structural-edge version = %v, want [php]", got)
 		}
 		// A store extracted before the generic-call fix must re-extract:
 		// until then, every call spelling explicit type arguments is missing
 		// from its graph entirely, and no content change will trigger it.
-		if got := ExtractorVersionStaleLangs(`{"go":1,"scala":1,"cpp":1,"swift":1}`); !reflect.DeepEqual(
-			got, []string{"cpp", "go", "scala", "swift"}) {
+		if got := ExtractorVersionStaleLangs(snapshotJSON(t, map[string]int{
+			"go": 1, "scala": 1, "cpp": 1, "swift": 1,
+		})); !reflect.DeepEqual(got, []string{"cpp", "go", "scala", "swift"}) {
 			t.Errorf("stored pre-generic-call version = %v, want all four", got)
 		}
 		// A store extracted before the C# params-shape fix must re-extract
 		// unchanged .cs, .razor, and .cshtml files. Without the bump, their
 		// persisted graph keeps the old arity and parameter evidence.
-		if got := ExtractorVersionStaleLangs(`{"csharp":10}`); !reflect.DeepEqual(got, []string{"csharp"}) {
+		if got := ExtractorVersionStaleLangs(
+			snapshotJSON(t, map[string]int{"csharp": 10})); !reflect.DeepEqual(got, []string{"csharp"}) {
 			t.Errorf("stored pre-params C# version = %v, want [csharp]", got)
+		}
+		// The Julia tree-sitter extractor shipped `.jl` into the salt map
+		// for the first time, so a previous release's snapshot has no julia
+		// key at all — the shape that must still restage.
+		if got := ExtractorVersionStaleLangs(
+			snapshotJSON(t, nil, "julia")); !reflect.DeepEqual(got, []string{"julia"}) {
+			t.Errorf("previous-release snapshot without julia = %v, want [julia]", got)
 		}
 		for _, path := range []string{"src/Handler.cs", "Views/Page.razor", "Views/Page.cshtml"} {
 			if got := merkleSaltFor(path); got != "csharp@12" {

--- a/internal/indexer/extractor_version_test.go
+++ b/internal/indexer/extractor_version_test.go
@@ -110,6 +110,14 @@ func TestStaleLangsDetection(t *testing.T) {
 		if got := ExtractorVersionStaleLangs(snapshotJSON(t, nil)); len(got) != 0 {
 			t.Errorf("stored at current = %v, want empty", got)
 		}
+		// A language MISSING from the snapshot but sitting at the
+		// baseline is not stale: only a version raised above the
+		// baseline is a bump. Java is the exemplar because its extractor
+		// has never been bumped, which keeps the check from being
+		// tautological.
+		if got := ExtractorVersionStaleLangs(snapshotJSON(t, nil, "java")); len(got) != 0 {
+			t.Errorf("absent baseline language = %v, want empty", got)
+		}
 		if got := ExtractorVersionStaleLangs(
 			snapshotJSON(t, map[string]int{"php": 1})); !reflect.DeepEqual(got, []string{"php"}) {
 			t.Errorf("stored PHP structural-edge version = %v, want [php]", got)

--- a/internal/mcp/freshness_rider.go
+++ b/internal/mcp/freshness_rider.go
@@ -52,11 +52,22 @@ func (s *Server) freshnessRiderFor(toolName string, req mcp.CallToolRequest) map
 	// names the exact languages to reindex rather than implying a full rebuild.
 	var indexState graph.RepoIndexState
 	var haveState bool
+	// Extractor-version staleness, narrowed to THIS file's language. The
+	// advisory rides on a per-file response, so a language the file is not
+	// written in is noise the reader cannot act on: the reindex it asks
+	// for would not touch the file in hand. Narrowing also keeps the
+	// banner off repositories that hold no file of the stale language at
+	// all — the comparison is against the baseline version every language
+	// implicitly carries, so a bumped language is "behind" in every
+	// repository indexed by an older binary, Go-only ones included.
 	var staleLangs []string
 	if r, ok := graph.Store(s.graph).(graph.RepoIndexStateReader); ok {
 		if st, found, _ := r.GetRepoIndexState(owner.RepoPrefix()); found {
 			indexState, haveState = st, true
-			staleLangs = indexer.ExtractorVersionStaleLangs(st.ExtractorVersions)
+			if fileLang := indexer.ExtractorLangForFile(repoRel); fileLang != "" &&
+				slices.Contains(indexer.ExtractorVersionStaleLangs(st.ExtractorVersions), fileLang) {
+				staleLangs = []string{fileLang}
+			}
 		}
 	}
 
@@ -95,9 +106,7 @@ func (s *Server) freshnessRiderFor(toolName string, req mcp.CallToolRequest) map
 	}
 	if len(staleLangs) > 0 {
 		out["extractor_stale_langs"] = staleLangs
-		if fileLang := indexer.ExtractorLangForFile(repoRel); fileLang != "" && slices.Contains(staleLangs, fileLang) {
-			out["extractor_stale_hint"] = "this file's language extractor was upgraded since indexing; reindex to pick up the newer extraction (gortex index .)"
-		}
+		out["extractor_stale_hint"] = "this file's language extractor was upgraded since indexing; reindex to pick up the newer extraction (gortex index .)"
 	}
 	if mismatch {
 		out["worktree_mismatch"] = true

--- a/internal/mcp/freshness_rider_extractor_lang_test.go
+++ b/internal/mcp/freshness_rider_extractor_lang_test.go
@@ -1,0 +1,107 @@
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// riderIndexStateStore wraps the in-memory graph with a durable-index-state
+// capability, so the rider has a stored extractor-version row to compare
+// against. The in-memory graph implements neither half on its own.
+type riderIndexStateStore struct {
+	graph.Store
+	st graph.RepoIndexState
+}
+
+func (s *riderIndexStateStore) GetRepoIndexState(string) (graph.RepoIndexState, bool, error) {
+	return s.st, true, nil
+}
+
+func (s *riderIndexStateStore) SetRepoIndexState(st graph.RepoIndexState) error {
+	s.st = st
+	return nil
+}
+
+// A bumped extractor version is compared against the baseline every
+// language implicitly carries, so ANY repository indexed by an older
+// binary reports the bumped language behind — a Go-only repository
+// included. Riding that on every file-scoped response would put a banner
+// on every read in every repository, naming a language the reader has no
+// file of and cannot act on. The advisory is narrowed to the language of
+// the file being described.
+func TestFreshnessRider_ExtractorStalenessIsScopedToTheFilesLanguage(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "repo-a")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"),
+		[]byte("package main\n\nfunc Hello() {}\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "geom.jl"),
+		[]byte("module Geom\nradius(c) = c.r\nend\n"), 0o644))
+
+	tmpCfg := filepath.Join(t.TempDir(), "config.yaml")
+	gc := &config.GlobalConfig{Repos: []config.RepoEntry{{Path: dir, Name: "repo-a"}}}
+	gc.SetConfigPath(tmpCfg)
+	require.NoError(t, gc.Save())
+	cm, err := config.NewConfigManager(tmpCfg)
+	require.NoError(t, err)
+
+	reg := parser.NewRegistry()
+	reg.Register(languages.NewGoExtractor())
+	reg.Register(languages.NewJuliaExtractor())
+	g := graph.New()
+	store := &riderIndexStateStore{Store: g}
+	mi := indexer.NewMultiIndexer(g, reg, search.NewNull(), cm, zap.NewNop())
+	_, err = mi.IndexAll()
+	require.NoError(t, err)
+
+	// The previous release's snapshot: every language it tracked, but no
+	// julia key, because it had no .jl mapping yet.
+	previous := map[string]int{}
+	for _, lang := range []string{"go", "python", "java", "ruby", "rust", "c", "cpp",
+		"csharp", "php", "swift", "kotlin", "scala", "objc", "objcpp", "lua",
+		"dart", "elixir", "bash", "javascript", "typescript"} {
+		previous[lang] = 1
+	}
+	previous["c"], previous["cpp"], previous["csharp"] = 3, 2, 12
+	previous["go"], previous["php"], previous["scala"], previous["swift"] = 3, 2, 2, 2
+	encoded, err := json.Marshal(previous)
+	require.NoError(t, err)
+	store.st = graph.RepoIndexState{RepoPrefix: "repo-a", ExtractorVersions: string(encoded)}
+
+	srv := NewServer(query.NewEngine(g), store, nil, nil, zap.NewNop(), nil, MultiRepoOptions{
+		ConfigManager: cm,
+		MultiIndexer:  mi,
+	})
+	read := func(path string) mcp.CallToolRequest {
+		return freshReq(map[string]any{"path": path})
+	}
+
+	// julia IS stale against that snapshot...
+	require.Contains(t, indexer.ExtractorVersionStaleLangs(string(encoded)), "julia")
+
+	// ...but a fresh Go file must draw no rider at all. Before the
+	// narrowing this returned {"extractor_stale_langs":["julia"], ...} on
+	// every read, in every repository, permanently.
+	require.Nil(t, srv.freshnessRiderFor("read_file", read("repo-a/main.go")),
+		"a fresh Go file must not be told that Julia's extractor moved")
+
+	// The Julia file, whose language really is behind, still gets the
+	// advisory and the actionable hint.
+	jlRider := srv.freshnessRiderFor("read_file", read("repo-a/geom.jl"))
+	require.NotNil(t, jlRider, "a file of the stale language must still be flagged")
+	require.Equal(t, []string{"julia"}, jlRider["extractor_stale_langs"])
+	require.NotEmpty(t, jlRider["extractor_stale_hint"])
+}

--- a/internal/parser/languages/julia.go
+++ b/internal/parser/languages/julia.go
@@ -1004,7 +1004,12 @@ func (e *JuliaExtractor) handleMacroCall(n *sitter.Node, src []byte, scope julia
 // as the documentation of `radius`. Leading paragraphs whose every line
 // is indented are that signature block and are skipped.
 func juliaDocText(n *sitter.Node, src []byte) string {
-	s := strings.TrimSpace(n.Content(src))
+	// A Windows-authored file separates paragraphs with "\r\n\r\n",
+	// which holds no "\n\n" — without normalising first, the signature
+	// block below would never be recognised and would be stored as the
+	// documentation.
+	s := strings.ReplaceAll(n.Content(src), "\r\n", "\n")
+	s = strings.TrimSpace(s)
 	if strings.HasPrefix(s, `"""`) {
 		s = strings.TrimSuffix(strings.TrimPrefix(s, `"""`), `"""`)
 	} else {

--- a/internal/parser/languages/julia.go
+++ b/internal/parser/languages/julia.go
@@ -29,11 +29,15 @@ import (
 //     module's `export` list; definitions inside get EdgeMemberOf
 //   - `const X = ...` constants (KindVariable)
 //
-// Imports: `using M`, `using M: a, b` (selected names in edge Meta),
-// `import M`, `import M as Alias` (alias in edge Meta), dotted and
-// relative import paths (`A.B`, `.Local`, `..Up`), and
+// Imports: `using M`, `using M: a, b`, `import M`, `import M as Alias`,
+// dotted and relative import paths (`A.B`, `.Local`, `..Up`), and
 // `include("file.jl")` — all as EdgeImports to
-// `unresolved::import::<module>`, never to a selected name.
+// `unresolved::import::<module>`, never to a selected name. A selective
+// list also emits one edge per binding to
+// `unresolved::import::<module>::<name>`, and a rename rides on
+// Edge.Alias (and on the module edge's Meta, which is the persisted
+// half). A module alias additionally rewrites qualified callees, so
+// `import Foo as F` + `F.process(x)` calls `Foo.process`.
 //
 // Calls: call_expression / broadcast_call_expression / macrocall
 // callees (identifier or qualified field_expression) attribute to the
@@ -70,6 +74,10 @@ type juliaWalkState struct {
 	result   *parser.ExtractionResult
 	seen     map[string]bool
 	nodes    map[string]*graph.Node
+	// importAliases maps a local module alias to the module it renames
+	// (`import Foo as F` → F→Foo), so a qualified call can name the
+	// module the resolver can find rather than a file-local nickname.
+	importAliases map[string]string
 }
 
 func (e *JuliaExtractor) Extract(filePath string, src []byte) (*parser.ExtractionResult, error) {
@@ -90,12 +98,17 @@ func (e *JuliaExtractor) Extract(filePath string, src []byte) (*parser.Extractio
 	result.Nodes = append(result.Nodes, fileNode)
 
 	st := &juliaWalkState{
-		filePath: filePath,
-		fileNode: fileNode,
-		result:   result,
-		seen:     make(map[string]bool),
-		nodes:    map[string]*graph.Node{filePath: fileNode},
+		filePath:      filePath,
+		fileNode:      fileNode,
+		result:        result,
+		seen:          make(map[string]bool),
+		nodes:         map[string]*graph.Node{filePath: fileNode},
+		importAliases: map[string]string{},
 	}
+	// Aliases are collected up front: the emitting walk is a single
+	// forward pass, and Julia does not require `import ... as ...` to
+	// precede the code that uses the alias.
+	juliaCollectImportAliases(root, src, st.importAliases)
 	e.walk(root, src, juliaScope{}, st)
 	return result, nil
 }
@@ -613,12 +626,38 @@ func juliaAliasParts(n *sitter.Node, src []byte) (orig, alias string) {
 	return orig, alias
 }
 
+// juliaCollectImportAliases records every `import M as A` / `using M as A`
+// module rename in the file, so handleCall can rewrite a qualified callee
+// onto the module it actually names. Only MODULE aliases are collected: a
+// renamed binding inside a selected list (`import Foo: bar as baz`)
+// renames a function, and rewriting a bare call through it would fight
+// any local shadowing the extractor cannot see.
+func juliaCollectImportAliases(n *sitter.Node, src []byte, out map[string]string) {
+	if n.Type() == "using_statement" || n.Type() == "import_statement" {
+		for c := range n.NamedChildren() {
+			if c.Type() != "import_alias" {
+				continue
+			}
+			if module, alias := juliaAliasParts(c, src); module != "" && alias != "" && alias != module {
+				out[alias] = module
+			}
+		}
+		return
+	}
+	for c := range n.NamedChildren() {
+		juliaCollectImportAliases(c, src, out)
+	}
+}
+
 // handleImport covers `using M`, `using M: a, b`, `import M`,
 // `import M as Alias`, and dotted / relative import paths. The import
-// target is always the MODULE; selected names and aliases ride on the
-// edge Meta.
+// target is always the MODULE; a selective list additionally emits one
+// binding-aware edge per selected name (the JS/TS per-binding
+// convention), so "who imports `mean` from Statistics" is a traversable
+// question rather than a Meta key nothing reads.
 func (e *JuliaExtractor) handleImport(n *sitter.Node, src []byte, st *juliaWalkState) {
-	emit := func(target string, meta map[string]any) {
+	line := int(n.StartPoint().Row) + 1
+	emit := func(target, alias string, meta map[string]any) {
 		if target == "" {
 			return
 		}
@@ -628,14 +667,32 @@ func (e *JuliaExtractor) handleImport(n *sitter.Node, src []byte, st *juliaWalkS
 		st.result.Edges = append(st.result.Edges, &graph.Edge{
 			From: st.fileNode.ID, To: "unresolved::import::" + target,
 			Kind:     graph.EdgeImports,
-			FilePath: st.filePath, Line: int(n.StartPoint().Row) + 1,
-			Meta: meta,
+			FilePath: st.filePath, Line: line,
+			// Edge.Alias is the graph's canonical spelling for a renamed
+			// binding; Meta keeps the same fact on the durable side,
+			// since the SQLite edges table has no alias column.
+			Alias: alias,
+			Meta:  meta,
+		})
+	}
+	// One edge per selected binding, targeting the binding rather than
+	// the module — the representation JS/TS already emits for
+	// `import { a, b as c } from "mod"`.
+	emitBinding := func(module, orig, alias string) {
+		if module == "" || orig == "" {
+			return
+		}
+		st.result.Edges = append(st.result.Edges, &graph.Edge{
+			From: st.fileNode.ID, To: "unresolved::import::" + module + "::" + orig,
+			Kind:     graph.EdgeImports,
+			FilePath: st.filePath, Line: line,
+			Alias: alias,
 		})
 	}
 	for c := range n.NamedChildren() {
 		switch c.Type() {
 		case "identifier", "import_path":
-			emit(c.Content(src), nil)
+			emit(c.Content(src), "", nil)
 		case "selected_import":
 			// `using A.B: x, y` — the module is the FIRST child and is
 			// an import_path whenever the path is dotted or relative.
@@ -643,6 +700,8 @@ func (e *JuliaExtractor) handleImport(n *sitter.Node, src []byte, st *juliaWalkS
 			// the first selected name to the import target.
 			module, next := juliaImportModule(c, src)
 			var names []string
+			type binding struct{ orig, alias string }
+			var bindings []binding
 			for i, count := next, int(c.NamedChildCount()); i < count; i++ {
 				s := c.NamedChild(i)
 				if s == nil {
@@ -653,25 +712,38 @@ func (e *JuliaExtractor) handleImport(n *sitter.Node, src []byte, st *juliaWalkS
 					// `using Base: +, -` selects operators, which are
 					// `operator` nodes rather than identifiers.
 					names = append(names, s.Content(src))
+					bindings = append(bindings, binding{orig: s.Content(src)})
 				case "import_alias":
 					// `import Foo: bar as baz` renames one binding.
-					if orig, _ := juliaAliasParts(s, src); orig != "" {
-						names = append(names, orig)
+					orig, alias := juliaAliasParts(s, src)
+					if orig == "" {
+						continue
 					}
+					names = append(names, orig)
+					if alias == orig {
+						alias = ""
+					}
+					bindings = append(bindings, binding{orig: orig, alias: alias})
 				}
 			}
 			meta := map[string]any{}
 			if len(names) > 0 {
 				meta["names"] = names
 			}
-			emit(module, meta)
+			emit(module, "", meta)
+			for _, b := range bindings {
+				emitBinding(module, b.orig, b.alias)
+			}
 		case "import_alias":
 			path, alias := juliaAliasParts(c, src)
+			if alias == path {
+				alias = ""
+			}
 			meta := map[string]any{}
 			if alias != "" {
 				meta["alias"] = alias
 			}
-			emit(path, meta)
+			emit(path, alias, meta)
 		}
 	}
 }
@@ -733,6 +805,12 @@ func (e *JuliaExtractor) handleCall(n *sitter.Node, src []byte, scope juliaScope
 	}
 	target := name
 	if receiver != "" {
+		// `import Foo as F` then `F.process(x)`: name the module, not
+		// the file-local nickname, so the call target is something
+		// another file's `module Foo` can be matched against.
+		if module, ok := st.importAliases[receiver]; ok {
+			receiver = module
+		}
 		target = receiver + "." + name
 	}
 	meta := map[string]any{}

--- a/internal/parser/languages/julia.go
+++ b/internal/parser/languages/julia.go
@@ -97,9 +97,13 @@ type juliaWalkState struct {
 	// constructor and attributed to the RIGHT type when one file declares
 	// two same-named types in different modules.
 	types map[string]string
-	// importAliases maps a local module alias to the module it renames
-	// (`import Foo as F` → F→Foo), so a qualified call can name the
-	// module the resolver can find rather than a file-local nickname.
+	// importAliases maps a module scope + local alias to the module it
+	// renames (`import Foo as F` inside `module A` → A/F→Foo), so a
+	// qualified call can name the module the resolver can find rather
+	// than a file-local nickname. Keyed by scope because `import ... as`
+	// binds in the module it appears in, and one file routinely holds
+	// several modules giving the same short nickname to different
+	// packages.
 	importAliases map[string]string
 }
 
@@ -132,7 +136,7 @@ func (e *JuliaExtractor) Extract(filePath string, src []byte) (*parser.Extractio
 	// Aliases are collected up front: the emitting walk is a single
 	// forward pass, and Julia does not require `import ... as ...` to
 	// precede the code that uses the alias.
-	juliaCollectImportAliases(root, src, st.importAliases)
+	juliaCollectImportAliases(root, src, "", st.importAliases)
 	e.walk(root, src, juliaScope{}, st)
 	return result, nil
 }
@@ -281,23 +285,18 @@ func (e *JuliaExtractor) handleModule(n *sitter.Node, src []byte, scope juliaSco
 // a same-named type in a sibling module of the same file.
 func juliaTypeKey(modulePath, name string) string { return modulePath + "\x00" + name }
 
-// lookupType finds the type a definition name would construct, searching
-// the current module then each enclosing one out to file scope — Julia's
-// own lexical lookup order.
+// lookupType finds the type a definition name would construct, in the
+// SAME module only. A Julia submodule does not inherit its parent's
+// bindings — each module starts with the implicit `using Base` and
+// nothing else — so `Outer.Inner.Thing` is an independent generic
+// function, not a constructor for `Outer.Thing`, unless it was imported
+// explicitly. Searching outward would fabricate a member_of edge into a
+// type the definition has no relationship with.
 func (st *juliaWalkState) lookupType(modulePath, name string) (id, declared string, ok bool) {
-	for path := modulePath; ; {
-		if id, hit := st.types[juliaTypeKey(path, name)]; hit {
-			return id, name, true
-		}
-		if path == "" {
-			return "", "", false
-		}
-		if i := strings.LastIndex(path, "."); i >= 0 {
-			path = path[:i]
-		} else {
-			path = ""
-		}
+	if id, hit := st.types[juliaTypeKey(modulePath, name)]; hit {
+		return id, name, true
 	}
+	return "", "", false
 }
 
 // juliaTypeHeadInfo decodes a `type_head` child: the declared name
@@ -773,25 +772,38 @@ func juliaAliasParts(n *sitter.Node, src []byte) (orig, alias string) {
 }
 
 // juliaCollectImportAliases records every `import M as A` / `using M as A`
-// module rename in the file, so handleCall can rewrite a qualified callee
-// onto the module it actually names. Only MODULE aliases are collected: a
-// renamed binding inside a selected list (`import Foo: bar as baz`)
-// renames a function, and rewriting a bare call through it would fight
-// any local shadowing the extractor cannot see.
-func juliaCollectImportAliases(n *sitter.Node, src []byte, out map[string]string) {
-	if n.Type() == "using_statement" || n.Type() == "import_statement" {
+// module rename in the file, keyed by the module the statement appears in,
+// so handleCall can rewrite a qualified callee onto the module it actually
+// names. The pre-pass exists because the emitting walk is a single forward
+// pass and Julia does not require the import to precede its use.
+//
+// Only MODULE aliases are collected: a renamed binding inside a selected
+// list (`import Foo: bar as baz`) renames a function, and rewriting a bare
+// call through it would fight any local shadowing the extractor cannot
+// see.
+func juliaCollectImportAliases(n *sitter.Node, src []byte, modulePath string, out map[string]string) {
+	switch n.Type() {
+	case "using_statement", "import_statement":
 		for c := range n.NamedChildren() {
 			if c.Type() != "import_alias" {
 				continue
 			}
 			if module, alias := juliaAliasParts(c, src); module != "" && alias != "" && alias != module {
-				out[alias] = module
+				out[juliaTypeKey(modulePath, alias)] = module
 			}
 		}
 		return
+	case "module_definition":
+		if nn := n.ChildByFieldName("name"); nn != nil && nn.Content(src) != "" {
+			if modulePath == "" {
+				modulePath = nn.Content(src)
+			} else {
+				modulePath += "." + nn.Content(src)
+			}
+		}
 	}
 	for c := range n.NamedChildren() {
-		juliaCollectImportAliases(c, src, out)
+		juliaCollectImportAliases(c, src, modulePath, out)
 	}
 }
 
@@ -953,8 +965,11 @@ func (e *JuliaExtractor) handleCall(n *sitter.Node, src []byte, scope juliaScope
 	if receiver != "" {
 		// `import Foo as F` then `F.process(x)`: name the module, not
 		// the file-local nickname, so the call target is something
-		// another file's `module Foo` can be matched against.
-		if module, ok := st.importAliases[receiver]; ok {
+		// another file's `module Foo` can be matched against. The alias
+		// is looked up in the module that declared it — a sibling module
+		// binding the same nickname to a different package must not
+		// rewrite this call.
+		if module, ok := st.importAliases[juliaTypeKey(scope.modulePath, receiver)]; ok {
 			receiver = module
 		}
 		target = receiver + "." + name

--- a/internal/parser/languages/julia.go
+++ b/internal/parser/languages/julia.go
@@ -97,6 +97,11 @@ type juliaWalkState struct {
 	// constructor and attributed to the RIGHT type when one file declares
 	// two same-named types in different modules.
 	types map[string]string
+	// declaredTypes holds the same keys for every type declared ANYWHERE
+	// in the file, filled by the pre-pass. The emitting walk is a single
+	// forward pass, and Julia routinely puts outer constructors above the
+	// struct they build.
+	declaredTypes map[string]bool
 	// importAliases maps a module scope + local alias to the module it
 	// renames (`import Foo as F` inside `module A` → A/F→Foo), so a
 	// qualified call can name the module the resolver can find rather
@@ -131,12 +136,10 @@ func (e *JuliaExtractor) Extract(filePath string, src []byte) (*parser.Extractio
 		seen:          make(map[string]bool),
 		nodes:         map[string]*graph.Node{filePath: fileNode},
 		types:         map[string]string{},
+		declaredTypes: map[string]bool{},
 		importAliases: map[string]string{},
 	}
-	// Aliases are collected up front: the emitting walk is a single
-	// forward pass, and Julia does not require `import ... as ...` to
-	// precede the code that uses the alias.
-	juliaCollectImportAliases(root, src, "", st.importAliases)
+	juliaPrescan(root, src, "", st)
 	e.walk(root, src, juliaScope{}, st)
 	return result, nil
 }
@@ -693,10 +696,24 @@ func (e *JuliaExtractor) emitCallable(
 
 	default:
 		typeID, typeName := "", ""
-		if scope.typeName == name && scope.typeID != "" {
+		// A macro name lives in a disjoint namespace — `macro Tag`
+		// defines `@Tag`, which has nothing to do with a type `Tag` — so
+		// a macro can never be a constructor.
+		switch {
+		case isMacro:
+		case scope.typeName == name && scope.typeID != "":
 			typeID, typeName = scope.typeID, scope.typeName // inner constructor
-		} else if id, declared, ok := st.lookupType(scope.modulePath, name); ok {
-			typeID, typeName = id, declared // outer constructor
+		default:
+			if id, declared, ok := st.lookupType(scope.modulePath, name); ok {
+				typeID, typeName = id, declared // outer constructor
+			} else if st.declaredTypes[juliaTypeKey(scope.modulePath, name)] &&
+				!st.seen[st.filePath+"::"+name] {
+				// The struct is declared further down the file. Predict
+				// the id it will take rather than taking it here — but
+				// only while that id is still free, so a same-named type
+				// in another module cannot be adopted by mistake.
+				typeID, typeName = st.filePath+"::"+name, name
+			}
 		}
 		if typeID != "" {
 			baseID = typeID + ".<init>"
@@ -807,17 +824,24 @@ func juliaAliasParts(n *sitter.Node, src []byte) (orig, alias string) {
 	return orig, alias
 }
 
-// juliaCollectImportAliases records every `import M as A` / `using M as A`
-// module rename in the file, keyed by the module the statement appears in,
-// so handleCall can rewrite a qualified callee onto the module it actually
-// names. The pre-pass exists because the emitting walk is a single forward
-// pass and Julia does not require the import to precede its use.
+// juliaPrescan walks the file once before extraction, collecting the two
+// facts the emitting pass needs BEFORE it reaches the declarations that
+// establish them — it is a single forward pass, and Julia orders neither.
 //
-// Only MODULE aliases are collected: a renamed binding inside a selected
-// list (`import Foo: bar as baz`) renames a function, and rewriting a bare
-// call through it would fight any local shadowing the extractor cannot
-// see.
-func juliaCollectImportAliases(n *sitter.Node, src []byte, modulePath string, out map[string]string) {
+// Module renames (`import M as A`) are keyed by the module the statement
+// appears in, so handleCall can rewrite a qualified callee onto the module
+// it actually names. Only MODULE aliases are collected: a renamed binding
+// inside a selected list (`import Foo: bar as baz`) renames a function,
+// and rewriting a bare call through it would fight any local shadowing the
+// extractor cannot see.
+//
+// Declared type names are keyed the same way, because a callable named
+// after a type is that type's constructor and outer constructors are
+// routinely written ABOVE the struct they build. Without knowing that up
+// front, such a constructor was minted as a plain function on the type's
+// own canonical id, and the struct that followed was demoted to a
+// line-suffixed one.
+func juliaPrescan(n *sitter.Node, src []byte, modulePath string, st *juliaWalkState) {
 	switch n.Type() {
 	case "using_statement", "import_statement":
 		for c := range n.NamedChildren() {
@@ -825,10 +849,20 @@ func juliaCollectImportAliases(n *sitter.Node, src []byte, modulePath string, ou
 				continue
 			}
 			if module, alias := juliaAliasParts(c, src); module != "" && alias != "" && alias != module {
-				out[juliaTypeKey(modulePath, alias)] = module
+				st.importAliases[juliaTypeKey(modulePath, alias)] = module
 			}
 		}
 		return
+	case "struct_definition", "abstract_definition", "primitive_definition":
+		for c := range n.NamedChildren() {
+			if c.Type() != "type_head" {
+				continue
+			}
+			if name, _ := juliaTypeHeadInfo(c, src); name != "" {
+				st.declaredTypes[juliaTypeKey(modulePath, name)] = true
+			}
+			break
+		}
 	case "module_definition":
 		if nn := n.ChildByFieldName("name"); nn != nil && nn.Content(src) != "" {
 			if modulePath == "" {
@@ -839,7 +873,7 @@ func juliaCollectImportAliases(n *sitter.Node, src []byte, modulePath string, ou
 		}
 	}
 	for c := range n.NamedChildren() {
-		juliaCollectImportAliases(c, src, modulePath, out)
+		juliaPrescan(c, src, modulePath, st)
 	}
 }
 

--- a/internal/parser/languages/julia.go
+++ b/internal/parser/languages/julia.go
@@ -154,15 +154,19 @@ func (e *JuliaExtractor) Extract(filePath string, src []byte) (*parser.Extractio
 // numbers are the only discriminator.
 func (e *JuliaExtractor) walk(n *sitter.Node, src []byte, scope juliaScope, st *juliaWalkState) {
 	// Only a few blocks can hold documentation: the file, a module body,
-	// and a begin / quote block. A string standing at the top of a
-	// FUNCTION body is ordinary executable code — Julia parses a function
-	// body with its plain expression production, never the docstring one
-	// — so a value returned from a helper must not become the doc of
-	// whatever is defined after it.
+	// and a begin / quote block outside any definition. A string standing
+	// in a FUNCTION body is ordinary executable code — Julia parses a
+	// function body with its plain expression production, never the
+	// docstring one — so a value returned from a helper must not become
+	// the doc of whatever is defined after it. The scope check matters
+	// for `quote ... end` in particular, which is how nearly every macro
+	// body is written.
 	docContext := false
 	switch n.Type() {
-	case "source_file", "module_definition", "compound_statement", "quote_statement":
+	case "source_file", "module_definition":
 		docContext = true
+	case "compound_statement", "quote_statement":
+		docContext = scope.functionID == ""
 	}
 
 	pendingDoc, pendingEnd, commentRows := "", 0, 0
@@ -222,12 +226,40 @@ func (e *JuliaExtractor) walk(n *sitter.Node, src []byte, scope juliaScope, st *
 
 		case "macrocall_expression":
 			e.handleMacroCall(c, src, scope, st)
-			e.walk(c, src, scope, st)
+			e.walkMacroArgs(c, src, scope, st, docFor(c))
 
 		default:
 			e.walk(c, src, scope, st)
 		}
 		pendingDoc, pendingEnd, commentRows = "", 0, 0
+	}
+}
+
+// walkMacroArgs walks a macro call's arguments, carrying a docstring that
+// sat above the macro CALL into the definition it wraps.
+// `Base.@kwdef struct S ... end` is a documented struct whose docstring
+// attaches to the wrapper, so stopping at the macro boundary would leave
+// the single most common documented struct form undocumented.
+func (e *JuliaExtractor) walkMacroArgs(n *sitter.Node, src []byte, scope juliaScope, st *juliaWalkState, doc string) {
+	for c := range n.NamedChildren() {
+		if doc == "" || c.Type() != "macro_argument_list" {
+			e.walk(c, src, scope, st)
+			continue
+		}
+		for a := range c.NamedChildren() {
+			switch a.Type() {
+			case "struct_definition", "abstract_definition", "primitive_definition":
+				e.handleType(a, src, scope, st, doc)
+			case "function_definition", "macro_definition":
+				e.handleFunction(a, src, scope, st, doc)
+			case "module_definition":
+				e.handleModule(a, src, scope, st, doc)
+			default:
+				e.walk(a, src, scope, st)
+				continue
+			}
+			doc = ""
+		}
 	}
 }
 

--- a/internal/parser/languages/julia.go
+++ b/internal/parser/languages/julia.go
@@ -730,11 +730,19 @@ func (e *JuliaExtractor) emitCallable(
 
 	id, minted := disambiguateID(st.seen, baseID, line)
 	if !minted {
-		// The same declaration reached twice. Leaving the scope
-		// untouched is deliberate: adopting the existing id here is
-		// what used to re-parent a shadowed definition's calls onto
-		// whichever twin was emitted first.
-		return scope
+		// Same base id AND same start line. Two shapes reach here: the
+		// same declaration walked twice, and two `;`-separated methods
+		// written on one physical line, which a line suffix cannot
+		// separate. Neither gets a second node, but the body still has
+		// to attribute its calls somewhere — dropping them loses edges
+		// the line-suffix fix was never meant to touch. Definitions on
+		// DIFFERENT lines no longer land here at all, which is where
+		// the re-parenting this guard used to cause actually mattered.
+		inner := scope
+		inner.functionID = id
+		inner.functionName = name
+		inner.functionRecv = receiver
+		return inner
 	}
 
 	node := &graph.Node{

--- a/internal/parser/languages/julia.go
+++ b/internal/parser/languages/julia.go
@@ -53,8 +53,9 @@ import (
 // `unresolved::[Mod.]name`. Unicode identifiers (θ, σ̂), bang names
 // (`foo!`), and broadcast (`f.(x)`) are native grammar forms.
 //
-// Docstrings — a string literal directly preceding a definition, or the
-// first statement of a function/module body — attach as Meta["doc"].
+// Docstrings — a string literal on the line DIRECTLY above a definition,
+// which is the adjacency Julia itself requires — attach as Meta["doc"],
+// on long and short definitions, types, modules and constants alike.
 type JuliaExtractor struct {
 	lang *sitter.Language
 }
@@ -137,61 +138,92 @@ func (e *JuliaExtractor) Extract(filePath string, src []byte) (*parser.Extractio
 }
 
 // walk iterates a node's named children, dispatching definition / import
-// / call handlers and recursing with updated scope. pendingDoc is the
-// last sibling string literal (Julia docstring convention).
+// / call handlers and recursing with updated scope.
+//
+// A string literal standing alone before a definition is that
+// definition's docstring — but only when it is IMMEDIATELY before it.
+// Julia's parser allows exactly one newline between the two, so a blank
+// line or an own-line comment detaches the string and leaves the
+// definition undocumented (the manual says so twice: "no blank lines or
+// comments may intervene"). tree-sitter gives no blank-line signal — the
+// adjacent and detached parses are structurally identical — so the line
+// numbers are the only discriminator.
 func (e *JuliaExtractor) walk(n *sitter.Node, src []byte, scope juliaScope, st *juliaWalkState) {
-	pendingDoc := ""
+	// Only a few blocks can hold documentation: the file, a module body,
+	// and a begin / quote block. A string standing at the top of a
+	// FUNCTION body is ordinary executable code — Julia parses a function
+	// body with its plain expression production, never the docstring one
+	// — so a value returned from a helper must not become the doc of
+	// whatever is defined after it.
+	docContext := false
+	switch n.Type() {
+	case "source_file", "module_definition", "compound_statement", "quote_statement":
+		docContext = true
+	}
+
+	pendingDoc, pendingEnd, commentRows := "", 0, 0
+	// docFor returns the pending docstring when it sits directly above c.
+	// Julia's lexer allows exactly one newline between a docstring and the
+	// object it documents, so a blank line detaches it. Comments are not
+	// newlines: a trailing `# note` on the docstring's own line, or a
+	// block comment that opens there, keeps the two adjacent — so the rows
+	// comments occupy are discounted from the distance.
+	docFor := func(c *sitter.Node) string {
+		if pendingDoc == "" || int(c.StartPoint().Row)-pendingEnd-commentRows > 1 {
+			return ""
+		}
+		return pendingDoc
+	}
 	for c := range n.NamedChildren() {
 		switch c.Type() {
 		case "string_literal":
-			pendingDoc = juliaDocText(c, src)
+			if docContext {
+				pendingDoc, pendingEnd, commentRows = juliaDocText(c, src), int(c.EndPoint().Row), 0
+				continue
+			}
+
+		case "line_comment", "block_comment":
+			commentRows += int(c.EndPoint().Row) - int(c.StartPoint().Row)
+			continue
 
 		case "module_definition":
-			e.handleModule(c, src, scope, st, pendingDoc)
-			pendingDoc = ""
+			e.handleModule(c, src, scope, st, docFor(c))
 
 		case "struct_definition", "abstract_definition", "primitive_definition":
-			e.handleType(c, src, scope, st, pendingDoc)
-			pendingDoc = ""
+			e.handleType(c, src, scope, st, docFor(c))
 
 		case "function_definition", "macro_definition":
-			e.handleFunction(c, src, scope, st, pendingDoc)
-			pendingDoc = ""
+			e.handleFunction(c, src, scope, st, docFor(c))
 
 		case "const_statement":
-			pendingDoc = ""
+			doc := docFor(c)
 			for a := range c.NamedChildren() {
 				if a.Type() == "assignment" {
-					e.handleAssignment(a, src, scope, st, true)
+					e.handleAssignment(a, src, scope, st, true, doc)
 				}
 			}
 
 		case "assignment":
-			e.handleAssignment(c, src, scope, st, false)
-			pendingDoc = ""
+			e.handleAssignment(c, src, scope, st, false, docFor(c))
 
 		case "using_statement", "import_statement":
 			e.handleImport(c, src, st)
-			pendingDoc = ""
 
 		case "export_statement":
 			e.handleExport(c, src, scope, st)
-			pendingDoc = ""
 
 		case "call_expression", "broadcast_call_expression":
 			e.handleCall(c, src, scope, st)
 			e.walk(c, src, scope, st)
-			pendingDoc = ""
 
 		case "macrocall_expression":
 			e.handleMacroCall(c, src, scope, st)
 			e.walk(c, src, scope, st)
-			pendingDoc = ""
 
 		default:
-			pendingDoc = ""
 			e.walk(c, src, scope, st)
 		}
+		pendingDoc, pendingEnd, commentRows = "", 0, 0
 	}
 }
 
@@ -537,18 +569,6 @@ func (e *JuliaExtractor) handleFunction(n *sitter.Node, src []byte, scope juliaS
 	if name != "" {
 		inner = e.emitCallable(n, name, receiver, doc, n.Type() == "macro_definition", scope, st)
 	}
-	// Body docstring: first body statement that is a string literal.
-	bodyDoc := ""
-	if name != "" && doc == "" {
-		if second := n.NamedChild(1); second != nil && second.Type() == "string_literal" {
-			bodyDoc = juliaDocText(second, src)
-		}
-	}
-	if bodyDoc != "" {
-		if node, ok := st.nodes[inner.functionID]; ok && node.Meta == nil {
-			node.Meta = map[string]any{"doc": bodyDoc}
-		}
-	}
 	e.walk(n, src, inner, st)
 }
 
@@ -556,7 +576,7 @@ func (e *JuliaExtractor) handleFunction(n *sitter.Node, src []byte, scope juliaS
 // short-form function definitions — the LHS is a call_expression,
 // directly or under a where_expression. `const X = ...` arrives with
 // isConst and a plain identifier LHS.
-func (e *JuliaExtractor) handleAssignment(n *sitter.Node, src []byte, scope juliaScope, st *juliaWalkState, isConst bool) {
+func (e *JuliaExtractor) handleAssignment(n *sitter.Node, src []byte, scope juliaScope, st *juliaWalkState, isConst bool, doc string) {
 	lhs := n.NamedChild(0)
 
 	// Short-form definition? The left-hand side carries the same
@@ -565,7 +585,7 @@ func (e *JuliaExtractor) handleAssignment(n *sitter.Node, src []byte, scope juli
 	// instead of unwrapping one fixed level.
 	if sig := juliaSignatureCall(lhs); sig != nil {
 		if name, receiver := juliaCalleeName(sig.NamedChild(0), src); name != "" {
-			e.emitShortFunction(n, sig, name, receiver, src, scope, st)
+			e.emitShortFunction(n, sig, name, receiver, doc, src, scope, st)
 			return
 		}
 	}
@@ -581,8 +601,15 @@ func (e *JuliaExtractor) handleAssignment(n *sitter.Node, src []byte, scope juli
 				EndLine:   int(n.EndPoint().Row) + 1,
 				Language:  "julia",
 			}
+			meta := map[string]any{}
+			if doc != "" {
+				meta["doc"] = doc
+			}
 			if scope.modulePath != "" {
-				node.Meta = map[string]any{"scope_mod": scope.modulePath}
+				meta["scope_mod"] = scope.modulePath
+			}
+			if len(meta) > 0 {
+				node.Meta = meta
 			}
 			st.result.Nodes = append(st.result.Nodes, node)
 			st.nodes[id] = node
@@ -596,8 +623,8 @@ func (e *JuliaExtractor) handleAssignment(n *sitter.Node, src []byte, scope juli
 	e.walk(n, src, scope, st)
 }
 
-func (e *JuliaExtractor) emitShortFunction(n, sig *sitter.Node, name, receiver string, src []byte, scope juliaScope, st *juliaWalkState) {
-	inner := e.emitCallable(n, name, receiver, "", false, scope, st)
+func (e *JuliaExtractor) emitShortFunction(n, sig *sitter.Node, name, receiver, doc string, src []byte, scope juliaScope, st *juliaWalkState) {
+	inner := e.emitCallable(n, name, receiver, doc, false, scope, st)
 	e.walk(n, src, inner, st)
 }
 
@@ -975,14 +1002,44 @@ func (e *JuliaExtractor) handleMacroCall(n *sitter.Node, src []byte, scope julia
 	}
 }
 
-// juliaDocText normalises a docstring string literal: strips quotes and
-// collapses to the first paragraph.
+// juliaDocText normalises a docstring literal down to its first prose
+// paragraph. Julia's own documentation convention opens a docstring with
+// the signature, indented by four spaces, then a blank line, then the
+// description — so taking the first paragraph blindly stores "radius(c)"
+// as the documentation of `radius`. Leading paragraphs whose every line
+// is indented are that signature block and are skipped.
 func juliaDocText(n *sitter.Node, src []byte) string {
-	s := juliaUnquote(n.Content(src))
-	if i := strings.Index(s, "\n\n"); i > 0 {
-		s = s[:i]
+	s := strings.TrimSpace(n.Content(src))
+	if strings.HasPrefix(s, `"""`) {
+		s = strings.TrimSuffix(strings.TrimPrefix(s, `"""`), `"""`)
+	} else {
+		s = strings.TrimSuffix(strings.TrimPrefix(s, `"`), `"`)
 	}
-	return strings.TrimSpace(s)
+	for {
+		s = strings.TrimLeft(s, "\n")
+		para, rest, found := strings.Cut(s, "\n\n")
+		if !found || !juliaIndentedParagraph(para) {
+			return strings.TrimSpace(para)
+		}
+		s = rest
+	}
+}
+
+// juliaIndentedParagraph reports whether every non-empty line of a
+// paragraph is indented — the shape of the signature block a Julia
+// docstring conventionally opens with.
+func juliaIndentedParagraph(p string) bool {
+	indented := false
+	for _, line := range strings.Split(p, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
+			return false
+		}
+		indented = true
+	}
+	return indented
 }
 
 func juliaUnquote(s string) string {

--- a/internal/parser/languages/julia.go
+++ b/internal/parser/languages/julia.go
@@ -1,148 +1,742 @@
 package languages
 
 import (
-	"regexp"
 	"strings"
 
+	juliaforest "github.com/alexaandru/go-sitter-forest/julia"
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/parser"
+	sitter "github.com/zzet/gortex/internal/parser/tsitter"
 )
 
-// Julia has an explicit `end`-terminated block structure for functions
-// and modules plus a short one-line form `name(args) = body`. We cover
-// both forms, struct / abstract type / primitive type declarations,
-// macros, and the three import statements (`import`, `using`,
-// `include(...)`).
-var (
-	juliaFuncRe      = regexp.MustCompile(`(?m)^\s*function\s+(\w+)`)
-	juliaShortFuncRe = regexp.MustCompile(`(?m)^\s*(\w+)\s*\([^)]*\)\s*=[^=]`)
-	juliaStructRe    = regexp.MustCompile(`(?m)^\s*(?:mutable\s+)?struct\s+(\w+)`)
-	juliaAbstractRe  = regexp.MustCompile(`(?m)^\s*(?:abstract|primitive)\s+type\s+(\w+)`)
-	juliaModuleRe    = regexp.MustCompile(`(?m)^\s*(?:bare)?module\s+(\w+)`)
-	juliaMacroRe     = regexp.MustCompile(`(?m)^\s*macro\s+(\w+)`)
-	juliaImportRe    = regexp.MustCompile(`(?m)^\s*(?:import|using)\s+([\w.]+)`)
-	juliaIncludeRe   = regexp.MustCompile(`\binclude\s*\(\s*"([^"]+)"\s*\)`)
-	juliaCallRe      = regexp.MustCompile(`\b([A-Za-z_]\w*)\s*\(`)
-)
+// JuliaExtractor extracts Julia source through the tree-sitter-julia
+// grammar (vendored via alexaandru/go-sitter-forest), replacing the
+// original line-regex extractor.
+//
+// Covered definition forms:
+//   - `function f(...) ... end`, including `where`-parametrised
+//     signatures and qualified/ operator callees (`function Base.show`,
+//     `function Base.:+`)
+//   - short-form definitions `f(x) = body` and `f(x)::T where T = body`,
+//     including nested closures inside `begin` blocks
+//   - `macro m(...) ... end`
+//   - `struct` / `mutable struct` / `abstract type` / `primitive type`
+//     with parametric names (`struct Pair{T,S}`) and supertypes
+//     (`<: Living` → EdgeExtends), plus struct fields (KindField)
+//   - `module` / `baremodule` — KindType node whose Meta carries the
+//     module's `export` list; definitions inside get EdgeMemberOf
+//   - `const X = ...` constants (KindVariable)
+//
+// Imports: `using M`, `using M: a, b` (selected names in edge Meta),
+// `import M`, `import M as Alias` (alias in edge Meta), dotted import
+// paths, and `include("file.jl")` — all as EdgeImports to
+// `unresolved::import::<path>`.
+//
+// Calls: call_expression / broadcast_call_expression / macrocall
+// callees (identifier or qualified field_expression) attribute to the
+// enclosing function-like definition as EdgeCalls to
+// `unresolved::[Mod.]name`. Unicode identifiers (θ, σ̂), bang names
+// (`foo!`), and broadcast (`f.(x)`) are native grammar forms.
+//
+// Docstrings — a string literal directly preceding a definition, or the
+// first statement of a function/module body — attach as Meta["doc"].
+type JuliaExtractor struct {
+	lang *sitter.Language
+}
 
-// JuliaExtractor extracts Julia source using regex.
-type JuliaExtractor struct{}
-
-func NewJuliaExtractor() *JuliaExtractor { return &JuliaExtractor{} }
+func NewJuliaExtractor() *JuliaExtractor {
+	return &JuliaExtractor{lang: sitter.NewLanguage(juliaforest.GetLanguage())}
+}
 
 func (e *JuliaExtractor) Language() string     { return "julia" }
 func (e *JuliaExtractor) Extensions() []string { return []string{".jl"} }
 
+// juliaScope carries the enclosing context down the walk: the innermost
+// module (for EdgeMemberOf and export attachment) and the innermost
+// function-like definition (for call attribution).
+type juliaScope struct {
+	moduleID     string
+	functionID   string
+	functionName string
+	functionRecv string
+}
+
+type juliaWalkState struct {
+	filePath string
+	fileNode *graph.Node
+	result   *parser.ExtractionResult
+	seen     map[string]bool
+	nodes    map[string]*graph.Node
+}
+
 func (e *JuliaExtractor) Extract(filePath string, src []byte) (*parser.ExtractionResult, error) {
-	lines := strings.Split(string(src), "\n")
+	tree, err := parser.ParseFile(src, e.lang)
+	if err != nil {
+		return nil, err
+	}
+	defer tree.Close()
+
+	root := tree.RootNode()
 	result := &parser.ExtractionResult{}
 
 	fileNode := &graph.Node{
 		ID: filePath, Kind: graph.KindFile, Name: filePath,
-		FilePath: filePath, StartLine: 1, EndLine: len(lines),
+		FilePath: filePath, StartLine: 1, EndLine: int(root.EndPoint().Row) + 1,
 		Language: "julia",
 	}
 	result.Nodes = append(result.Nodes, fileNode)
 
-	seen := make(map[string]bool)
-	add := func(name string, kind graph.NodeKind, start, end int) {
-		if name == "" || isJuliaKeyword(name) {
-			return
-		}
-		id := filePath + "::" + name
-		if seen[id] {
-			return
-		}
-		seen[id] = true
-		result.Nodes = append(result.Nodes, &graph.Node{
-			ID: id, Kind: kind, Name: name,
-			FilePath: filePath, StartLine: start, EndLine: end,
-			Language: "julia",
-		})
-		result.Edges = append(result.Edges, &graph.Edge{
-			From: fileNode.ID, To: id, Kind: graph.EdgeDefines,
-			FilePath: filePath, Line: start,
-		})
+	st := &juliaWalkState{
+		filePath: filePath,
+		fileNode: fileNode,
+		result:   result,
+		seen:     make(map[string]bool),
+		nodes:    map[string]*graph.Node{filePath: fileNode},
 	}
-
-	for _, m := range juliaModuleRe.FindAllSubmatchIndex(src, -1) {
-		name := string(src[m[2]:m[3]])
-		line := lineAt(src, m[0])
-		add(name, graph.KindType, line, findKeywordBlockEnd(lines, line, "end"))
-	}
-	for _, m := range juliaStructRe.FindAllSubmatchIndex(src, -1) {
-		name := string(src[m[2]:m[3]])
-		line := lineAt(src, m[0])
-		add(name, graph.KindType, line, findKeywordBlockEnd(lines, line, "end"))
-	}
-	for _, m := range juliaAbstractRe.FindAllSubmatchIndex(src, -1) {
-		name := string(src[m[2]:m[3]])
-		line := lineAt(src, m[0])
-		add(name, graph.KindType, line, line)
-	}
-	for _, m := range juliaFuncRe.FindAllSubmatchIndex(src, -1) {
-		name := string(src[m[2]:m[3]])
-		line := lineAt(src, m[0])
-		add(name, graph.KindFunction, line, findKeywordBlockEnd(lines, line, "end"))
-	}
-	for _, m := range juliaMacroRe.FindAllSubmatchIndex(src, -1) {
-		name := string(src[m[2]:m[3]])
-		line := lineAt(src, m[0])
-		add(name, graph.KindFunction, line, findKeywordBlockEnd(lines, line, "end"))
-	}
-	for _, m := range juliaShortFuncRe.FindAllSubmatchIndex(src, -1) {
-		name := string(src[m[2]:m[3]])
-		line := lineAt(src, m[0])
-		add(name, graph.KindFunction, line, line)
-	}
-
-	for _, m := range juliaImportRe.FindAllSubmatchIndex(src, -1) {
-		mod := string(src[m[2]:m[3]])
-		line := lineAt(src, m[0])
-		result.Edges = append(result.Edges, &graph.Edge{
-			From: fileNode.ID, To: "unresolved::import::" + mod,
-			Kind: graph.EdgeImports, FilePath: filePath, Line: line,
-		})
-	}
-	for _, m := range juliaIncludeRe.FindAllSubmatchIndex(src, -1) {
-		path := string(src[m[2]:m[3]])
-		line := lineAt(src, m[0])
-		result.Edges = append(result.Edges, &graph.Edge{
-			From: fileNode.ID, To: "unresolved::import::" + path,
-			Kind: graph.EdgeImports, FilePath: filePath, Line: line,
-		})
-	}
-
-	funcRanges := buildFuncRanges(result)
-	for _, m := range juliaCallRe.FindAllSubmatchIndex(src, -1) {
-		name := string(src[m[2]:m[3]])
-		if isJuliaKeyword(name) || name == "include" {
-			continue
-		}
-		line := lineAt(src, m[0])
-		callerID := findEnclosingFunc(funcRanges, line)
-		if callerID == "" || strings.HasSuffix(callerID, "::"+name) {
-			continue
-		}
-		result.Edges = append(result.Edges, &graph.Edge{
-			From: callerID, To: "unresolved::" + name,
-			Kind: graph.EdgeCalls, FilePath: filePath, Line: line,
-		})
-	}
-
+	e.walk(root, src, juliaScope{}, st)
 	return result, nil
 }
 
-func isJuliaKeyword(s string) bool {
-	switch s {
-	case "if", "else", "elseif", "end", "for", "while", "do", "break", "continue",
-		"return", "function", "macro", "module", "baremodule", "struct", "mutable",
-		"abstract", "primitive", "type", "import", "using", "export", "let",
-		"local", "global", "const", "begin", "try", "catch", "finally", "throw",
-		"where", "in", "isa", "true", "false", "nothing", "missing":
-		return true
+// walk iterates a node's named children, dispatching definition / import
+// / call handlers and recursing with updated scope. pendingDoc is the
+// last sibling string literal (Julia docstring convention).
+func (e *JuliaExtractor) walk(n *sitter.Node, src []byte, scope juliaScope, st *juliaWalkState) {
+	pendingDoc := ""
+	for c := range n.NamedChildren() {
+		switch c.Type() {
+		case "string_literal":
+			pendingDoc = juliaDocText(c, src)
+
+		case "module_definition":
+			e.handleModule(c, src, scope, st, pendingDoc)
+			pendingDoc = ""
+
+		case "struct_definition", "abstract_definition", "primitive_definition":
+			e.handleType(c, src, scope, st, pendingDoc)
+			pendingDoc = ""
+
+		case "function_definition", "macro_definition":
+			e.handleFunction(c, src, scope, st, pendingDoc)
+			pendingDoc = ""
+
+		case "const_statement":
+			pendingDoc = ""
+			for a := range c.NamedChildren() {
+				if a.Type() == "assignment" {
+					e.handleAssignment(a, src, scope, st, true)
+				}
+			}
+
+		case "assignment":
+			e.handleAssignment(c, src, scope, st, false)
+			pendingDoc = ""
+
+		case "using_statement", "import_statement":
+			e.handleImport(c, src, st)
+			pendingDoc = ""
+
+		case "export_statement":
+			e.handleExport(c, src, scope, st)
+			pendingDoc = ""
+
+		case "call_expression", "broadcast_call_expression":
+			e.handleCall(c, src, scope, st)
+			e.walk(c, src, scope, st)
+			pendingDoc = ""
+
+		case "macrocall_expression":
+			e.handleMacroCall(c, src, scope, st)
+			e.walk(c, src, scope, st)
+			pendingDoc = ""
+
+		default:
+			pendingDoc = ""
+			e.walk(c, src, scope, st)
+		}
 	}
-	return false
+}
+
+// handleModule emits the module as a KindType node (legacy mapping;
+// graph.KindModule is reserved for ecosystem packages) and walks its
+// body with the module scope pushed.
+func (e *JuliaExtractor) handleModule(n *sitter.Node, src []byte, scope juliaScope, st *juliaWalkState, doc string) {
+	name := ""
+	if nn := n.ChildByFieldName("name"); nn != nil {
+		name = nn.Content(src)
+	}
+	inner := scope
+	if name != "" {
+		id := st.filePath + "::" + name
+		if !st.seen[id] {
+			st.seen[id] = true
+			node := &graph.Node{
+				ID: id, Kind: graph.KindType, Name: name,
+				FilePath:  st.filePath,
+				StartLine: int(n.StartPoint().Row) + 1,
+				EndLine:   int(n.EndPoint().Row) + 1,
+				Language:  "julia",
+			}
+			if doc != "" {
+				node.Meta = map[string]any{"doc": doc}
+			}
+			st.result.Nodes = append(st.result.Nodes, node)
+			st.nodes[id] = node
+			st.result.Edges = append(st.result.Edges, &graph.Edge{
+				From: st.fileNode.ID, To: id, Kind: graph.EdgeDefines,
+				FilePath: st.filePath, Line: int(n.StartPoint().Row) + 1,
+			})
+		}
+		inner.moduleID = id
+	}
+	e.walk(n, src, inner, st)
+}
+
+// juliaTypeHeadInfo decodes a `type_head` child: the declared name
+// (inside identifier / parametrized_type_expression / the lhs of the
+// `<:` binary_expression), its type parameters, and the supertype text.
+func juliaTypeHeadInfo(head *sitter.Node, src []byte) (name, super string, params []string) {
+	if head == nil || head.Type() != "type_head" {
+		return "", "", nil
+	}
+	c := head.NamedChild(0)
+	if c == nil {
+		return "", "", nil
+	}
+	if c.Type() == "binary_expression" {
+		// Named children are [lhs, operator, rhs] — the operator is a
+		// named node in this grammar, so address by position, not index 1.
+		lhs := c.NamedChild(0)
+		rhs := c.NamedChild(int(c.NamedChildCount()) - 1)
+		if lhs != nil {
+			name, params = juliaNameAndParams(lhs, src)
+		}
+		if rhs != nil && rhs.Type() != "operator" {
+			super = rhs.Content(src)
+		}
+		return name, super, params
+	}
+	name, params = juliaNameAndParams(c, src)
+	return name, "", params
+}
+
+// juliaNameAndParams extracts name + type parameters from an identifier
+// or a parametrized_type_expression (`Pair{T,S}`).
+func juliaNameAndParams(n *sitter.Node, src []byte) (string, []string) {
+	if n == nil {
+		return "", nil
+	}
+	switch n.Type() {
+	case "identifier":
+		return n.Content(src), nil
+	case "parametrized_type_expression":
+		var params []string
+		name := ""
+		for c := range n.NamedChildren() {
+			switch c.Type() {
+			case "identifier":
+				if name == "" {
+					name = c.Content(src)
+				}
+			case "curly_expression":
+				for g := range c.NamedChildren() {
+					if g.Type() == "identifier" {
+						params = append(params, g.Content(src))
+					}
+				}
+			}
+		}
+		return name, params
+	}
+	return "", nil
+}
+
+// handleType covers struct / mutable struct / abstract type /
+// primitive type: KindType node, EdgeExtends for the supertype (bare
+// name target + full path in Meta, matching the python extractor
+// convention), KindField nodes for struct members, and EdgeMemberOf for
+// definitions nested inside.
+func (e *JuliaExtractor) handleType(n *sitter.Node, src []byte, scope juliaScope, st *juliaWalkState, doc string) {
+	var head *sitter.Node
+	for c := range n.NamedChildren() {
+		if c.Type() == "type_head" {
+			head = c
+			break
+		}
+	}
+	name, super, _ := juliaTypeHeadInfo(head, src)
+	if name == "" {
+		e.walk(n, src, scope, st)
+		return
+	}
+
+	id := st.filePath + "::" + name
+	if !st.seen[id] {
+		st.seen[id] = true
+		node := &graph.Node{
+			ID: id, Kind: graph.KindType, Name: name,
+			FilePath:  st.filePath,
+			StartLine: int(n.StartPoint().Row) + 1,
+			EndLine:   int(n.EndPoint().Row) + 1,
+			Language:  "julia",
+		}
+		if doc != "" {
+			node.Meta = map[string]any{"doc": doc}
+		}
+		st.result.Nodes = append(st.result.Nodes, node)
+		st.nodes[id] = node
+		st.result.Edges = append(st.result.Edges, &graph.Edge{
+			From: st.fileNode.ID, To: id, Kind: graph.EdgeDefines,
+			FilePath: st.filePath, Line: int(n.StartPoint().Row) + 1,
+		})
+		if super != "" {
+			bare := super
+			if idx := strings.IndexAny(bare, "{"); idx > 0 {
+				bare = bare[:idx]
+			}
+			edge := &graph.Edge{
+				From: id, To: "unresolved::" + bare, Kind: graph.EdgeExtends,
+				FilePath: st.filePath, Line: int(n.StartPoint().Row) + 1,
+			}
+			if super != bare {
+				edge.Meta = map[string]any{"base_path": super}
+			}
+			st.result.Edges = append(st.result.Edges, edge)
+		}
+		if scope.moduleID != "" {
+			st.result.Edges = append(st.result.Edges, &graph.Edge{
+				From: id, To: scope.moduleID, Kind: graph.EdgeMemberOf,
+				FilePath: st.filePath, Line: int(n.StartPoint().Row) + 1,
+			})
+		}
+	}
+
+	// Struct fields: typed_expression (`x::T`) or bare identifier
+	// members at the top level of the struct body.
+	if n.Type() == "struct_definition" {
+		for c := range n.NamedChildren() {
+			if c.Type() == "type_head" {
+				continue
+			}
+			var fieldName string
+			switch c.Type() {
+			case "typed_expression":
+				if lhs := c.NamedChild(0); lhs != nil && lhs.Type() == "identifier" {
+					fieldName = lhs.Content(src)
+				}
+			case "identifier":
+				fieldName = c.Content(src)
+			}
+			if fieldName == "" {
+				continue
+			}
+			fid := id + "." + fieldName
+			if st.seen[fid] {
+				continue
+			}
+			st.seen[fid] = true
+			st.result.Nodes = append(st.result.Nodes, &graph.Node{
+				ID: fid, Kind: graph.KindField, Name: fieldName,
+				FilePath:  st.filePath,
+				StartLine: int(c.StartPoint().Row) + 1,
+				EndLine:   int(c.EndPoint().Row) + 1,
+				Language:  "julia",
+			})
+			st.result.Edges = append(st.result.Edges, &graph.Edge{
+				From: fid, To: id, Kind: graph.EdgeMemberOf,
+				FilePath: st.filePath, Line: int(c.StartPoint().Row) + 1,
+			})
+		}
+	}
+
+	e.walk(n, src, scope, st)
+}
+
+// juliaCalleeName decodes a call callee: bare identifier or qualified
+// field_expression (`Base.show`, `Base.:+`). Returns name, receiver.
+func juliaCalleeName(n *sitter.Node, src []byte) (name, receiver string) {
+	if n == nil {
+		return "", ""
+	}
+	switch n.Type() {
+	case "identifier":
+		return n.Content(src), ""
+	case "field_expression":
+		full := n.Content(src)
+		idx := strings.LastIndex(full, ".")
+		if idx <= 0 {
+			return strings.TrimPrefix(full, ":"), ""
+		}
+		receiver = full[:idx]
+		name = strings.TrimPrefix(full[idx+1:], ":") // Base.:+ → +
+		return name, receiver
+	case "quote_expression": // bare operator callee, e.g. `:+`
+		if inner := n.NamedChild(0); inner != nil {
+			return inner.Content(src), ""
+		}
+	}
+	return "", ""
+}
+
+// juliaUnwrapSignature returns the call_expression behind a `signature`
+// node, descending through `where_expression`.
+func juliaUnwrapSignature(sig *sitter.Node) *sitter.Node {
+	if sig == nil {
+		return nil
+	}
+	c := sig
+	if c.Type() == "signature" {
+		c = c.NamedChild(0)
+	}
+	if c == nil {
+		return nil
+	}
+	if c.Type() == "where_expression" {
+		c = c.NamedChild(0)
+	}
+	if c != nil && c.Type() == "call_expression" {
+		return c
+	}
+	return nil
+}
+
+// handleFunction covers `function f(...) end` and `macro m(...) end`.
+// The grammar has no named fields here: the first named child is the
+// `signature` wrapping the callee call_expression (optionally inside a
+// where_expression). Qualified callees become KindMethod with
+// Meta["receiver"] + EdgeMemberOf, mirroring the luau extractor.
+func (e *JuliaExtractor) handleFunction(n *sitter.Node, src []byte, scope juliaScope, st *juliaWalkState, doc string) {
+	call := juliaUnwrapSignature(n.NamedChild(0))
+	name, receiver := "", ""
+	if call != nil {
+		name, receiver = juliaCalleeName(call.NamedChild(0), src)
+	}
+
+	inner := scope
+	if name != "" {
+		kind := graph.KindFunction
+		id := st.filePath + "::" + name
+		if receiver != "" {
+			kind = graph.KindMethod
+			id = st.filePath + "::" + receiver + "." + name
+		}
+		if !st.seen[id] {
+			st.seen[id] = true
+			node := &graph.Node{
+				ID: id, Kind: kind, Name: name,
+				FilePath:  st.filePath,
+				StartLine: int(n.StartPoint().Row) + 1,
+				EndLine:   int(n.EndPoint().Row) + 1,
+				Language:  "julia",
+			}
+			meta := map[string]any{}
+			if receiver != "" {
+				meta["receiver"] = receiver
+			}
+			if n.Type() == "macro_definition" {
+				meta["macro"] = true
+			}
+			if doc != "" {
+				meta["doc"] = doc
+			}
+			if len(meta) > 0 {
+				node.Meta = meta
+			}
+			st.result.Nodes = append(st.result.Nodes, node)
+			st.nodes[id] = node
+			st.result.Edges = append(st.result.Edges, &graph.Edge{
+				From: st.fileNode.ID, To: id, Kind: graph.EdgeDefines,
+				FilePath: st.filePath, Line: int(n.StartPoint().Row) + 1,
+			})
+			if receiver != "" {
+				st.result.Edges = append(st.result.Edges, &graph.Edge{
+					From: id, To: st.filePath + "::" + receiver, Kind: graph.EdgeMemberOf,
+					FilePath: st.filePath, Line: int(n.StartPoint().Row) + 1,
+				})
+			}
+			if scope.moduleID != "" {
+				st.result.Edges = append(st.result.Edges, &graph.Edge{
+					From: id, To: scope.moduleID, Kind: graph.EdgeMemberOf,
+					FilePath: st.filePath, Line: int(n.StartPoint().Row) + 1,
+				})
+			}
+		}
+		inner.functionID = id
+		inner.functionName = name
+		inner.functionRecv = receiver
+	}
+	// Body docstring: first body statement that is a string literal.
+	bodyDoc := ""
+	if name != "" && doc == "" {
+		if second := n.NamedChild(1); second != nil && second.Type() == "string_literal" {
+			bodyDoc = juliaDocText(second, src)
+		}
+	}
+	if bodyDoc != "" {
+		if node, ok := st.nodes[inner.functionID]; ok && node.Meta == nil {
+			node.Meta = map[string]any{"doc": bodyDoc}
+		}
+	}
+	e.walk(n, src, inner, st)
+}
+
+// handleAssignment: `f(x) = body` (and `f(x) where T = body`) are
+// short-form function definitions — the LHS is a call_expression,
+// directly or under a where_expression. `const X = ...` arrives with
+// isConst and a plain identifier LHS.
+func (e *JuliaExtractor) handleAssignment(n *sitter.Node, src []byte, scope juliaScope, st *juliaWalkState, isConst bool) {
+	lhs := n.NamedChild(0)
+
+	// Short-form definition?
+	sig := lhs
+	if sig != nil && sig.Type() == "where_expression" {
+		sig = sig.NamedChild(0)
+	}
+	if sig != nil && sig.Type() == "call_expression" {
+		if name, receiver := juliaCalleeName(sig.NamedChild(0), src); name != "" {
+			e.emitShortFunction(n, sig, name, receiver, src, scope, st)
+			return
+		}
+	}
+
+	if isConst && lhs != nil && lhs.Type() == "identifier" {
+		name := lhs.Content(src)
+		id := st.filePath + "::" + name
+		if !st.seen[id] {
+			st.seen[id] = true
+			st.result.Nodes = append(st.result.Nodes, &graph.Node{
+				ID: id, Kind: graph.KindVariable, Name: name,
+				FilePath:  st.filePath,
+				StartLine: int(n.StartPoint().Row) + 1,
+				EndLine:   int(n.EndPoint().Row) + 1,
+				Language:  "julia",
+			})
+			st.result.Edges = append(st.result.Edges, &graph.Edge{
+				From: st.fileNode.ID, To: id, Kind: graph.EdgeDefines,
+				FilePath: st.filePath, Line: int(n.StartPoint().Row) + 1,
+			})
+		}
+	}
+
+	e.walk(n, src, scope, st)
+}
+
+func (e *JuliaExtractor) emitShortFunction(n, sig *sitter.Node, name, receiver string, src []byte, scope juliaScope, st *juliaWalkState) {
+	kind := graph.KindFunction
+	id := st.filePath + "::" + name
+	if receiver != "" {
+		kind = graph.KindMethod
+		id = st.filePath + "::" + receiver + "." + name
+	}
+	if !st.seen[id] {
+		st.seen[id] = true
+		node := &graph.Node{
+			ID: id, Kind: kind, Name: name,
+			FilePath:  st.filePath,
+			StartLine: int(n.StartPoint().Row) + 1,
+			EndLine:   int(n.EndPoint().Row) + 1,
+			Language:  "julia",
+		}
+		if receiver != "" {
+			node.Meta = map[string]any{"receiver": receiver}
+		}
+		st.result.Nodes = append(st.result.Nodes, node)
+		st.nodes[id] = node
+		st.result.Edges = append(st.result.Edges, &graph.Edge{
+			From: st.fileNode.ID, To: id, Kind: graph.EdgeDefines,
+			FilePath: st.filePath, Line: int(n.StartPoint().Row) + 1,
+		})
+		if receiver != "" {
+			st.result.Edges = append(st.result.Edges, &graph.Edge{
+				From: id, To: st.filePath + "::" + receiver, Kind: graph.EdgeMemberOf,
+				FilePath: st.filePath, Line: int(n.StartPoint().Row) + 1,
+			})
+		}
+		if scope.moduleID != "" {
+			st.result.Edges = append(st.result.Edges, &graph.Edge{
+				From: id, To: scope.moduleID, Kind: graph.EdgeMemberOf,
+				FilePath: st.filePath, Line: int(n.StartPoint().Row) + 1,
+			})
+		}
+	}
+	inner := scope
+	inner.functionID = id
+	inner.functionName = name
+	inner.functionRecv = receiver
+	e.walk(n, src, inner, st)
+}
+
+// handleImport covers `using M`, `using M: a, b`, `import M`,
+// `import M as Alias`, and dotted import paths. Selected names and
+// aliases ride on the edge Meta for the resolver to consume.
+func (e *JuliaExtractor) handleImport(n *sitter.Node, src []byte, st *juliaWalkState) {
+	emit := func(target string, meta map[string]any) {
+		if target == "" {
+			return
+		}
+		st.result.Edges = append(st.result.Edges, &graph.Edge{
+			From: st.fileNode.ID, To: "unresolved::import::" + target,
+			Kind:     graph.EdgeImports,
+			FilePath: st.filePath, Line: int(n.StartPoint().Row) + 1,
+			Meta: meta,
+		})
+	}
+	for c := range n.NamedChildren() {
+		switch c.Type() {
+		case "identifier":
+			emit(c.Content(src), nil)
+		case "import_path":
+			emit(c.Content(src), nil)
+		case "selected_import":
+			module, names := "", []string{}
+			for s := range c.NamedChildren() {
+				if s.Type() == "identifier" {
+					if module == "" {
+						module = s.Content(src)
+					} else {
+						names = append(names, s.Content(src))
+					}
+				}
+			}
+			meta := map[string]any{}
+			if len(names) > 0 {
+				meta["names"] = names
+			}
+			emit(module, meta)
+		case "import_alias":
+			path, alias := "", ""
+			for a := range c.NamedChildren() {
+				if a.Type() != "identifier" {
+					continue
+				}
+				if path == "" {
+					path = a.Content(src)
+				} else {
+					alias = a.Content(src)
+				}
+			}
+			meta := map[string]any{}
+			if alias != "" {
+				meta["alias"] = alias
+			}
+			emit(path, meta)
+		}
+	}
+}
+
+// handleExport records the module's public surface on the enclosing
+// module node's Meta (Julia export lists are only meaningful inside
+// modules).
+func (e *JuliaExtractor) handleExport(n *sitter.Node, src []byte, scope juliaScope, st *juliaWalkState) {
+	if scope.moduleID == "" {
+		return
+	}
+	node, ok := st.nodes[scope.moduleID]
+	if !ok {
+		return
+	}
+	names := []string{}
+	for c := range n.NamedChildren() {
+		if c.Type() == "identifier" {
+			names = append(names, c.Content(src))
+		}
+	}
+	if len(names) == 0 {
+		return
+	}
+	if node.Meta == nil {
+		node.Meta = map[string]any{}
+	}
+	prev, _ := node.Meta["exports"].([]string)
+	node.Meta["exports"] = append(prev, names...)
+}
+
+// handleCall emits EdgeCalls from the enclosing function to the callee
+// (bare or qualified). `include("f.jl")` becomes an import edge instead,
+// preserving the legacy extractor's contract.
+func (e *JuliaExtractor) handleCall(n *sitter.Node, src []byte, scope juliaScope, st *juliaWalkState) {
+	callee := n.NamedChild(0)
+	name, receiver := juliaCalleeName(callee, src)
+	if name == "" {
+		return
+	}
+	if name == "include" && receiver == "" {
+		if args := n.NamedChild(1); args != nil && args.Type() == "argument_list" {
+			if lit := args.NamedChild(0); lit != nil && lit.Type() == "string_literal" {
+				st.result.Edges = append(st.result.Edges, &graph.Edge{
+					From:     st.fileNode.ID,
+					To:       "unresolved::import::" + juliaUnquote(lit.Content(src)),
+					Kind:     graph.EdgeImports,
+					FilePath: st.filePath, Line: int(n.StartPoint().Row) + 1,
+				})
+			}
+		}
+		return
+	}
+	if scope.functionID == "" {
+		return
+	}
+	if scope.functionName == name && scope.functionRecv == receiver {
+		return // direct recursion
+	}
+	target := name
+	if receiver != "" {
+		target = receiver + "." + name
+	}
+	meta := map[string]any{}
+	if n.Type() == "broadcast_call_expression" {
+		meta["broadcast"] = true
+	}
+	edge := &graph.Edge{
+		From: scope.functionID, To: "unresolved::" + target,
+		Kind:     graph.EdgeCalls,
+		FilePath: st.filePath, Line: int(n.StartPoint().Row) + 1,
+	}
+	if len(meta) > 0 {
+		edge.Meta = meta
+	}
+	st.result.Edges = append(st.result.Edges, edge)
+}
+
+// handleMacroCall attributes `@macroname ...` invocations to the
+// enclosing function as calls to the bare macro name.
+func (e *JuliaExtractor) handleMacroCall(n *sitter.Node, src []byte, scope juliaScope, st *juliaWalkState) {
+	if scope.functionID == "" {
+		return
+	}
+	for c := range n.NamedChildren() {
+		if c.Type() != "macro_identifier" {
+			continue
+		}
+		for m := range c.NamedChildren() {
+			if m.Type() == "identifier" {
+				st.result.Edges = append(st.result.Edges, &graph.Edge{
+					From: scope.functionID, To: "unresolved::" + m.Content(src),
+					Kind:     graph.EdgeCalls,
+					Meta:     map[string]any{"macro": true},
+					FilePath: st.filePath, Line: int(n.StartPoint().Row) + 1,
+				})
+			}
+		}
+	}
+}
+
+// juliaDocText normalises a docstring string literal: strips quotes and
+// collapses to the first paragraph.
+func juliaDocText(n *sitter.Node, src []byte) string {
+	s := juliaUnquote(n.Content(src))
+	if i := strings.Index(s, "\n\n"); i > 0 {
+		s = s[:i]
+	}
+	return strings.TrimSpace(s)
+}
+
+func juliaUnquote(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "\"\"\"")
+	s = strings.TrimSuffix(s, "\"\"\"")
+	s = strings.TrimPrefix(s, "\"")
+	s = strings.TrimSuffix(s, "\"")
+	return strings.TrimSpace(s)
 }
 
 var _ parser.Extractor = (*JuliaExtractor)(nil)

--- a/internal/parser/languages/julia.go
+++ b/internal/parser/languages/julia.go
@@ -302,14 +302,22 @@ func (st *juliaWalkState) lookupType(modulePath, name string) (id, declared stri
 
 // juliaTypeHeadInfo decodes a `type_head` child: the declared name
 // (inside identifier / parametrized_type_expression / the lhs of the
-// `<:` binary_expression), its type parameters, and the supertype text.
-func juliaTypeHeadInfo(head *sitter.Node, src []byte) (name, super string, params []string) {
+// `<:` binary_expression) and the supertype text.
+//
+// Type parameters are deliberately not collected. The house key for them
+// is Node.Meta["type_params"], whose readers are language-gated (the Go
+// generic-instantiation lookup and the Rust scope index), and whose
+// []map[string]string shape falls outside the store's flat meta codec —
+// so stamping it here would spill every parametric type node's metadata
+// into the JSON fallback to feed nothing. The supertype's own parameters
+// are already preserved on the extends edge as Meta["base_path"].
+func juliaTypeHeadInfo(head *sitter.Node, src []byte) (name, super string) {
 	if head == nil || head.Type() != "type_head" {
-		return "", "", nil
+		return "", ""
 	}
 	c := head.NamedChild(0)
 	if c == nil {
-		return "", "", nil
+		return "", ""
 	}
 	if c.Type() == "binary_expression" {
 		// Named children are [lhs, operator, rhs] — the operator is a
@@ -317,46 +325,33 @@ func juliaTypeHeadInfo(head *sitter.Node, src []byte) (name, super string, param
 		lhs := c.NamedChild(0)
 		rhs := c.NamedChild(int(c.NamedChildCount()) - 1)
 		if lhs != nil {
-			name, params = juliaNameAndParams(lhs, src)
+			name = juliaTypeHeadName(lhs, src)
 		}
 		if rhs != nil && rhs.Type() != "operator" {
 			super = rhs.Content(src)
 		}
-		return name, super, params
+		return name, super
 	}
-	name, params = juliaNameAndParams(c, src)
-	return name, "", params
+	return juliaTypeHeadName(c, src), ""
 }
 
-// juliaNameAndParams extracts name + type parameters from an identifier
-// or a parametrized_type_expression (`Pair{T,S}`).
-func juliaNameAndParams(n *sitter.Node, src []byte) (string, []string) {
+// juliaTypeHeadName extracts the declared name from an identifier or a
+// parametrized_type_expression (`Pair{T,S}` → `Pair`).
+func juliaTypeHeadName(n *sitter.Node, src []byte) string {
 	if n == nil {
-		return "", nil
+		return ""
 	}
 	switch n.Type() {
 	case "identifier":
-		return n.Content(src), nil
+		return n.Content(src)
 	case "parametrized_type_expression":
-		var params []string
-		name := ""
 		for c := range n.NamedChildren() {
-			switch c.Type() {
-			case "identifier":
-				if name == "" {
-					name = c.Content(src)
-				}
-			case "curly_expression":
-				for g := range c.NamedChildren() {
-					if g.Type() == "identifier" {
-						params = append(params, g.Content(src))
-					}
-				}
+			if c.Type() == "identifier" {
+				return c.Content(src)
 			}
 		}
-		return name, params
 	}
-	return "", nil
+	return ""
 }
 
 // juliaFieldName returns the field a direct struct member declares, or ""
@@ -403,7 +398,7 @@ func (e *JuliaExtractor) handleType(n *sitter.Node, src []byte, scope juliaScope
 			break
 		}
 	}
-	name, super, _ := juliaTypeHeadInfo(head, src)
+	name, super := juliaTypeHeadInfo(head, src)
 	if name == "" {
 		e.walk(n, src, scope, st)
 		return
@@ -585,7 +580,7 @@ func (e *JuliaExtractor) handleAssignment(n *sitter.Node, src []byte, scope juli
 	// instead of unwrapping one fixed level.
 	if sig := juliaSignatureCall(lhs); sig != nil {
 		if name, receiver := juliaCalleeName(sig.NamedChild(0), src); name != "" {
-			e.emitShortFunction(n, sig, name, receiver, doc, src, scope, st)
+			e.emitShortFunction(n, name, receiver, doc, src, scope, st)
 			return
 		}
 	}
@@ -623,7 +618,7 @@ func (e *JuliaExtractor) handleAssignment(n *sitter.Node, src []byte, scope juli
 	e.walk(n, src, scope, st)
 }
 
-func (e *JuliaExtractor) emitShortFunction(n, sig *sitter.Node, name, receiver, doc string, src []byte, scope juliaScope, st *juliaWalkState) {
+func (e *JuliaExtractor) emitShortFunction(n *sitter.Node, name, receiver, doc string, src []byte, scope juliaScope, st *juliaWalkState) {
 	inner := e.emitCallable(n, name, receiver, doc, false, scope, st)
 	e.walk(n, src, inner, st)
 }

--- a/internal/parser/languages/julia.go
+++ b/internal/parser/languages/julia.go
@@ -159,6 +159,12 @@ func (e *JuliaExtractor) Extract(filePath string, src []byte) (*parser.Extractio
 // adjacent and detached parses are structurally identical — so the line
 // numbers are the only discriminator.
 func (e *JuliaExtractor) walk(n *sitter.Node, src []byte, scope juliaScope, st *juliaWalkState) {
+	e.walkFrom(n, src, scope, st, 0)
+}
+
+// walkFrom is walk starting at the given named-child index, so a
+// definition can skip its own signature and dispatch only its body.
+func (e *JuliaExtractor) walkFrom(n *sitter.Node, src []byte, scope juliaScope, st *juliaWalkState, start int) {
 	// Only a few blocks can hold documentation: the file, a module body,
 	// and a begin / quote block outside any definition. A string standing
 	// in a FUNCTION body is ordinary executable code — Julia parses a
@@ -188,7 +194,11 @@ func (e *JuliaExtractor) walk(n *sitter.Node, src []byte, scope juliaScope, st *
 		}
 		return pendingDoc
 	}
-	for c := range n.NamedChildren() {
+	for i, count := start, int(n.NamedChildCount()); i < count; i++ {
+		c := n.NamedChild(i)
+		if c == nil {
+			continue
+		}
 		switch c.Type() {
 		case "string_literal":
 			if docContext {
@@ -601,7 +611,21 @@ func (e *JuliaExtractor) handleFunction(n *sitter.Node, src []byte, scope juliaS
 	if name != "" {
 		inner = e.emitCallable(n, name, receiver, doc, n.Type() == "macro_definition", scope, st)
 	}
-	e.walk(n, src, inner, st)
+	e.walkDefinitionBody(n, juliaSignatureCall(head), src, inner, st)
+}
+
+// walkDefinitionBody dispatches a definition's body, treating its own
+// signature as a declaration rather than a call site. The signature IS a
+// call_expression in this grammar, so walking the definition whole made
+// every definition appear to call itself — masked until now by the
+// direct-recursion guard, which a constructor no longer applies. Its
+// children are still walked, so a call inside a default argument value
+// is not lost with it.
+func (e *JuliaExtractor) walkDefinitionBody(n, sig *sitter.Node, src []byte, scope juliaScope, st *juliaWalkState) {
+	if sig != nil {
+		e.walk(sig, src, scope, st)
+	}
+	e.walkFrom(n, src, scope, st, 1)
 }
 
 // handleAssignment: `f(x) = body` (and `f(x) where T = body`) are
@@ -617,7 +641,7 @@ func (e *JuliaExtractor) handleAssignment(n *sitter.Node, src []byte, scope juli
 	// instead of unwrapping one fixed level.
 	if sig := juliaSignatureCall(lhs); sig != nil {
 		if name, receiver := juliaCalleeName(sig.NamedChild(0), src); name != "" {
-			e.emitShortFunction(n, name, receiver, doc, src, scope, st)
+			e.emitShortFunction(n, sig, name, receiver, doc, src, scope, st)
 			return
 		}
 	}
@@ -655,9 +679,9 @@ func (e *JuliaExtractor) handleAssignment(n *sitter.Node, src []byte, scope juli
 	e.walk(n, src, scope, st)
 }
 
-func (e *JuliaExtractor) emitShortFunction(n *sitter.Node, name, receiver, doc string, src []byte, scope juliaScope, st *juliaWalkState) {
+func (e *JuliaExtractor) emitShortFunction(n, sig *sitter.Node, name, receiver, doc string, src []byte, scope juliaScope, st *juliaWalkState) {
 	inner := e.emitCallable(n, name, receiver, doc, false, scope, st)
-	e.walk(n, src, inner, st)
+	e.walkDefinitionBody(n, sig, src, inner, st)
 }
 
 // emitCallable mints one function / method / constructor node and returns
@@ -687,6 +711,7 @@ func (e *JuliaExtractor) emitCallable(
 	line := int(n.StartPoint().Row) + 1
 	kind := graph.KindMethod
 	nodeName := name
+	isCtor := false
 	var baseID, ownerID, ownerName string
 
 	switch {
@@ -722,6 +747,7 @@ func (e *JuliaExtractor) emitCallable(
 			baseID = typeID + ".<init>"
 			ownerID, ownerName = typeID, typeName
 			nodeName = typeName + ".<init>"
+			isCtor = true
 		} else {
 			kind = graph.KindFunction
 			baseID = st.filePath + "::" + name
@@ -742,6 +768,7 @@ func (e *JuliaExtractor) emitCallable(
 		inner.functionID = id
 		inner.functionName = name
 		inner.functionRecv = receiver
+		inner.functionIsCtor = isCtor
 		return inner
 	}
 
@@ -791,7 +818,7 @@ func (e *JuliaExtractor) emitCallable(
 	inner.functionID = id
 	inner.functionName = name
 	inner.functionRecv = receiver
-	inner.functionIsCtor = ownerID != "" && strings.HasSuffix(id, ".<init>")
+	inner.functionIsCtor = isCtor
 	return inner
 }
 

--- a/internal/parser/languages/julia.go
+++ b/internal/parser/languages/julia.go
@@ -24,7 +24,8 @@ import (
 //   - `macro m(...) ... end`
 //   - `struct` / `mutable struct` / `abstract type` / `primitive type`
 //     with parametric names (`struct Pair{T,S}`) and supertypes
-//     (`<: Living` → EdgeExtends), plus struct fields (KindField)
+//     (`<: Living` → EdgeExtends), plus struct fields (KindField),
+//     including the `x::T = default` form `Base.@kwdef` requires
 //   - `module` / `baremodule` — KindType node whose Meta carries the
 //     module's `export` list; definitions inside get EdgeMemberOf
 //   - `const X = ...` constants (KindVariable)
@@ -326,6 +327,37 @@ func juliaNameAndParams(n *sitter.Node, src []byte) (string, []string) {
 	return "", nil
 }
 
+// juliaFieldName returns the field a direct struct member declares, or ""
+// when the member is not a field. Three shapes reach it:
+//
+//	x::T        typed_expression
+//	x           identifier
+//	x::T = 1    assignment — the shape `Base.@kwdef` requires, and the
+//	            shape every field of a @kwdef struct therefore has
+//
+// The assignment case is deliberately narrow: an INNER CONSTRUCTOR is a
+// direct struct child and an assignment too (`Guard(v) = new(v)`), but its
+// left-hand side is a call, so it falls through and is left to the
+// definition handling.
+func juliaFieldName(c *sitter.Node, src []byte) string {
+	n := c
+	if n.Type() == "assignment" {
+		n = n.NamedChild(0)
+	}
+	if n == nil {
+		return ""
+	}
+	switch n.Type() {
+	case "typed_expression":
+		if id := n.NamedChild(0); id != nil && id.Type() == "identifier" {
+			return id.Content(src)
+		}
+	case "identifier":
+		return n.Content(src)
+	}
+	return ""
+}
+
 // handleType covers struct / mutable struct / abstract type /
 // primitive type: KindType node, EdgeExtends for the supertype (bare
 // name target + full path in Meta, matching the python extractor
@@ -396,8 +428,7 @@ func (e *JuliaExtractor) handleType(n *sitter.Node, src []byte, scope juliaScope
 		})
 	}
 
-	// Struct fields: typed_expression (`x::T`) or bare identifier
-	// members at the top level of the struct body. This runs only for a
+	// Struct fields at the top level of the struct body. This runs only for a
 	// struct THIS call minted, so a struct whose name collides with an
 	// earlier declaration cannot hang its fields off that other node.
 	if n.Type() == "struct_definition" {
@@ -405,15 +436,7 @@ func (e *JuliaExtractor) handleType(n *sitter.Node, src []byte, scope juliaScope
 			if c.Type() == "type_head" {
 				continue
 			}
-			var fieldName string
-			switch c.Type() {
-			case "typed_expression":
-				if lhs := c.NamedChild(0); lhs != nil && lhs.Type() == "identifier" {
-					fieldName = lhs.Content(src)
-				}
-			case "identifier":
-				fieldName = c.Content(src)
-			}
+			fieldName := juliaFieldName(c, src)
 			if fieldName == "" {
 				continue
 			}

--- a/internal/parser/languages/julia.go
+++ b/internal/parser/languages/julia.go
@@ -795,6 +795,12 @@ func (e *JuliaExtractor) emitCallable(
 	return inner
 }
 
+// juliaImportBindingCap bounds how many per-binding import edges one
+// statement may contribute, mirroring jsImportBindingCap. Above it the
+// module edge alone records the dependency: the selected names stay in
+// that edge's Meta, so nothing is lost that a reader cannot recover.
+const juliaImportBindingCap = 64
+
 // juliaImportHead returns what a `selected_import` / `import_alias` names
 // first, plus the index of the child after it. For a statement-level node
 // that is the module: a dotted or relative path (`A.B`, `.Local`, `..Up`)
@@ -917,17 +923,23 @@ func (e *JuliaExtractor) handleImport(n *sitter.Node, src []byte, st *juliaWalkS
 	}
 	// One edge per selected binding, targeting the binding rather than
 	// the module — the representation JS/TS already emits for
-	// `import { a, b as c } from "mod"`.
+	// `import { a, b as c } from "mod"`. A rename rides on Edge.Alias
+	// and, because the SQLite edges table has no alias column, on Meta
+	// as well, which is the half that survives the round-trip.
 	emitBinding := func(module, orig, alias string) {
 		if module == "" || orig == "" {
 			return
 		}
-		st.result.Edges = append(st.result.Edges, &graph.Edge{
+		edge := &graph.Edge{
 			From: st.fileNode.ID, To: "unresolved::import::" + module + "::" + orig,
 			Kind:     graph.EdgeImports,
 			FilePath: st.filePath, Line: line,
 			Alias: alias,
-		})
+		}
+		if alias != "" {
+			edge.Meta = map[string]any{"alias": alias}
+		}
+		st.result.Edges = append(st.result.Edges, edge)
 	}
 	for c := range n.NamedChildren() {
 		switch c.Type() {
@@ -972,8 +984,13 @@ func (e *JuliaExtractor) handleImport(n *sitter.Node, src []byte, st *juliaWalkS
 				meta["names"] = names
 			}
 			emit(module, "", meta)
-			for _, b := range bindings {
-				emitBinding(module, b.orig, b.alias)
+			// Past the cap only the module edge is kept, so one
+			// statement cannot dwarf a file's graph — the same bound the
+			// JS/TS per-binding helper applies for the same reason.
+			if len(bindings) <= juliaImportBindingCap {
+				for _, b := range bindings {
+					emitBinding(module, b.orig, b.alias)
+				}
 			}
 		case "import_alias":
 			path, alias := juliaAliasParts(c, src)

--- a/internal/parser/languages/julia.go
+++ b/internal/parser/languages/julia.go
@@ -15,10 +15,12 @@ import (
 //
 // Covered definition forms:
 //   - `function f(...) ... end`, including `where`-parametrised
-//     signatures and qualified/ operator callees (`function Base.show`,
-//     `function Base.:+`)
-//   - short-form definitions `f(x) = body` and `f(x)::T where T = body`,
-//     including nested closures inside `begin` blocks
+//     signatures, declared return types (`function f(x)::Int`), the
+//     empty generic declaration `function f end`, and qualified /
+//     operator callees (`function Base.show`, `function Base.:+`)
+//   - short-form definitions `f(x) = body`, `f(x)::T = body` and
+//     `f(x)::T where T = body`, including nested closures inside `begin`
+//     blocks
 //   - `macro m(...) ... end`
 //   - `struct` / `mutable struct` / `abstract type` / `primitive type`
 //     with parametric names (`struct Pair{T,S}`) and supertypes
@@ -377,24 +379,29 @@ func juliaCalleeName(n *sitter.Node, src []byte) (name, receiver string) {
 	return "", ""
 }
 
-// juliaUnwrapSignature returns the call_expression behind a `signature`
-// node, descending through `where_expression`.
-func juliaUnwrapSignature(sig *sitter.Node) *sitter.Node {
-	if sig == nil {
-		return nil
-	}
-	c := sig
-	if c.Type() == "signature" {
-		c = c.NamedChild(0)
-	}
-	if c == nil {
-		return nil
-	}
-	if c.Type() == "where_expression" {
-		c = c.NamedChild(0)
-	}
-	if c != nil && c.Type() == "call_expression" {
-		return c
+// juliaSignatureCall peels the wrappers a definition head can carry until
+// it reaches the call_expression that names the definition. Three wrappers
+// occur, and they nest in either order:
+//
+//	signature          the long form's head, `function f(x) ... end`
+//	where_expression   `f(x) where T`          → where(call)
+//	typed_expression   `f(x)::Int`             → typed(call)
+//	                   `f(x)::T where T`       → where(typed(call))
+//
+// so the peel is a loop rather than a fixed descent. Anything else stops
+// it: an assignment whose left-hand side is `x::Int` peels the
+// typed_expression and finds a bare identifier, which is a typed variable,
+// not a definition.
+func juliaSignatureCall(n *sitter.Node) *sitter.Node {
+	for n != nil {
+		switch n.Type() {
+		case "call_expression":
+			return n
+		case "signature", "where_expression", "typed_expression":
+			n = n.NamedChild(0)
+		default:
+			return nil
+		}
 	}
 	return nil
 }
@@ -405,10 +412,14 @@ func juliaUnwrapSignature(sig *sitter.Node) *sitter.Node {
 // where_expression). Qualified callees become KindMethod with
 // Meta["receiver"] + EdgeMemberOf, mirroring the luau extractor.
 func (e *JuliaExtractor) handleFunction(n *sitter.Node, src []byte, scope juliaScope, st *juliaWalkState, doc string) {
-	call := juliaUnwrapSignature(n.NamedChild(0))
+	head := n.NamedChild(0)
 	name, receiver := "", ""
-	if call != nil {
+	if call := juliaSignatureCall(head); call != nil {
 		name, receiver = juliaCalleeName(call.NamedChild(0), src)
+	} else if head != nil && head.Type() == "signature" {
+		// `function f end` declares an empty generic function: there is
+		// no argument list, so the signature holds the callee directly.
+		name, receiver = juliaCalleeName(head.NamedChild(0), src)
 	}
 
 	inner := scope
@@ -486,12 +497,11 @@ func (e *JuliaExtractor) handleFunction(n *sitter.Node, src []byte, scope juliaS
 func (e *JuliaExtractor) handleAssignment(n *sitter.Node, src []byte, scope juliaScope, st *juliaWalkState, isConst bool) {
 	lhs := n.NamedChild(0)
 
-	// Short-form definition?
-	sig := lhs
-	if sig != nil && sig.Type() == "where_expression" {
-		sig = sig.NamedChild(0)
-	}
-	if sig != nil && sig.Type() == "call_expression" {
+	// Short-form definition? The left-hand side carries the same
+	// wrappers a long-form signature does — `f(x) where T`,
+	// `f(x)::Int`, `f(x)::T where T` — so peel with the shared helper
+	// instead of unwrapping one fixed level.
+	if sig := juliaSignatureCall(lhs); sig != nil {
 		if name, receiver := juliaCalleeName(sig.NamedChild(0), src); name != "" {
 			e.emitShortFunction(n, sig, name, receiver, src, scope, st)
 			return

--- a/internal/parser/languages/julia.go
+++ b/internal/parser/languages/julia.go
@@ -30,9 +30,10 @@ import (
 //   - `const X = ...` constants (KindVariable)
 //
 // Imports: `using M`, `using M: a, b` (selected names in edge Meta),
-// `import M`, `import M as Alias` (alias in edge Meta), dotted import
-// paths, and `include("file.jl")` — all as EdgeImports to
-// `unresolved::import::<path>`.
+// `import M`, `import M as Alias` (alias in edge Meta), dotted and
+// relative import paths (`A.B`, `.Local`, `..Up`), and
+// `include("file.jl")` — all as EdgeImports to
+// `unresolved::import::<module>`, never to a selected name.
 //
 // Calls: call_expression / broadcast_call_expression / macrocall
 // callees (identifier or qualified field_expression) attribute to the
@@ -575,13 +576,54 @@ func (e *JuliaExtractor) emitShortFunction(n, sig *sitter.Node, name, receiver s
 	e.walk(n, src, inner, st)
 }
 
+// juliaImportModule returns the module a `selected_import` /
+// `import_alias` names, plus the index of the first child after it. A
+// dotted or relative path (`A.B`, `.Local`, `..Up`) is an `import_path`
+// node; a single-segment module is a bare `identifier`. Everything after
+// it is the selected bindings or the alias.
+func juliaImportModule(n *sitter.Node, src []byte) (module string, next int) {
+	first := n.NamedChild(0)
+	if first == nil {
+		return "", 0
+	}
+	switch first.Type() {
+	case "import_path", "identifier":
+		return first.Content(src), 1
+	}
+	return "", 0
+}
+
+// juliaAliasParts decodes an `import_alias` — `Foo as F`, `C.D as CD` at
+// statement level, `bar as baz` inside a selected list — into the
+// upstream name and the local alias.
+func juliaAliasParts(n *sitter.Node, src []byte) (orig, alias string) {
+	orig, next := juliaImportModule(n, src)
+	if orig == "" {
+		return "", ""
+	}
+	for i, count := next, int(n.NamedChildCount()); i < count; i++ {
+		s := n.NamedChild(i)
+		if s == nil {
+			continue
+		}
+		if s.Type() == "identifier" || s.Type() == "operator" {
+			alias = s.Content(src)
+		}
+	}
+	return orig, alias
+}
+
 // handleImport covers `using M`, `using M: a, b`, `import M`,
-// `import M as Alias`, and dotted import paths. Selected names and
-// aliases ride on the edge Meta for the resolver to consume.
+// `import M as Alias`, and dotted / relative import paths. The import
+// target is always the MODULE; selected names and aliases ride on the
+// edge Meta.
 func (e *JuliaExtractor) handleImport(n *sitter.Node, src []byte, st *juliaWalkState) {
 	emit := func(target string, meta map[string]any) {
 		if target == "" {
 			return
+		}
+		if len(meta) == 0 {
+			meta = nil
 		}
 		st.result.Edges = append(st.result.Edges, &graph.Edge{
 			From: st.fileNode.ID, To: "unresolved::import::" + target,
@@ -592,18 +634,29 @@ func (e *JuliaExtractor) handleImport(n *sitter.Node, src []byte, st *juliaWalkS
 	}
 	for c := range n.NamedChildren() {
 		switch c.Type() {
-		case "identifier":
-			emit(c.Content(src), nil)
-		case "import_path":
+		case "identifier", "import_path":
 			emit(c.Content(src), nil)
 		case "selected_import":
-			module, names := "", []string{}
-			for s := range c.NamedChildren() {
-				if s.Type() == "identifier" {
-					if module == "" {
-						module = s.Content(src)
-					} else {
-						names = append(names, s.Content(src))
+			// `using A.B: x, y` — the module is the FIRST child and is
+			// an import_path whenever the path is dotted or relative.
+			// Scanning for identifiers instead skipped it and promoted
+			// the first selected name to the import target.
+			module, next := juliaImportModule(c, src)
+			var names []string
+			for i, count := next, int(c.NamedChildCount()); i < count; i++ {
+				s := c.NamedChild(i)
+				if s == nil {
+					continue
+				}
+				switch s.Type() {
+				case "identifier", "operator":
+					// `using Base: +, -` selects operators, which are
+					// `operator` nodes rather than identifiers.
+					names = append(names, s.Content(src))
+				case "import_alias":
+					// `import Foo: bar as baz` renames one binding.
+					if orig, _ := juliaAliasParts(s, src); orig != "" {
+						names = append(names, orig)
 					}
 				}
 			}
@@ -613,17 +666,7 @@ func (e *JuliaExtractor) handleImport(n *sitter.Node, src []byte, st *juliaWalkS
 			}
 			emit(module, meta)
 		case "import_alias":
-			path, alias := "", ""
-			for a := range c.NamedChildren() {
-				if a.Type() != "identifier" {
-					continue
-				}
-				if path == "" {
-					path = a.Content(src)
-				} else {
-					alias = a.Content(src)
-				}
-			}
+			path, alias := juliaAliasParts(c, src)
 			meta := map[string]any{}
 			if alias != "" {
 				meta["alias"] = alias

--- a/internal/parser/languages/julia.go
+++ b/internal/parser/languages/julia.go
@@ -29,6 +29,13 @@ import (
 //     module's `export` list; definitions inside get EdgeMemberOf
 //   - `const X = ...` constants (KindVariable)
 //
+// Node ids stay flat (`<file>::<Name>`, `<file>::<Owner>.<member>`) as in
+// every other extractor; the enclosing module rides on
+// Meta["scope_mod"], and two definitions that would share an id separate
+// through the shared line-suffix helper. A callable named after a type is
+// that type's constructor and takes the cross-language `<Type>.<init>`
+// spelling.
+//
 // Imports: `using M`, `using M: a, b`, `import M`, `import M as Alias`,
 // dotted and relative import paths (`A.B`, `.Local`, `..Up`), and
 // `include("file.jl")` — all as EdgeImports to
@@ -62,7 +69,16 @@ func (e *JuliaExtractor) Extensions() []string { return []string{".jl"} }
 // module (for EdgeMemberOf and export attachment) and the innermost
 // function-like definition (for call attribution).
 type juliaScope struct {
-	moduleID     string
+	moduleID string
+	// modulePath is the dotted lexical module path (`Outer.Inner`). Node
+	// ids stay flat — see emitCallable — and the path rides on
+	// Meta["scope_mod"], the convention the Rust extractor established
+	// for exactly this shape.
+	modulePath string
+	// typeID / typeName name the struct whose body is being walked, so an
+	// inner constructor can be attributed to it.
+	typeID       string
+	typeName     string
 	functionID   string
 	functionName string
 	functionRecv string
@@ -74,6 +90,11 @@ type juliaWalkState struct {
 	result   *parser.ExtractionResult
 	seen     map[string]bool
 	nodes    map[string]*graph.Node
+	// types maps a lexical scope + declared type name to the minted type
+	// id, so a definition that shares a type's name is recognised as its
+	// constructor and attributed to the RIGHT type when one file declares
+	// two same-named types in different modules.
+	types map[string]string
 	// importAliases maps a local module alias to the module it renames
 	// (`import Foo as F` → F→Foo), so a qualified call can name the
 	// module the resolver can find rather than a file-local nickname.
@@ -103,6 +124,7 @@ func (e *JuliaExtractor) Extract(filePath string, src []byte) (*parser.Extractio
 		result:        result,
 		seen:          make(map[string]bool),
 		nodes:         map[string]*graph.Node{filePath: fileNode},
+		types:         map[string]string{},
 		importAliases: map[string]string{},
 	}
 	// Aliases are collected up front: the emitting walk is a single
@@ -182,29 +204,67 @@ func (e *JuliaExtractor) handleModule(n *sitter.Node, src []byte, scope juliaSco
 	}
 	inner := scope
 	if name != "" {
-		id := st.filePath + "::" + name
-		if !st.seen[id] {
-			st.seen[id] = true
+		line := int(n.StartPoint().Row) + 1
+		id, minted := disambiguateID(st.seen, st.filePath+"::"+name, line)
+		if minted {
 			node := &graph.Node{
 				ID: id, Kind: graph.KindType, Name: name,
 				FilePath:  st.filePath,
-				StartLine: int(n.StartPoint().Row) + 1,
+				StartLine: line,
 				EndLine:   int(n.EndPoint().Row) + 1,
 				Language:  "julia",
 			}
+			meta := map[string]any{}
 			if doc != "" {
-				node.Meta = map[string]any{"doc": doc}
+				meta["doc"] = doc
+			}
+			if scope.modulePath != "" {
+				meta["scope_mod"] = scope.modulePath
+			}
+			if len(meta) > 0 {
+				node.Meta = meta
 			}
 			st.result.Nodes = append(st.result.Nodes, node)
 			st.nodes[id] = node
 			st.result.Edges = append(st.result.Edges, &graph.Edge{
 				From: st.fileNode.ID, To: id, Kind: graph.EdgeDefines,
-				FilePath: st.filePath, Line: int(n.StartPoint().Row) + 1,
+				FilePath: st.filePath, Line: line,
 			})
 		}
 		inner.moduleID = id
+		inner.modulePath = name
+		if scope.modulePath != "" {
+			inner.modulePath = scope.modulePath + "." + name
+		}
+		// A module body opens a fresh type scope: a struct declared
+		// outside it does not own a constructor declared inside.
+		inner.typeID, inner.typeName = "", ""
 	}
 	e.walk(n, src, inner, st)
+}
+
+// juliaTypeKey keys the file's type table by lexical module path, so a
+// constructor binds to the type declared in its own module rather than to
+// a same-named type in a sibling module of the same file.
+func juliaTypeKey(modulePath, name string) string { return modulePath + "\x00" + name }
+
+// lookupType finds the type a definition name would construct, searching
+// the current module then each enclosing one out to file scope — Julia's
+// own lexical lookup order.
+func (st *juliaWalkState) lookupType(modulePath, name string) (id, declared string, ok bool) {
+	for path := modulePath; ; {
+		if id, hit := st.types[juliaTypeKey(path, name)]; hit {
+			return id, name, true
+		}
+		if path == "" {
+			return "", "", false
+		}
+		if i := strings.LastIndex(path, "."); i >= 0 {
+			path = path[:i]
+		} else {
+			path = ""
+		}
+	}
 }
 
 // juliaTypeHeadInfo decodes a `type_head` child: the declared name
@@ -285,49 +345,61 @@ func (e *JuliaExtractor) handleType(n *sitter.Node, src []byte, scope juliaScope
 		return
 	}
 
-	id := st.filePath + "::" + name
-	if !st.seen[id] {
-		st.seen[id] = true
-		node := &graph.Node{
-			ID: id, Kind: graph.KindType, Name: name,
-			FilePath:  st.filePath,
-			StartLine: int(n.StartPoint().Row) + 1,
-			EndLine:   int(n.EndPoint().Row) + 1,
-			Language:  "julia",
+	line := int(n.StartPoint().Row) + 1
+	id, minted := disambiguateID(st.seen, st.filePath+"::"+name, line)
+	if !minted {
+		e.walk(n, src, scope, st)
+		return
+	}
+	node := &graph.Node{
+		ID: id, Kind: graph.KindType, Name: name,
+		FilePath:  st.filePath,
+		StartLine: line,
+		EndLine:   int(n.EndPoint().Row) + 1,
+		Language:  "julia",
+	}
+	meta := map[string]any{}
+	if doc != "" {
+		meta["doc"] = doc
+	}
+	if scope.modulePath != "" {
+		meta["scope_mod"] = scope.modulePath
+	}
+	if len(meta) > 0 {
+		node.Meta = meta
+	}
+	st.result.Nodes = append(st.result.Nodes, node)
+	st.nodes[id] = node
+	st.types[juliaTypeKey(scope.modulePath, name)] = id
+	st.result.Edges = append(st.result.Edges, &graph.Edge{
+		From: st.fileNode.ID, To: id, Kind: graph.EdgeDefines,
+		FilePath: st.filePath, Line: line,
+	})
+	if super != "" {
+		bare := super
+		if idx := strings.IndexAny(bare, "{"); idx > 0 {
+			bare = bare[:idx]
 		}
-		if doc != "" {
-			node.Meta = map[string]any{"doc": doc}
+		edge := &graph.Edge{
+			From: id, To: "unresolved::" + bare, Kind: graph.EdgeExtends,
+			FilePath: st.filePath, Line: line,
 		}
-		st.result.Nodes = append(st.result.Nodes, node)
-		st.nodes[id] = node
+		if super != bare {
+			edge.Meta = map[string]any{"base_path": super}
+		}
+		st.result.Edges = append(st.result.Edges, edge)
+	}
+	if scope.moduleID != "" {
 		st.result.Edges = append(st.result.Edges, &graph.Edge{
-			From: st.fileNode.ID, To: id, Kind: graph.EdgeDefines,
-			FilePath: st.filePath, Line: int(n.StartPoint().Row) + 1,
+			From: id, To: scope.moduleID, Kind: graph.EdgeMemberOf,
+			FilePath: st.filePath, Line: line,
 		})
-		if super != "" {
-			bare := super
-			if idx := strings.IndexAny(bare, "{"); idx > 0 {
-				bare = bare[:idx]
-			}
-			edge := &graph.Edge{
-				From: id, To: "unresolved::" + bare, Kind: graph.EdgeExtends,
-				FilePath: st.filePath, Line: int(n.StartPoint().Row) + 1,
-			}
-			if super != bare {
-				edge.Meta = map[string]any{"base_path": super}
-			}
-			st.result.Edges = append(st.result.Edges, edge)
-		}
-		if scope.moduleID != "" {
-			st.result.Edges = append(st.result.Edges, &graph.Edge{
-				From: id, To: scope.moduleID, Kind: graph.EdgeMemberOf,
-				FilePath: st.filePath, Line: int(n.StartPoint().Row) + 1,
-			})
-		}
 	}
 
 	// Struct fields: typed_expression (`x::T`) or bare identifier
-	// members at the top level of the struct body.
+	// members at the top level of the struct body. This runs only for a
+	// struct THIS call minted, so a struct whose name collides with an
+	// earlier declaration cannot hang its fields off that other node.
 	if n.Type() == "struct_definition" {
 		for c := range n.NamedChildren() {
 			if c.Type() == "type_head" {
@@ -345,26 +417,28 @@ func (e *JuliaExtractor) handleType(n *sitter.Node, src []byte, scope juliaScope
 			if fieldName == "" {
 				continue
 			}
-			fid := id + "." + fieldName
-			if st.seen[fid] {
+			fieldLine := int(c.StartPoint().Row) + 1
+			fid, fieldMinted := disambiguateID(st.seen, id+"."+fieldName, fieldLine)
+			if !fieldMinted {
 				continue
 			}
-			st.seen[fid] = true
 			st.result.Nodes = append(st.result.Nodes, &graph.Node{
 				ID: fid, Kind: graph.KindField, Name: fieldName,
 				FilePath:  st.filePath,
-				StartLine: int(c.StartPoint().Row) + 1,
+				StartLine: fieldLine,
 				EndLine:   int(c.EndPoint().Row) + 1,
 				Language:  "julia",
 			})
 			st.result.Edges = append(st.result.Edges, &graph.Edge{
 				From: fid, To: id, Kind: graph.EdgeMemberOf,
-				FilePath: st.filePath, Line: int(c.StartPoint().Row) + 1,
+				FilePath: st.filePath, Line: fieldLine,
 			})
 		}
 	}
 
-	e.walk(n, src, scope, st)
+	inner := scope
+	inner.typeID, inner.typeName = id, name
+	e.walk(n, src, inner, st)
 }
 
 // juliaCalleeName decodes a call callee: bare identifier or qualified
@@ -438,56 +512,7 @@ func (e *JuliaExtractor) handleFunction(n *sitter.Node, src []byte, scope juliaS
 
 	inner := scope
 	if name != "" {
-		kind := graph.KindFunction
-		id := st.filePath + "::" + name
-		if receiver != "" {
-			kind = graph.KindMethod
-			id = st.filePath + "::" + receiver + "." + name
-		}
-		if !st.seen[id] {
-			st.seen[id] = true
-			node := &graph.Node{
-				ID: id, Kind: kind, Name: name,
-				FilePath:  st.filePath,
-				StartLine: int(n.StartPoint().Row) + 1,
-				EndLine:   int(n.EndPoint().Row) + 1,
-				Language:  "julia",
-			}
-			meta := map[string]any{}
-			if receiver != "" {
-				meta["receiver"] = receiver
-			}
-			if n.Type() == "macro_definition" {
-				meta["macro"] = true
-			}
-			if doc != "" {
-				meta["doc"] = doc
-			}
-			if len(meta) > 0 {
-				node.Meta = meta
-			}
-			st.result.Nodes = append(st.result.Nodes, node)
-			st.nodes[id] = node
-			st.result.Edges = append(st.result.Edges, &graph.Edge{
-				From: st.fileNode.ID, To: id, Kind: graph.EdgeDefines,
-				FilePath: st.filePath, Line: int(n.StartPoint().Row) + 1,
-			})
-			if receiver != "" {
-				st.result.Edges = append(st.result.Edges, &graph.Edge{
-					From: id, To: st.filePath + "::" + receiver, Kind: graph.EdgeMemberOf,
-					FilePath: st.filePath, Line: int(n.StartPoint().Row) + 1,
-				})
-			}
-			if scope.moduleID != "" {
-				st.result.Edges = append(st.result.Edges, &graph.Edge{
-					From: id, To: scope.moduleID, Kind: graph.EdgeMemberOf,
-					FilePath: st.filePath, Line: int(n.StartPoint().Row) + 1,
-				})
-			}
-		}
-		inner.functionID = id
-		inner.functionName = name
-		inner.functionRecv = receiver
+		inner = e.emitCallable(n, name, receiver, doc, n.Type() == "macro_definition", scope, st)
 	}
 	// Body docstring: first body statement that is a string literal.
 	bodyDoc := ""
@@ -524,19 +549,23 @@ func (e *JuliaExtractor) handleAssignment(n *sitter.Node, src []byte, scope juli
 
 	if isConst && lhs != nil && lhs.Type() == "identifier" {
 		name := lhs.Content(src)
-		id := st.filePath + "::" + name
-		if !st.seen[id] {
-			st.seen[id] = true
-			st.result.Nodes = append(st.result.Nodes, &graph.Node{
+		line := int(n.StartPoint().Row) + 1
+		if id, minted := disambiguateID(st.seen, st.filePath+"::"+name, line); minted {
+			node := &graph.Node{
 				ID: id, Kind: graph.KindVariable, Name: name,
 				FilePath:  st.filePath,
-				StartLine: int(n.StartPoint().Row) + 1,
+				StartLine: line,
 				EndLine:   int(n.EndPoint().Row) + 1,
 				Language:  "julia",
-			})
+			}
+			if scope.modulePath != "" {
+				node.Meta = map[string]any{"scope_mod": scope.modulePath}
+			}
+			st.result.Nodes = append(st.result.Nodes, node)
+			st.nodes[id] = node
 			st.result.Edges = append(st.result.Edges, &graph.Edge{
 				From: st.fileNode.ID, To: id, Kind: graph.EdgeDefines,
-				FilePath: st.filePath, Line: int(n.StartPoint().Row) + 1,
+				FilePath: st.filePath, Line: line,
 			})
 		}
 	}
@@ -545,48 +574,120 @@ func (e *JuliaExtractor) handleAssignment(n *sitter.Node, src []byte, scope juli
 }
 
 func (e *JuliaExtractor) emitShortFunction(n, sig *sitter.Node, name, receiver string, src []byte, scope juliaScope, st *juliaWalkState) {
-	kind := graph.KindFunction
-	id := st.filePath + "::" + name
-	if receiver != "" {
-		kind = graph.KindMethod
-		id = st.filePath + "::" + receiver + "." + name
+	inner := e.emitCallable(n, name, receiver, "", false, scope, st)
+	e.walk(n, src, inner, st)
+}
+
+// emitCallable mints one function / method / constructor node and returns
+// the scope its body should walk under.
+//
+// Node ids stay FLAT — `<file>::<Name>`, `<file>::<Owner>.<member>` — as
+// every other extractor mints them; the enclosing module rides on
+// Meta["scope_mod"] instead (the Rust `mod` precedent). Folding the module
+// into the id would break graph.EnclosingFromID, which recovers a
+// method's or field's owner by cutting at the LAST dot. Two definitions
+// that would collide on one id — `f` in module A and `f` in module B —
+// separate through the shared line-suffix helper, so both survive as
+// navigable nodes instead of one silently swallowing the other's call
+// edges.
+//
+// A callable whose name is a type's name is that type's CONSTRUCTOR:
+// Julia has no separate keyword, so `Box(x) = …` beside `struct Box` and
+// `function Box() … end` inside it are both constructors. They take the
+// cross-language `<Type>.<init>` spelling that Java, C# and Swift already
+// emit, so constructor-aware consumers need no Julia special case — and,
+// critically, they no longer collide with the type node itself, which
+// used to swallow the constructor and adopt its body's call edges.
+func (e *JuliaExtractor) emitCallable(
+	n *sitter.Node, name, receiver, doc string, isMacro bool,
+	scope juliaScope, st *juliaWalkState,
+) juliaScope {
+	line := int(n.StartPoint().Row) + 1
+	kind := graph.KindMethod
+	nodeName := name
+	var baseID, ownerID, ownerName string
+
+	switch {
+	case receiver != "":
+		ownerID, ownerName = st.filePath+"::"+receiver, receiver
+		if id, _, ok := st.lookupType(scope.modulePath, receiver); ok {
+			ownerID = id
+		}
+		baseID = ownerID + "." + name
+
+	default:
+		typeID, typeName := "", ""
+		if scope.typeName == name && scope.typeID != "" {
+			typeID, typeName = scope.typeID, scope.typeName // inner constructor
+		} else if id, declared, ok := st.lookupType(scope.modulePath, name); ok {
+			typeID, typeName = id, declared // outer constructor
+		}
+		if typeID != "" {
+			baseID = typeID + ".<init>"
+			ownerID, ownerName = typeID, typeName
+			nodeName = typeName + ".<init>"
+		} else {
+			kind = graph.KindFunction
+			baseID = st.filePath + "::" + name
+		}
 	}
-	if !st.seen[id] {
-		st.seen[id] = true
-		node := &graph.Node{
-			ID: id, Kind: kind, Name: name,
-			FilePath:  st.filePath,
-			StartLine: int(n.StartPoint().Row) + 1,
-			EndLine:   int(n.EndPoint().Row) + 1,
-			Language:  "julia",
-		}
-		if receiver != "" {
-			node.Meta = map[string]any{"receiver": receiver}
-		}
-		st.result.Nodes = append(st.result.Nodes, node)
-		st.nodes[id] = node
+
+	id, minted := disambiguateID(st.seen, baseID, line)
+	if !minted {
+		// The same declaration reached twice. Leaving the scope
+		// untouched is deliberate: adopting the existing id here is
+		// what used to re-parent a shadowed definition's calls onto
+		// whichever twin was emitted first.
+		return scope
+	}
+
+	node := &graph.Node{
+		ID: id, Kind: kind, Name: nodeName,
+		FilePath:  st.filePath,
+		StartLine: line,
+		EndLine:   int(n.EndPoint().Row) + 1,
+		Language:  "julia",
+	}
+	meta := map[string]any{}
+	if ownerName != "" {
+		meta["receiver"] = ownerName
+	}
+	if isMacro {
+		meta["macro"] = true
+	}
+	if doc != "" {
+		meta["doc"] = doc
+	}
+	if scope.modulePath != "" {
+		meta["scope_mod"] = scope.modulePath
+	}
+	if len(meta) > 0 {
+		node.Meta = meta
+	}
+	st.result.Nodes = append(st.result.Nodes, node)
+	st.nodes[id] = node
+	st.result.Edges = append(st.result.Edges, &graph.Edge{
+		From: st.fileNode.ID, To: id, Kind: graph.EdgeDefines,
+		FilePath: st.filePath, Line: line,
+	})
+	if ownerID != "" {
 		st.result.Edges = append(st.result.Edges, &graph.Edge{
-			From: st.fileNode.ID, To: id, Kind: graph.EdgeDefines,
-			FilePath: st.filePath, Line: int(n.StartPoint().Row) + 1,
+			From: id, To: ownerID, Kind: graph.EdgeMemberOf,
+			FilePath: st.filePath, Line: line,
 		})
-		if receiver != "" {
-			st.result.Edges = append(st.result.Edges, &graph.Edge{
-				From: id, To: st.filePath + "::" + receiver, Kind: graph.EdgeMemberOf,
-				FilePath: st.filePath, Line: int(n.StartPoint().Row) + 1,
-			})
-		}
-		if scope.moduleID != "" {
-			st.result.Edges = append(st.result.Edges, &graph.Edge{
-				From: id, To: scope.moduleID, Kind: graph.EdgeMemberOf,
-				FilePath: st.filePath, Line: int(n.StartPoint().Row) + 1,
-			})
-		}
 	}
+	if scope.moduleID != "" {
+		st.result.Edges = append(st.result.Edges, &graph.Edge{
+			From: id, To: scope.moduleID, Kind: graph.EdgeMemberOf,
+			FilePath: st.filePath, Line: line,
+		})
+	}
+
 	inner := scope
 	inner.functionID = id
 	inner.functionName = name
 	inner.functionRecv = receiver
-	e.walk(n, src, inner, st)
+	return inner
 }
 
 // juliaImportModule returns the module a `selected_import` /

--- a/internal/parser/languages/julia.go
+++ b/internal/parser/languages/julia.go
@@ -766,18 +766,21 @@ func (e *JuliaExtractor) emitCallable(
 	return inner
 }
 
-// juliaImportModule returns the module a `selected_import` /
-// `import_alias` names, plus the index of the first child after it. A
-// dotted or relative path (`A.B`, `.Local`, `..Up`) is an `import_path`
-// node; a single-segment module is a bare `identifier`. Everything after
-// it is the selected bindings or the alias.
-func juliaImportModule(n *sitter.Node, src []byte) (module string, next int) {
+// juliaImportHead returns what a `selected_import` / `import_alias` names
+// first, plus the index of the child after it. For a statement-level node
+// that is the module: a dotted or relative path (`A.B`, `.Local`, `..Up`)
+// is an `import_path`, a single-segment module a bare `identifier`.
+// Inside a selected list the same position holds the RENAMED BINDING, so
+// operators and macros are accepted there too — `import Base: + as plus`
+// and `import Base: @time as t` both put a non-identifier in it.
+// Everything after is the selection or the alias.
+func juliaImportHead(n *sitter.Node, src []byte) (head string, next int) {
 	first := n.NamedChild(0)
 	if first == nil {
 		return "", 0
 	}
 	switch first.Type() {
-	case "import_path", "identifier":
+	case "import_path", "identifier", "operator", "macro_identifier":
 		return first.Content(src), 1
 	}
 	return "", 0
@@ -787,7 +790,7 @@ func juliaImportModule(n *sitter.Node, src []byte) (module string, next int) {
 // statement level, `bar as baz` inside a selected list — into the
 // upstream name and the local alias.
 func juliaAliasParts(n *sitter.Node, src []byte) (orig, alias string) {
-	orig, next := juliaImportModule(n, src)
+	orig, next := juliaImportHead(n, src)
 	if orig == "" {
 		return "", ""
 	}
@@ -796,7 +799,8 @@ func juliaAliasParts(n *sitter.Node, src []byte) (orig, alias string) {
 		if s == nil {
 			continue
 		}
-		if s.Type() == "identifier" || s.Type() == "operator" {
+		switch s.Type() {
+		case "identifier", "operator", "macro_identifier":
 			alias = s.Content(src)
 		}
 	}
@@ -888,7 +892,7 @@ func (e *JuliaExtractor) handleImport(n *sitter.Node, src []byte, st *juliaWalkS
 			// an import_path whenever the path is dotted or relative.
 			// Scanning for identifiers instead skipped it and promoted
 			// the first selected name to the import target.
-			module, next := juliaImportModule(c, src)
+			module, next := juliaImportHead(c, src)
 			var names []string
 			type binding struct{ orig, alias string }
 			var bindings []binding
@@ -898,9 +902,10 @@ func (e *JuliaExtractor) handleImport(n *sitter.Node, src []byte, st *juliaWalkS
 					continue
 				}
 				switch s.Type() {
-				case "identifier", "operator":
-					// `using Base: +, -` selects operators, which are
-					// `operator` nodes rather than identifiers.
+				case "identifier", "operator", "macro_identifier":
+					// `using Base: +, -` selects operators and
+					// `using Base: @time` a macro; neither is an
+					// identifier node.
 					names = append(names, s.Content(src))
 					bindings = append(bindings, binding{orig: s.Content(src)})
 				case "import_alias":

--- a/internal/parser/languages/julia.go
+++ b/internal/parser/languages/julia.go
@@ -84,6 +84,9 @@ type juliaScope struct {
 	functionID   string
 	functionName string
 	functionRecv string
+	// functionIsCtor marks the enclosing definition as a constructor, so
+	// the direct-recursion guard does not eat its delegation calls.
+	functionIsCtor bool
 }
 
 type juliaWalkState struct {
@@ -780,6 +783,7 @@ func (e *JuliaExtractor) emitCallable(
 	inner.functionID = id
 	inner.functionName = name
 	inner.functionRecv = receiver
+	inner.functionIsCtor = ownerID != "" && strings.HasSuffix(id, ".<init>")
 	return inner
 }
 
@@ -1029,8 +1033,13 @@ func (e *JuliaExtractor) handleCall(n *sitter.Node, src []byte, scope juliaScope
 	if scope.functionID == "" {
 		return
 	}
-	if scope.functionName == name && scope.functionRecv == receiver {
-		return // direct recursion
+	// Direct recursion carries no information, so it is dropped — except
+	// from a constructor, where a call to the type's own name is
+	// delegation to a DIFFERENT method (`Box() = Box(0)`), which is the
+	// single most idiomatic constructor body Julia has. A constructor
+	// that genuinely recursed into itself would not terminate.
+	if !scope.functionIsCtor && scope.functionName == name && scope.functionRecv == receiver {
+		return
 	}
 	target := name
 	if receiver != "" {

--- a/internal/parser/languages/julia.go
+++ b/internal/parser/languages/julia.go
@@ -1016,8 +1016,14 @@ func (e *JuliaExtractor) handleMacroCall(n *sitter.Node, src []byte, scope julia
 // paragraph. Julia's own documentation convention opens a docstring with
 // the signature, indented by four spaces, then a blank line, then the
 // description — so taking the first paragraph blindly stores "radius(c)"
-// as the documentation of `radius`. Leading paragraphs whose every line
-// is indented are that signature block and are skipped.
+// as the documentation of `radius`. Leading paragraphs that are indented
+// RELATIVE TO THE BODY are that signature block and are skipped.
+//
+// The relative part is load-bearing: a docstring written inside an
+// indented module or `begin` body has every line indented, so an absolute
+// test would call every paragraph a signature block and eat the whole
+// docstring. Julia's own Docs machinery dedents the literal before
+// anything else; so does this.
 func juliaDocText(n *sitter.Node, src []byte) string {
 	// A Windows-authored file separates paragraphs with "\r\n\r\n",
 	// which holds no "\n\n" — without normalising first, the signature
@@ -1030,19 +1036,63 @@ func juliaDocText(n *sitter.Node, src []byte) string {
 	} else {
 		s = strings.TrimSuffix(strings.TrimPrefix(s, `"`), `"`)
 	}
+	s = juliaDedent(s)
 	for {
 		s = strings.TrimLeft(s, "\n")
 		para, rest, found := strings.Cut(s, "\n\n")
-		if !found || !juliaIndentedParagraph(para) {
+		// Never skip the last paragraph: a docstring that is nothing but
+		// a signature still documents better than an empty string.
+		if !found || strings.TrimSpace(rest) == "" || !juliaIndentedParagraph(para) {
 			return strings.TrimSpace(para)
 		}
 		s = rest
 	}
 }
 
+// juliaDedent strips the whitespace prefix every non-empty line shares,
+// the way Julia's documentation machinery does before storing a
+// docstring. The literal's first line has already lost its indentation to
+// the opening quotes, so it is excluded from the common-prefix scan.
+func juliaDedent(s string) string {
+	lines := strings.Split(s, "\n")
+	prefix, seen := "", false
+	for _, line := range lines[min(1, len(lines)):] {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		indent := line[:len(line)-len(strings.TrimLeft(line, " \t"))]
+		if !seen {
+			prefix, seen = indent, true
+			continue
+		}
+		prefix = juliaCommonPrefix(prefix, indent)
+		if prefix == "" {
+			return s
+		}
+	}
+	if !seen || prefix == "" {
+		return s
+	}
+	for i, line := range lines {
+		lines[i] = strings.TrimPrefix(line, prefix)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func juliaCommonPrefix(a, b string) string {
+	n := min(len(a), len(b))
+	for i := 0; i < n; i++ {
+		if a[i] != b[i] {
+			return a[:i]
+		}
+	}
+	return a[:n]
+}
+
 // juliaIndentedParagraph reports whether every non-empty line of a
 // paragraph is indented — the shape of the signature block a Julia
-// docstring conventionally opens with.
+// docstring conventionally opens with, once the docstring's own common
+// indent has been removed.
 func juliaIndentedParagraph(p string) bool {
 	indented := false
 	for _, line := range strings.Split(p, "\n") {

--- a/internal/parser/languages/julia_test.go
+++ b/internal/parser/languages/julia_test.go
@@ -886,6 +886,46 @@ end
 	}
 	assert.Equal(t, "Prose here.", crlfDoc, "CRLF paragraphs must split like LF ones")
 
+	// A docstring written inside an indented body has EVERY line
+	// indented, so an absolute "is this paragraph indented" test calls
+	// all of them signature blocks and eats the docstring. The signature
+	// block is indented relative to the prose, which only shows after the
+	// literal's own common indent is removed.
+	nested, err := NewJuliaExtractor().Extract("nested.jl", []byte(`module Mod
+    """
+        render(s)
+
+    Renders a shape.
+
+    Returns a string.
+    """
+    function render(s)
+        s
+    end
+end
+`))
+	require.NoError(t, err)
+	var nestedDoc string
+	for _, n := range nested.Nodes {
+		if n.ID == "nested.jl::render" {
+			nestedDoc, _ = n.Meta["doc"].(string)
+		}
+	}
+	assert.Equal(t, "Renders a shape.", nestedDoc,
+		"an indented docstring keeps its first prose paragraph")
+
+	// A docstring that is nothing but a signature still documents better
+	// than nothing.
+	only, err := NewJuliaExtractor().Extract("only.jl", []byte("\"\"\"\n    sig(x)\n\"\"\"\nsig(x) = x\n"))
+	require.NoError(t, err)
+	var onlyDoc string
+	for _, n := range only.Nodes {
+		if n.ID == "only.jl::sig" {
+			onlyDoc, _ = n.Meta["doc"].(string)
+		}
+	}
+	assert.Equal(t, "sig(x)", onlyDoc, "a signature-only docstring must not vanish")
+
 	for _, id := range []string{
 		"attach.jl::blank", "attach.jl::commented",
 		"attach.jl::returns_a_string", "attach.jl::nested",

--- a/internal/parser/languages/julia_test.go
+++ b/internal/parser/languages/julia_test.go
@@ -1,6 +1,7 @@
 package languages
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -269,6 +270,204 @@ end
 	exports, ok := mod.Meta["exports"].([]string)
 	require.True(t, ok, "module Meta exports missing")
 	assert.ElementsMatch(t, []string{"area", "Circle"}, exports)
+}
+
+// juliaOwners maps each node to the set of member_of targets it carries.
+// A method or constructor inside a module has TWO owners — its type and
+// its module — so a last-write-wins map would silently pick one.
+func juliaOwners(edges []*graph.Edge) map[string]map[string]bool {
+	out := map[string]map[string]bool{}
+	for _, ed := range edges {
+		if ed.Kind != graph.EdgeMemberOf {
+			continue
+		}
+		if out[ed.From] == nil {
+			out[ed.From] = map[string]bool{}
+		}
+		out[ed.From][ed.To] = true
+	}
+	return out
+}
+
+// One file, two modules, one name. Node ids stay flat (the house
+// convention — folding the module in would break the owner derivation
+// that cuts a method id at its last dot), so both definitions have to
+// separate through the shared line-suffix helper and carry their module
+// on Meta["scope_mod"]. Before this, the second definition was dropped
+// AND its body's calls were re-parented onto the first, so the surviving
+// node reported calls it does not make.
+func TestJuliaExtractor_SameNameAcrossModulesBothSurvive(t *testing.T) {
+	src := []byte(`module A
+f() = from_a()
+
+struct S
+    a::Int
+end
+end
+
+module B
+f() = from_b()
+
+struct S
+    b::Int
+end
+end
+`)
+	res, err := NewJuliaExtractor().Extract("dup.jl", src)
+	require.NoError(t, err)
+
+	nodes := map[string]*graph.Node{}
+	for _, n := range res.Nodes {
+		nodes[n.ID] = n
+	}
+
+	first, second := nodes["dup.jl::f"], nodes["dup.jl::f_L10"]
+	require.NotNil(t, first, "the first f must keep the clean id")
+	require.NotNil(t, second, "the second f must survive under a disambiguated id")
+	assert.Equal(t, "A", first.Meta["scope_mod"])
+	assert.Equal(t, "B", second.Meta["scope_mod"])
+
+	calls := map[string]string{}
+	for _, ed := range res.Edges {
+		if ed.Kind == graph.EdgeCalls {
+			calls[ed.To] = ed.From
+		}
+	}
+	owners := juliaOwners(res.Edges)
+	assert.Equal(t, "dup.jl::f", calls["unresolved::from_a"])
+	assert.Equal(t, "dup.jl::f_L10", calls["unresolved::from_b"],
+		"each definition must own the calls in its own body")
+	assert.True(t, owners["dup.jl::f"]["dup.jl::A"])
+	assert.True(t, owners["dup.jl::f_L10"]["dup.jl::B"])
+
+	// Same for the two structs, and each field must point at its own.
+	require.NotNil(t, nodes["dup.jl::S"])
+	require.NotNil(t, nodes["dup.jl::S_L12"])
+	require.NotNil(t, nodes["dup.jl::S.a"])
+	require.NotNil(t, nodes["dup.jl::S_L12.b"])
+	assert.True(t, owners["dup.jl::S.a"]["dup.jl::S"])
+	assert.True(t, owners["dup.jl::S_L12.b"]["dup.jl::S_L12"],
+		"a field must belong to its own struct, not to whichever came first")
+}
+
+// Julia has no constructor keyword: a callable named after a type IS that
+// type's constructor. Sharing the type's id meant the type node swallowed
+// every constructor and — worse — adopted the calls in their bodies, so
+// `struct Box` reported calling `make_box`. Constructors take the
+// cross-language `<Type>.<init>` spelling instead.
+func TestJuliaExtractor_ConstructorsAreDistinctFromTheirType(t *testing.T) {
+	src := []byte(`struct Box
+    x::Int
+    Box(x) = new(check(x))
+    function Box()
+        new(0)
+    end
+end
+
+Box(x, y) = make_box(x, y)
+
+function Box(x, y, z)
+    make_box3(x, y, z)
+end
+`)
+	res, err := NewJuliaExtractor().Extract("ctor.jl", src)
+	require.NoError(t, err)
+
+	nodes := map[string]*graph.Node{}
+	for _, n := range res.Nodes {
+		nodes[n.ID] = n
+	}
+	boxType := nodes["ctor.jl::Box"]
+	require.NotNil(t, boxType, "the struct itself must still be a type node")
+	assert.Equal(t, graph.KindType, boxType.Kind)
+
+	// Four constructors: inner short, inner long, outer short, outer long.
+	var ctors []*graph.Node
+	for _, n := range res.Nodes {
+		if n.Kind == graph.KindMethod && strings.HasPrefix(n.ID, "ctor.jl::Box.<init>") {
+			ctors = append(ctors, n)
+		}
+	}
+	require.Len(t, ctors, 4, "every constructor form needs its own node")
+	for _, n := range ctors {
+		assert.Equal(t, "Box.<init>", n.Name)
+		assert.Equal(t, "Box", n.Meta["receiver"])
+	}
+
+	owners := juliaOwners(res.Edges)
+	callers := map[string]string{}
+	for _, ed := range res.Edges {
+		if ed.Kind == graph.EdgeCalls {
+			callers[ed.To] = ed.From
+		}
+	}
+	for _, n := range ctors {
+		assert.True(t, owners[n.ID]["ctor.jl::Box"], "%s must belong to Box", n.ID)
+	}
+
+	// Constructor bodies must attribute to the constructor, never to the
+	// type node.
+	for _, target := range []string{"unresolved::check", "unresolved::make_box", "unresolved::make_box3"} {
+		from := callers[target]
+		require.NotEmpty(t, from, "missing call to %s", target)
+		assert.NotEqual(t, "ctor.jl::Box", from,
+			"a constructor body's calls must not be attributed to the type node")
+		assert.True(t, strings.HasPrefix(from, "ctor.jl::Box.<init>"),
+			"%s should be called by a constructor, got %s", target, from)
+	}
+}
+
+// A nested module contributes its full dotted path, and a constructor
+// binds to the type declared in its own module rather than to a
+// same-named type in a sibling one.
+func TestJuliaExtractor_NestedModuleScope(t *testing.T) {
+	src := []byte(`module Outer
+
+module Inner
+struct Node
+    v::Int
+end
+Node(v) = build_inner(v)
+end
+
+struct Node
+    w::Int
+end
+Node(w) = build_outer(w)
+
+end
+`)
+	res, err := NewJuliaExtractor().Extract("nest.jl", src)
+	require.NoError(t, err)
+
+	nodes := map[string]*graph.Node{}
+	for _, n := range res.Nodes {
+		nodes[n.ID] = n
+	}
+	require.NotNil(t, nodes["nest.jl::Inner"])
+	assert.Equal(t, "Outer", nodes["nest.jl::Inner"].Meta["scope_mod"])
+	require.NotNil(t, nodes["nest.jl::Node"])
+	assert.Equal(t, "Outer.Inner", nodes["nest.jl::Node"].Meta["scope_mod"])
+	require.NotNil(t, nodes["nest.jl::Node_L10"])
+	assert.Equal(t, "Outer", nodes["nest.jl::Node_L10"].Meta["scope_mod"])
+
+	owners := juliaOwners(res.Edges)
+	callers := map[string]string{}
+	for _, ed := range res.Edges {
+		if ed.Kind == graph.EdgeCalls {
+			callers[ed.To] = ed.From
+		}
+	}
+	inner := callers["unresolved::build_inner"]
+	outer := callers["unresolved::build_outer"]
+	require.NotEmpty(t, inner)
+	require.NotEmpty(t, outer)
+	assert.True(t, owners[inner]["nest.jl::Node"],
+		"the inner module's constructor must belong to the inner module's type")
+	assert.True(t, owners[outer]["nest.jl::Node_L10"],
+		"the outer module's constructor must belong to the outer module's type")
+	assert.False(t, owners[outer]["nest.jl::Node"],
+		"it must NOT bind to the same-named type in the nested module")
 }
 
 func TestJuliaExtractor_Imports(t *testing.T) {

--- a/internal/parser/languages/julia_test.go
+++ b/internal/parser/languages/julia_test.go
@@ -470,6 +470,56 @@ end
 		"it must NOT bind to the same-named type in the nested module")
 }
 
+// `Base.@kwdef` is the idiomatic way to give struct fields defaults, and
+// it makes every field an `assignment` node whose left-hand side is the
+// declaration. A field scanner that recognised only `x::T` and `x` saw a
+// @kwdef struct as having no fields at all.
+func TestJuliaExtractor_KwdefStructFields(t *testing.T) {
+	src := []byte(`Base.@kwdef struct Config
+    host::String = "localhost"
+    port::Int = 8080
+    debug = false
+end
+
+@kwdef struct Bare
+    n::Int = 1
+end
+
+struct Guarded
+    v::Int = 0
+    Guarded(v) = new(check(v))
+end
+`)
+	res, err := NewJuliaExtractor().Extract("kw.jl", src)
+	require.NoError(t, err)
+
+	nodes := map[string]*graph.Node{}
+	for _, n := range res.Nodes {
+		nodes[n.ID] = n
+	}
+	owners := juliaOwners(res.Edges)
+
+	for _, fid := range []string{
+		"kw.jl::Config.host", "kw.jl::Config.port", "kw.jl::Config.debug",
+		"kw.jl::Bare.n", "kw.jl::Guarded.v",
+	} {
+		n, ok := nodes[fid]
+		require.True(t, ok, "missing field %s", fid)
+		assert.Equal(t, graph.KindField, n.Kind)
+	}
+	assert.True(t, owners["kw.jl::Config.host"]["kw.jl::Config"])
+	assert.True(t, owners["kw.jl::Bare.n"]["kw.jl::Bare"],
+		"the bare @kwdef form must work too, not just Base.@kwdef")
+
+	// An inner constructor is an assignment child of the struct as well,
+	// but it is a definition, not a field.
+	ctor, ok := nodes["kw.jl::Guarded.<init>"]
+	require.True(t, ok, "an inner constructor must stay a constructor")
+	assert.Equal(t, graph.KindMethod, ctor.Kind)
+	_, isField := nodes["kw.jl::Guarded.Guarded"]
+	assert.False(t, isField, "an inner constructor must not be read as a field")
+}
+
 func TestJuliaExtractor_Imports(t *testing.T) {
 	src := []byte(`module M
 using LinearAlgebra

--- a/internal/parser/languages/julia_test.go
+++ b/internal/parser/languages/julia_test.go
@@ -805,6 +805,20 @@ end
 	assert.Equal(t, "trailing comment doc", docs["attach.jl::adjacent"],
 		"a comment on the docstring's own line does not detach it")
 
+	// A Windows-authored file separates paragraphs with "\r\n\r\n",
+	// which holds no "\n\n" — the signature block has to be recognised
+	// there too, or it becomes the documentation.
+	crlf, err := NewJuliaExtractor().Extract("crlf.jl",
+		[]byte("\"\"\"\r\n    api(x)\r\n\r\nProse here.\r\n\"\"\"\r\napi(x) = x\r\n"))
+	require.NoError(t, err)
+	var crlfDoc string
+	for _, n := range crlf.Nodes {
+		if n.ID == "crlf.jl::api" {
+			crlfDoc, _ = n.Meta["doc"].(string)
+		}
+	}
+	assert.Equal(t, "Prose here.", crlfDoc, "CRLF paragraphs must split like LF ones")
+
 	for _, id := range []string{
 		"attach.jl::blank", "attach.jl::commented",
 		"attach.jl::returns_a_string", "attach.jl::nested",

--- a/internal/parser/languages/julia_test.go
+++ b/internal/parser/languages/julia_test.go
@@ -462,6 +462,26 @@ end
 	}
 	assert.Equal(t, 2, ctors, "the constructor above the struct counts too")
 
+	// Delegation to another method of the same constructor is the most
+	// idiomatic constructor body Julia has, and it is NOT recursion —
+	// multiple dispatch sends it to a different method.
+	deleg, err := NewJuliaExtractor().Extract("dg.jl", []byte(`struct Box
+    x::Int
+    Box(x) = new(check(x))
+end
+
+Box() = Box(0)
+`))
+	require.NoError(t, err)
+	var delegated bool
+	for _, ed := range deleg.Edges {
+		if ed.Kind == graph.EdgeCalls && strings.HasPrefix(ed.From, "dg.jl::Box.<init>") &&
+			ed.To == "unresolved::Box" {
+			delegated = true
+		}
+	}
+	assert.True(t, delegated, "a delegating constructor must keep its call edge")
+
 	// The macro is a macro, not Tag's constructor.
 	_, tagCtor := nodes["fw.jl::Tag.<init>"]
 	assert.False(t, tagCtor, "a macro must never be read as a constructor")

--- a/internal/parser/languages/julia_test.go
+++ b/internal/parser/languages/julia_test.go
@@ -498,6 +498,41 @@ Box() = Box(0)
 	}
 	assert.True(t, delegated, "a delegating constructor must keep its call edge")
 
+	// Exactly one: a definition's own signature is a call_expression in
+	// this grammar, and counting it as a call site would make every
+	// definition appear to call itself — invisible while the recursion
+	// guard swallowed it, visible the moment a constructor stops
+	// applying that guard. A call in a DEFAULT ARGUMENT is still a call
+	// and must survive.
+	sig, err := NewJuliaExtractor().Extract("sig.jl", []byte(`struct Rep
+    n::Int
+    tag::Bool
+end
+
+Rep(n) = Rep(n, false)
+
+function build(x = fallback())
+    use(x)
+end
+`))
+	require.NoError(t, err)
+	var selfCalls int
+	sigCalls := map[string]bool{}
+	for _, ed := range sig.Edges {
+		if ed.Kind != graph.EdgeCalls {
+			continue
+		}
+		sigCalls[ed.From+" -> "+ed.To] = true
+		if ed.To == "unresolved::Rep" {
+			selfCalls++
+		}
+	}
+	assert.Equal(t, 1, selfCalls,
+		"the delegation is one call; the signature is not a second one")
+	assert.True(t, sigCalls["sig.jl::build -> unresolved::fallback"],
+		"a call in a default argument value must still be recorded")
+	assert.True(t, sigCalls["sig.jl::build -> unresolved::use"])
+
 	// The macro is a macro, not Tag's constructor.
 	_, tagCtor := nodes["fw.jl::Tag.<init>"]
 	assert.False(t, tagCtor, "a macro must never be read as a constructor")

--- a/internal/parser/languages/julia_test.go
+++ b/internal/parser/languages/julia_test.go
@@ -474,6 +474,73 @@ end
 // it makes every field an `assignment` node whose left-hand side is the
 // declaration. A field scanner that recognised only `x::T` and `x` saw a
 // @kwdef struct as having no fields at all.
+// `import X as A` binds in the module it appears in. One file routinely
+// gives the same short nickname to different packages in different
+// modules, so a file-global alias map lets the last one win and rewrites
+// the earlier module's calls to a package they never touch. And a
+// submodule does NOT inherit its parent's bindings, so a definition
+// inside it that happens to share a name with an outer type is an
+// independent function, not that type's constructor.
+func TestJuliaExtractor_ModuleScopedAliasesAndTypes(t *testing.T) {
+	src := []byte(`module Plotting
+import Plots as P
+render(x) = P.plot(x)
+end
+
+module Reporting
+import PrettyTables as P
+show_it(x) = P.pretty_table(x)
+end
+
+module Outer
+
+struct Thing
+    v::Int
+end
+
+module Inner
+function Thing(x)
+    build(x)
+end
+end
+
+end
+`)
+	res, err := NewJuliaExtractor().Extract("sc.jl", src)
+	require.NoError(t, err)
+
+	calls := map[string]string{}
+	for _, ed := range res.Edges {
+		if ed.Kind == graph.EdgeCalls {
+			calls[ed.From] = ed.To
+		}
+	}
+	assert.Equal(t, "unresolved::Plots.plot", calls["sc.jl::render"],
+		"an alias declared in another module must not rewrite this call")
+	assert.Equal(t, "unresolved::PrettyTables.pretty_table", calls["sc.jl::show_it"])
+
+	nodes := map[string]*graph.Node{}
+	for _, n := range res.Nodes {
+		nodes[n.ID] = n
+	}
+	require.NotNil(t, nodes["sc.jl::Thing"], "the outer struct keeps its id")
+	_, isCtor := nodes["sc.jl::Thing.<init>"]
+	assert.False(t, isCtor,
+		"a submodule does not inherit the parent's types, so this is not a constructor")
+
+	var inner *graph.Node
+	for _, n := range res.Nodes {
+		if n.Name == "Thing" && n.Kind == graph.KindFunction {
+			inner = n
+		}
+	}
+	require.NotNil(t, inner, "the submodule definition must survive as a plain function")
+	assert.Equal(t, "Outer.Inner", inner.Meta["scope_mod"])
+	owners := juliaOwners(res.Edges)
+	assert.False(t, owners[inner.ID]["sc.jl::Thing"],
+		"it must not claim membership of the outer type")
+}
+
 func TestJuliaExtractor_KwdefStructFields(t *testing.T) {
 	src := []byte(`Base.@kwdef struct Config
     host::String = "localhost"

--- a/internal/parser/languages/julia_test.go
+++ b/internal/parser/languages/julia_test.go
@@ -926,6 +926,46 @@ end
 	}
 	assert.Equal(t, "sig(x)", onlyDoc, "a signature-only docstring must not vanish")
 
+	// A block comment spans rows, and those rows must be discounted from
+	// the adjacency distance rather than breaking it — the single-line
+	// case above spans zero rows and so cannot pin the arithmetic.
+	// A macro-wrapped definition takes the docstring above the WRAPPER,
+	// and a `quote` block inside a macro body is code, not a doc context.
+	more, err := NewJuliaExtractor().Extract("more.jl", []byte(`"""block doc""" #=
+spanning
+three rows
+=#
+blocked(x) = x
+
+"""kwdef doc"""
+Base.@kwdef struct Wrapped
+    n::Int = 1
+end
+
+macro gen(ex)
+    quote
+        "not documentation"
+        function generated()
+            1
+        end
+    end
+end
+`))
+	require.NoError(t, err)
+	moreDocs := map[string]string{}
+	for _, n := range more.Nodes {
+		if d, ok := n.Meta["doc"].(string); ok {
+			moreDocs[n.ID] = d
+		}
+	}
+	assert.Equal(t, "block doc", moreDocs["more.jl::blocked"],
+		"a block comment opening on the docstring's line does not detach it")
+	assert.Equal(t, "kwdef doc", moreDocs["more.jl::Wrapped"],
+		"a macro-wrapped struct takes the docstring above the macro call")
+	_, generatedDoc := moreDocs["more.jl::generated"]
+	assert.False(t, generatedDoc,
+		"a string inside a quote block in a macro body is code, not documentation")
+
 	for _, id := range []string{
 		"attach.jl::blank", "attach.jl::commented",
 		"attach.jl::returns_a_string", "attach.jl::nested",

--- a/internal/parser/languages/julia_test.go
+++ b/internal/parser/languages/julia_test.go
@@ -84,3 +84,283 @@ func TestJuliaExtractor_EmptyInput(t *testing.T) {
 	require.Len(t, res.Nodes, 1)
 	assert.Equal(t, graph.KindFile, res.Nodes[0].Kind)
 }
+
+// Definitions the regex extractor missed: where-parametrised
+// signatures, unicode / bang names, operator methods.
+func TestJuliaExtractor_DefinitionForms(t *testing.T) {
+	src := []byte(`function typed(a::Int, b::T) where T <: Number
+    return a + b
+end
+
+typedshort(x::Vector{T}) where T = sum(x)
+
+θ(σ̂) = σ̂ + 1
+
+foo!(x) = push!(x, 1)
+
+function Base.:+(a::Point, b::Point)
+    return a
+end
+
+macro mymacro(ex)
+    esc(ex)
+end
+`)
+	res, err := NewJuliaExtractor().Extract("forms.jl", src)
+	require.NoError(t, err)
+
+	kinds := map[string]graph.NodeKind{}
+	for _, n := range res.Nodes {
+		if n.ID == "forms.jl::"+n.Name || n.ID == "forms.jl::Base.+" {
+			kinds[n.Name] = n.Kind
+		}
+	}
+	assert.Equal(t, graph.KindFunction, kinds["typed"])
+	assert.Equal(t, graph.KindFunction, kinds["typedshort"])
+	assert.Equal(t, graph.KindFunction, kinds["θ"])
+	assert.Equal(t, graph.KindFunction, kinds["foo!"])
+	assert.Equal(t, graph.KindMethod, kinds["+"])
+
+	// Receiver metadata on the operator method.
+	var recvMeta bool
+	for _, n := range res.Nodes {
+		if n.Name == "+" && n.Kind == graph.KindMethod {
+			if m, ok := n.Meta["receiver"].(string); ok && m == "Base" {
+				recvMeta = true
+			}
+		}
+	}
+	assert.True(t, recvMeta, "Base.:+ should carry receiver metadata")
+
+	// Macro flag.
+	var macroFlag bool
+	for _, n := range res.Nodes {
+		if n.Name == "mymacro" {
+			if flag, ok := n.Meta["macro"].(bool); ok && flag {
+				macroFlag = true
+			}
+		}
+	}
+	assert.True(t, macroFlag)
+}
+
+func TestJuliaExtractor_TypesAndFields(t *testing.T) {
+	src := []byte(`module Shapes
+
+export area, Circle
+
+abstract type AbstractShape end
+abstract type Animal{T} <: Living end
+
+struct Point
+    x::Float64
+    y
+end
+
+mutable struct Counter <: AbstractShape
+    n::Int
+end
+
+struct Pair{T, S}
+    a::T
+    b::S
+end
+
+end
+`)
+	res, err := NewJuliaExtractor().Extract("shapes.jl", src)
+	require.NoError(t, err)
+
+	nodes := map[string]*graph.Node{}
+	for _, n := range res.Nodes {
+		nodes[n.ID] = n
+	}
+
+	// All type forms present.
+	for _, name := range []string{"AbstractShape", "Animal", "Point", "Counter", "Pair"} {
+		n, ok := nodes["shapes.jl::"+name]
+		require.True(t, ok, "missing type %s", name)
+		assert.Equal(t, graph.KindType, n.Kind)
+	}
+
+	// Struct fields with member_of edges into the struct.
+	for _, fid := range []string{
+		"shapes.jl::Point.x", "shapes.jl::Point.y",
+		"shapes.jl::Counter.n", "shapes.jl::Pair.a", "shapes.jl::Pair.b",
+	} {
+		n, ok := nodes[fid]
+		require.True(t, ok, "missing field %s", fid)
+		assert.Equal(t, graph.KindField, n.Kind)
+	}
+	var pointMemberOf int
+	for _, ed := range res.Edges {
+		if ed.Kind == graph.EdgeMemberOf && ed.To == "shapes.jl::Point" {
+			pointMemberOf++
+		}
+	}
+	assert.GreaterOrEqual(t, pointMemberOf, 2, "fields should member_of Point")
+
+	// Supertype edges: Animal → Living, Counter → AbstractShape.
+	var extendsAnimal, extendsCounter bool
+	for _, ed := range res.Edges {
+		if ed.Kind == graph.EdgeExtends && ed.From == "shapes.jl::Animal" && ed.To == "unresolved::Living" {
+			extendsAnimal = true
+		}
+		if ed.Kind == graph.EdgeExtends && ed.From == "shapes.jl::Counter" && ed.To == "unresolved::AbstractShape" {
+			extendsCounter = true
+		}
+	}
+	assert.True(t, extendsAnimal, "Animal <: Living edge missing")
+	assert.True(t, extendsCounter, "Counter <: AbstractShape edge missing")
+
+	// Export list recorded on the module node.
+	mod := nodes["shapes.jl::Shapes"]
+	require.NotNil(t, mod)
+	exports, ok := mod.Meta["exports"].([]string)
+	require.True(t, ok, "module Meta exports missing")
+	assert.ElementsMatch(t, []string{"area", "Circle"}, exports)
+}
+
+func TestJuliaExtractor_Imports(t *testing.T) {
+	src := []byte(`module M
+using LinearAlgebra
+using Statistics: mean, std
+import Base: show
+import Foo as F
+import A.B.C
+end
+`)
+	res, err := NewJuliaExtractor().Extract("imports.jl", src)
+	require.NoError(t, err)
+
+	targets := map[string]map[string]any{}
+	for _, ed := range res.Edges {
+		if ed.Kind != graph.EdgeImports {
+			continue
+		}
+		meta := map[string]any{}
+		for k, v := range ed.Meta {
+			meta[k] = v
+		}
+		targets[ed.To] = meta
+	}
+
+	require.Contains(t, targets, "unresolved::import::LinearAlgebra")
+	require.Contains(t, targets, "unresolved::import::Statistics")
+	names, ok := targets["unresolved::import::Statistics"]["names"].([]string)
+	require.True(t, ok, "selected import names missing")
+	assert.ElementsMatch(t, []string{"mean", "std"}, names)
+
+	require.Contains(t, targets, "unresolved::import::Base")
+	names, ok = targets["unresolved::import::Base"]["names"].([]string)
+	require.True(t, ok)
+	assert.ElementsMatch(t, []string{"show"}, names)
+
+	require.Contains(t, targets, "unresolved::import::Foo")
+	alias, ok := targets["unresolved::import::Foo"]["alias"].(string)
+	require.True(t, ok)
+	assert.Equal(t, "F", alias)
+
+	require.Contains(t, targets, "unresolved::import::A.B.C")
+}
+
+func TestJuliaExtractor_Calls(t *testing.T) {
+	src := []byte(`module Calls
+
+function outer(xs)
+    s = sum(xs)
+    m = MyMod.helper(xs)
+    b = sin.(xs)
+    @time helper(xs)
+    return θ(s)
+end
+
+inner() = begin
+    nested() = 1
+    nested()
+end
+
+end
+`)
+	res, err := NewJuliaExtractor().Extract("calls.jl", src)
+	require.NoError(t, err)
+
+	nodes := map[string]*graph.Node{}
+	for _, n := range res.Nodes {
+		nodes[n.ID] = n
+	}
+	require.Contains(t, nodes, "calls.jl::outer")
+	require.Contains(t, nodes, "calls.jl::inner")
+	require.Contains(t, nodes, "calls.jl::nested", "closure inside begin block should be extracted")
+
+	type call struct {
+		from, to string
+		meta     map[string]any
+	}
+	var calls []call
+	for _, ed := range res.Edges {
+		if ed.Kind == graph.EdgeCalls {
+			meta := map[string]any{}
+			for k, v := range ed.Meta {
+				meta[k] = v
+			}
+			calls = append(calls, call{ed.From, ed.To, meta})
+		}
+	}
+	find := func(from, to string) *call {
+		for i := range calls {
+			if calls[i].from == from && calls[i].to == to {
+				return &calls[i]
+			}
+		}
+		return nil
+	}
+
+	require.NotNil(t, find("calls.jl::outer", "unresolved::sum"), "bare call")
+	require.NotNil(t, find("calls.jl::outer", "unresolved::MyMod.helper"), "qualified call")
+	bc := find("calls.jl::outer", "unresolved::sin")
+	require.NotNil(t, bc, "broadcast call")
+	if flag, ok := bc.meta["broadcast"].(bool); !ok || !flag {
+		t.Errorf("broadcast call missing broadcast meta: %+v", bc.meta)
+	}
+	require.NotNil(t, find("calls.jl::outer", "unresolved::helper"), "call inside macro invocation")
+	require.NotNil(t, find("calls.jl::outer", "unresolved::time"), "macro invocation edge")
+	require.NotNil(t, find("calls.jl::outer", "unresolved::θ"), "unicode callee")
+	require.NotNil(t, find("calls.jl::inner", "unresolved::nested"), "closure call attributed to closure")
+
+	// Direct recursion must not emit an edge from nested to itself.
+	for _, c := range calls {
+		if c.from == "calls.jl::nested" && c.to == "unresolved::nested" {
+			t.Errorf("self-recursion edge emitted")
+		}
+	}
+}
+
+func TestJuliaExtractor_ConstAndDocstrings(t *testing.T) {
+	src := []byte(`"""
+Circle radius helpers.
+"""
+function radius(c)
+    c.r
+end
+
+const DEFAULT = 42
+`)
+	res, err := NewJuliaExtractor().Extract("doc.jl", src)
+	require.NoError(t, err)
+
+	nodes := map[string]*graph.Node{}
+	for _, n := range res.Nodes {
+		nodes[n.ID] = n
+	}
+
+	r := nodes["doc.jl::radius"]
+	require.NotNil(t, r)
+	doc, ok := r.Meta["doc"].(string)
+	require.True(t, ok, "preceding docstring should attach")
+	assert.Equal(t, "Circle radius helpers.", doc)
+
+	c := nodes["doc.jl::DEFAULT"]
+	require.NotNil(t, c)
+	assert.Equal(t, graph.KindVariable, c.Kind)
+}

--- a/internal/parser/languages/julia_test.go
+++ b/internal/parser/languages/julia_test.go
@@ -417,6 +417,65 @@ end
 	}
 }
 
+// Julia does not require a struct to precede the constructors that build
+// it, and a macro sharing a type's name is not a constructor at all —
+// `macro Tag` defines `@Tag`, a name in a disjoint namespace.
+func TestJuliaExtractor_ConstructorRecognitionEdges(t *testing.T) {
+	src := []byte(`Box(x) = make_box(x)
+
+struct Box
+    x::Int
+end
+
+Box(x, y) = make_box2(x, y)
+
+struct Tag
+    v::Int
+end
+
+macro Tag(x)
+    x
+end
+`)
+	res, err := NewJuliaExtractor().Extract("fw.jl", src)
+	require.NoError(t, err)
+
+	nodes := map[string]*graph.Node{}
+	for _, n := range res.Nodes {
+		nodes[n.ID] = n
+	}
+	owners := juliaOwners(res.Edges)
+
+	// The TYPE keeps the canonical id even though a constructor was
+	// written above it.
+	box := nodes["fw.jl::Box"]
+	require.NotNil(t, box, "the struct must keep the canonical id")
+	assert.Equal(t, graph.KindType, box.Kind)
+	require.NotNil(t, nodes["fw.jl::Box.x"], "and so must its field")
+
+	var ctors int
+	for _, n := range res.Nodes {
+		if n.Kind == graph.KindMethod && strings.HasPrefix(n.ID, "fw.jl::Box.<init>") {
+			ctors++
+			assert.True(t, owners[n.ID]["fw.jl::Box"], "%s must belong to Box", n.ID)
+		}
+	}
+	assert.Equal(t, 2, ctors, "the constructor above the struct counts too")
+
+	// The macro is a macro, not Tag's constructor.
+	_, tagCtor := nodes["fw.jl::Tag.<init>"]
+	assert.False(t, tagCtor, "a macro must never be read as a constructor")
+	var macroNode *graph.Node
+	for _, n := range res.Nodes {
+		if n.Name == "Tag" && n.Meta["macro"] == true {
+			macroNode = n
+		}
+	}
+	require.NotNil(t, macroNode, "the macro must survive as its own node")
+	assert.Equal(t, graph.KindFunction, macroNode.Kind)
+	assert.False(t, owners[macroNode.ID]["fw.jl::Tag"])
+}
+
 // A nested module contributes its full dotted path, and a constructor
 // binds to the type declared in its own module rather than to a
 // same-named type in a sibling one.

--- a/internal/parser/languages/julia_test.go
+++ b/internal/parser/languages/julia_test.go
@@ -345,6 +345,21 @@ end
 	require.NotNil(t, nodes["dup.jl::S_L12"])
 	require.NotNil(t, nodes["dup.jl::S.a"])
 	require.NotNil(t, nodes["dup.jl::S_L12.b"])
+	// Two methods of one name written on ONE physical line cannot be
+	// separated by a line suffix. Only one node is minted, but the
+	// second body's calls must still be attributed rather than dropped.
+	oneLine, err := NewJuliaExtractor().Extract("one.jl", []byte("g(x) = h(x); g(y) = k(y)\n"))
+	require.NoError(t, err)
+	oneLineCalls := map[string]bool{}
+	for _, ed := range oneLine.Edges {
+		if ed.Kind == graph.EdgeCalls {
+			oneLineCalls[ed.From+" -> "+ed.To] = true
+		}
+	}
+	assert.True(t, oneLineCalls["one.jl::g -> unresolved::h"])
+	assert.True(t, oneLineCalls["one.jl::g -> unresolved::k"],
+		"a same-line twin's calls must not be dropped")
+
 	assert.True(t, owners["dup.jl::S.a"]["dup.jl::S"])
 	assert.True(t, owners["dup.jl::S_L12.b"]["dup.jl::S_L12"],
 		"a field must belong to its own struct, not to whichever came first")

--- a/internal/parser/languages/julia_test.go
+++ b/internal/parser/languages/julia_test.go
@@ -144,6 +144,56 @@ end
 	assert.True(t, macroFlag)
 }
 
+// A declared return type nests the callee one level deeper — the grammar
+// parses `f(x)::Int` as typed_expression(call_expression) and
+// `f(x)::T where T` as where_expression(typed_expression(call_expression)) —
+// so a peeler that knew only `where_expression` lost the definition AND
+// every call in its body. The base regex extractor still emitted the long
+// form, which makes that half a straight regression.
+func TestJuliaExtractor_ReturnTypeAnnotatedDefinitions(t *testing.T) {
+	src := []byte(`function long_form(x)::Int
+    helper(x)
+end
+
+short_plain(x)::Int = helper(x)
+
+short_where(x)::T where T = helper(x)
+
+function bare_where(x) where T
+    helper(x)
+end
+
+function empty_generic end
+`)
+	res, err := NewJuliaExtractor().Extract("ret.jl", src)
+	require.NoError(t, err)
+
+	nodes := map[string]*graph.Node{}
+	for _, n := range res.Nodes {
+		nodes[n.ID] = n
+	}
+	calls := map[string]bool{}
+	for _, ed := range res.Edges {
+		if ed.Kind == graph.EdgeCalls {
+			calls[ed.From+" -> "+ed.To] = true
+		}
+	}
+
+	for _, name := range []string{"long_form", "short_plain", "short_where", "bare_where"} {
+		n, ok := nodes["ret.jl::"+name]
+		require.True(t, ok, "missing definition %s", name)
+		assert.Equal(t, graph.KindFunction, n.Kind)
+		assert.True(t, calls["ret.jl::"+name+" -> unresolved::helper"],
+			"%s should attribute its body call", name)
+	}
+
+	// `function f end` declares an empty generic function: the signature
+	// holds the name directly, with no argument list to peel to.
+	n, ok := nodes["ret.jl::empty_generic"]
+	require.True(t, ok, "empty generic declaration should still be a definition")
+	assert.Equal(t, graph.KindFunction, n.Kind)
+}
+
 func TestJuliaExtractor_TypesAndFields(t *testing.T) {
 	src := []byte(`module Shapes
 

--- a/internal/parser/languages/julia_test.go
+++ b/internal/parser/languages/julia_test.go
@@ -1,6 +1,7 @@
 package languages
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -832,6 +833,43 @@ import Base: + as plus, -
 		"a renamed operator selection must not vanish")
 	assert.Equal(t, "plus", bindings["unresolved::import::Base::+"])
 	require.Contains(t, bindings, "unresolved::import::Base::-")
+
+	// A rename must survive the store, which drops Edge.Alias — so it
+	// rides on Meta too.
+	for _, ed := range res.Edges {
+		if ed.To == "unresolved::import::Base::+" {
+			assert.Equal(t, "plus", ed.Meta["alias"],
+				"the local name needs a persisted half, not only Edge.Alias")
+		}
+	}
+
+	// One statement must not dwarf a file's graph: past the cap only the
+	// module edge is kept, and the selected names stay in its Meta.
+	var wide strings.Builder
+	wide.WriteString("using Base: ")
+	for i := 0; i < juliaImportBindingCap+1; i++ {
+		if i > 0 {
+			wide.WriteString(", ")
+		}
+		fmt.Fprintf(&wide, "n%d", i)
+	}
+	wide.WriteString("\n")
+	big, err := NewJuliaExtractor().Extract("big.jl", []byte(wide.String()))
+	require.NoError(t, err)
+	var bigImports int
+	var bigNames []string
+	for _, ed := range big.Edges {
+		if ed.Kind != graph.EdgeImports {
+			continue
+		}
+		bigImports++
+		if v, ok := ed.Meta["names"].([]string); ok {
+			bigNames = v
+		}
+	}
+	assert.Equal(t, 1, bigImports, "past the cap only the module edge is emitted")
+	assert.Len(t, bigNames, juliaImportBindingCap+1,
+		"and the selected names are still recorded on it")
 }
 
 func TestJuliaExtractor_Calls(t *testing.T) {

--- a/internal/parser/languages/julia_test.go
+++ b/internal/parser/languages/julia_test.go
@@ -702,6 +702,44 @@ import Foo: bar as baz
 	assert.ElementsMatch(t, []string{"bar"}, byTarget["unresolved::import::Foo"][0].names)
 }
 
+// A selected macro is a `macro_identifier` node and a selected operator an
+// `operator` node, so an identifier-only scan drops both — including from
+// the per-binding edges the module edge's `names` meta exists to back.
+// `using Base: @time` and `import Base: + as plus` are ordinary Julia.
+func TestJuliaExtractor_MacroAndOperatorSelections(t *testing.T) {
+	src := []byte(`using Base: @time, isempty
+import Base.Threads: @spawn
+import Base: + as plus, -
+`)
+	res, err := NewJuliaExtractor().Extract("sel.jl", src)
+	require.NoError(t, err)
+
+	names := map[string][]string{}
+	bindings := map[string]string{}
+	for _, ed := range res.Edges {
+		if ed.Kind != graph.EdgeImports {
+			continue
+		}
+		if v, ok := ed.Meta["names"].([]string); ok {
+			names[ed.To] = append(names[ed.To], v...)
+		}
+		bindings[ed.To] = ed.Alias
+	}
+
+	// Two statements select from Base, so the names accumulate.
+	assert.ElementsMatch(t, []string{"@time", "isempty", "+", "-"},
+		names["unresolved::import::Base"])
+	require.Contains(t, bindings, "unresolved::import::Base::@time",
+		"a selected macro needs its own binding edge")
+	require.Contains(t, bindings, "unresolved::import::Base.Threads::@spawn")
+	assert.ElementsMatch(t, []string{"@spawn"}, names["unresolved::import::Base.Threads"])
+
+	require.Contains(t, bindings, "unresolved::import::Base::+",
+		"a renamed operator selection must not vanish")
+	assert.Equal(t, "plus", bindings["unresolved::import::Base::+"])
+	require.Contains(t, bindings, "unresolved::import::Base::-")
+}
+
 func TestJuliaExtractor_Calls(t *testing.T) {
 	src := []byte(`module Calls
 

--- a/internal/parser/languages/julia_test.go
+++ b/internal/parser/languages/julia_test.go
@@ -513,10 +513,19 @@ Box() = Box(0)
 }
 
 // A nested module contributes its full dotted path, and a constructor
-// binds to the type declared in its own module rather than to a
-// same-named type in a sibling one.
+// binds to the type declared in its OWN module.
+//
+// The declaration order is the point: the outer struct comes first and
+// its constructor last, so a flat last-write-wins name table would hold
+// the INNER module's Node by the time the outer constructor is reached
+// and would bind it to the wrong type. Only keying by module gets this
+// right.
 func TestJuliaExtractor_NestedModuleScope(t *testing.T) {
 	src := []byte(`module Outer
+
+struct Node
+    w::Int
+end
 
 module Inner
 struct Node
@@ -525,9 +534,6 @@ end
 Node(v) = build_inner(v)
 end
 
-struct Node
-    w::Int
-end
 Node(w) = build_outer(w)
 
 end
@@ -541,10 +547,10 @@ end
 	}
 	require.NotNil(t, nodes["nest.jl::Inner"])
 	assert.Equal(t, "Outer", nodes["nest.jl::Inner"].Meta["scope_mod"])
-	require.NotNil(t, nodes["nest.jl::Node"])
-	assert.Equal(t, "Outer.Inner", nodes["nest.jl::Node"].Meta["scope_mod"])
-	require.NotNil(t, nodes["nest.jl::Node_L10"])
-	assert.Equal(t, "Outer", nodes["nest.jl::Node_L10"].Meta["scope_mod"])
+	require.NotNil(t, nodes["nest.jl::Node"], "the outer struct keeps the clean id")
+	assert.Equal(t, "Outer", nodes["nest.jl::Node"].Meta["scope_mod"])
+	require.NotNil(t, nodes["nest.jl::Node_L8"], "the inner struct is disambiguated")
+	assert.Equal(t, "Outer.Inner", nodes["nest.jl::Node_L8"].Meta["scope_mod"])
 
 	owners := juliaOwners(res.Edges)
 	callers := map[string]string{}
@@ -557,129 +563,12 @@ end
 	outer := callers["unresolved::build_outer"]
 	require.NotEmpty(t, inner)
 	require.NotEmpty(t, outer)
-	assert.True(t, owners[inner]["nest.jl::Node"],
+	assert.True(t, owners[inner]["nest.jl::Node_L8"],
 		"the inner module's constructor must belong to the inner module's type")
-	assert.True(t, owners[outer]["nest.jl::Node_L10"],
+	assert.True(t, owners[outer]["nest.jl::Node"],
 		"the outer module's constructor must belong to the outer module's type")
-	assert.False(t, owners[outer]["nest.jl::Node"],
-		"it must NOT bind to the same-named type in the nested module")
-}
-
-// `Base.@kwdef` is the idiomatic way to give struct fields defaults, and
-// it makes every field an `assignment` node whose left-hand side is the
-// declaration. A field scanner that recognised only `x::T` and `x` saw a
-// @kwdef struct as having no fields at all.
-// `import X as A` binds in the module it appears in. One file routinely
-// gives the same short nickname to different packages in different
-// modules, so a file-global alias map lets the last one win and rewrites
-// the earlier module's calls to a package they never touch. And a
-// submodule does NOT inherit its parent's bindings, so a definition
-// inside it that happens to share a name with an outer type is an
-// independent function, not that type's constructor.
-func TestJuliaExtractor_ModuleScopedAliasesAndTypes(t *testing.T) {
-	src := []byte(`module Plotting
-import Plots as P
-render(x) = P.plot(x)
-end
-
-module Reporting
-import PrettyTables as P
-show_it(x) = P.pretty_table(x)
-end
-
-module Outer
-
-struct Thing
-    v::Int
-end
-
-module Inner
-function Thing(x)
-    build(x)
-end
-end
-
-end
-`)
-	res, err := NewJuliaExtractor().Extract("sc.jl", src)
-	require.NoError(t, err)
-
-	calls := map[string]string{}
-	for _, ed := range res.Edges {
-		if ed.Kind == graph.EdgeCalls {
-			calls[ed.From] = ed.To
-		}
-	}
-	assert.Equal(t, "unresolved::Plots.plot", calls["sc.jl::render"],
-		"an alias declared in another module must not rewrite this call")
-	assert.Equal(t, "unresolved::PrettyTables.pretty_table", calls["sc.jl::show_it"])
-
-	nodes := map[string]*graph.Node{}
-	for _, n := range res.Nodes {
-		nodes[n.ID] = n
-	}
-	require.NotNil(t, nodes["sc.jl::Thing"], "the outer struct keeps its id")
-	_, isCtor := nodes["sc.jl::Thing.<init>"]
-	assert.False(t, isCtor,
-		"a submodule does not inherit the parent's types, so this is not a constructor")
-
-	var inner *graph.Node
-	for _, n := range res.Nodes {
-		if n.Name == "Thing" && n.Kind == graph.KindFunction {
-			inner = n
-		}
-	}
-	require.NotNil(t, inner, "the submodule definition must survive as a plain function")
-	assert.Equal(t, "Outer.Inner", inner.Meta["scope_mod"])
-	owners := juliaOwners(res.Edges)
-	assert.False(t, owners[inner.ID]["sc.jl::Thing"],
-		"it must not claim membership of the outer type")
-}
-
-func TestJuliaExtractor_KwdefStructFields(t *testing.T) {
-	src := []byte(`Base.@kwdef struct Config
-    host::String = "localhost"
-    port::Int = 8080
-    debug = false
-end
-
-@kwdef struct Bare
-    n::Int = 1
-end
-
-struct Guarded
-    v::Int = 0
-    Guarded(v) = new(check(v))
-end
-`)
-	res, err := NewJuliaExtractor().Extract("kw.jl", src)
-	require.NoError(t, err)
-
-	nodes := map[string]*graph.Node{}
-	for _, n := range res.Nodes {
-		nodes[n.ID] = n
-	}
-	owners := juliaOwners(res.Edges)
-
-	for _, fid := range []string{
-		"kw.jl::Config.host", "kw.jl::Config.port", "kw.jl::Config.debug",
-		"kw.jl::Bare.n", "kw.jl::Guarded.v",
-	} {
-		n, ok := nodes[fid]
-		require.True(t, ok, "missing field %s", fid)
-		assert.Equal(t, graph.KindField, n.Kind)
-	}
-	assert.True(t, owners["kw.jl::Config.host"]["kw.jl::Config"])
-	assert.True(t, owners["kw.jl::Bare.n"]["kw.jl::Bare"],
-		"the bare @kwdef form must work too, not just Base.@kwdef")
-
-	// An inner constructor is an assignment child of the struct as well,
-	// but it is a definition, not a field.
-	ctor, ok := nodes["kw.jl::Guarded.<init>"]
-	require.True(t, ok, "an inner constructor must stay a constructor")
-	assert.Equal(t, graph.KindMethod, ctor.Kind)
-	_, isField := nodes["kw.jl::Guarded.Guarded"]
-	assert.False(t, isField, "an inner constructor must not be read as a field")
+	assert.False(t, owners[outer]["nest.jl::Node_L8"],
+		"it must NOT bind to the same-named type declared later in a submodule")
 }
 
 func TestJuliaExtractor_Imports(t *testing.T) {

--- a/internal/parser/languages/julia_test.go
+++ b/internal/parser/languages/julia_test.go
@@ -314,6 +314,78 @@ end
 	require.Contains(t, targets, "unresolved::import::A.B.C")
 }
 
+// The cross-product the isolated per-feature tests missed: a dotted or
+// relative module path COMBINED with a selective list or an alias. In
+// those shapes the module is an `import_path` child, so the
+// identifier-only scan skipped it and promoted the first selected name
+// (or the alias) to the import target — `using A.B: x, y` imported "x".
+// The regex extractor this replaced still recorded `A.B`.
+func TestJuliaExtractor_CombinedImportPaths(t *testing.T) {
+	src := []byte(`using A.B: x, y
+import C.D as CD
+using .Local: z
+import .Local as L
+import ..Up: q
+using Base: +, -
+import Foo: bar as baz
+`)
+	res, err := NewJuliaExtractor().Extract("imp.jl", src)
+	require.NoError(t, err)
+
+	type imp struct {
+		names []string
+		alias string
+	}
+	byTarget := map[string][]imp{}
+	for _, ed := range res.Edges {
+		if ed.Kind != graph.EdgeImports {
+			continue
+		}
+		var got imp
+		if v, ok := ed.Meta["names"].([]string); ok {
+			got.names = v
+		}
+		if v, ok := ed.Meta["alias"].(string); ok {
+			got.alias = v
+		}
+		byTarget[ed.To] = append(byTarget[ed.To], got)
+	}
+
+	require.Contains(t, byTarget, "unresolved::import::A.B", "dotted + selective must keep the module")
+	assert.ElementsMatch(t, []string{"x", "y"}, byTarget["unresolved::import::A.B"][0].names)
+
+	require.Contains(t, byTarget, "unresolved::import::C.D", "dotted + alias must keep the module")
+	assert.Equal(t, "CD", byTarget["unresolved::import::C.D"][0].alias)
+
+	require.Contains(t, byTarget, "unresolved::import::..Up", "a relative path keeps its leading dots")
+	assert.ElementsMatch(t, []string{"q"}, byTarget["unresolved::import::..Up"][0].names)
+
+	// One relative module reached both ways in the same file.
+	local := byTarget["unresolved::import::.Local"]
+	require.Len(t, local, 2, "relative + selective and relative + alias are two imports of .Local")
+	var sawNames, sawAlias bool
+	for _, got := range local {
+		if len(got.names) == 1 && got.names[0] == "z" {
+			sawNames = true
+		}
+		if got.alias == "L" {
+			sawAlias = true
+		}
+	}
+	assert.True(t, sawNames, "relative + selective must record the selected name")
+	assert.True(t, sawAlias, "relative + alias must record the alias")
+
+	// Operators are `operator` nodes, not identifiers, so an
+	// identifier-only scan recorded an empty selection for them.
+	require.Contains(t, byTarget, "unresolved::import::Base")
+	assert.ElementsMatch(t, []string{"+", "-"}, byTarget["unresolved::import::Base"][0].names)
+
+	// A renamed binding inside a selected list still selects the
+	// UPSTREAM name.
+	require.Contains(t, byTarget, "unresolved::import::Foo")
+	assert.ElementsMatch(t, []string{"bar"}, byTarget["unresolved::import::Foo"][0].names)
+}
+
 func TestJuliaExtractor_Calls(t *testing.T) {
 	src := []byte(`module Calls
 

--- a/internal/parser/languages/julia_test.go
+++ b/internal/parser/languages/julia_test.go
@@ -735,3 +735,81 @@ const DEFAULT = 42
 	require.NotNil(t, c)
 	assert.Equal(t, graph.KindVariable, c.Kind)
 }
+
+// Julia attaches a docstring to the object IMMEDIATELY below it: its
+// parser allows exactly one newline between the two, and the manual says
+// twice that no blank line or comment may intervene. A string at the top
+// of a function BODY is not documentation at all — a function body is
+// parsed with the ordinary expression production — so a helper that
+// returns a string used to document itself with its own return value.
+func TestJuliaExtractor_DocstringAttachment(t *testing.T) {
+	src := []byte(`"""
+    radius(c)
+
+Return the radius of ` + "`c`" + `.
+"""
+long(c) = c.r
+
+"""short doc"""
+short(x) = x
+
+"""const doc"""
+const TUNED = 1
+
+"""type doc"""
+struct Documented
+    a
+end
+
+"""trailing comment doc""" # still adjacent
+adjacent(x) = x
+
+"""detached by a blank line"""
+
+blank(x) = x
+
+"""detached by a comment"""
+# an own line
+commented(x) = x
+
+function returns_a_string()
+    "not documentation, just the return value"
+end
+
+function outer()
+    "not documentation either"
+    function nested()
+        1
+    end
+end
+`)
+	res, err := NewJuliaExtractor().Extract("attach.jl", src)
+	require.NoError(t, err)
+
+	docs := map[string]string{}
+	for _, n := range res.Nodes {
+		if d, ok := n.Meta["doc"].(string); ok {
+			docs[n.ID] = d
+		}
+	}
+
+	// Julia's own convention opens a docstring with the signature,
+	// indented, then a blank line, then the prose — so the summary is the
+	// FIRST PROSE paragraph, not literally the first one.
+	assert.Equal(t, "Return the radius of `c`.", docs["attach.jl::long"],
+		"the indented signature block is not the documentation")
+	assert.Equal(t, "short doc", docs["attach.jl::short"],
+		"a short-form definition takes a docstring like any other")
+	assert.Equal(t, "const doc", docs["attach.jl::TUNED"])
+	assert.Equal(t, "type doc", docs["attach.jl::Documented"])
+	assert.Equal(t, "trailing comment doc", docs["attach.jl::adjacent"],
+		"a comment on the docstring's own line does not detach it")
+
+	for _, id := range []string{
+		"attach.jl::blank", "attach.jl::commented",
+		"attach.jl::returns_a_string", "attach.jl::nested",
+	} {
+		_, ok := docs[id]
+		assert.False(t, ok, "%s must not be documented, got %q", id, docs[id])
+	}
+}

--- a/internal/resolver/julia_import_alias_test.go
+++ b/internal/resolver/julia_import_alias_test.go
@@ -1,0 +1,120 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// buildJuliaGraph extracts every fixture with the real Julia extractor and
+// loads the result into a fresh graph, so ResolveAll runs against exactly
+// the unresolved edges a live index would hold.
+func buildJuliaGraph(t *testing.T, files map[string]string) graph.Store {
+	t.Helper()
+	g := graph.New()
+	jl := languages.NewJuliaExtractor()
+	for path, src := range files {
+		r, err := jl.Extract(path, []byte(src))
+		require.NoError(t, err, "extract %s", path)
+		for _, n := range r.Nodes {
+			g.AddNode(n)
+		}
+		for _, e := range r.Edges {
+			g.AddEdge(e)
+		}
+	}
+	return g
+}
+
+func juliaOutEdge(g graph.Store, fromID string, kind graph.EdgeKind) []*graph.Edge {
+	var out []*graph.Edge
+	for _, e := range g.GetOutEdges(fromID) {
+		if e.Kind == kind {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// An `import M as A` renames a module for one file only, so `A.f(x)` has
+// to reach whatever `M.f(x)` reaches. The extractor used to emit the
+// nickname verbatim, giving `unresolved::A.f` — a name no module in the
+// graph carries — so the aliased and unaliased spellings produced
+// different graphs and nothing downstream could map one back to the
+// other. Recording the alias in edge metadata did not help: the resolver
+// reads the edge target, and nothing in the repository reads that Meta.
+//
+// This runs extraction through ResolveAll, which is where the difference
+// would show up.
+func TestJuliaImports_AliasedCallMatchesUnaliasedCall(t *testing.T) {
+	const provider = "foo.jl"
+	const providerSrc = `module Foo
+
+process(x) = x + 1
+
+end
+`
+	aliased := buildJuliaGraph(t, map[string]string{
+		provider: providerSrc,
+		"run.jl": "import Foo as F\nrun(x) = F.process(x)\n",
+	})
+	New(aliased).ResolveAll()
+
+	plain := buildJuliaGraph(t, map[string]string{
+		provider: providerSrc,
+		"run.jl": "import Foo\nrun(x) = Foo.process(x)\n",
+	})
+	New(plain).ResolveAll()
+
+	aliasedCalls := juliaOutEdge(aliased, "run.jl::run", graph.EdgeCalls)
+	plainCalls := juliaOutEdge(plain, "run.jl::run", graph.EdgeCalls)
+	require.Len(t, aliasedCalls, 1)
+	require.Len(t, plainCalls, 1)
+	assert.Equal(t, plainCalls[0].To, aliasedCalls[0].To,
+		"the alias is a file-local nickname; it must not change what the call names")
+	assert.Equal(t, "unresolved::Foo.process", aliasedCalls[0].To,
+		"the call must name the imported module, not the local alias")
+
+	// The module import edge carries the rename in the graph's canonical
+	// field as well as in Meta — Meta is the half the SQLite edges table
+	// persists, since it has no alias column.
+	imports := juliaOutEdge(aliased, "run.jl", graph.EdgeImports)
+	require.Len(t, imports, 1)
+	assert.Equal(t, "F", imports[0].Alias)
+	assert.Equal(t, "F", imports[0].Meta["alias"])
+}
+
+// A selective import binds names, not just a module, so each binding gets
+// its own edge — the representation JS/TS already emits for
+// `import { a, b as c } from "mod"`. Without it the selected names lived
+// only in an edge Meta key that nothing in the repository reads.
+func TestJuliaImports_SelectiveBindingsAreTraversable(t *testing.T) {
+	g := buildJuliaGraph(t, map[string]string{
+		"stats.jl": "module Stats\nmean(x) = x\nstd(x) = x\nend\n",
+		"use.jl":   "using Stats: mean, std\nimport Stats: mean as average\nrun(x) = mean(x)\n",
+	})
+	New(g).ResolveAll()
+
+	byTarget := map[string]*graph.Edge{}
+	for _, e := range juliaOutEdge(g, "use.jl", graph.EdgeImports) {
+		byTarget[e.To] = e
+	}
+	require.Contains(t, byTarget, "external::Stats::mean",
+		"a selected name must be reachable as its own import edge")
+	require.Contains(t, byTarget, "external::Stats::std")
+
+	var renamed *graph.Edge
+	for _, e := range juliaOutEdge(g, "use.jl", graph.EdgeImports) {
+		if e.Alias != "" {
+			renamed = e
+		}
+	}
+	require.NotNil(t, renamed, "a renamed binding must record its local name")
+	assert.Equal(t, "average", renamed.Alias)
+	assert.Equal(t, "external::Stats::mean", renamed.To,
+		"the edge still targets the upstream name; the alias is the local one")
+}


### PR DESCRIPTION
## Summary

Replaces the regex-based Julia extractor with a tree-sitter extractor, upgrading .jl files from shallow line-scan extraction to full concrete-syntax-tree analysis. Bumps the extractor version to 2 so stale regex-era extractions are re-indexed.

## Changes

- internal/parser/languages/julia.go — rewritten around tree-sitter-julia (go-sitter-forest):
  - Modules (module/baremodule) index as KindType carrying Meta["exports"]; nested definitions get member_of edges
  - Types: abstract/primitive/mutable/parametric structs; fields as KindField + member_of; supertypes emit extends edges with the full parametric RHS preserved in Meta["base_path"] (python-extractor convention)
  - Functions/macros: long-form, short-form (f(x) = body, incl. where clauses), unicode/bang identifiers, operator methods (Base.:+) as KindMethod with Meta["receiver"] + EdgeMemberOf (luau convention), macros flagged via Meta["macro"]
  - Imports: all four forms (using M, using M: a, b → names meta, import M as Alias → alias meta, dotted paths); include("f.jl") still emits an imports edge, preserving the legacy extractor's contract
  - Calls: bare, qualified (MyMod.helper), broadcast (sin.(xs) → broadcast meta), and macro invocations (@time f(x) emits both macro and inner call edges); direct self-recursion suppressed
  - Preceding and body docstrings attach as Meta["doc"]
- internal/parser/languages/julia_test.go — 8 scenarios covering modules/exports, type & field extraction, definition forms, imports, calls (incl. closure attribution + recursion suppression), docstrings, and empty input
- internal/indexer/extractor_version.go — "julia": 2 version bump + .jl salt entry so existing .jl graph entries re-extract
- docs/languages.md — Julia promoted into the bespoke tree-sitter tier; new "Julia specifics" section documenting node kinds and metadata conventions

## Testing

- All tests pass (go test -race ./...) — branch-scoped packages green (internal/indexer, merkle, internal/parser/languages); two unrelated packages flake only under full-suite parallel load and pass on isolated rerun
- New tests added for new functionality
- Benchmarks run if performance-relevant (N/A — extraction-correctness change, no hot-path algorithm changes)

## Checklist

- Code follows existing patterns in the codebase (mirrors python base_path and luau receiver conventions already documented in docs/languages.md)
- No unnecessary abstractions added (only two small internal state structs: juliaScope, juliaWalkState)
- Language extractor includes Meta["methods"] for interfaces (N/A — Julia has no interface construct)
- Methods have EdgeMemberOf edges to their containing type (qualified methods → receiver type; struct fields and module members likewise)