### PR TITLE
csharp: EF Core ORM model attribution (models_table for the seventh ecosystem)

### DIFF
--- a/internal/indexer/coverage_strip_test.go
+++ b/internal/indexer/coverage_strip_test.go
@@ -66,3 +66,58 @@ func TestStripFunctionShape(t *testing.T) {
 		t.Error("defines edge missing after strip")
 	}
 }
+
+// TestStripSQLArtifacts_PreservesORMTableNodes: the sql domain gates
+// the NOISY code-side string-literal SQL extraction. ORM model
+// attribution (models_table) is declaration-anchored — attributes,
+// DbSet properties, schema classes — and must survive the gate the
+// same way migration-origin DDL does, or the models_table layer is
+// silently empty for every ORM ecosystem under the default config.
+func TestStripSQLArtifacts_PreservesORMTableNodes(t *testing.T) {
+	result := &parser.ExtractionResult{
+		Nodes: []*graph.Node{
+			{ID: "Models/StockCrate.cs::StockCrate", Kind: graph.KindType, Name: "StockCrate"},
+			{ID: "db::orm::stock_crates", Kind: graph.KindTable, Name: "stock_crates",
+				Meta: map[string]any{"dialect": "orm", "schema": "", "source": "csharp-orm"}},
+			{ID: "db::sqlite::guessed", Kind: graph.KindTable, Name: "guessed"},
+			{ID: "db::sqlite::from_ddl", Kind: graph.KindTable, Name: "from_ddl",
+				Meta: map[string]any{"origin": "migration"}},
+			{ID: "str::sql1", Kind: graph.KindString, Name: "q",
+				Meta: map[string]any{"context": "sql"}},
+		},
+		Edges: []*graph.Edge{
+			{From: "Models/StockCrate.cs::StockCrate", To: "db::orm::stock_crates", Kind: graph.EdgeModelsTable},
+			{From: "svc::repo.Load", To: "db::sqlite::guessed", Kind: graph.EdgeQueries},
+		},
+	}
+	stripSQLArtifacts(result)
+
+	kept := map[string]bool{}
+	for _, n := range result.Nodes {
+		kept[n.ID] = true
+	}
+	if !kept["db::orm::stock_crates"] {
+		t.Errorf("ORM table node stripped — models_table layer dies under the default config")
+	}
+	if !kept["db::sqlite::from_ddl"] {
+		t.Errorf("migration-origin table node should survive as before")
+	}
+	if kept["db::sqlite::guessed"] {
+		t.Errorf("code-side SQL table guess should still be stripped")
+	}
+	if kept["str::sql1"] {
+		t.Errorf("sql-context string registry node should still be stripped")
+	}
+	hasModels := false
+	for _, e := range result.Edges {
+		if e.Kind == graph.EdgeModelsTable {
+			hasModels = true
+		}
+		if e.Kind == graph.EdgeQueries {
+			t.Errorf("queries edge should still be stripped: %+v", e)
+		}
+	}
+	if !hasModels {
+		t.Errorf("models_table edge to the surviving ORM table node should be kept")
+	}
+}

--- a/internal/indexer/extractor_version.go
+++ b/internal/indexer/extractor_version.go
@@ -32,7 +32,7 @@ var extractorVersions = map[string]int{
 	//   "go": 2,
 	"c":      generatedParserProjectionPolicyVersion, // generated parser projection covers all strictly detected table sizes
 	"php":    2,                                      // class/interface inheritance now emits typed structural edges
-	"csharp": 12,                                     // receiverless calls carry arg_count / type_arg_count for #559 (was: params parameters emit complete shape and arity evidence)
+	"csharp": 13,                                     // EF Core ORM facts: [Table] models_table edges, ef_config_* and ef_fluent stamps (was: receiverless calls carry arg_count / type_arg_count for #559)
 	"scala":  2,                                      // explicitly instantiated generic calls emit call edges
 	"go":     3,                                      // generic instantiations are marked so indexing a func value cannot bind (was: generic calls emit call edges)
 	"cpp":    2,                                      // templated and namespace-qualified calls emit call edges

--- a/internal/indexer/extractor_version_test.go
+++ b/internal/indexer/extractor_version_test.go
@@ -62,9 +62,13 @@ func TestStaleLangsDetection(t *testing.T) {
 		if got := ExtractorVersionStaleLangs(`{"csharp":10}`); !reflect.DeepEqual(got, []string{"csharp"}) {
 			t.Errorf("stored pre-params C# version = %v, want [csharp]", got)
 		}
+		// A store extracted before the EF Core ORM stamps must re-extract
+		// unchanged .cs files: the models_table pass reads facts ([Table]
+		// edges, ef_config_* and ef_fluent stamps) that only re-extraction
+		// can mint.
 		for _, path := range []string{"src/Handler.cs", "Views/Page.razor", "Views/Page.cshtml"} {
-			if got := merkleSaltFor(path); got != "csharp@12" {
-				t.Errorf("C# extractor salt for %s = %q, want csharp@12", path, got)
+			if got := merkleSaltFor(path); got != "csharp@13" {
+				t.Errorf("C# extractor salt for %s = %q, want csharp@13", path, got)
 			}
 		}
 		if got := merkleSaltFor("src/Handler.php"); got != "php@2" {

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -1809,11 +1809,21 @@ func applyMigrationExtraction(relPath string, src []byte, result *parser.Extract
 // defaults off because string-literal pattern matching against
 // db.Get / db.Query / db.Exec produces false positives when
 // domain code shares method names (cache.Get, etc.).
+//
+// Two table-node origins survive the gate, because neither is the
+// noisy code-side matching the gate exists for: migration-origin DDL
+// (unambiguous CREATE TABLE — see applyMigrationExtraction), and
+// ORM-origin model attribution (declaration-anchored: @Entity/@Table
+// annotations, [Table] attributes, ActiveRecord bases, DbSet
+// properties). Stripping the ORM nodes would leave the models_table
+// layer silently empty for every ORM ecosystem under the default
+// config.
 func stripSQLArtifacts(result *parser.ExtractionResult) {
 	stripped := make(map[string]struct{})
 	keptNodes := result.Nodes[:0]
 	for _, n := range result.Nodes {
-		if (n.Kind == graph.KindTable || n.Kind == graph.KindMigration) && !isMigrationOriginNode(n) {
+		if (n.Kind == graph.KindTable || n.Kind == graph.KindMigration) &&
+			!isMigrationOriginNode(n) && !isORMOriginTableNode(n) {
 			stripped[n.ID] = struct{}{}
 			continue
 		}
@@ -1892,6 +1902,18 @@ func isMigrationOriginNode(n *graph.Node) bool {
 	}
 	o, _ := n.Meta["origin"].(string)
 	return o == "migration"
+}
+
+// isORMOriginTableNode reports whether a KindTable node was minted by
+// an ORM model-attribution extractor (go/java/python/ruby/ts/elixir/
+// csharp *_orm paths). They all stamp Meta["dialect"] = "orm" on the
+// shared db::orm:: table nodes.
+func isORMOriginTableNode(n *graph.Node) bool {
+	if n == nil || n.Kind != graph.KindTable || n.Meta == nil {
+		return false
+	}
+	d, _ := n.Meta["dialect"].(string)
+	return d == "orm"
 }
 
 // isInfraOriginConfigKey reports whether a KindConfigKey node was

--- a/internal/mcp/tools_analyze_framework.go
+++ b/internal/mcp/tools_analyze_framework.go
@@ -403,7 +403,7 @@ func routeMethodAndPath(n *graph.Node) (string, string) {
 // persist?" queries.
 //
 // Filters:
-//   - orm:    orm flavour (gorm / sqlalchemy / django / activerecord / jpa / typeorm)
+//   - orm:    orm flavour (gorm / sqlalchemy / django / activerecord / jpa / typeorm / ecto / efcore)
 //   - table:  substring match on the table name
 //   - model:  substring match on the model class name
 func (s *Server) handleAnalyzeModels(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -841,6 +841,12 @@ func (e *CSharpExtractor) emitContainer(m parser.QueryResult, kind string, nodeK
 	if doc := extractCSharpDoc(src, def.StartLine); doc != "" {
 		meta["doc"] = doc
 	}
+	// EF Core fluent mapping: a class implementing
+	// IEntityTypeConfiguration<T> carries facts the resolver joins to
+	// the entity class later — the entity lives in another file.
+	if kind == "class" || kind == "record" {
+		stampCSharpEFConfig(def.Node, src, meta)
+	}
 	result.Nodes = append(result.Nodes, &graph.Node{
 		ID: id, Kind: nodeKind, Name: name,
 		FilePath: filePath, StartLine: def.StartLine + 1, EndLine: def.EndLine + 1,

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -304,6 +304,7 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 	fileID := fileNode.ID
 	result.Nodes = append(result.Nodes, fileNode)
 	stampCSharpUsings(root, src, fileNode)
+	stampCSharpEFFluent(root, src, fileNode)
 
 	seen := make(map[string]bool)
 	annotationSeen := make(map[string]bool)

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -851,6 +851,11 @@ func (e *CSharpExtractor) emitContainer(m parser.QueryResult, kind string, nodeK
 		From: fileID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: def.StartLine + 1,
 	})
 	emitCSharpAnnotationEdges(csharpCollectAttributes(def.Node, src), id, filePath, result, annotationSeen)
+	// EF Core model attribution: [Table] → EdgeModelsTable. Classes and
+	// records only — EF entities are reference types.
+	if kind == "class" || kind == "record" {
+		emitCSharpORMEdges(def.Node, src, id, filePath, result)
+	}
 	emitCSharpGenericParamNodes(id, def.Node, src, filePath, def.StartLine+1, result)
 	// Classes, structs, records, and interfaces carry a base list;
 	// emitCSharpBaseList derives each entry's edge kind from the

--- a/internal/parser/languages/csharp_orm.go
+++ b/internal/parser/languages/csharp_orm.go
@@ -1,0 +1,122 @@
+package languages
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	sitter "github.com/zzet/gortex/internal/parser/tsitter"
+)
+
+// detectCSharpORMModel inspects a C# class/record for a [Table]
+// attribute (System.ComponentModel.DataAnnotations.Schema — the EF
+// Core mapping attribute, shared by Dapper.Contrib) and emits an
+// EdgeModelsTable to a synthetic KindTable node when one is found.
+//
+// Only the attribute form is decided at extraction time: EF's other
+// two table-name sources — DbSet<T> property-name convention and
+// fluent ToTable(...) configuration — live in files other than the
+// entity's, so they are joined by a resolver pass over stamped facts,
+// not here. A class with no [Table] attribute emits nothing.
+func detectCSharpORMModel(classNode *sitter.Node, src []byte, classID, filePath string) []*graph.Edge {
+	if classNode == nil {
+		return nil
+	}
+	tableName := ""
+	schema := ""
+	for _, ann := range csharpCollectAttributes(classNode, src) {
+		if !csharpIsTableAttr(ann.name) {
+			continue
+		}
+		name := csharpAttrPositionalString(ann.args)
+		if name == "" {
+			continue
+		}
+		tableName = name
+		schema = javaAnnotationStringArg(ann.args, "Schema")
+		break
+	}
+	if tableName == "" {
+		return nil
+	}
+	qualified := tableName
+	if schema != "" {
+		qualified = schema + "." + tableName
+	}
+	tableID := ormTableNodeID(qualified)
+	meta := map[string]any{
+		"orm":        "efcore",
+		"binding":    "attribute",
+		"table_name": tableName,
+		"derivation": "override",
+	}
+	if schema != "" {
+		meta["schema"] = schema
+	}
+	return []*graph.Edge{
+		{
+			From:     classID,
+			To:       tableID,
+			Kind:     graph.EdgeModelsTable,
+			FilePath: filePath,
+			Line:     int(classNode.StartPoint().Row) + 1,
+			Origin:   graph.OriginASTResolved,
+			Meta:     meta,
+		},
+	}
+}
+
+// csharpIsTableAttr reports whether an attribute name denotes [Table].
+// C# lets the attribute appear qualified (Schema.Table, or the full
+// namespace path) and with the explicit Attribute suffix, so compare
+// the final dotted segment against both spellings.
+func csharpIsTableAttr(name string) bool {
+	if i := strings.LastIndexByte(name, '.'); i >= 0 {
+		name = name[i+1:]
+	}
+	return name == "Table" || name == "TableAttribute"
+}
+
+// csharpAttrPositionalStringArg matches a leading (optionally
+// verbatim) string literal — [Table("name", ...)]'s table name is the
+// attribute's first positional argument, unlike JPA's key=value form.
+var csharpAttrPositionalStringArg = regexp.MustCompile(`^\s*@?"([^"]*)"`)
+
+// csharpAttrPositionalString extracts the first positional string
+// literal from an attribute's verbatim argument text. Non-literal
+// firsts (nameof(...), constants) return "" — fail-open, no guess.
+func csharpAttrPositionalString(args string) string {
+	m := csharpAttrPositionalStringArg.FindStringSubmatch(args)
+	if len(m) < 2 {
+		return ""
+	}
+	return strings.TrimSpace(m[1])
+}
+
+// emitCSharpORMEdges materialises the KindTable node + EdgeModelsTable
+// edges for a C# type, mirroring emitJavaORMEdges: the per-file table
+// node dedup happens in one place.
+func emitCSharpORMEdges(classNode *sitter.Node, src []byte, classID, filePath string, result *parser.ExtractionResult) {
+	for _, e := range detectCSharpORMModel(classNode, src, classID, filePath) {
+		if e == nil {
+			continue
+		}
+		if !ormTableNodeAlreadyEmitted(result, e.To) {
+			schema, _ := e.Meta["schema"].(string)
+			result.Nodes = append(result.Nodes, &graph.Node{
+				ID:       e.To,
+				Kind:     graph.KindTable,
+				Name:     e.Meta["table_name"].(string),
+				FilePath: filePath,
+				Language: "csharp",
+				Meta: map[string]any{
+					"dialect": "orm",
+					"schema":  schema,
+					"source":  "csharp-orm",
+				},
+			})
+		}
+		result.Edges = append(result.Edges, e)
+	}
+}

--- a/internal/parser/languages/csharp_orm.go
+++ b/internal/parser/languages/csharp_orm.go
@@ -161,51 +161,144 @@ func csharpEFConfigTableCall(decl *sitter.Node, src []byte) (table, schema, rela
 		if table != "" {
 			return false
 		}
-		if n.Type() != "invocation_expression" {
+		t, s, r, ok := csharpEFTableViewArgs(n, src)
+		if !ok {
 			return true
 		}
-		fn := n.ChildByFieldName("function")
-		if fn == nil || fn.Type() != "member_access_expression" {
-			return true
-		}
-		name := ""
-		if nm := fn.ChildByFieldName("name"); nm != nil {
-			name = nm.Content(src)
-		}
-		if name != "ToTable" && name != "ToView" {
-			return true
-		}
-		args := n.ChildByFieldName("arguments")
-		if args == nil {
-			return true
-		}
-		var lits []string
-		for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
-			a := args.NamedChild(i)
-			if a == nil {
-				continue
-			}
-			lit := csharpAttrPositionalString(a.Content(src))
-			if i == 0 && lit == "" {
-				return true
-			}
-			lits = append(lits, lit)
-		}
-		if len(lits) == 0 || lits[0] == "" {
-			return true
-		}
-		table = lits[0]
-		if len(lits) > 1 {
-			schema = lits[1]
-		}
-		if name == "ToView" {
-			relation = "view"
-		} else {
-			relation = "table"
-		}
+		table, schema, relation = t, s, r
 		return false
 	})
 	return table, schema, relation
+}
+
+// csharpEFTableViewArgs recognises an invocation node as a
+// ToTable/ToView call with a literal name and returns its arguments.
+// The first argument must itself be a string literal — the
+// lambda-only overloads configure without naming, so a non-literal
+// first argument is not a table fact.
+func csharpEFTableViewArgs(n *sitter.Node, src []byte) (table, schema, relation string, ok bool) {
+	if n.Type() != "invocation_expression" {
+		return "", "", "", false
+	}
+	fn := n.ChildByFieldName("function")
+	if fn == nil || fn.Type() != "member_access_expression" {
+		return "", "", "", false
+	}
+	name := ""
+	if nm := fn.ChildByFieldName("name"); nm != nil {
+		name = nm.Content(src)
+	}
+	if name != "ToTable" && name != "ToView" {
+		return "", "", "", false
+	}
+	args := n.ChildByFieldName("arguments")
+	if args == nil {
+		return "", "", "", false
+	}
+	var lits []string
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
+		a := args.NamedChild(i)
+		if a == nil {
+			continue
+		}
+		lit := csharpAttrPositionalString(a.Content(src))
+		if i == 0 && lit == "" {
+			return "", "", "", false
+		}
+		lits = append(lits, lit)
+	}
+	if len(lits) == 0 || lits[0] == "" {
+		return "", "", "", false
+	}
+	table = lits[0]
+	if len(lits) > 1 {
+		schema = lits[1]
+	}
+	relation = "table"
+	if name == "ToView" {
+		relation = "view"
+	}
+	return table, schema, relation, true
+}
+
+// csharpEFEntityGenericArg matches the Entity<T> generic-name link of
+// a modelBuilder fluent chain.
+var csharpEFEntityGenericArg = regexp.MustCompile(`^Entity\s*<\s*([^<>,]+?)\s*>$`)
+
+// csharpEFEntityFromChain walks a ToTable/ToView call's receiver
+// chain (`modelBuilder.Entity<T>().HasKey(...).ToTable(...)`) down to
+// the Entity<T> link and returns T's final name segment, or "" when
+// the chain never names an entity.
+func csharpEFEntityFromChain(fn *sitter.Node, src []byte) string {
+	expr := fn.ChildByFieldName("expression")
+	for expr != nil {
+		switch expr.Type() {
+		case "invocation_expression":
+			expr = expr.ChildByFieldName("function")
+		case "member_access_expression":
+			if nm := expr.ChildByFieldName("name"); nm != nil && nm.Type() == "generic_name" {
+				if m := csharpEFEntityGenericArg.FindStringSubmatch(nm.Content(src)); len(m) >= 2 {
+					entity := strings.TrimSpace(m[1])
+					if i := strings.LastIndexByte(entity, '.'); i >= 0 {
+						entity = entity[i+1:]
+					}
+					return strings.TrimPrefix(entity, "@")
+				}
+			}
+			expr = expr.ChildByFieldName("expression")
+		default:
+			return ""
+		}
+	}
+	return ""
+}
+
+// stampCSharpEFFluent records the OnModelCreating inline fluent
+// mapping facts on the file node as Meta["ef_fluent"], one
+// "entity|table|schema|relation" entry per Entity<T> chain that ends
+// in a literal ToTable/ToView. Only OnModelCreating bodies are
+// scanned: that is where EF looks, and a helper method reached from
+// there is a cross-file/cross-method chase the extractor stays out
+// of. The resolver joins entries to entity class nodes by name, same
+// as the config-class stamps.
+func stampCSharpEFFluent(root *sitter.Node, src []byte, fileNode *graph.Node) {
+	var entries []string
+	seen := map[string]bool{}
+	walkNodes(root, func(n *sitter.Node) {
+		if n.Type() != "method_declaration" {
+			return
+		}
+		if nm := n.ChildByFieldName("name"); nm == nil || nm.Content(src) != "OnModelCreating" {
+			return
+		}
+		body := n.ChildByFieldName("body")
+		if body == nil {
+			return
+		}
+		walkAST(body, func(inv *sitter.Node) bool {
+			table, schema, relation, ok := csharpEFTableViewArgs(inv, src)
+			if !ok {
+				return true
+			}
+			entity := csharpEFEntityFromChain(inv.ChildByFieldName("function"), src)
+			if entity == "" {
+				return true
+			}
+			entry := entity + "|" + table + "|" + schema + "|" + relation
+			if !seen[entry] {
+				seen[entry] = true
+				entries = append(entries, entry)
+			}
+			return true
+		})
+	})
+	if len(entries) == 0 {
+		return
+	}
+	if fileNode.Meta == nil {
+		fileNode.Meta = map[string]any{}
+	}
+	fileNode.Meta["ef_fluent"] = entries
 }
 
 // emitCSharpORMEdges materialises the KindTable node + EdgeModelsTable

--- a/internal/parser/languages/csharp_orm.go
+++ b/internal/parser/languages/csharp_orm.go
@@ -2,6 +2,7 @@ package languages
 
 import (
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -81,6 +82,10 @@ func csharpIsTableAttr(name string) bool {
 // csharpAttrPositionalStringArg matches a leading (optionally
 // verbatim) string literal — [Table("name", ...)]'s table name is the
 // attribute's first positional argument, unlike JPA's key=value form.
+// Known limits, accepted for the fixed-cost regex: an escaped quote
+// truncates the name (`"a\"b"` → `a\` — table names with quotes do
+// not survive real databases either), and a C#11 raw string literal
+// ("""...""") matches its empty prefix and is skipped as unnamed.
 var csharpAttrPositionalStringArg = regexp.MustCompile(`^\s*@?"([^"]*)"`)
 
 // csharpAttrPositionalString extracts the first positional string
@@ -126,15 +131,28 @@ func stampCSharpEFConfig(decl *sitter.Node, src []byte, meta map[string]any) {
 	if baseList == nil {
 		return
 	}
-	m := csharpEFConfigIfaceArg.FindStringSubmatch(baseList.Content(src))
-	if len(m) < 2 {
+	// A class may implement IEntityTypeConfiguration<A> AND <B> (legal,
+	// two Configure overloads). A single-entity stamp cannot say whose
+	// ToTable the body scan found, so more than one distinct T refuses.
+	matches := csharpEFConfigIfaceArg.FindAllStringSubmatch(baseList.Content(src), -1)
+	if len(matches) == 0 {
 		return
 	}
-	entity := strings.TrimSpace(m[1])
-	if i := strings.LastIndexByte(entity, '.'); i >= 0 {
-		entity = entity[i+1:]
+	entity := ""
+	for _, m := range matches {
+		cand := strings.TrimSpace(m[1])
+		if i := strings.LastIndexByte(cand, '.'); i >= 0 {
+			cand = cand[i+1:]
+		}
+		cand = strings.TrimPrefix(cand, "@")
+		if cand == "" {
+			continue
+		}
+		if entity != "" && cand != entity {
+			return
+		}
+		entity = cand
 	}
-	entity = strings.TrimPrefix(entity, "@")
 	if entity == "" {
 		return
 	}
@@ -150,24 +168,46 @@ func stampCSharpEFConfig(decl *sitter.Node, src []byte, meta map[string]any) {
 	}
 }
 
-// csharpEFConfigTableCall finds the first builder.ToTable(...) or
-// builder.ToView(...) invocation in the declaration's subtree and
-// returns its literal name/schema arguments. The first argument must
-// itself be a string literal — the lambda-only ToTable overloads
-// configure without naming, so a non-literal first argument returns
-// nothing rather than fishing a string out of a nested lambda.
+// csharpEFConfigTableCall finds the first ToTable(...) / ToView(...)
+// invocation in the declaration's subtree whose receiver is a PLAIN
+// IDENTIFIER outside any lambda, and returns its literal name/schema
+// arguments. Both restrictions are misattribution guards, not
+// conveniences: a ToTable inside a lambda is an owned-type mapping
+// (`builder.OwnsOne(c => c.Slot, s => s.ToTable(...))`) naming the
+// OWNED type's table, and a ToTable chained onto another call
+// (`builder.OwnsOne(...).ToTable(...)`) hangs off a builder for a
+// different entity. Refusing those loses the rare
+// `builder.HasAnnotation(...).ToTable(...)` chain — a miss, never a
+// wrong edge.
 func csharpEFConfigTableCall(decl *sitter.Node, src []byte) (table, schema, relation string) {
-	walkAST(decl, func(n *sitter.Node) bool {
-		if table != "" {
-			return false
-		}
-		t, s, r, ok := csharpEFTableViewArgs(n, src)
-		if !ok {
+	var walk func(n *sitter.Node, inLambda bool) bool
+	walk = func(n *sitter.Node, inLambda bool) bool {
+		if n == nil {
 			return true
 		}
-		table, schema, relation = t, s, r
-		return false
-	})
+		switch n.Type() {
+		case "lambda_expression", "anonymous_method_expression":
+			inLambda = true
+		case "invocation_expression":
+			if !inLambda {
+				if t, s, r, ok := csharpEFTableViewArgs(n, src); ok {
+					if fn := n.ChildByFieldName("function"); fn != nil {
+						if recv := fn.ChildByFieldName("expression"); recv != nil && recv.Type() == "identifier" {
+							table, schema, relation = t, s, r
+							return false
+						}
+					}
+				}
+			}
+		}
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
+			if !walk(n.NamedChild(i), inLambda) {
+				return false
+			}
+		}
+		return true
+	}
+	walk(decl, false)
 	return table, schema, relation
 }
 
@@ -225,10 +265,23 @@ func csharpEFTableViewArgs(n *sitter.Node, src []byte) (table, schema, relation 
 // a modelBuilder fluent chain.
 var csharpEFEntityGenericArg = regexp.MustCompile(`^Entity\s*<\s*([^<>,]+?)\s*>$`)
 
+// csharpEFSubjectChangers are the fluent links that return a builder
+// for a DIFFERENT entity (owned types, navigations): a ToTable past
+// one of these names that other entity's table, so the chain walk
+// refuses rather than crediting T.
+var csharpEFSubjectChangers = map[string]bool{
+	"OwnsOne": true, "OwnsMany": true,
+	"HasOne": true, "HasMany": true,
+	"WithOne": true, "WithMany": true,
+	"Navigation": true, "ComplexProperty": true,
+}
+
 // csharpEFEntityFromChain walks a ToTable/ToView call's receiver
 // chain (`modelBuilder.Entity<T>().HasKey(...).ToTable(...)`) down to
 // the Entity<T> link and returns T's final name segment, or "" when
-// the chain never names an entity.
+// the chain never names an entity — or passes through a
+// subject-changing link (`Entity<T>().OwnsOne(...).ToTable(...)` is
+// the owned type's table-splitting spelling, not T's table).
 func csharpEFEntityFromChain(fn *sitter.Node, src []byte) string {
 	expr := fn.ChildByFieldName("expression")
 	for expr != nil {
@@ -236,13 +289,24 @@ func csharpEFEntityFromChain(fn *sitter.Node, src []byte) string {
 		case "invocation_expression":
 			expr = expr.ChildByFieldName("function")
 		case "member_access_expression":
-			if nm := expr.ChildByFieldName("name"); nm != nil && nm.Type() == "generic_name" {
-				if m := csharpEFEntityGenericArg.FindStringSubmatch(nm.Content(src)); len(m) >= 2 {
-					entity := strings.TrimSpace(m[1])
-					if i := strings.LastIndexByte(entity, '.'); i >= 0 {
-						entity = entity[i+1:]
+			if nm := expr.ChildByFieldName("name"); nm != nil {
+				txt := nm.Content(src)
+				if nm.Type() == "generic_name" {
+					if m := csharpEFEntityGenericArg.FindStringSubmatch(txt); len(m) >= 2 {
+						entity := strings.TrimSpace(m[1])
+						if i := strings.LastIndexByte(entity, '.'); i >= 0 {
+							entity = entity[i+1:]
+						}
+						return strings.TrimPrefix(entity, "@")
 					}
-					return strings.TrimPrefix(entity, "@")
+					// OwnsOne<Address>(...) spells the subject change as a
+					// generic name — strip the argument list before the check.
+					if i := strings.IndexByte(txt, '<'); i >= 0 {
+						txt = strings.TrimSpace(txt[:i])
+					}
+				}
+				if csharpEFSubjectChangers[txt] {
+					return ""
 				}
 			}
 			expr = expr.ChildByFieldName("expression")
@@ -255,8 +319,10 @@ func csharpEFEntityFromChain(fn *sitter.Node, src []byte) string {
 
 // stampCSharpEFFluent records the OnModelCreating inline fluent
 // mapping facts on the file node as Meta["ef_fluent"], one
-// "entity|table|schema|relation" entry per Entity<T> chain that ends
-// in a literal ToTable/ToView. Only OnModelCreating bodies are
+// "entity|table|schema|relation|line" entry per Entity<T> chain that
+// ends in a literal ToTable/ToView — line is the call's own line, so
+// the resolver's edge evidence points at the mapping statement rather
+// than the file top. Only OnModelCreating bodies are
 // scanned: that is where EF looks, and a helper method reached from
 // there is a cross-file/cross-method chase the extractor stays out
 // of. The resolver joins entries to entity class nodes by name, same
@@ -284,7 +350,8 @@ func stampCSharpEFFluent(root *sitter.Node, src []byte, fileNode *graph.Node) {
 			if entity == "" {
 				return true
 			}
-			entry := entity + "|" + table + "|" + schema + "|" + relation
+			entry := entity + "|" + table + "|" + schema + "|" + relation +
+				"|" + strconv.Itoa(int(inv.StartPoint().Row)+1)
 			if !seen[entry] {
 				seen[entry] = true
 				entries = append(entries, entry)

--- a/internal/parser/languages/csharp_orm.go
+++ b/internal/parser/languages/csharp_orm.go
@@ -94,6 +94,120 @@ func csharpAttrPositionalString(args string) string {
 	return strings.TrimSpace(m[1])
 }
 
+// csharpEFConfigIfaceArg pulls the single type argument out of an
+// IEntityTypeConfiguration<T> base-list entry. Text-level on purpose:
+// the base list is one short line, and the extractor needs only T's
+// name — qualification is stripped after the match.
+var csharpEFConfigIfaceArg = regexp.MustCompile(`IEntityTypeConfiguration\s*<\s*([^<>,]+?)\s*>`)
+
+// stampCSharpEFConfig detects an EF Core entity-configuration class —
+// one implementing IEntityTypeConfiguration<T> — and stamps the facts
+// a resolver pass needs to join fluent table mapping to the entity:
+//
+//	ef_config_entity    T's final name segment (always, when detected)
+//	ef_config_table     first ToTable/ToView string arg (when present)
+//	ef_config_relation  "table" or "view" (with ef_config_table)
+//	ef_config_schema    second string arg (when present)
+//
+// The entity class, the config class, and the DbContext registration
+// live in different files, so the extractor only records what this
+// file proves; the cross-file join happens at resolve time.
+func stampCSharpEFConfig(decl *sitter.Node, src []byte, meta map[string]any) {
+	if decl == nil {
+		return
+	}
+	var baseList *sitter.Node
+	for i, _nc := 0, int(decl.ChildCount()); i < _nc; i++ {
+		if c := decl.Child(i); c != nil && c.Type() == "base_list" {
+			baseList = c
+			break
+		}
+	}
+	if baseList == nil {
+		return
+	}
+	m := csharpEFConfigIfaceArg.FindStringSubmatch(baseList.Content(src))
+	if len(m) < 2 {
+		return
+	}
+	entity := strings.TrimSpace(m[1])
+	if i := strings.LastIndexByte(entity, '.'); i >= 0 {
+		entity = entity[i+1:]
+	}
+	entity = strings.TrimPrefix(entity, "@")
+	if entity == "" {
+		return
+	}
+	meta["ef_config_entity"] = entity
+	table, schema, relation := csharpEFConfigTableCall(decl, src)
+	if table == "" {
+		return
+	}
+	meta["ef_config_table"] = table
+	meta["ef_config_relation"] = relation
+	if schema != "" {
+		meta["ef_config_schema"] = schema
+	}
+}
+
+// csharpEFConfigTableCall finds the first builder.ToTable(...) or
+// builder.ToView(...) invocation in the declaration's subtree and
+// returns its literal name/schema arguments. The first argument must
+// itself be a string literal — the lambda-only ToTable overloads
+// configure without naming, so a non-literal first argument returns
+// nothing rather than fishing a string out of a nested lambda.
+func csharpEFConfigTableCall(decl *sitter.Node, src []byte) (table, schema, relation string) {
+	walkAST(decl, func(n *sitter.Node) bool {
+		if table != "" {
+			return false
+		}
+		if n.Type() != "invocation_expression" {
+			return true
+		}
+		fn := n.ChildByFieldName("function")
+		if fn == nil || fn.Type() != "member_access_expression" {
+			return true
+		}
+		name := ""
+		if nm := fn.ChildByFieldName("name"); nm != nil {
+			name = nm.Content(src)
+		}
+		if name != "ToTable" && name != "ToView" {
+			return true
+		}
+		args := n.ChildByFieldName("arguments")
+		if args == nil {
+			return true
+		}
+		var lits []string
+		for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
+			a := args.NamedChild(i)
+			if a == nil {
+				continue
+			}
+			lit := csharpAttrPositionalString(a.Content(src))
+			if i == 0 && lit == "" {
+				return true
+			}
+			lits = append(lits, lit)
+		}
+		if len(lits) == 0 || lits[0] == "" {
+			return true
+		}
+		table = lits[0]
+		if len(lits) > 1 {
+			schema = lits[1]
+		}
+		if name == "ToView" {
+			relation = "view"
+		} else {
+			relation = "table"
+		}
+		return false
+	})
+	return table, schema, relation
+}
+
 // emitCSharpORMEdges materialises the KindTable node + EdgeModelsTable
 // edges for a C# type, mirroring emitJavaORMEdges: the per-file table
 // node dedup happens in one place.

--- a/internal/parser/languages/csharp_orm_test.go
+++ b/internal/parser/languages/csharp_orm_test.go
@@ -73,6 +73,71 @@ public class BinItem
 	assert.Equal(t, "audit", tableNode.Meta["schema"])
 }
 
+func TestCSharpORM_ConfigClassStampsEntityAndTable(t *testing.T) {
+	src := `using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Probe.Data.Config;
+
+public class WidgetConfig : IEntityTypeConfiguration<Widget>
+{
+    public void Configure(EntityTypeBuilder<Widget> builder)
+    {
+        builder.ToTable("widgets_v2", "sales");
+        builder.HasKey(w => w.Id);
+    }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Config/WidgetConfig.cs", src)
+	cfg := fix.nodesByID["Config/WidgetConfig.cs::WidgetConfig"]
+	require.NotNil(t, cfg)
+	assert.Equal(t, "Widget", cfg.Meta["ef_config_entity"])
+	assert.Equal(t, "widgets_v2", cfg.Meta["ef_config_table"])
+	assert.Equal(t, "sales", cfg.Meta["ef_config_schema"])
+	assert.Equal(t, "table", cfg.Meta["ef_config_relation"])
+}
+
+func TestCSharpORM_ConfigClassToViewStampsViewRelation(t *testing.T) {
+	src := `namespace Probe.Data.Config;
+
+public class TallyConfig : Microsoft.EntityFrameworkCore.IEntityTypeConfiguration<Domain.CrateTally>
+{
+    public void Configure(EntityTypeBuilder<Domain.CrateTally> builder)
+    {
+        builder.ToView("crate_tallies");
+    }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Config/TallyConfig.cs", src)
+	cfg := fix.nodesByID["Config/TallyConfig.cs::TallyConfig"]
+	require.NotNil(t, cfg)
+	assert.Equal(t, "CrateTally", cfg.Meta["ef_config_entity"],
+		"qualified iface and qualified entity arg both reduce to final segments")
+	assert.Equal(t, "crate_tallies", cfg.Meta["ef_config_table"])
+	assert.Equal(t, "view", cfg.Meta["ef_config_relation"])
+	_, hasSchema := cfg.Meta["ef_config_schema"]
+	assert.False(t, hasSchema, "no schema arg, no schema stamp")
+}
+
+func TestCSharpORM_ConfigClassWithoutToTableStampsEntityOnly(t *testing.T) {
+	src := `namespace Probe.Data.Config;
+
+public class GadgetConfig : IEntityTypeConfiguration<Gadget>
+{
+    public void Configure(EntityTypeBuilder<Gadget> builder)
+    {
+        builder.HasIndex(g => g.Serial);
+    }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Config/GadgetConfig.cs", src)
+	cfg := fix.nodesByID["Config/GadgetConfig.cs::GadgetConfig"]
+	require.NotNil(t, cfg)
+	assert.Equal(t, "Gadget", cfg.Meta["ef_config_entity"])
+	_, hasTable := cfg.Meta["ef_config_table"]
+	assert.False(t, hasTable, "no ToTable/ToView call, no table stamp")
+}
+
 func TestCSharpORM_PlainClassIgnored(t *testing.T) {
 	src := `namespace Probe.Core;
 

--- a/internal/parser/languages/csharp_orm_test.go
+++ b/internal/parser/languages/csharp_orm_test.go
@@ -138,6 +138,108 @@ public class GadgetConfig : IEntityTypeConfiguration<Gadget>
 	assert.False(t, hasTable, "no ToTable/ToView call, no table stamp")
 }
 
+func TestCSharpORM_ConfigOwnedTypeLambdaToTableNotStamped(t *testing.T) {
+	src := `namespace Probe.Data.Config;
+
+public class CrateSlotConfig : IEntityTypeConfiguration<CrateSlot>
+{
+    public void Configure(EntityTypeBuilder<CrateSlot> builder)
+    {
+        builder.OwnsOne(c => c.Slot, s => s.ToTable("slot_rows"));
+    }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Config/CrateSlotConfig.cs", src)
+	cfg := fix.nodesByID["Config/CrateSlotConfig.cs::CrateSlotConfig"]
+	require.NotNil(t, cfg)
+	assert.Equal(t, "CrateSlot", cfg.Meta["ef_config_entity"])
+	_, hasTable := cfg.Meta["ef_config_table"]
+	assert.False(t, hasTable,
+		"an owned-type ToTable inside a lambda names the OWNED type's table, not T's — must not stamp")
+}
+
+func TestCSharpORM_ConfigChainedOwnsOneToTableNotStamped(t *testing.T) {
+	src := `namespace Probe.Data.Config;
+
+public class ParcelConfig : IEntityTypeConfiguration<Parcel>
+{
+    public void Configure(EntityTypeBuilder<Parcel> builder)
+    {
+        builder.OwnsOne(p => p.Stub).ToTable("stub_rows");
+    }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Config/ParcelConfig.cs", src)
+	cfg := fix.nodesByID["Config/ParcelConfig.cs::ParcelConfig"]
+	require.NotNil(t, cfg)
+	assert.Equal(t, "Parcel", cfg.Meta["ef_config_entity"])
+	_, hasTable := cfg.Meta["ef_config_table"]
+	assert.False(t, hasTable,
+		"ToTable on an OwnsOne return names the owned type's table — the receiver is not the entity builder")
+}
+
+func TestCSharpORM_ConfigDualInterfaceRefusesEntirely(t *testing.T) {
+	src := `namespace Probe.Data.Config;
+
+public class PairConfig : IEntityTypeConfiguration<Drum>, IEntityTypeConfiguration<Spool>
+{
+    public void Configure(EntityTypeBuilder<Drum> builder)
+    {
+        builder.HasKey(d => d.Id);
+    }
+
+    public void Configure(EntityTypeBuilder<Spool> builder)
+    {
+        builder.ToTable("spool_rows");
+    }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Config/PairConfig.cs", src)
+	cfg := fix.nodesByID["Config/PairConfig.cs::PairConfig"]
+	require.NotNil(t, cfg)
+	_, hasEntity := cfg.Meta["ef_config_entity"]
+	assert.False(t, hasEntity,
+		"two IEntityTypeConfiguration<T> arguments: a single-entity stamp cannot say whose ToTable it found — refuse")
+}
+
+func TestCSharpORM_ConfigLambdaOnlyToTableNotStamped(t *testing.T) {
+	src := `namespace Probe.Data.Config;
+
+public class VaultConfig : IEntityTypeConfiguration<Vault>
+{
+    public void Configure(EntityTypeBuilder<Vault> builder)
+    {
+        builder.ToTable(tb => tb.HasComment("keyless vault"));
+    }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Config/VaultConfig.cs", src)
+	cfg := fix.nodesByID["Config/VaultConfig.cs::VaultConfig"]
+	require.NotNil(t, cfg)
+	assert.Equal(t, "Vault", cfg.Meta["ef_config_entity"])
+	_, hasTable := cfg.Meta["ef_config_table"]
+	assert.False(t, hasTable, "lambda-only ToTable overload names no table — the string inside the lambda is a comment")
+}
+
+func TestCSharpORM_InlineChainedOwnsOneNotStamped(t *testing.T) {
+	src := `namespace Probe.Data;
+
+public class ShipContext : DbContext
+{
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Parcel>().OwnsOne(p => p.Stub).ToTable("stub_split");
+        modelBuilder.Entity<Parcel>().ToTable("parcels_main");
+    }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Data/ShipContext.cs", src)
+	fileNode := fix.nodesByID["Data/ShipContext.cs"]
+	require.NotNil(t, fileNode)
+	assert.Equal(t, []string{"Parcel|parcels_main||table|8"}, fileNode.Meta["ef_fluent"],
+		"the OwnsOne chain's ToTable names the OWNED type's table — the walk must stop at subject-changing links")
+}
+
 func TestCSharpORM_OnModelCreatingFluentFileStamp(t *testing.T) {
 	src := `using Microsoft.EntityFrameworkCore;
 
@@ -160,10 +262,10 @@ public class ProbeContext : DbContext
 	fileNode := fix.nodesByID["Data/ProbeContext.cs"]
 	require.NotNil(t, fileNode)
 	assert.Equal(t, []string{
-		"Widget|widget_master|core|table",
-		"Gadget|gadget_view||view",
+		"Widget|widget_master|core|table|11",
+		"Gadget|gadget_view||view|13",
 	}, fileNode.Meta["ef_fluent"],
-		"one entry per Entity<T> chain ending in a literal ToTable/ToView; chains without one stamp nothing")
+		"one entry per Entity<T> chain ending in a literal ToTable/ToView, line-stamped; chains without one stamp nothing")
 }
 
 func TestCSharpORM_FluentOutsideOnModelCreatingNotStamped(t *testing.T) {
@@ -182,6 +284,39 @@ public class MapHelper
 	require.NotNil(t, fileNode)
 	_, has := fileNode.Meta["ef_fluent"]
 	assert.False(t, has, "only OnModelCreating bodies are scanned in v1")
+}
+
+func TestCSharpORM_NameofTableArgRefused(t *testing.T) {
+	src := `using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Probe.Core.Domain;
+
+[Table(nameof(SlateBin))]
+public class SlateBin
+{
+    public int Id { get; set; }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Models/SlateBin.cs", src)
+	assert.Empty(t, fix.edgesByKind[graph.EdgeModelsTable],
+		"a non-literal table name (nameof, constants) stamps nothing — fail-open, no guess")
+}
+
+func TestCSharpORM_VerbatimStringAndAttributeSuffix(t *testing.T) {
+	src := `using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Probe.Core.Domain;
+
+[TableAttribute(@"vault_rows")]
+public class VaultRow
+{
+    public int Id { get; set; }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Models/VaultRow.cs", src)
+	models := fix.edgesByKind[graph.EdgeModelsTable]
+	require.Len(t, models, 1, "the explicit Attribute suffix and a verbatim string are both ordinary spellings")
+	assert.Equal(t, "db::orm::vault_rows", models[0].To)
 }
 
 func TestCSharpORM_PlainClassIgnored(t *testing.T) {

--- a/internal/parser/languages/csharp_orm_test.go
+++ b/internal/parser/languages/csharp_orm_test.go
@@ -1,0 +1,86 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func runCSharpExtractFixtureORM(t *testing.T, filePath, src string) *extractedFixture {
+	t.Helper()
+	result, err := NewCSharpExtractor().Extract(filePath, []byte(src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return foldFixture(result)
+}
+
+func TestCSharpORM_TableAttributeOverride(t *testing.T) {
+	src := `using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Probe.Core.Domain;
+
+[Table("stock_crates")]
+public class StockCrate
+{
+    public int Id { get; set; }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Models/StockCrate.cs", src)
+	models := fix.edgesByKind[graph.EdgeModelsTable]
+	require.Len(t, models, 1, "StockCrate should produce a models_table edge from [Table]")
+	assert.Equal(t, "Models/StockCrate.cs::StockCrate", models[0].From)
+	assert.Equal(t, "db::orm::stock_crates", models[0].To)
+	assert.Equal(t, "efcore", models[0].Meta["orm"])
+	assert.Equal(t, "attribute", models[0].Meta["binding"])
+	assert.Equal(t, "stock_crates", models[0].Meta["table_name"])
+	assert.Equal(t, "override", models[0].Meta["derivation"])
+
+	tableNode := fix.nodesByID["db::orm::stock_crates"]
+	require.NotNil(t, tableNode, "the KindTable node must be materialised alongside the edge")
+	assert.Equal(t, graph.KindTable, tableNode.Kind)
+	assert.Equal(t, "stock_crates", tableNode.Name)
+	assert.Equal(t, "orm", tableNode.Meta["dialect"])
+	assert.Equal(t, "csharp-orm", tableNode.Meta["source"])
+	assert.Equal(t, "", tableNode.Meta["schema"])
+}
+
+func TestCSharpORM_TableAttributeWithSchema(t *testing.T) {
+	src := `using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Probe.Core.Domain;
+
+[Table("bin_items", Schema = "audit")]
+public class BinItem
+{
+    public int Id { get; set; }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Models/BinItem.cs", src)
+	models := fix.edgesByKind[graph.EdgeModelsTable]
+	require.Len(t, models, 1)
+	assert.Equal(t, "db::orm::audit.bin_items", models[0].To)
+	assert.Equal(t, "bin_items", models[0].Meta["table_name"])
+	assert.Equal(t, "audit", models[0].Meta["schema"])
+	assert.Equal(t, "override", models[0].Meta["derivation"])
+
+	tableNode := fix.nodesByID["db::orm::audit.bin_items"]
+	require.NotNil(t, tableNode)
+	assert.Equal(t, "bin_items", tableNode.Name)
+	assert.Equal(t, "audit", tableNode.Meta["schema"])
+}
+
+func TestCSharpORM_PlainClassIgnored(t *testing.T) {
+	src := `namespace Probe.Core;
+
+public class PlainService
+{
+    public void Handle() { }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Services/PlainService.cs", src)
+	assert.Empty(t, fix.edgesByKind[graph.EdgeModelsTable])
+}

--- a/internal/parser/languages/csharp_orm_test.go
+++ b/internal/parser/languages/csharp_orm_test.go
@@ -138,6 +138,52 @@ public class GadgetConfig : IEntityTypeConfiguration<Gadget>
 	assert.False(t, hasTable, "no ToTable/ToView call, no table stamp")
 }
 
+func TestCSharpORM_OnModelCreatingFluentFileStamp(t *testing.T) {
+	src := `using Microsoft.EntityFrameworkCore;
+
+namespace Probe.Data;
+
+public class ProbeContext : DbContext
+{
+    public DbSet<Widget> Widgets { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Widget>().ToTable("widget_master", "core");
+        modelBuilder.Entity<Domain.Gadget>().HasKey(g => g.Id);
+        modelBuilder.Entity<Domain.Gadget>().ToView("gadget_view");
+        modelBuilder.Entity<Sprocket>().HasIndex(s => s.Serial);
+    }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Data/ProbeContext.cs", src)
+	fileNode := fix.nodesByID["Data/ProbeContext.cs"]
+	require.NotNil(t, fileNode)
+	assert.Equal(t, []string{
+		"Widget|widget_master|core|table",
+		"Gadget|gadget_view||view",
+	}, fileNode.Meta["ef_fluent"],
+		"one entry per Entity<T> chain ending in a literal ToTable/ToView; chains without one stamp nothing")
+}
+
+func TestCSharpORM_FluentOutsideOnModelCreatingNotStamped(t *testing.T) {
+	src := `namespace Probe.Data;
+
+public class MapHelper
+{
+    public void Wire(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Widget>().ToTable("widgets_elsewhere");
+    }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Data/MapHelper.cs", src)
+	fileNode := fix.nodesByID["Data/MapHelper.cs"]
+	require.NotNil(t, fileNode)
+	_, has := fileNode.Meta["ef_fluent"]
+	assert.False(t, has, "only OnModelCreating bodies are scanned in v1")
+}
+
 func TestCSharpORM_PlainClassIgnored(t *testing.T) {
 	src := `namespace Probe.Core;
 

--- a/internal/resolver/csharp_efcore_models.go
+++ b/internal/resolver/csharp_efcore_models.go
@@ -2,6 +2,8 @@ package resolver
 
 import (
 	"regexp"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -26,8 +28,8 @@ import (
 // than adding a second edge, and an entity a fluent fact claimed never
 // falls through to the DbSet convention. Within the fluent tier an
 // inline OnModelCreating entry beats a config class (EF applies
-// OnModelCreating statements after ApplyConfiguration); two
-// same-tier facts that disagree drop the entity entirely.
+// OnModelCreating statements after ApplyConfiguration); two facts in
+// the WINNING tier that disagree drop the entity entirely.
 //
 // Facts join to entity classes by unique class name within the same
 // boundary — an ambiguous name (two classes called Widget) skips
@@ -55,6 +57,9 @@ func ResolveCSharpEFCoreModels(g graph.Store) int {
 		if n == nil {
 			continue
 		}
+		// File nodes skip the language gate deliberately: they carry no
+		// Language, and only the C# extractor mints ef_fluent — key
+		// presence is the filter.
 		if n.Kind == graph.KindFile {
 			fluents = append(fluents, csharpEFInlineFactsFromFile(n)...)
 			continue
@@ -77,6 +82,15 @@ func ResolveCSharpEFCoreModels(g graph.Store) int {
 	if len(dbsets) == 0 && len(fluents) == 0 {
 		return 0
 	}
+	// Node scans are map-ordered; sort every fact list before first-wins
+	// logic so edge content and evidence sites are deterministic across
+	// runs (the mediatr/gin sibling idiom).
+	sort.Slice(dbsets, func(i, j int) bool {
+		if dbsets[i].entity != dbsets[j].entity {
+			return dbsets[i].entity < dbsets[j].entity
+		}
+		return dbsets[i].siteID < dbsets[j].siteID
+	})
 
 	// Entities that already model a table: the attribute binding was
 	// decided at extraction, and a prior run of this pass already
@@ -115,6 +129,13 @@ func ResolveCSharpEFCoreModels(g graph.Store) int {
 			meta["relation"] = f.relation
 		}
 		if es := edgesByFrom[cls.ID]; len(es) > 0 {
+			// Rewire in place. The edge keeps its FilePath/Line (the
+			// entity's own file): the edge's From side is the model, and
+			// anchoring evidence there survives re-extraction of the
+			// fact file. The superseded attribute's table node is
+			// deliberately left behind even if nothing points at it any
+			// more — same call go_orm's override rewire makes; a table
+			// node is cheap and another entity may share it.
 			e := es[0]
 			if e.To == tableID {
 				continue
@@ -200,34 +221,48 @@ type csharpEFFluentFact struct {
 }
 
 // csharpEFMergeFluentFacts reduces the fluent facts to at most one per
-// entity name: inline OnModelCreating entries beat config classes, and
-// two same-tier facts that disagree on the mapping drop the entity —
-// refusing beats guessing.
+// entity name. Two-phase so the verdict never depends on arrival order
+// (facts come off a map-ordered node scan): the inline OnModelCreating
+// tier wins outright when present — a disagreement in the config tier
+// below it is irrelevant — and only the WINNING tier's facts are
+// checked for conflicts; two of those that disagree on the mapping
+// drop the entity, refusing over guessing. Agreeing duplicates keep
+// the lowest-siteID fact, so the retained evidence site is
+// deterministic too.
 func csharpEFMergeFluentFacts(fluents []csharpEFFluentFact) []csharpEFFluentFact {
-	merged := map[string]csharpEFFluentFact{}
-	dropped := map[string]bool{}
+	byEntity := map[string][]csharpEFFluentFact{}
 	var order []string
 	for _, f := range fluents {
-		cur, ok := merged[f.entity]
-		if !ok {
-			merged[f.entity] = f
+		if _, ok := byEntity[f.entity]; !ok {
 			order = append(order, f.entity)
-			continue
 		}
-		if f.inline != cur.inline {
-			if f.inline {
-				merged[f.entity] = f
-			}
-			continue
-		}
-		if f.table != cur.table || f.schema != cur.schema || f.relation != cur.relation {
-			dropped[f.entity] = true
-		}
+		byEntity[f.entity] = append(byEntity[f.entity], f)
 	}
+	sort.Strings(order)
 	var out []csharpEFFluentFact
-	for _, name := range order {
-		if !dropped[name] {
-			out = append(out, merged[name])
+	for _, entity := range order {
+		facts := byEntity[entity]
+		// Winning tier: inline when any inline fact exists.
+		tier := facts[:0:0]
+		for _, f := range facts {
+			if f.inline {
+				tier = append(tier, f)
+			}
+		}
+		if len(tier) == 0 {
+			tier = facts
+		}
+		sort.Slice(tier, func(i, j int) bool { return tier[i].siteID < tier[j].siteID })
+		winner := tier[0]
+		conflict := false
+		for _, f := range tier[1:] {
+			if f.table != winner.table || f.schema != winner.schema || f.relation != winner.relation {
+				conflict = true
+				break
+			}
+		}
+		if !conflict {
+			out = append(out, winner)
 		}
 	}
 	return out
@@ -254,8 +289,9 @@ func csharpEFConfigFactFromNode(n *graph.Node) (csharpEFFluentFact, bool) {
 }
 
 // csharpEFInlineFactsFromFile parses the ef_fluent
-// "entity|table|schema|relation" entries off a file node. Meta lists
-// round-trip through persistence as []any, so both shapes decode.
+// "entity|table|schema|relation|line" entries off a file node. Meta
+// lists round-trip through persistence as []any, so both shapes
+// decode.
 func csharpEFInlineFactsFromFile(n *graph.Node) []csharpEFFluentFact {
 	if n.Meta == nil {
 		return nil
@@ -273,14 +309,18 @@ func csharpEFInlineFactsFromFile(n *graph.Node) []csharpEFFluentFact {
 	}
 	var out []csharpEFFluentFact
 	for _, entry := range entries {
-		parts := strings.SplitN(entry, "|", 4)
-		if len(parts) != 4 || parts[0] == "" || parts[1] == "" {
+		parts := strings.SplitN(entry, "|", 5)
+		if len(parts) != 5 || parts[0] == "" || parts[1] == "" {
 			continue
+		}
+		line, err := strconv.Atoi(parts[4])
+		if err != nil || line < 1 {
+			line = 1
 		}
 		out = append(out, csharpEFFluentFact{
 			entity: parts[0], table: parts[1], schema: parts[2], relation: parts[3],
 			inline: true,
-			siteID: n.ID, filePath: n.FilePath, line: 1,
+			siteID: n.ID, filePath: n.FilePath, line: line,
 		})
 	}
 	return out

--- a/internal/resolver/csharp_efcore_models.go
+++ b/internal/resolver/csharp_efcore_models.go
@@ -16,47 +16,135 @@ import (
 //     (verbatim — not a pluralization of the class name), and the
 //     property lives on the DbContext, not the entity.
 //
+//   - Fluent configuration: an IEntityTypeConfiguration<T> class's
+//     ToTable/ToView (stamped as ef_config_* class meta) or an
+//     OnModelCreating Entity<T>() chain (stamped as ef_fluent file
+//     meta) names the table from yet another file.
+//
+// Precedence is fluent > attribute > dbset: a fluent fact REWIRES an
+// existing attribute edge in place (go_orm's override model) rather
+// than adding a second edge, and an entity a fluent fact claimed never
+// falls through to the DbSet convention. Within the fluent tier an
+// inline OnModelCreating entry beats a config class (EF applies
+// OnModelCreating statements after ApplyConfiguration); two
+// same-tier facts that disagree drop the entity entirely.
+//
 // Facts join to entity classes by unique class name within the same
 // boundary — an ambiguous name (two classes called Widget) skips
 // rather than guesses. An entity that already carries a models_table
-// edge (attribute-bound at extraction, or a previous run of this
-// pass) is left alone, which is also what makes the pass idempotent.
+// edge at its final target is left alone, which is also what makes
+// the pass idempotent.
 //
-// Returns the number of edges synthesized.
+// Returns the number of edges synthesized or rewired.
 func ResolveCSharpEFCoreModels(g graph.Store) int {
 	if g == nil {
 		return 0
 	}
 	classesByName := map[string][]*graph.Node{}
 	var dbsets []csharpDbSetFact
-	for _, n := range nodesByKindsOrAll(g, graph.KindType, graph.KindField) {
-		if n == nil || !strings.EqualFold(n.Language, "csharp") {
+	var fluents []csharpEFFluentFact
+	for _, n := range nodesByKindsOrAll(g, graph.KindType, graph.KindField, graph.KindFile) {
+		if n == nil {
+			continue
+		}
+		if n.Kind == graph.KindFile {
+			fluents = append(fluents, csharpEFInlineFactsFromFile(n)...)
+			continue
+		}
+		if !strings.EqualFold(n.Language, "csharp") {
 			continue
 		}
 		switch n.Kind {
 		case graph.KindType:
 			classesByName[n.Name] = append(classesByName[n.Name], n)
+			if f, ok := csharpEFConfigFactFromNode(n); ok {
+				fluents = append(fluents, f)
+			}
 		case graph.KindField:
 			if f, ok := csharpDbSetFactFromNode(n); ok {
 				dbsets = append(dbsets, f)
 			}
 		}
 	}
-	if len(dbsets) == 0 {
+	if len(dbsets) == 0 && len(fluents) == 0 {
 		return 0
 	}
 
-	// Entities that already model a table keep their edge: the
-	// attribute binding was decided at extraction with the entity's own
-	// file as evidence, and a prior run of this pass already landed.
+	// Entities that already model a table: the attribute binding was
+	// decided at extraction, and a prior run of this pass already
+	// landed. Fluent facts may rewire these; the DbSet leg never
+	// touches them.
 	mapped := map[string]bool{}
+	edgesByFrom := map[string][]*graph.Edge{}
 	for e := range g.EdgesByKind(graph.EdgeModelsTable) {
 		if e != nil {
 			mapped[e.From] = true
+			edgesByFrom[e.From] = append(edgesByFrom[e.From], e)
 		}
 	}
 
 	resolved := 0
+
+	// Fluent tier first, so its claims shadow the DbSet convention.
+	var reindex []graph.EdgeReindex
+	for _, f := range csharpEFMergeFluentFacts(fluents) {
+		cands := sameBoundaryCandidates(g, f.siteID, classesByName[f.entity])
+		if len(cands) != 1 {
+			continue
+		}
+		cls := cands[0]
+		tableID := csharpEFTableNodeID(f.table, f.schema)
+		meta := map[string]any{
+			"orm":        "efcore",
+			"binding":    "fluent",
+			"table_name": f.table,
+			"derivation": "override",
+		}
+		if f.schema != "" {
+			meta["schema"] = f.schema
+		}
+		if f.relation != "" {
+			meta["relation"] = f.relation
+		}
+		if es := edgesByFrom[cls.ID]; len(es) > 0 {
+			e := es[0]
+			if e.To == tableID {
+				continue
+			}
+			csharpEFEnsureTableNode(g, tableID, f.table, f.schema, f.filePath)
+			oldTo := e.To
+			e.To = tableID
+			e.Origin = graph.OriginASTInferred
+			e.Confidence = ConfidenceTyped
+			e.ConfidenceLabel = graph.ConfidenceLabelFor(graph.EdgeModelsTable, ConfidenceTyped)
+			e.Meta = meta
+			StampSynthesizedTyped(e, SynthCSharpEFCoreModels)
+			reindex = append(reindex, graph.EdgeReindex{Edge: e, OldTo: oldTo})
+			resolved++
+			continue
+		}
+		if mapped[cls.ID] {
+			continue
+		}
+		mapped[cls.ID] = true
+		csharpEFEnsureTableNode(g, tableID, f.table, f.schema, f.filePath)
+		e := &graph.Edge{
+			From: cls.ID, To: tableID, Kind: graph.EdgeModelsTable,
+			FilePath:        f.filePath,
+			Line:            f.line,
+			Origin:          graph.OriginASTInferred,
+			Confidence:      ConfidenceTyped,
+			ConfidenceLabel: graph.ConfidenceLabelFor(graph.EdgeModelsTable, ConfidenceTyped),
+			Meta:            meta,
+		}
+		StampSynthesizedTyped(e, SynthCSharpEFCoreModels)
+		g.AddEdge(e)
+		resolved++
+	}
+	if len(reindex) > 0 {
+		g.ReindexEdges(reindex)
+	}
+
 	for _, f := range dbsets {
 		cands := sameBoundaryCandidates(g, f.siteID, classesByName[f.entity])
 		if len(cands) != 1 {
@@ -67,21 +155,8 @@ func ResolveCSharpEFCoreModels(g graph.Store) int {
 			continue
 		}
 		mapped[cls.ID] = true
-		tableID := "db::orm::" + f.table
-		if g.GetNode(tableID) == nil {
-			g.AddNode(&graph.Node{
-				ID:       tableID,
-				Kind:     graph.KindTable,
-				Name:     f.table,
-				FilePath: f.filePath,
-				Language: "csharp",
-				Meta: map[string]any{
-					"dialect": "orm",
-					"schema":  "",
-					"source":  "csharp-orm",
-				},
-			})
-		}
+		tableID := csharpEFTableNodeID(f.table, "")
+		csharpEFEnsureTableNode(g, tableID, f.table, "", f.filePath)
 		e := &graph.Edge{
 			From: cls.ID, To: tableID, Kind: graph.EdgeModelsTable,
 			FilePath:        f.filePath,
@@ -101,6 +176,135 @@ func ResolveCSharpEFCoreModels(g graph.Store) int {
 		resolved++
 	}
 	return resolved
+}
+
+// csharpEFFluentFact is one fluent table naming: from a config class
+// (inline=false) or an OnModelCreating entry (inline=true).
+type csharpEFFluentFact struct {
+	entity   string
+	table    string
+	schema   string
+	relation string
+	inline   bool
+	siteID   string
+	filePath string
+	line     int
+}
+
+// csharpEFMergeFluentFacts reduces the fluent facts to at most one per
+// entity name: inline OnModelCreating entries beat config classes, and
+// two same-tier facts that disagree on the mapping drop the entity —
+// refusing beats guessing.
+func csharpEFMergeFluentFacts(fluents []csharpEFFluentFact) []csharpEFFluentFact {
+	merged := map[string]csharpEFFluentFact{}
+	dropped := map[string]bool{}
+	var order []string
+	for _, f := range fluents {
+		cur, ok := merged[f.entity]
+		if !ok {
+			merged[f.entity] = f
+			order = append(order, f.entity)
+			continue
+		}
+		if f.inline != cur.inline {
+			if f.inline {
+				merged[f.entity] = f
+			}
+			continue
+		}
+		if f.table != cur.table || f.schema != cur.schema || f.relation != cur.relation {
+			dropped[f.entity] = true
+		}
+	}
+	var out []csharpEFFluentFact
+	for _, name := range order {
+		if !dropped[name] {
+			out = append(out, merged[name])
+		}
+	}
+	return out
+}
+
+// csharpEFConfigFactFromNode reads the ef_config_* stamps off an
+// IEntityTypeConfiguration<T> class node. A config class without a
+// literal ToTable/ToView carries no table fact.
+func csharpEFConfigFactFromNode(n *graph.Node) (csharpEFFluentFact, bool) {
+	if n.Meta == nil {
+		return csharpEFFluentFact{}, false
+	}
+	entity, _ := n.Meta["ef_config_entity"].(string)
+	table, _ := n.Meta["ef_config_table"].(string)
+	if entity == "" || table == "" {
+		return csharpEFFluentFact{}, false
+	}
+	schema, _ := n.Meta["ef_config_schema"].(string)
+	relation, _ := n.Meta["ef_config_relation"].(string)
+	return csharpEFFluentFact{
+		entity: entity, table: table, schema: schema, relation: relation,
+		siteID: n.ID, filePath: n.FilePath, line: n.StartLine,
+	}, true
+}
+
+// csharpEFInlineFactsFromFile parses the ef_fluent
+// "entity|table|schema|relation" entries off a file node. Meta lists
+// round-trip through persistence as []any, so both shapes decode.
+func csharpEFInlineFactsFromFile(n *graph.Node) []csharpEFFluentFact {
+	if n.Meta == nil {
+		return nil
+	}
+	var entries []string
+	switch v := n.Meta["ef_fluent"].(type) {
+	case []string:
+		entries = v
+	case []any:
+		for _, x := range v {
+			if s, ok := x.(string); ok {
+				entries = append(entries, s)
+			}
+		}
+	}
+	var out []csharpEFFluentFact
+	for _, entry := range entries {
+		parts := strings.SplitN(entry, "|", 4)
+		if len(parts) != 4 || parts[0] == "" || parts[1] == "" {
+			continue
+		}
+		out = append(out, csharpEFFluentFact{
+			entity: parts[0], table: parts[1], schema: parts[2], relation: parts[3],
+			inline: true,
+			siteID: n.ID, filePath: n.FilePath, line: 1,
+		})
+	}
+	return out
+}
+
+// csharpEFTableNodeID mirrors the db::<dialect>::<schema>.<table>
+// convention the other ORM passes share.
+func csharpEFTableNodeID(table, schema string) string {
+	if schema != "" {
+		return "db::orm::" + schema + "." + table
+	}
+	return "db::orm::" + table
+}
+
+// csharpEFEnsureTableNode mints the KindTable node when the store does
+// not already hold it.
+func csharpEFEnsureTableNode(g graph.Store, tableID, table, schema, filePath string) {
+	if g.GetNode(tableID) != nil {
+		return
+	}
+	g.AddNode(&graph.Node{
+		ID:       tableID,
+		Kind:     graph.KindTable,
+		Name:     table,
+		FilePath: filePath,
+		Language: "csharp",
+		Meta: map[string]any{
+			"dialect": "orm",
+			"schema":  schema,
+			"source":  "csharp-orm",
+		},
+	})
 }
 
 // csharpDbSetFact is one DbSet<T> property: the entity it names, the

--- a/internal/resolver/csharp_efcore_models.go
+++ b/internal/resolver/csharp_efcore_models.go
@@ -1,0 +1,154 @@
+package resolver
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// ResolveCSharpEFCoreModels joins the EF Core mapping facts the C#
+// extractor stamps into models_table edges. The extractor decides only
+// the in-file form — a [Table] attribute on the entity itself; the two
+// cross-file forms land here:
+//
+//   - DbSet<T> convention: EF names the table after the DbSet PROPERTY
+//     (verbatim — not a pluralization of the class name), and the
+//     property lives on the DbContext, not the entity.
+//
+// Facts join to entity classes by unique class name within the same
+// boundary — an ambiguous name (two classes called Widget) skips
+// rather than guesses. An entity that already carries a models_table
+// edge (attribute-bound at extraction, or a previous run of this
+// pass) is left alone, which is also what makes the pass idempotent.
+//
+// Returns the number of edges synthesized.
+func ResolveCSharpEFCoreModels(g graph.Store) int {
+	if g == nil {
+		return 0
+	}
+	classesByName := map[string][]*graph.Node{}
+	var dbsets []csharpDbSetFact
+	for _, n := range nodesByKindsOrAll(g, graph.KindType, graph.KindField) {
+		if n == nil || !strings.EqualFold(n.Language, "csharp") {
+			continue
+		}
+		switch n.Kind {
+		case graph.KindType:
+			classesByName[n.Name] = append(classesByName[n.Name], n)
+		case graph.KindField:
+			if f, ok := csharpDbSetFactFromNode(n); ok {
+				dbsets = append(dbsets, f)
+			}
+		}
+	}
+	if len(dbsets) == 0 {
+		return 0
+	}
+
+	// Entities that already model a table keep their edge: the
+	// attribute binding was decided at extraction with the entity's own
+	// file as evidence, and a prior run of this pass already landed.
+	mapped := map[string]bool{}
+	for e := range g.EdgesByKind(graph.EdgeModelsTable) {
+		if e != nil {
+			mapped[e.From] = true
+		}
+	}
+
+	resolved := 0
+	for _, f := range dbsets {
+		cands := sameBoundaryCandidates(g, f.siteID, classesByName[f.entity])
+		if len(cands) != 1 {
+			continue
+		}
+		cls := cands[0]
+		if mapped[cls.ID] {
+			continue
+		}
+		mapped[cls.ID] = true
+		tableID := "db::orm::" + f.table
+		if g.GetNode(tableID) == nil {
+			g.AddNode(&graph.Node{
+				ID:       tableID,
+				Kind:     graph.KindTable,
+				Name:     f.table,
+				FilePath: f.filePath,
+				Language: "csharp",
+				Meta: map[string]any{
+					"dialect": "orm",
+					"schema":  "",
+					"source":  "csharp-orm",
+				},
+			})
+		}
+		e := &graph.Edge{
+			From: cls.ID, To: tableID, Kind: graph.EdgeModelsTable,
+			FilePath:        f.filePath,
+			Line:            f.line,
+			Origin:          graph.OriginASTInferred,
+			Confidence:      ConfidenceTyped,
+			ConfidenceLabel: graph.ConfidenceLabelFor(graph.EdgeModelsTable, ConfidenceTyped),
+			Meta: map[string]any{
+				"orm":        "efcore",
+				"binding":    "dbset",
+				"table_name": f.table,
+				"derivation": "convention",
+			},
+		}
+		StampSynthesizedTyped(e, SynthCSharpEFCoreModels)
+		g.AddEdge(e)
+		resolved++
+	}
+	return resolved
+}
+
+// csharpDbSetFact is one DbSet<T> property: the entity it names, the
+// table EF derives (the property name, verbatim), and the property's
+// site as edge evidence.
+type csharpDbSetFact struct {
+	entity   string
+	table    string
+	siteID   string
+	filePath string
+	line     int
+}
+
+// csharpDbSetType matches a (possibly qualified) DbSet<T> property
+// type and captures T.
+var csharpDbSetType = regexp.MustCompile(`^(?:[A-Za-z_][\w.]*\.)?DbSet<(.+)>\??$`)
+
+// csharpDbSetFactFromNode recognises a C# property node whose type is
+// DbSet<T>. A nested-generic argument (DbSet<Pair<A,B>>) is not an
+// entity registration and returns no fact.
+func csharpDbSetFactFromNode(n *graph.Node) (csharpDbSetFact, bool) {
+	if n.Meta == nil {
+		return csharpDbSetFact{}, false
+	}
+	if k, _ := n.Meta["kind"].(string); k != "property" {
+		return csharpDbSetFact{}, false
+	}
+	ft, _ := n.Meta["field_type"].(string)
+	m := csharpDbSetType.FindStringSubmatch(strings.TrimSpace(ft))
+	if len(m) < 2 {
+		return csharpDbSetFact{}, false
+	}
+	entity := strings.TrimSpace(m[1])
+	if strings.ContainsAny(entity, "<>,") {
+		return csharpDbSetFact{}, false
+	}
+	if i := strings.LastIndexByte(entity, '.'); i >= 0 {
+		entity = entity[i+1:]
+	}
+	entity = strings.TrimPrefix(entity, "@")
+	if entity == "" || n.Name == "" {
+		return csharpDbSetFact{}, false
+	}
+	return csharpDbSetFact{
+		entity:   entity,
+		table:    n.Name,
+		siteID:   n.ID,
+		filePath: n.FilePath,
+		line:     n.StartLine,
+	}, true
+}

--- a/internal/resolver/csharp_efcore_models.go
+++ b/internal/resolver/csharp_efcore_models.go
@@ -115,7 +115,7 @@ func ResolveCSharpEFCoreModels(g graph.Store) int {
 			continue
 		}
 		cls := cands[0]
-		tableID := csharpEFTableNodeID(f.table, f.schema)
+		tableID := csharpEFTableNodeID(cls.RepoPrefix, f.table, f.schema)
 		meta := map[string]any{
 			"orm":        "efcore",
 			"binding":    "fluent",
@@ -140,7 +140,7 @@ func ResolveCSharpEFCoreModels(g graph.Store) int {
 			if e.To == tableID {
 				continue
 			}
-			csharpEFEnsureTableNode(g, tableID, f.table, f.schema, f.filePath)
+			csharpEFEnsureTableNode(g, tableID, f.table, f.schema, f.filePath, cls.RepoPrefix)
 			oldTo := e.To
 			e.To = tableID
 			e.Origin = graph.OriginASTInferred
@@ -156,7 +156,7 @@ func ResolveCSharpEFCoreModels(g graph.Store) int {
 			continue
 		}
 		mapped[cls.ID] = true
-		csharpEFEnsureTableNode(g, tableID, f.table, f.schema, f.filePath)
+		csharpEFEnsureTableNode(g, tableID, f.table, f.schema, f.filePath, cls.RepoPrefix)
 		e := &graph.Edge{
 			From: cls.ID, To: tableID, Kind: graph.EdgeModelsTable,
 			FilePath:        f.filePath,
@@ -184,8 +184,8 @@ func ResolveCSharpEFCoreModels(g graph.Store) int {
 			continue
 		}
 		mapped[cls.ID] = true
-		tableID := csharpEFTableNodeID(f.table, "")
-		csharpEFEnsureTableNode(g, tableID, f.table, "", f.filePath)
+		tableID := csharpEFTableNodeID(cls.RepoPrefix, f.table, "")
+		csharpEFEnsureTableNode(g, tableID, f.table, "", f.filePath, cls.RepoPrefix)
 		e := &graph.Edge{
 			From: cls.ID, To: tableID, Kind: graph.EdgeModelsTable,
 			FilePath:        f.filePath,
@@ -327,26 +327,36 @@ func csharpEFInlineFactsFromFile(n *graph.Node) []csharpEFFluentFact {
 }
 
 // csharpEFTableNodeID mirrors the db::<dialect>::<schema>.<table>
-// convention the other ORM passes share.
-func csharpEFTableNodeID(table, schema string) string {
+// convention the other ORM passes share. In a workspace store, ingest
+// prefixes every extraction ID with the repo — the extractor-minted
+// db::orm:: nodes included — so resolver-minted IDs carry the joined
+// entity's RepoPrefix to keep one logical table one identity
+// regardless of which binding path named it. RepoPrefix is empty in a
+// single-repo store and the ID stays bare, same as extraction.
+func csharpEFTableNodeID(repoPrefix, table, schema string) string {
+	id := "db::orm::" + table
 	if schema != "" {
-		return "db::orm::" + schema + "." + table
+		id = "db::orm::" + schema + "." + table
 	}
-	return "db::orm::" + table
+	if repoPrefix != "" {
+		id = repoPrefix + "/" + id
+	}
+	return id
 }
 
 // csharpEFEnsureTableNode mints the KindTable node when the store does
 // not already hold it.
-func csharpEFEnsureTableNode(g graph.Store, tableID, table, schema, filePath string) {
+func csharpEFEnsureTableNode(g graph.Store, tableID, table, schema, filePath, repoPrefix string) {
 	if g.GetNode(tableID) != nil {
 		return
 	}
 	g.AddNode(&graph.Node{
-		ID:       tableID,
-		Kind:     graph.KindTable,
-		Name:     table,
-		FilePath: filePath,
-		Language: "csharp",
+		ID:         tableID,
+		Kind:       graph.KindTable,
+		Name:       table,
+		FilePath:   filePath,
+		Language:   "csharp",
+		RepoPrefix: repoPrefix,
 		Meta: map[string]any{
 			"dialect": "orm",
 			"schema":  schema,

--- a/internal/resolver/csharp_efcore_models.go
+++ b/internal/resolver/csharp_efcore_models.go
@@ -35,6 +35,14 @@ import (
 // edge at its final target is left alone, which is also what makes
 // the pass idempotent.
 //
+// Scoped (incremental) invocations run through frameworkScopedStore
+// with no bespoke scopedFn: the pass only sees nodes in the changed
+// frontier, so a cross-file join whose other half did not change joins
+// nothing — fail-open, never wrong. The one transient window: a fluent
+// fact whose file is out of scope cannot shadow the DbSet convention,
+// so an incremental run may land the convention name until the next
+// full settle rewires it. Full resolves see everything.
+//
 // Returns the number of edges synthesized or rewired.
 func ResolveCSharpEFCoreModels(g graph.Store) int {
 	if g == nil {

--- a/internal/resolver/csharp_efcore_models_test.go
+++ b/internal/resolver/csharp_efcore_models_test.go
@@ -172,6 +172,132 @@ public class ProbeContext : DbContext
 	assert.Equal(t, "view", te.Meta["relation"])
 }
 
+// TestCSharpEFMergeFluentFacts_OrderIndependent: the merge's verdict
+// for an entity must not depend on fact arrival order — facts come off
+// a map-ordered node scan, so every permutation of the same set must
+// produce the same result.
+func TestCSharpEFMergeFluentFacts_OrderIndependent(t *testing.T) {
+	configA := csharpEFFluentFact{entity: "Widget", table: "w1", siteID: "a.cs::AConfig"}
+	configB := csharpEFFluentFact{entity: "Widget", table: "w2", siteID: "b.cs::BConfig"}
+	inline := csharpEFFluentFact{entity: "Widget", table: "w3", inline: true, siteID: "ctx.cs"}
+
+	perms := [][]csharpEFFluentFact{
+		{configA, configB, inline},
+		{configA, inline, configB},
+		{inline, configA, configB},
+		{inline, configB, configA},
+		{configB, inline, configA},
+		{configB, configA, inline},
+	}
+	for i, p := range perms {
+		out := csharpEFMergeFluentFacts(p)
+		require.Len(t, out, 1, "perm %d: inline tier wins outright — config disagreement below it is irrelevant", i)
+		assert.Equal(t, "w3", out[0].table, "perm %d", i)
+		assert.True(t, out[0].inline, "perm %d", i)
+	}
+
+	// No inline tier: the config disagreement drops the entity, both orders.
+	for i, p := range [][]csharpEFFluentFact{{configA, configB}, {configB, configA}} {
+		assert.Empty(t, csharpEFMergeFluentFacts(p), "conflict perm %d", i)
+	}
+
+	// Agreeing same-tier facts: kept, and the retained site is the
+	// deterministic (lowest-siteID) one regardless of order.
+	configA2 := csharpEFFluentFact{entity: "Widget", table: "w1", siteID: "z.cs::ZConfig"}
+	agreeA := csharpEFFluentFact{entity: "Widget", table: "w1", siteID: "a.cs::AConfig"}
+	for i, p := range [][]csharpEFFluentFact{{configA2, agreeA}, {agreeA, configA2}} {
+		out := csharpEFMergeFluentFacts(p)
+		require.Len(t, out, 1, "agree perm %d", i)
+		assert.Equal(t, "a.cs::AConfig", out[0].siteID, "agree perm %d: lowest siteID wins deterministically", i)
+	}
+}
+
+// TestResolveCSharpEFCoreModels_InlineBeatsConfigClass: within the
+// fluent tier, an OnModelCreating inline entry beats a config class —
+// EF applies OnModelCreating statements after ApplyConfiguration.
+func TestResolveCSharpEFCoreModels_InlineBeatsConfigClass(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Domain/Gadget.cs": `namespace App.Domain;
+
+public class Gadget
+{
+    public int Id { get; set; }
+}
+`,
+		"Config/GadgetConfig.cs": `using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace App.Config;
+
+public class GadgetConfig : IEntityTypeConfiguration<Gadget>
+{
+    public void Configure(EntityTypeBuilder<Gadget> builder)
+    {
+        builder.ToTable("cfg_gadgets");
+    }
+}
+`,
+		"Data/ProbeContext.cs": `using Microsoft.EntityFrameworkCore;
+
+namespace App.Data;
+
+public class ProbeContext : DbContext
+{
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Gadget>().ToTable("inline_gadgets");
+    }
+}
+`,
+	})
+	assert.Equal(t, 1, ResolveCSharpEFCoreModels(g))
+	models := efModelsTableEdges(g)
+	require.Len(t, models, 1)
+	assert.Equal(t, "db::orm::inline_gadgets", models[0].To)
+}
+
+// TestResolveCSharpEFCoreModels_EfFluentAnySliceDecodes: meta lists
+// round-trip through persistence as []any — the pass must decode both
+// shapes, not just the in-process []string.
+func TestResolveCSharpEFCoreModels_EfFluentAnySliceDecodes(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Domain/Gadget.cs": `namespace App.Domain;
+
+public class Gadget
+{
+    public int Id { get; set; }
+}
+`,
+		"Data/ProbeContext.cs": `using Microsoft.EntityFrameworkCore;
+
+namespace App.Data;
+
+public class ProbeContext : DbContext
+{
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Gadget>().ToTable("gadget_rows");
+    }
+}
+`,
+	})
+	fileNode := g.GetNode("Data/ProbeContext.cs")
+	require.NotNil(t, fileNode)
+	entries, ok := fileNode.Meta["ef_fluent"].([]string)
+	require.True(t, ok, "extractor stamps []string in-process")
+	anyEntries := make([]any, len(entries))
+	for i, e := range entries {
+		anyEntries[i] = e
+	}
+	fileNode.Meta["ef_fluent"] = anyEntries
+
+	assert.Equal(t, 1, ResolveCSharpEFCoreModels(g))
+	models := efModelsTableEdges(g)
+	require.Len(t, models, 1)
+	assert.Equal(t, "db::orm::gadget_rows", models[0].To)
+	assert.Greater(t, models[0].Line, 1, "edge evidence carries the mapping statement's line, not the file top")
+}
+
 // TestResolveCSharpEFCoreModels_AmbiguousEntityNameSkips: the join is
 // by unique class name — two classes sharing the entity's name means
 // the pass refuses to guess and emits nothing.

--- a/internal/resolver/csharp_efcore_models_test.go
+++ b/internal/resolver/csharp_efcore_models_test.go
@@ -1,0 +1,100 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// efModelsTableEdges collects every models_table edge in the store.
+func efModelsTableEdges(g graph.Store) []*graph.Edge {
+	var out []*graph.Edge
+	for e := range g.EdgesByKind(graph.EdgeModelsTable) {
+		if e != nil {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// TestResolveCSharpEFCoreModels_DbSetConventionBindsPropertyName pins
+// EF's actual convention: the table name is the DbSet PROPERTY name,
+// verbatim — not a pluralization of the entity class name.
+func TestResolveCSharpEFCoreModels_DbSetConventionBindsPropertyName(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Domain/Widget.cs": `namespace App.Domain;
+
+public class Widget
+{
+    public int Id { get; set; }
+}
+`,
+		"Data/ProbeContext.cs": `using Microsoft.EntityFrameworkCore;
+
+namespace App.Data;
+
+public class ProbeContext : DbContext
+{
+    public DbSet<Widget> StockWidgets { get; set; }
+}
+`,
+	})
+	n := ResolveCSharpEFCoreModels(g)
+	assert.Equal(t, 1, n)
+
+	models := efModelsTableEdges(g)
+	require.Len(t, models, 1)
+	e := models[0]
+	assert.Equal(t, "Domain/Widget.cs::Widget", e.From)
+	assert.Equal(t, "db::orm::StockWidgets", e.To,
+		"table = DbSet property name verbatim, never a pluralized class name")
+	assert.Equal(t, "efcore", e.Meta["orm"])
+	assert.Equal(t, "dbset", e.Meta["binding"])
+	assert.Equal(t, "StockWidgets", e.Meta["table_name"])
+	assert.Equal(t, "convention", e.Meta["derivation"])
+
+	tableNode := g.GetNode("db::orm::StockWidgets")
+	require.NotNil(t, tableNode, "the KindTable node is minted with the edge")
+	assert.Equal(t, graph.KindTable, tableNode.Kind)
+	assert.Equal(t, "orm", tableNode.Meta["dialect"])
+	assert.Equal(t, "csharp-orm", tableNode.Meta["source"])
+
+	assert.Equal(t, 0, ResolveCSharpEFCoreModels(g), "second run is a no-op")
+	assert.Len(t, efModelsTableEdges(g), 1, "idempotent: no duplicate edges")
+}
+
+// TestResolveCSharpEFCoreModels_AmbiguousEntityNameSkips: the join is
+// by unique class name — two classes sharing the entity's name means
+// the pass refuses to guess and emits nothing.
+func TestResolveCSharpEFCoreModels_AmbiguousEntityNameSkips(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Domain/Widget.cs": `namespace App.Domain;
+
+public class Widget
+{
+    public int Id { get; set; }
+}
+`,
+		"Legacy/Widget.cs": `namespace App.Legacy;
+
+public class Widget
+{
+    public string Tag { get; set; }
+}
+`,
+		"Data/ProbeContext.cs": `using Microsoft.EntityFrameworkCore;
+
+namespace App.Data;
+
+public class ProbeContext : DbContext
+{
+    public DbSet<Widget> Widgets { get; set; }
+}
+`,
+	})
+	assert.Equal(t, 0, ResolveCSharpEFCoreModels(g))
+	assert.Empty(t, efModelsTableEdges(g))
+}

--- a/internal/resolver/csharp_efcore_models_test.go
+++ b/internal/resolver/csharp_efcore_models_test.go
@@ -66,6 +66,112 @@ public class ProbeContext : DbContext
 	assert.Len(t, efModelsTableEdges(g), 1, "idempotent: no duplicate edges")
 }
 
+// TestResolveCSharpEFCoreModels_FluentConfigRewiresAttributeEdge: the
+// precedence is fluent > attribute — a config class's ToTable rewires
+// the extractor's attribute edge in place, go_orm's override model.
+func TestResolveCSharpEFCoreModels_FluentConfigRewiresAttributeEdge(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Domain/Widget.cs": `using System.ComponentModel.DataAnnotations.Schema;
+
+namespace App.Domain;
+
+[Table("attr_widgets")]
+public class Widget
+{
+    public int Id { get; set; }
+}
+`,
+		"Config/WidgetConfig.cs": `using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace App.Config;
+
+public class WidgetConfig : IEntityTypeConfiguration<Widget>
+{
+    public void Configure(EntityTypeBuilder<Widget> builder)
+    {
+        builder.ToTable("fluent_widgets", "sales");
+    }
+}
+`,
+	})
+	n := ResolveCSharpEFCoreModels(g)
+	assert.Equal(t, 1, n, "the rewire counts as resolution work")
+
+	models := efModelsTableEdges(g)
+	require.Len(t, models, 1, "rewired in place — never a second edge")
+	e := models[0]
+	assert.Equal(t, "Domain/Widget.cs::Widget", e.From)
+	assert.Equal(t, "db::orm::sales.fluent_widgets", e.To)
+	assert.Equal(t, "fluent", e.Meta["binding"])
+	assert.Equal(t, "fluent_widgets", e.Meta["table_name"])
+	assert.Equal(t, "sales", e.Meta["schema"])
+	assert.Equal(t, "override", e.Meta["derivation"])
+	require.NotNil(t, g.GetNode("db::orm::sales.fluent_widgets"))
+
+	assert.Equal(t, 0, ResolveCSharpEFCoreModels(g), "second run is a no-op")
+	assert.Len(t, efModelsTableEdges(g), 1)
+}
+
+// TestResolveCSharpEFCoreModels_InlineFluentBeatsDbSet: an
+// OnModelCreating Entity<T>().ToTable wins over the DbSet property
+// convention for the same entity — one edge, fluent-bound; a ToView
+// carries relation=view.
+func TestResolveCSharpEFCoreModels_InlineFluentBeatsDbSet(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Domain/Gadget.cs": `namespace App.Domain;
+
+public class Gadget
+{
+    public int Id { get; set; }
+}
+`,
+		"Domain/CrateTally.cs": `namespace App.Domain;
+
+public class CrateTally
+{
+    public int Total { get; set; }
+}
+`,
+		"Data/ProbeContext.cs": `using Microsoft.EntityFrameworkCore;
+
+namespace App.Data;
+
+public class ProbeContext : DbContext
+{
+    public DbSet<Gadget> Gadgets { get; set; }
+    public DbSet<CrateTally> Tallies { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Gadget>().ToTable("gadget_rows");
+        modelBuilder.Entity<CrateTally>().ToView("crate_tallies");
+    }
+}
+`,
+	})
+	n := ResolveCSharpEFCoreModels(g)
+	assert.Equal(t, 2, n)
+
+	byFrom := map[string]*graph.Edge{}
+	for _, e := range efModelsTableEdges(g) {
+		require.NotContains(t, byFrom, e.From, "one edge per entity")
+		byFrom[e.From] = e
+	}
+	require.Len(t, byFrom, 2)
+
+	ge := byFrom["Domain/Gadget.cs::Gadget"]
+	require.NotNil(t, ge)
+	assert.Equal(t, "db::orm::gadget_rows", ge.To, "fluent beats the DbSet convention name")
+	assert.Equal(t, "fluent", ge.Meta["binding"])
+	assert.Equal(t, "override", ge.Meta["derivation"])
+
+	te := byFrom["Domain/CrateTally.cs::CrateTally"]
+	require.NotNil(t, te)
+	assert.Equal(t, "db::orm::crate_tallies", te.To)
+	assert.Equal(t, "view", te.Meta["relation"])
+}
+
 // TestResolveCSharpEFCoreModels_AmbiguousEntityNameSkips: the join is
 // by unique class name — two classes sharing the entity's name means
 // the pass refuses to guess and emits nothing.

--- a/internal/resolver/csharp_efcore_models_test.go
+++ b/internal/resolver/csharp_efcore_models_test.go
@@ -298,6 +298,38 @@ public class ProbeContext : DbContext
 	assert.Greater(t, models[0].Line, 1, "edge evidence carries the mapping statement's line, not the file top")
 }
 
+// TestResolveCSharpEFCoreModels_RepoPrefixedStoreSpelling: in a
+// workspace store, ingest prefixes every extraction ID with the repo —
+// including the extractor-minted db::orm:: table nodes. Edges the
+// RESOLVER mints must use the same spelling, or one logical table
+// splits into a bare and a prefixed identity depending on which
+// binding path named it.
+func TestResolveCSharpEFCoreModels_RepoPrefixedStoreSpelling(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID: "probe/Domain\\Widget.cs::Widget", Kind: graph.KindType, Name: "Widget",
+		FilePath: "probe/Domain\\Widget.cs", Language: "csharp", RepoPrefix: "probe",
+	})
+	g.AddNode(&graph.Node{
+		ID: "probe/Data\\Ctx.cs::ProbeContext", Kind: graph.KindType, Name: "ProbeContext",
+		FilePath: "probe/Data\\Ctx.cs", Language: "csharp", RepoPrefix: "probe",
+	})
+	g.AddNode(&graph.Node{
+		ID: "probe/Data\\Ctx.cs::ProbeContext.StockWidgets", Kind: graph.KindField, Name: "StockWidgets",
+		FilePath: "probe/Data\\Ctx.cs", Language: "csharp", RepoPrefix: "probe", StartLine: 7,
+		Meta: map[string]any{"kind": "property", "field_type": "DbSet<Widget>", "receiver": "ProbeContext"},
+	})
+
+	assert.Equal(t, 1, ResolveCSharpEFCoreModels(g))
+	models := efModelsTableEdges(g)
+	require.Len(t, models, 1)
+	assert.Equal(t, "probe/db::orm::StockWidgets", models[0].To,
+		"resolver-minted table IDs carry the entity's repo prefix, matching the ingest spelling")
+	tableNode := g.GetNode("probe/db::orm::StockWidgets")
+	require.NotNil(t, tableNode)
+	assert.Equal(t, "probe", tableNode.RepoPrefix)
+}
+
 // TestResolveCSharpEFCoreModels_AmbiguousEntityNameSkips: the join is
 // by unique class name — two classes sharing the entity's name means
 // the pass refuses to guess and emits nothing.

--- a/internal/resolver/framework_synth.go
+++ b/internal/resolver/framework_synth.go
@@ -111,6 +111,7 @@ const (
 	SynthMediatR             = "mediatr-dispatch"
 	SynthCSharpIfaceDispatch = "csharp-iface-dispatch"
 	SynthCSharpDIIfaces      = "csharp-di-implemented-interfaces"
+	SynthCSharpEFCoreModels  = "csharp-efcore-models"
 	SynthSidekiq             = "sidekiq-dispatch"
 	SynthLaravelEvent        = "laravel-event"
 	SynthFnPointerDispatch   = "fn-pointer-dispatch"
@@ -239,6 +240,7 @@ var frameworkSynthLanguageFamilies = map[string][]string{
 	SynthMediatR:             {"dotnet"},
 	SynthCSharpIfaceDispatch: {"dotnet"},
 	SynthCSharpDIIfaces:      {"dotnet"},
+	SynthCSharpEFCoreModels:  {"dotnet"},
 	SynthSidekiq:             {"ruby"},
 	SynthLaravelEvent:        {"php"},
 	SynthFnPointerDispatch:   {"c"},
@@ -941,6 +943,7 @@ func defaultFrameworkSynthesizers() []FrameworkSynthesizer {
 		// find_usages / get_callers result. After the implements-producing
 		// passes so the impl fan-out is complete.
 		synthFunc{name: SynthCSharpIfaceDispatch, fn: ResolveCSharpInterfaceDispatch, scopedFn: ResolveCSharpInterfaceDispatchScoped},
+		synthFunc{name: SynthCSharpEFCoreModels, fn: ResolveCSharpEFCoreModels},
 		// Sidekiq job dispatch: Worker.perform_async(...) → the worker's
 		// perform, namespace-aware. Include-gated, typed tier.
 		synthFunc{name: SynthSidekiq, fn: ResolveSidekiqCalls},

--- a/internal/resolver/framework_synth.go
+++ b/internal/resolver/framework_synth.go
@@ -943,6 +943,11 @@ func defaultFrameworkSynthesizers() []FrameworkSynthesizer {
 		// find_usages / get_callers result. After the implements-producing
 		// passes so the impl fan-out is complete.
 		synthFunc{name: SynthCSharpIfaceDispatch, fn: ResolveCSharpInterfaceDispatch, scopedFn: ResolveCSharpInterfaceDispatchScoped},
+		// csharp-efcore-models joins the extractor's EF Core facts
+		// (attribute models_table edges, ef_config_*/ef_fluent stamps)
+		// into the models_table layer. Position-independent: it reads
+		// only its own stamps and models_table itself, and no other
+		// pass consumes models_table during synthesis.
 		synthFunc{name: SynthCSharpEFCoreModels, fn: ResolveCSharpEFCoreModels},
 		// Sidekiq job dispatch: Worker.perform_async(...) → the worker's
 		// perform, namespace-aware. Include-gated, typed tier.


### PR DESCRIPTION
models_table ships for six ecosystems (go, java, python, ruby,
typescript, elixir) and C# had none: my production store holds zero
models_table edges, zero orm table nodes. EF Core is the reason a
straight java_orm port does not work - the table name can come from
three places, and two of them live in files other than the entity's:

1. `[Table("name")]` / `[Table("name", Schema = "s")]` on the entity
itself (the attribute is shared by Dapper.Contrib, so this form pays
for itself beyond EF).

2. Fluent configuration: a class implementing
`IEntityTypeConfiguration<T>` calling `builder.ToTable(...)`, or an
`OnModelCreating` body calling `modelBuilder.Entity<T>().ToTable(...)`.

3. The DbSet convention: with neither of the above, EF names the table
after the DbSet PROPERTY on the context - verbatim, not a
pluralization of the class name. `DbSet<Widget> StockWidgets` maps
`StockWidgets`.

The split follows from that: the extractor decides only the in-file
form (the attribute, java_orm's model - same `db::orm::` table nodes,
same edge meta shape, schema-qualified IDs as `db::orm::schema.table`)
and stamps the cross-file forms as facts: `ef_config_entity` /
`ef_config_table` / `ef_config_schema` / `ef_config_relation` on
config classes, `ef_fluent` entries ("entity|table|schema|relation")
on files with an OnModelCreating body. A resolver pass
(SynthCSharpEFCoreModels, registered beside the other dotnet
synthesizers) joins the facts to entity classes by unique
same-boundary class name and applies precedence fluent > attribute >
dbset: a fluent fact REWIRES the attribute edge in place (go_orm's
override model, via ReindexEdges) rather than adding a second edge,
and an entity the fluent tier claimed never falls through to the DbSet
convention. Within the fluent tier an inline OnModelCreating entry
beats a config class, matching EF's application order.

Everything fails open, refusing over guessing:

- An ambiguous entity name (two classes sharing it) joins nothing.
- Two facts in the winning fluent tier that disagree drop the entity;
the merge is two-phase and fact lists are sorted first, so the verdict
and the retained evidence site never depend on map iteration order.
- A non-literal table name (nameof, a constant, the lambda-only
ToTable overloads) stamps nothing.
- A ToTable reached through an owned-type or navigation builder names
a DIFFERENT entity's table (`builder.OwnsOne(...).ToTable(...)`, the
OwnsOne-lambda form, and the inline chained spellings, generic
included) - both the config scan and the inline chain walk refuse
these: the config side requires a plain-identifier receiver outside
any lambda, the inline side stops at subject-changing links.
- A class implementing IEntityTypeConfiguration for two entities
refuses entirely - a single-entity stamp cannot say whose ToTable the
body scan found.
- A DbSet whose type argument is a nested generic is not an entity
registration.
- OnModelCreating scanning stays inside the method body - a helper
method reached from there is a cross-method chase the extractor does
not attempt.
- The pass is idempotent: an entity already carrying a models_table
edge at its final target is left alone.

`ToView` rides as `relation: view` on the edge, so view-backed keyless
entities attribute without pretending to be tables.

Two fixes came out of validating the branch against a live store (an
isolated daemon, cold-indexing my production C# codebase plus my
acceptance fixtures) - both invisible to unit tests because they live
in the ingest pipeline:

1. The sql coverage domain defaults off, and stripSQLArtifacts then
dropped EVERY KindTable node without origin=migration, plus all edges
touching them. That silently empties the models_table layer for every
ORM ecosystem under the default config, not just this one - the six
older *_orm extractors mint the same nodes. The gate exists for the
noisy code-side string-literal SQL matching; ORM attribution is
declaration-anchored, so dialect=orm table nodes now ride through the
gate the same way migration-origin DDL already does (RED-tested).

2. In a workspace store, ingest prefixes extraction IDs with the repo -
the extractor-minted db::orm:: nodes included - while the resolver
pass minted bare IDs, so one logical table split into two identities
depending on which binding path named it. Resolver-minted table IDs
now derive from the joined entity's RepoPrefix (empty in single-repo
stores, where extraction IDs are bare too - one rule, one spelling).

With those in, the live run attributes 482 model-to-table edges on my
production codebase (456 attribute-bound, 26 DbSet-convention) where
the store previously had zero, and every acceptance scenario behaves:
attribute-only, schema-qualified, convention-pins-property-name,
separate-file fluent rewire, inline fluent, ToView, and the
ambiguous-name guard binding nothing.

On scoped (incremental) invocations the pass runs through the scoped
store with no bespoke scopedFn: a cross-file join whose other half is
outside the changed frontier joins nothing - fail-open, never wrong.
The one transient window is a fluent fact whose file is out of scope:
it cannot shadow the DbSet convention until the next full settle
rewires the edge. I judged that acceptable for a first cut and
documented it on the pass; a scopedFn that pulls the fact files into
the frontier is the follow-up if it matters in practice. I also swept
the existing models_table consumers: analyze models needs no changes
(the orm filter doc gains ecto and efcore), and the Rails
resolve pass's model-class set is gated behind a .rb-caller check
before it consults membership, so cross-language entries are inert.

Extractor version: csharp bumps to 13, because a store extracted
before the stamps has no facts for the pass to join and no content
change would mint them. Note the number collides with my other two
open branches' bumps (the PR 677 revision and the virtual-dispatch
branch each claim the next slot from their own base); whichever merges
first is fine and I will renumber the others on rebase.

Named non-goals for this round, so the review has edges: `[Column]`
property mapping, owned types (OwnsOne/OwnsMany), inheritance
strategies (TPH/TPT/TPC), and FromSqlRaw/Dapper query-text edges.

Verification: RED-first throughout (extractor fixtures for each
attribute/config/fluent shape including a mutation check on the
OnModelCreating scope gate; resolver e2e tests through the real
extractor covering the property-name-verbatim pin, the
attribute-rewire, fluent-beats-dbset precedence, ToView, ambiguity
skip, and double-run idempotency). My counted acceptance fixtures add
a round covering the general surface: attribute-only, schema form,
convention pin with a property name that matches no pluralization,
separate-file fluent override, inline fluent, ToView, and an
ambiguous-name guard cell that must never bind. Full race suite:
fail-name set identical to my Windows baseline at the merge base,
except one Swift localization timing test that fails identically on an
unmodified checkout (this branch touches no Swift or localization
code).
