### PR TITLE
fix(csharp): harden EF Core model attribution

### DIFF
--- a/internal/graph/store_sqlite/meta_json.go
+++ b/internal/graph/store_sqlite/meta_json.go
@@ -133,6 +133,7 @@ var metaStringSliceKeys = map[string]bool{
 // metaMapSliceKeys are keys whose array value must be []map[string]any.
 var metaMapSliceKeys = map[string]bool{
 	"response_envelope": true,
+	"ef_fluent":         true,
 }
 
 // UnmarshalJSON decodes the typed fields and captures every other key into

--- a/internal/graph/store_sqlite/meta_json_test.go
+++ b/internal/graph/store_sqlite/meta_json_test.go
@@ -31,7 +31,47 @@ func roundTrip(t *testing.T, in map[string]any) map[string]any {
 // TestMetaRoundTripExactTypes is the fidelity canary: every key the audit
 // found read with a raw type-assertion must survive a JSON round-trip with
 // its exact Go type, or the corresponding reader silently breaks.
+func TestDecodeLegacyJSONEFFluentExactType(t *testing.T) {
+	got, err := decodeMeta([]byte(`{
+		"ef_fluent": [{
+			"context": "ProbeContext",
+			"kind": "mapping",
+			"line": 12,
+			"ordinal": 0,
+			"entity": "Widget",
+			"table": "widget|rows",
+			"schema": "core",
+			"relation": "table"
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("decode legacy JSON ef_fluent: %v", err)
+	}
+	actions, ok := got["ef_fluent"].([]map[string]any)
+	if !ok {
+		t.Fatalf("ef_fluent type = %T, want []map[string]any", got["ef_fluent"])
+	}
+	if len(actions) != 1 {
+		t.Fatalf("ef_fluent length = %d, want 1", len(actions))
+	}
+	assertType[string](t, actions[0], "table", "widget|rows")
+	assertType[int](t, actions[0], "line", 12)
+	assertType[int](t, actions[0], "ordinal", 0)
+}
+
 func TestMetaRoundTripExactTypes(t *testing.T) {
+	var efWire metaWire
+	if err := efWire.UnmarshalJSON([]byte(`{"ef_fluent":[{"context":"ProbeContext","kind":"mapping","line":11,"ordinal":0,"entity":"Widget","table":"widgets","schema":"","relation":"table"}]}`)); err != nil {
+		t.Fatalf("decode structured ef_fluent: %v", err)
+	}
+	actions, ok := efWire.Extra["ef_fluent"].([]map[string]any)
+	if !ok {
+		t.Fatalf("structured ef_fluent type = %T, want []map[string]any", efWire.Extra["ef_fluent"])
+	}
+	if len(actions) != 1 || actions[0]["kind"] != "mapping" || actions[0]["entity"] != "Widget" {
+		t.Fatalf("structured ef_fluent = %#v", actions)
+	}
+
 	shape := &contracts.Shape{
 		Kind:   "struct",
 		Fields: []contracts.ShapeField{{Name: "id", Type: "int64", Required: true}},

--- a/internal/indexer/coverage_strip_test.go
+++ b/internal/indexer/coverage_strip_test.go
@@ -66,3 +66,58 @@ func TestStripFunctionShape(t *testing.T) {
 		t.Error("defines edge missing after strip")
 	}
 }
+
+// TestStripSQLArtifacts_PreservesORMTableNodes: the sql domain gates
+// the NOISY code-side string-literal SQL extraction. ORM model
+// attribution (models_table) is declaration-anchored — attributes,
+// DbSet properties, schema classes — and must survive the gate the
+// same way migration-origin DDL does, or the models_table layer is
+// silently empty for every ORM ecosystem under the default config.
+func TestStripSQLArtifacts_PreservesORMTableNodes(t *testing.T) {
+	result := &parser.ExtractionResult{
+		Nodes: []*graph.Node{
+			{ID: "Models/StockCrate.cs::StockCrate", Kind: graph.KindType, Name: "StockCrate"},
+			{ID: "db::orm::stock_crates", Kind: graph.KindTable, Name: "stock_crates",
+				Meta: map[string]any{"dialect": "orm", "schema": "", "source": "csharp-orm"}},
+			{ID: "db::sqlite::guessed", Kind: graph.KindTable, Name: "guessed"},
+			{ID: "db::sqlite::from_ddl", Kind: graph.KindTable, Name: "from_ddl",
+				Meta: map[string]any{"origin": "migration"}},
+			{ID: "str::sql1", Kind: graph.KindString, Name: "q",
+				Meta: map[string]any{"context": "sql"}},
+		},
+		Edges: []*graph.Edge{
+			{From: "Models/StockCrate.cs::StockCrate", To: "db::orm::stock_crates", Kind: graph.EdgeModelsTable},
+			{From: "svc::repo.Load", To: "db::sqlite::guessed", Kind: graph.EdgeQueries},
+		},
+	}
+	stripSQLArtifacts(result)
+
+	kept := map[string]bool{}
+	for _, n := range result.Nodes {
+		kept[n.ID] = true
+	}
+	if !kept["db::orm::stock_crates"] {
+		t.Errorf("ORM table node stripped — models_table layer dies under the default config")
+	}
+	if !kept["db::sqlite::from_ddl"] {
+		t.Errorf("migration-origin table node should survive as before")
+	}
+	if kept["db::sqlite::guessed"] {
+		t.Errorf("code-side SQL table guess should still be stripped")
+	}
+	if kept["str::sql1"] {
+		t.Errorf("sql-context string registry node should still be stripped")
+	}
+	hasModels := false
+	for _, e := range result.Edges {
+		if e.Kind == graph.EdgeModelsTable {
+			hasModels = true
+		}
+		if e.Kind == graph.EdgeQueries {
+			t.Errorf("queries edge should still be stripped: %+v", e)
+		}
+	}
+	if !hasModels {
+		t.Errorf("models_table edge to the surviving ORM table node should be kept")
+	}
+}

--- a/internal/indexer/extractor_version.go
+++ b/internal/indexer/extractor_version.go
@@ -12,6 +12,14 @@ import (
 	"github.com/zzet/gortex/internal/graph"
 )
 
+const (
+	// postExtractionPolicySnapshotKey is a reserved RepoIndexState extractor-
+	// version key. It versions admission rules that run after every language
+	// extractor, so it must never be returned as a language to re-stage.
+	postExtractionPolicySnapshotKey = "_post_extraction_policy"
+	postExtractionPolicyVersion     = 2
+)
+
 // extractorVersions records the logic version of each language's
 // extractor. Bump a language's entry when its extraction logic changes
 // in a way that should re-extract already-indexed files whose content
@@ -106,21 +114,21 @@ func extractorVersionForLang(lang string) int {
 	return 1
 }
 
-// merkleSaltFor returns the Merkle leaf salt for a repo-relative path:
-// "" when the file's language extractor is at the baseline version 1
-// (so the leaf equals the content hash and nothing changes), or
-// "lang@N" once a language's extractor version is bumped, so its files
-// re-extract on the next reconcile even when their content is unchanged.
+// merkleSaltFor returns the Merkle leaf salt for a repo-relative path. Every
+// mapped source language carries the global post-extraction policy epoch; a
+// bumped language additionally carries its extractor version. An unmapped
+// extension remains content-only and therefore has no salt.
 func merkleSaltFor(rel string) string {
 	lang := extractorSaltExtLang[strings.ToLower(filepath.Ext(rel))]
 	if lang == "" {
 		return ""
 	}
+	policySalt := postExtractionPolicySnapshotKey + "@" + strconv.Itoa(postExtractionPolicyVersion)
 	v := extractorVersionForLang(lang)
 	if v <= 1 {
-		return ""
+		return policySalt
 	}
-	return lang + "@" + strconv.Itoa(v)
+	return policySalt + "|" + lang + "@" + strconv.Itoa(v)
 }
 
 // ExtractorVersionStaleLangs reports which languages' extractors have been
@@ -146,14 +154,32 @@ func ExtractorVersionStaleLangs(storedJSON string) []string {
 }
 
 // staleLangsBetween returns the languages whose stored version is behind the
-// current version — only languages present in BOTH maps are compared, so a
-// language the stored snapshot never recorded is not spuriously flagged.
+// current version. Per-language entries are compared only when present in both
+// maps. The reserved post-extraction policy epoch is global: when current tracks
+// it and stored is missing or behind, every real current language is stale.
 func staleLangsBetween(stored, current map[string]int) []string {
-	var stale []string
-	for lang, storedV := range stored {
-		if cur, ok := current[lang]; ok && storedV < cur {
-			stale = append(stale, lang)
+	staleSet := make(map[string]struct{})
+	if currentPolicy, tracked := current[postExtractionPolicySnapshotKey]; tracked {
+		storedPolicy, found := stored[postExtractionPolicySnapshotKey]
+		if !found || storedPolicy < currentPolicy {
+			for lang := range current {
+				if lang != postExtractionPolicySnapshotKey {
+					staleSet[lang] = struct{}{}
+				}
+			}
 		}
+	}
+	for lang, storedV := range stored {
+		if lang == postExtractionPolicySnapshotKey {
+			continue
+		}
+		if cur, ok := current[lang]; ok && storedV < cur {
+			staleSet[lang] = struct{}{}
+		}
+	}
+	stale := make([]string, 0, len(staleSet))
+	for lang := range staleSet {
+		stale = append(stale, lang)
 	}
 	sort.Strings(stale)
 	return stale
@@ -201,11 +227,11 @@ func extractorLangStale(set map[string]struct{}, rel string) bool {
 	return ok
 }
 
-// extractorVersionsSnapshot returns a copy of the current per-language
-// extractor versions for persistence in repo_index_state, so a future
-// reconcile can tell which extractor produced the stored graph.
+// extractorVersionsSnapshot returns the current per-language extractor versions
+// plus the reserved global post-extraction policy epoch for persistence in
+// repo_index_state.
 func extractorVersionsSnapshot() map[string]int {
-	out := make(map[string]int, len(extractorSaltExtLang))
+	out := make(map[string]int, len(extractorSaltExtLang)+1)
 	seen := map[string]bool{}
 	for _, lang := range extractorSaltExtLang {
 		if seen[lang] {
@@ -214,5 +240,6 @@ func extractorVersionsSnapshot() map[string]int {
 		seen[lang] = true
 		out[lang] = extractorVersionForLang(lang)
 	}
+	out[postExtractionPolicySnapshotKey] = postExtractionPolicyVersion
 	return out
 }

--- a/internal/indexer/extractor_version.go
+++ b/internal/indexer/extractor_version.go
@@ -32,7 +32,7 @@ var extractorVersions = map[string]int{
 	//   "go": 2,
 	"c":      generatedParserProjectionPolicyVersion, // generated parser projection covers all strictly detected table sizes
 	"php":    2,                                      // class/interface inheritance now emits typed structural edges
-	"csharp": 12,                                     // receiverless calls carry arg_count / type_arg_count for #559 (was: params parameters emit complete shape and arity evidence)
+	"csharp": 13,                                     // EF Core ORM facts: [Table] models_table edges, ef_config_* and ef_fluent stamps (was: receiverless calls carry arg_count / type_arg_count for #559)
 	"scala":  2,                                      // explicitly instantiated generic calls emit call edges
 	"go":     3,                                      // generic instantiations are marked so indexing a func value cannot bind (was: generic calls emit call edges)
 	"cpp":    2,                                      // templated and namespace-qualified calls emit call edges

--- a/internal/indexer/extractor_version_restage_test.go
+++ b/internal/indexer/extractor_version_restage_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/zzet/gortex/internal/config"
 	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
 	"github.com/zzet/gortex/internal/parser"
 	"github.com/zzet/gortex/internal/parser/languages"
 	"github.com/zzet/gortex/internal/search"
@@ -57,7 +58,10 @@ func TestIncrementalReindex_NonMerkleExtractorBumpRestagesLanguage(t *testing.T)
 
 	// Simulate the upgrade: the stored row predates the current csharp
 	// extractor version. File content and mtimes are untouched.
-	stale, _ := json.Marshal(map[string]int{"csharp": extractorVersionForLang("csharp") - 1})
+	stale, _ := json.Marshal(map[string]int{
+		postExtractionPolicySnapshotKey: postExtractionPolicyVersion,
+		"csharp":                        extractorVersionForLang("csharp") - 1,
+	})
 	store.st = graph.RepoIndexState{ExtractorVersions: string(stale)}
 	store.found = true
 
@@ -92,7 +96,10 @@ func TestIncrementalReindex_NonMerkleVersionCurrentNoRestage(t *testing.T) {
 	_, err := idx.IndexCtx(testCtx(), dir)
 	require.NoError(t, err)
 
-	current, _ := json.Marshal(map[string]int{"csharp": extractorVersionForLang("csharp")})
+	current, _ := json.Marshal(map[string]int{
+		postExtractionPolicySnapshotKey: postExtractionPolicyVersion,
+		"csharp":                        extractorVersionForLang("csharp"),
+	})
 	store.st = graph.RepoIndexState{ExtractorVersions: string(current)}
 	store.found = true
 
@@ -103,4 +110,131 @@ func TestIncrementalReindex_NonMerkleVersionCurrentNoRestage(t *testing.T) {
 	if !strings.Contains(store.st.ExtractorVersions, "csharp") {
 		t.Fatalf("stored row lost: %q", store.st.ExtractorVersions)
 	}
+}
+
+func TestIncrementalReindex_NonMerkleAdmissionPolicyUpgradeRestoresPersistedORMFacts(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "model.go"), "package model\n\ntype User struct {\n\tID int `gorm:\"primaryKey\"`\n}\n")
+
+	dbPath := filepath.Join(t.TempDir(), "warm.sqlite")
+	store1, err := store_sqlite.Open(dbPath)
+	require.NoError(t, err)
+	store1Closed := false
+	t.Cleanup(func() {
+		if !store1Closed {
+			_ = store1.Close()
+		}
+	})
+
+	const repoPrefix = "warm"
+	reg := parser.NewRegistry()
+	reg.Register(languages.NewGoExtractor())
+	idx := New(store1, reg, config.IndexConfig{Workers: 1}, zap.NewNop())
+	idx.search = search.NewNull()
+	idx.SetRepoPrefix(repoPrefix)
+	idx.SetRootPath(root)
+	_, err = idx.IndexCtx(testCtx(), root)
+	require.NoError(t, err)
+
+	graphPath := idx.prefixPath("model.go")
+	nodes, edges := store1.GetFileSubGraph(graphPath)
+	hasTable, hasModelEdge := persistedORMFacts(nodes, edges)
+	require.True(t, hasTable, "fixture must initially emit an ORM table")
+	require.True(t, hasModelEdge, "fixture must initially emit models_table")
+
+	// Recreate the pre-policy persisted graph: the source file and its mtime
+	// stay current, but the old strip pass removed the ORM table and its edge.
+	strippedIDs := make(map[string]struct{})
+	keptNodes := make([]*graph.Node, 0, len(nodes))
+	for _, node := range nodes {
+		dialect, _ := node.Meta["dialect"].(string)
+		if node.Kind == graph.KindTable && dialect == "orm" {
+			strippedIDs[node.ID] = struct{}{}
+			continue
+		}
+		keptNodes = append(keptNodes, node)
+	}
+	require.NotEmpty(t, strippedIDs)
+	keptEdges := make([]*graph.Edge, 0, len(edges))
+	for _, edge := range edges {
+		_, fromStripped := strippedIDs[edge.From]
+		_, toStripped := strippedIDs[edge.To]
+		if fromStripped || toStripped {
+			continue
+		}
+		keptEdges = append(keptEdges, edge)
+	}
+	store1.EvictFile(graphPath)
+	store1.AddBatch(keptNodes, keptEdges)
+	hasTable, hasModelEdge = persistedORMFacts(store1.GetFileSubGraph(graphPath))
+	require.False(t, hasTable)
+	require.False(t, hasModelEdge)
+
+	state, found, err := store1.GetRepoIndexState(repoPrefix)
+	require.NoError(t, err)
+	require.True(t, found)
+	legacyVersions := extractorVersionsSnapshot()
+	delete(legacyVersions, postExtractionPolicySnapshotKey)
+	encoded, err := json.Marshal(legacyVersions)
+	require.NoError(t, err)
+	state.ExtractorVersions = string(encoded)
+	require.NoError(t, store1.SetRepoIndexState(state))
+	require.NoError(t, store1.Close())
+	store1Closed = true
+
+	store2, err := store_sqlite.Open(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store2.Close() })
+	reg = parser.NewRegistry()
+	reg.Register(languages.NewGoExtractor())
+	idx = New(store2, reg, config.IndexConfig{Workers: 1}, zap.NewNop())
+	idx.search = search.NewNull()
+	idx.SetRepoPrefix(repoPrefix)
+	idx.SetRootPath(root)
+	persistedMtimes := store2.LoadFileMtimes(repoPrefix)
+	require.NotEmpty(t, persistedMtimes)
+	idx.SetFileMtimes(persistedMtimes)
+
+	result, err := idx.incrementalReindexPathsMode(root, nil, incrementalPathMode{detectDeletions: true})
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, result.StaleFileCount, 1,
+		"the missing global policy epoch must restage unchanged source")
+	hasTable, hasModelEdge = persistedORMFacts(store2.GetFileSubGraph(graphPath))
+	require.True(t, hasTable, "upgrade restage must restore the ORM table")
+	require.True(t, hasModelEdge, "upgrade restage must restore models_table")
+
+	state, found, err = store2.GetRepoIndexState(repoPrefix)
+	require.NoError(t, err)
+	require.True(t, found)
+	var restamped map[string]int
+	require.NoError(t, json.Unmarshal([]byte(state.ExtractorVersions), &restamped))
+	require.Equal(t, postExtractionPolicyVersion, restamped[postExtractionPolicySnapshotKey])
+
+	result, err = idx.incrementalReindexPathsMode(root, nil, incrementalPathMode{detectDeletions: true})
+	require.NoError(t, err)
+	require.Zero(t, result.StaleFileCount,
+		"the persisted current epoch must make the second reconcile a no-op")
+}
+
+func persistedORMFacts(nodes []*graph.Node, edges []*graph.Edge) (hasTable, hasModelEdge bool) {
+	tableIDs := make(map[string]struct{})
+	for _, node := range nodes {
+		if node == nil || node.Kind != graph.KindTable {
+			continue
+		}
+		dialect, _ := node.Meta["dialect"].(string)
+		if dialect == "orm" {
+			tableIDs[node.ID] = struct{}{}
+			hasTable = true
+		}
+	}
+	for _, edge := range edges {
+		if edge == nil || edge.Kind != graph.EdgeModelsTable {
+			continue
+		}
+		if _, ok := tableIDs[edge.To]; ok {
+			hasModelEdge = true
+		}
+	}
+	return hasTable, hasModelEdge
 }

--- a/internal/indexer/extractor_version_test.go
+++ b/internal/indexer/extractor_version_test.go
@@ -62,9 +62,13 @@ func TestStaleLangsDetection(t *testing.T) {
 		if got := ExtractorVersionStaleLangs(`{"csharp":10}`); !reflect.DeepEqual(got, []string{"csharp"}) {
 			t.Errorf("stored pre-params C# version = %v, want [csharp]", got)
 		}
+		// A store extracted before the EF Core ORM stamps must re-extract
+		// unchanged .cs files: the models_table pass reads facts ([Table]
+		// edges, ef_config_* and ef_fluent stamps) that only re-extraction
+		// can mint.
 		for _, path := range []string{"src/Handler.cs", "Views/Page.razor", "Views/Page.cshtml"} {
-			if got := merkleSaltFor(path); got != "csharp@12" {
-				t.Errorf("C# extractor salt for %s = %q, want csharp@12", path, got)
+			if got := merkleSaltFor(path); got != "csharp@13" {
+				t.Errorf("C# extractor salt for %s = %q, want csharp@13", path, got)
 			}
 		}
 		if got := merkleSaltFor("src/Handler.php"); got != "php@2" {

--- a/internal/indexer/extractor_version_test.go
+++ b/internal/indexer/extractor_version_test.go
@@ -1,22 +1,20 @@
 package indexer
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 )
 
-// TestStaleLangsDetection proves the per-language extractor-staleness signal:
-// only languages whose stored version is behind the current one are flagged
-// (so the advisory names the exact languages to reindex — a scoped reindex
-// rather than a full cold rebuild), a language the snapshot never recorded is
-// never spuriously flagged, and an empty baseline reports nothing.
+// TestStaleLangsDetection proves both the precise per-language extractor signal
+// and the global post-extraction policy epoch used for admission-rule upgrades.
 func TestStaleLangsDetection(t *testing.T) {
 	t.Run("only_behind_langs", func(t *testing.T) {
 		stored := map[string]int{"go": 1, "python": 2, "ruby": 1}
 		current := map[string]int{"go": 2, "python": 2, "ruby": 1, "rust": 3}
 		got := staleLangsBetween(stored, current)
-		// go is behind (1<2); python/ruby are current; rust is absent from
-		// stored (no baseline) so it is NOT flagged.
+		// Synthetic maps without the reserved policy key retain the legacy
+		// per-language behavior: absent rust has no baseline and is not stale.
 		if want := []string{"go"}; !reflect.DeepEqual(got, want) {
 			t.Errorf("staleLangsBetween = %v, want %v", got, want)
 		}
@@ -31,6 +29,69 @@ func TestStaleLangsDetection(t *testing.T) {
 		}
 	})
 
+	t.Run("post_extraction_policy_epoch", func(t *testing.T) {
+		current := map[string]int{
+			postExtractionPolicySnapshotKey: postExtractionPolicyVersion,
+			"go":                            3,
+			"java":                          1,
+			"ruby":                          1,
+		}
+		cases := []struct {
+			name   string
+			stored map[string]int
+			want   []string
+		}{
+			{
+				name:   "legacy_snapshot_missing_epoch",
+				stored: map[string]int{"go": 3, "java": 1, "ruby": 1},
+				want:   []string{"go", "java", "ruby"},
+			},
+			{
+				name: "epoch_behind",
+				stored: map[string]int{
+					postExtractionPolicySnapshotKey: postExtractionPolicyVersion - 1,
+					"go":                            3,
+					"java":                          1,
+					"ruby":                          1,
+				},
+				want: []string{"go", "java", "ruby"},
+			},
+			{
+				name: "epoch_current_keeps_per_language_precision",
+				stored: map[string]int{
+					postExtractionPolicySnapshotKey: postExtractionPolicyVersion,
+					"go":                            2,
+					"java":                          1,
+					"ruby":                          1,
+				},
+				want: []string{"go"},
+			},
+			{
+				name: "all_current",
+				stored: map[string]int{
+					postExtractionPolicySnapshotKey: postExtractionPolicyVersion,
+					"go":                            3,
+					"java":                          1,
+					"ruby":                          1,
+				},
+				want: []string{},
+			},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				got := staleLangsBetween(tc.stored, current)
+				if !reflect.DeepEqual(got, tc.want) {
+					t.Fatalf("staleLangsBetween = %v, want %v", got, tc.want)
+				}
+				for _, lang := range got {
+					if lang == postExtractionPolicySnapshotKey {
+						t.Fatalf("reserved policy key leaked as a language: %v", got)
+					}
+				}
+			})
+		}
+	})
+
 	t.Run("json_and_empty", func(t *testing.T) {
 		// An empty / unparseable baseline reports nothing.
 		if got := ExtractorVersionStaleLangs(""); got != nil {
@@ -39,43 +100,68 @@ func TestStaleLangsDetection(t *testing.T) {
 		if got := ExtractorVersionStaleLangs("not json"); got != nil {
 			t.Errorf("bad json = %v, want nil", got)
 		}
+		atCurrentPolicy := func(versions map[string]int) string {
+			snapshot := make(map[string]int, len(versions)+1)
+			for lang, version := range versions {
+				snapshot[lang] = version
+			}
+			snapshot[postExtractionPolicySnapshotKey] = postExtractionPolicyVersion
+			encoded, err := json.Marshal(snapshot)
+			if err != nil {
+				t.Fatalf("marshal extractor versions: %v", err)
+			}
+			return string(encoded)
+		}
 		// Against the live extractor versions, an unchanged baseline language
 		// is not stale. Java is the exemplar because its extractor has never
 		// been bumped — a language whose version this suite also asserts
 		// would make the check tautological.
-		if got := ExtractorVersionStaleLangs(`{"java":1}`); len(got) != 0 {
+		if got := ExtractorVersionStaleLangs(atCurrentPolicy(map[string]int{"java": 1})); len(got) != 0 {
 			t.Errorf("stored at current = %v, want empty", got)
 		}
-		if got := ExtractorVersionStaleLangs(`{"java":1,"php":1}`); !reflect.DeepEqual(got, []string{"php"}) {
+		if got := ExtractorVersionStaleLangs(atCurrentPolicy(map[string]int{"java": 1, "php": 1})); !reflect.DeepEqual(got, []string{"php"}) {
 			t.Errorf("stored PHP structural-edge version = %v, want [php]", got)
 		}
 		// A store extracted before the generic-call fix must re-extract:
 		// until then, every call spelling explicit type arguments is missing
 		// from its graph entirely, and no content change will trigger it.
-		if got := ExtractorVersionStaleLangs(`{"go":1,"scala":1,"cpp":1,"swift":1}`); !reflect.DeepEqual(
+		if got := ExtractorVersionStaleLangs(atCurrentPolicy(map[string]int{"go": 1, "scala": 1, "cpp": 1, "swift": 1})); !reflect.DeepEqual(
 			got, []string{"cpp", "go", "scala", "swift"}) {
 			t.Errorf("stored pre-generic-call version = %v, want all four", got)
 		}
 		// A store extracted before the C# params-shape fix must re-extract
 		// unchanged .cs, .razor, and .cshtml files. Without the bump, their
 		// persisted graph keeps the old arity and parameter evidence.
-		if got := ExtractorVersionStaleLangs(`{"csharp":10}`); !reflect.DeepEqual(got, []string{"csharp"}) {
+		if got := ExtractorVersionStaleLangs(atCurrentPolicy(map[string]int{"csharp": 10})); !reflect.DeepEqual(got, []string{"csharp"}) {
 			t.Errorf("stored pre-params C# version = %v, want [csharp]", got)
 		}
-		// A store extracted before the EF Core ORM stamps must re-extract
-		// unchanged .cs files: the models_table pass reads facts ([Table]
-		// edges, ef_config_* and ef_fluent stamps) that only re-extraction
-		// can mint.
-		for _, path := range []string{"src/Handler.cs", "Views/Page.razor", "Views/Page.cshtml"} {
-			if got := merkleSaltFor(path); got != "csharp@13" {
-				t.Errorf("C# extractor salt for %s = %q, want csharp@13", path, got)
+		if got := extractorVersionsSnapshot()[postExtractionPolicySnapshotKey]; got != postExtractionPolicyVersion {
+			t.Errorf("persisted policy epoch = %d, want %d", got, postExtractionPolicyVersion)
+		}
+
+		policySalt := "_post_extraction_policy@2"
+		for _, path := range []string{"model.py", "Model.java", "model.rb", "model.ts", "schema.ex", "model.js"} {
+			if got := merkleSaltFor(path); got != policySalt {
+				t.Errorf("global policy salt for %s = %q, want %q", path, got, policySalt)
 			}
 		}
-		if got := merkleSaltFor("src/Handler.php"); got != "php@2" {
-			t.Errorf("PHP extractor salt = %q, want php@2", got)
+		if got, want := merkleSaltFor("model.go"), policySalt+"|go@3"; got != want {
+			t.Errorf("Go extractor salt = %q, want %q", got, want)
 		}
-		if got := merkleSaltFor("include/widget.hxx"); got != "cpp@2" {
-			t.Errorf("C++ extractor salt for .hxx = %q, want cpp@2", got)
+		for _, path := range []string{"src/Handler.cs", "Views/Page.razor", "Views/Page.cshtml"} {
+			want := policySalt + "|csharp@13"
+			if got := merkleSaltFor(path); got != want {
+				t.Errorf("C# extractor salt for %s = %q, want %q", path, got, want)
+			}
+		}
+		if got, want := merkleSaltFor("src/Handler.php"), policySalt+"|php@2"; got != want {
+			t.Errorf("PHP extractor salt = %q, want %q", got, want)
+		}
+		if got, want := merkleSaltFor("include/widget.hxx"), policySalt+"|cpp@2"; got != want {
+			t.Errorf("C++ extractor salt for .hxx = %q, want %q", got, want)
+		}
+		if got := merkleSaltFor("README.zzz"); got != "" {
+			t.Errorf("unmapped extension salt = %q, want empty", got)
 		}
 	})
 

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -1809,11 +1809,21 @@ func applyMigrationExtraction(relPath string, src []byte, result *parser.Extract
 // defaults off because string-literal pattern matching against
 // db.Get / db.Query / db.Exec produces false positives when
 // domain code shares method names (cache.Get, etc.).
+//
+// Two table-node origins survive the gate, because neither is the
+// noisy code-side matching the gate exists for: migration-origin DDL
+// (unambiguous CREATE TABLE — see applyMigrationExtraction), and
+// ORM-origin model attribution (declaration-anchored: @Entity/@Table
+// annotations, [Table] attributes, ActiveRecord bases, DbSet
+// properties). Stripping the ORM nodes would leave the models_table
+// layer silently empty for every ORM ecosystem under the default
+// config.
 func stripSQLArtifacts(result *parser.ExtractionResult) {
 	stripped := make(map[string]struct{})
 	keptNodes := result.Nodes[:0]
 	for _, n := range result.Nodes {
-		if (n.Kind == graph.KindTable || n.Kind == graph.KindMigration) && !isMigrationOriginNode(n) {
+		if (n.Kind == graph.KindTable || n.Kind == graph.KindMigration) &&
+			!isMigrationOriginNode(n) && !isORMOriginTableNode(n) {
 			stripped[n.ID] = struct{}{}
 			continue
 		}
@@ -1892,6 +1902,18 @@ func isMigrationOriginNode(n *graph.Node) bool {
 	}
 	o, _ := n.Meta["origin"].(string)
 	return o == "migration"
+}
+
+// isORMOriginTableNode reports whether a KindTable node was minted by
+// an ORM model-attribution extractor (go/java/python/ruby/ts/elixir/
+// csharp *_orm paths). They all stamp Meta["dialect"] = "orm" on the
+// shared db::orm:: table nodes.
+func isORMOriginTableNode(n *graph.Node) bool {
+	if n == nil || n.Kind != graph.KindTable || n.Meta == nil {
+		return false
+	}
+	d, _ := n.Meta["dialect"].(string)
+	return d == "orm"
 }
 
 // isInfraOriginConfigKey reports whether a KindConfigKey node was

--- a/internal/mcp/tools_analyze_framework.go
+++ b/internal/mcp/tools_analyze_framework.go
@@ -403,7 +403,7 @@ func routeMethodAndPath(n *graph.Node) (string, string) {
 // persist?" queries.
 //
 // Filters:
-//   - orm:    orm flavour (gorm / sqlalchemy / django / activerecord / jpa / typeorm)
+//   - orm:    orm flavour (gorm / sqlalchemy / django / activerecord / jpa / typeorm / ecto / efcore)
 //   - table:  substring match on the table name
 //   - model:  substring match on the model class name
 func (s *Server) handleAnalyzeModels(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -841,6 +841,12 @@ func (e *CSharpExtractor) emitContainer(m parser.QueryResult, kind string, nodeK
 	if doc := extractCSharpDoc(src, def.StartLine); doc != "" {
 		meta["doc"] = doc
 	}
+	// EF Core fluent mapping: a class implementing
+	// IEntityTypeConfiguration<T> carries facts the resolver joins to
+	// the entity class later — the entity lives in another file.
+	if kind == "class" || kind == "record" {
+		stampCSharpEFConfig(def.Node, src, meta)
+	}
 	result.Nodes = append(result.Nodes, &graph.Node{
 		ID: id, Kind: nodeKind, Name: name,
 		FilePath: filePath, StartLine: def.StartLine + 1, EndLine: def.EndLine + 1,

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -304,6 +304,7 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 	fileID := fileNode.ID
 	result.Nodes = append(result.Nodes, fileNode)
 	stampCSharpUsings(root, src, fileNode)
+	stampCSharpEFFluent(root, src, fileNode)
 
 	seen := make(map[string]bool)
 	annotationSeen := make(map[string]bool)

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -851,6 +851,11 @@ func (e *CSharpExtractor) emitContainer(m parser.QueryResult, kind string, nodeK
 		From: fileID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: def.StartLine + 1,
 	})
 	emitCSharpAnnotationEdges(csharpCollectAttributes(def.Node, src), id, filePath, result, annotationSeen)
+	// EF Core model attribution: [Table] → EdgeModelsTable. Classes and
+	// records only — EF entities are reference types.
+	if kind == "class" || kind == "record" {
+		emitCSharpORMEdges(def.Node, src, id, filePath, result)
+	}
 	emitCSharpGenericParamNodes(id, def.Node, src, filePath, def.StartLine+1, result)
 	// Classes, structs, records, and interfaces carry a base list;
 	// emitCSharpBaseList derives each entry's edge kind from the

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -846,6 +846,7 @@ func (e *CSharpExtractor) emitContainer(m parser.QueryResult, kind string, nodeK
 	// IEntityTypeConfiguration<T> carries facts the resolver joins to
 	// the entity class later — the entity lives in another file.
 	if kind == "class" || kind == "record" {
+		stampCSharpEFAttribute(def.Node, src, meta)
 		stampCSharpEFConfig(def.Node, src, meta)
 	}
 	result.Nodes = append(result.Nodes, &graph.Node{

--- a/internal/parser/languages/csharp_orm.go
+++ b/internal/parser/languages/csharp_orm.go
@@ -1,9 +1,9 @@
 package languages
 
 import (
-	"regexp"
-	"strconv"
 	"strings"
+	"unicode/utf16"
+	"unicode/utf8"
 
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/parser"
@@ -20,25 +20,100 @@ import (
 // fluent ToTable(...) configuration — live in files other than the
 // entity's, so they are joined by a resolver pass over stamped facts,
 // not here. A class with no [Table] attribute emits nothing.
+func csharpEFAttributeArguments(list *sitter.Node, src []byte) ([]csharpEFArgument, bool) {
+	if list == nil || list.Type() != "attribute_argument_list" {
+		return nil, false
+	}
+	args := make([]csharpEFArgument, 0, list.NamedChildCount())
+	for i, count := 0, int(list.NamedChildCount()); i < count; i++ {
+		argument := list.NamedChild(i)
+		if argument == nil || argument.Type() != "attribute_argument" || argument.NamedChildCount() == 0 {
+			return nil, false
+		}
+		name := ""
+		if nameNode := argument.ChildByFieldName("name"); nameNode != nil {
+			if argument.NamedChildCount() < 2 {
+				return nil, false
+			}
+			name = strings.TrimPrefix(strings.TrimSpace(nameNode.Content(src)), "@")
+			if name == "" {
+				return nil, false
+			}
+		}
+		args = append(args, csharpEFArgument{
+			name:  name,
+			value: argument.NamedChild(int(argument.NamedChildCount()) - 1),
+		})
+	}
+	return args, len(args) != 0
+}
+
+func csharpEFTableAttribute(decl *sitter.Node, src []byte) (table, schema string, ok bool) {
+	if decl == nil {
+		return "", "", false
+	}
+	for i, count := 0, int(decl.NamedChildCount()); i < count; i++ {
+		list := decl.NamedChild(i)
+		if list == nil || list.Type() != "attribute_list" {
+			continue
+		}
+		for j, attrCount := 0, int(list.NamedChildCount()); j < attrCount; j++ {
+			attribute := list.NamedChild(j)
+			if attribute == nil || attribute.Type() != "attribute" {
+				continue
+			}
+			nameNode := attribute.ChildByFieldName("name")
+			if nameNode == nil || !csharpIsTableAttr(nameNode.Content(src)) {
+				continue
+			}
+			arguments, valid := csharpEFAttributeArguments(
+				csharpDirectChildOfType(attribute, "attribute_argument_list"),
+				src,
+			)
+			if !valid {
+				continue
+			}
+			tableValue := ""
+			schemaValue := ""
+			tableSet := false
+			schemaSet := false
+			for index, argument := range arguments {
+				key := argument.name
+				if key == "" && index == 0 {
+					key = "name"
+				}
+				value, literal := csharpDecodeStringLiteral(argument.value.Content(src))
+				switch key {
+				case "name":
+					if tableSet || !literal || value == "" {
+						valid = false
+					} else {
+						tableValue, tableSet = value, true
+					}
+				case "Schema":
+					if schemaSet || !literal {
+						valid = false
+					} else {
+						schemaValue, schemaSet = value, true
+					}
+				default:
+					valid = false
+				}
+				if !valid {
+					break
+				}
+			}
+			if valid && tableSet {
+				return tableValue, schemaValue, true
+			}
+		}
+	}
+	return "", "", false
+}
+
 func detectCSharpORMModel(classNode *sitter.Node, src []byte, classID, filePath string) []*graph.Edge {
-	if classNode == nil {
-		return nil
-	}
-	tableName := ""
-	schema := ""
-	for _, ann := range csharpCollectAttributes(classNode, src) {
-		if !csharpIsTableAttr(ann.name) {
-			continue
-		}
-		name := csharpAttrPositionalString(ann.args)
-		if name == "" {
-			continue
-		}
-		tableName = name
-		schema = javaAnnotationStringArg(ann.args, "Schema")
-		break
-	}
-	if tableName == "" {
+	tableName, schema, ok := csharpEFTableAttribute(classNode, src)
+	if !ok {
 		return nil
 	}
 	qualified := tableName
@@ -68,6 +143,17 @@ func detectCSharpORMModel(classNode *sitter.Node, src []byte, classID, filePath 
 	}
 }
 
+func stampCSharpEFAttribute(decl *sitter.Node, src []byte, meta map[string]any) {
+	table, schema, ok := csharpEFTableAttribute(decl, src)
+	if !ok {
+		return
+	}
+	meta["ef_attribute_table"] = table
+	if schema != "" {
+		meta["ef_attribute_schema"] = schema
+	}
+}
+
 // csharpIsTableAttr reports whether an attribute name denotes [Table].
 // C# lets the attribute appear qualified (Schema.Table, or the full
 // namespace path) and with the explicit Attribute suffix, so compare
@@ -79,85 +165,396 @@ func csharpIsTableAttr(name string) bool {
 	return name == "Table" || name == "TableAttribute"
 }
 
-// csharpAttrPositionalStringArg matches a leading (optionally
-// verbatim) string literal — [Table("name", ...)]'s table name is the
-// attribute's first positional argument, unlike JPA's key=value form.
-// Known limits, accepted for the fixed-cost regex: an escaped quote
-// truncates the name (`"a\"b"` → `a\` — table names with quotes do
-// not survive real databases either), and a C#11 raw string literal
-// ("""...""") matches its empty prefix and is skipped as unnamed.
-var csharpAttrPositionalStringArg = regexp.MustCompile(`^\s*@?"([^"]*)"`)
-
-// csharpAttrPositionalString extracts the first positional string
-// literal from an attribute's verbatim argument text. Non-literal
-// firsts (nameof(...), constants) return "" — fail-open, no guess.
+// csharpAttrPositionalString extracts and decodes the first positional
+// string literal from an attribute's verbatim argument text. Only C#
+// regular and verbatim literals are accepted; constants, interpolated
+// strings, raw strings, UTF-8 literals, and malformed escapes fail open.
 func csharpAttrPositionalString(args string) string {
-	m := csharpAttrPositionalStringArg.FindStringSubmatch(args)
-	if len(m) < 2 {
+	text := strings.TrimSpace(args)
+	value, consumed, ok := csharpDecodeStringLiteralPrefix(text)
+	if !ok {
 		return ""
 	}
-	return strings.TrimSpace(m[1])
+	rest := strings.TrimSpace(text[consumed:])
+	if rest != "" && rest[0] != ',' {
+		return ""
+	}
+	return value
 }
 
-// csharpEFConfigIfaceArg pulls the single type argument out of an
-// IEntityTypeConfiguration<T> base-list entry. Text-level on purpose:
-// the base list is one short line, and the extractor needs only T's
-// name — qualification is stripped after the match.
-var csharpEFConfigIfaceArg = regexp.MustCompile(`IEntityTypeConfiguration\s*<\s*([^<>,]+?)\s*>`)
-
-// stampCSharpEFConfig detects an EF Core entity-configuration class —
-// one implementing IEntityTypeConfiguration<T> — and stamps the facts
-// a resolver pass needs to join fluent table mapping to the entity:
-//
-//	ef_config_entity    T's final name segment (always, when detected)
-//	ef_config_table     first ToTable/ToView string arg (when present)
-//	ef_config_relation  "table" or "view" (with ef_config_table)
-//	ef_config_schema    second string arg (when present)
-//
-// The entity class, the config class, and the DbContext registration
-// live in different files, so the extractor only records what this
-// file proves; the cross-file join happens at resolve time.
-func stampCSharpEFConfig(decl *sitter.Node, src []byte, meta map[string]any) {
-	if decl == nil {
-		return
+// csharpDecodeStringLiteral decodes one complete C# regular or verbatim
+// string literal. It intentionally rejects newer raw/interpolated/UTF-8
+// spellings: accepting a prefix of one of those would manufacture a table
+// name that the source does not state as a runtime System.String value.
+func csharpDecodeStringLiteral(text string) (string, bool) {
+	text = strings.TrimSpace(text)
+	value, consumed, ok := csharpDecodeStringLiteralPrefix(text)
+	if !ok || strings.TrimSpace(text[consumed:]) != "" {
+		return "", false
 	}
-	var baseList *sitter.Node
-	for i, _nc := 0, int(decl.ChildCount()); i < _nc; i++ {
-		if c := decl.Child(i); c != nil && c.Type() == "base_list" {
-			baseList = c
+	return value, true
+}
+
+func csharpDecodeStringLiteralPrefix(text string) (string, int, bool) {
+	if strings.HasPrefix(text, `@"`) {
+		return csharpDecodeVerbatimStringPrefix(text)
+	}
+	if len(text) < 2 || text[0] != '"' || strings.HasPrefix(text, `"""`) {
+		return "", 0, false
+	}
+
+	decoded := make([]rune, 0, len(text))
+	for i := 1; i < len(text); {
+		switch text[i] {
+		case '"':
+			consumed := i + 1
+			if strings.HasPrefix(text[consumed:], "u8") {
+				return "", 0, false
+			}
+			value, ok := csharpNormalizeStringRunes(decoded)
+			return value, consumed, ok
+		case '\r', '\n':
+			return "", 0, false
+		case '\\':
+			i++
+			if i >= len(text) {
+				return "", 0, false
+			}
+			switch text[i] {
+			case '\'', '"', '\\':
+				decoded = append(decoded, rune(text[i]))
+				i++
+			case '0':
+				decoded = append(decoded, 0)
+				i++
+			case 'a':
+				decoded = append(decoded, '\a')
+				i++
+			case 'b':
+				decoded = append(decoded, '\b')
+				i++
+			case 'e':
+				decoded = append(decoded, 0x1b)
+				i++
+			case 'f':
+				decoded = append(decoded, '\f')
+				i++
+			case 'n':
+				decoded = append(decoded, '\n')
+				i++
+			case 'r':
+				decoded = append(decoded, '\r')
+				i++
+			case 't':
+				decoded = append(decoded, '\t')
+				i++
+			case 'v':
+				decoded = append(decoded, '\v')
+				i++
+			case 'x':
+				value, next, ok := csharpReadHexEscape(text, i+1, 1, 4)
+				if !ok {
+					return "", 0, false
+				}
+				decoded = append(decoded, rune(value))
+				i = next
+			case 'u':
+				value, next, ok := csharpReadHexEscape(text, i+1, 4, 4)
+				if !ok {
+					return "", 0, false
+				}
+				decoded = append(decoded, rune(value))
+				i = next
+			case 'U':
+				value, next, ok := csharpReadHexEscape(text, i+1, 8, 8)
+				if !ok || value > utf8.MaxRune || value >= 0xd800 && value <= 0xdfff {
+					return "", 0, false
+				}
+				decoded = append(decoded, rune(value))
+				i = next
+			default:
+				return "", 0, false
+			}
+		default:
+			r, size := utf8.DecodeRuneInString(text[i:])
+			if r == utf8.RuneError && size == 1 || csharpIsRegularStringNewline(r) {
+				return "", 0, false
+			}
+			decoded = append(decoded, r)
+			i += size
+		}
+	}
+	return "", 0, false
+}
+
+func csharpDecodeVerbatimStringPrefix(text string) (string, int, bool) {
+	decoded := make([]rune, 0, len(text))
+	for i := 2; i < len(text); {
+		if text[i] == '"' {
+			if i+1 < len(text) && text[i+1] == '"' {
+				decoded = append(decoded, '"')
+				i += 2
+				continue
+			}
+			consumed := i + 1
+			if strings.HasPrefix(text[consumed:], "u8") {
+				return "", 0, false
+			}
+			value, ok := csharpNormalizeStringRunes(decoded)
+			return value, consumed, ok
+		}
+		r, size := utf8.DecodeRuneInString(text[i:])
+		if r == utf8.RuneError && size == 1 {
+			return "", 0, false
+		}
+		decoded = append(decoded, r)
+		i += size
+	}
+	return "", 0, false
+}
+
+func csharpReadHexEscape(text string, start, minDigits, maxDigits int) (uint32, int, bool) {
+	var value uint32
+	i := start
+	for i < len(text) && i-start < maxDigits {
+		digit, ok := csharpHexDigit(text[i])
+		if !ok {
 			break
 		}
+		value = value*16 + uint32(digit)
+		i++
 	}
-	if baseList == nil {
-		return
+	if i-start < minDigits {
+		return 0, start, false
 	}
-	// A class may implement IEntityTypeConfiguration<A> AND <B> (legal,
-	// two Configure overloads). A single-entity stamp cannot say whose
-	// ToTable the body scan found, so more than one distinct T refuses.
-	matches := csharpEFConfigIfaceArg.FindAllStringSubmatch(baseList.Content(src), -1)
-	if len(matches) == 0 {
-		return
+	return value, i, true
+}
+
+func csharpHexDigit(b byte) (byte, bool) {
+	switch {
+	case b >= '0' && b <= '9':
+		return b - '0', true
+	case b >= 'a' && b <= 'f':
+		return b - 'a' + 10, true
+	case b >= 'A' && b <= 'F':
+		return b - 'A' + 10, true
+	default:
+		return 0, false
 	}
-	entity := ""
-	for _, m := range matches {
-		cand := strings.TrimSpace(m[1])
-		if i := strings.LastIndexByte(cand, '.'); i >= 0 {
-			cand = cand[i+1:]
+}
+
+func csharpNormalizeStringRunes(decoded []rune) (string, bool) {
+	out := make([]rune, 0, len(decoded))
+	for i := 0; i < len(decoded); i++ {
+		r := decoded[i]
+		switch {
+		case r >= 0xd800 && r <= 0xdbff:
+			if i+1 >= len(decoded) || decoded[i+1] < 0xdc00 || decoded[i+1] > 0xdfff {
+				return "", false
+			}
+			out = append(out, utf16.DecodeRune(r, decoded[i+1]))
+			i++
+		case r >= 0xdc00 && r <= 0xdfff, !utf8.ValidRune(r):
+			return "", false
+		default:
+			out = append(out, r)
 		}
-		cand = strings.TrimPrefix(cand, "@")
-		if cand == "" {
+	}
+	return string(out), true
+}
+
+func csharpIsRegularStringNewline(r rune) bool {
+	return r == '\r' || r == '\n' || r == '\u0085' || r == '\u2028' || r == '\u2029'
+}
+
+// csharpEFConfigEntity validates a direct base-list entry whose terminal
+// type is exactly IEntityTypeConfiguration<T>. Nested occurrences such as
+// Wrapper<IEntityTypeConfiguration<T>> are deliberately not configuration
+// facts. Multiple distinct entity arguments are ambiguous and fail open.
+func csharpEFConfigEntity(decl *sitter.Node, src []byte) (entity, identity string, ok bool) {
+	baseList := csharpDirectChildOfType(decl, "base_list")
+	if baseList == nil {
+		return "", "", false
+	}
+	for i, count := 0, int(baseList.NamedChildCount()); i < count; i++ {
+		arg, matched := csharpEFGenericTypeArgument(baseList.NamedChild(i), src, "IEntityTypeConfiguration")
+		if !matched {
 			continue
 		}
-		if entity != "" && cand != entity {
-			return
+		candidateIdentity, candidateEntity, named := csharpEFNamedType(arg, src)
+		if !named {
+			return "", "", false
 		}
-		entity = cand
+		if identity != "" && candidateIdentity != identity {
+			return "", "", false
+		}
+		identity, entity = candidateIdentity, candidateEntity
 	}
-	if entity == "" {
+	return entity, identity, identity != ""
+}
+
+func csharpEFGenericTypeArgument(typeNode *sitter.Node, src []byte, expected string) (*sitter.Node, bool) {
+	terminal := csharpEFTerminalTypeNode(typeNode)
+	if terminal == nil || terminal.Type() != "generic_name" {
+		return nil, false
+	}
+	name := terminal.ChildByFieldName("name")
+	if name == nil && terminal.NamedChildCount() != 0 {
+		name = terminal.NamedChild(0)
+	}
+	if name == nil || strings.TrimPrefix(name.Content(src), "@") != expected {
+		return nil, false
+	}
+	typeArgs := terminal.ChildByFieldName("type_arguments")
+	if typeArgs == nil {
+		typeArgs = csharpDirectChildOfType(terminal, "type_argument_list")
+	}
+	if typeArgs == nil || typeArgs.NamedChildCount() != 1 {
+		return nil, false
+	}
+	return typeArgs.NamedChild(0), true
+}
+
+func csharpEFTerminalTypeNode(typeNode *sitter.Node) *sitter.Node {
+	for typeNode != nil {
+		switch typeNode.Type() {
+		case "simple_base_type":
+			if typeNode.NamedChildCount() != 1 {
+				return typeNode
+			}
+			typeNode = typeNode.NamedChild(0)
+		case "qualified_name", "alias_qualified_name":
+			next := typeNode.ChildByFieldName("name")
+			if next == nil && typeNode.NamedChildCount() != 0 {
+				next = typeNode.NamedChild(int(typeNode.NamedChildCount()) - 1)
+			}
+			typeNode = next
+		default:
+			return typeNode
+		}
+	}
+	return nil
+}
+
+func csharpEFNamedType(typeNode *sitter.Node, src []byte) (identity, terminal string, ok bool) {
+	last := csharpEFTerminalTypeNode(typeNode)
+	if last == nil || last.Type() != "identifier" {
+		return "", "", false
+	}
+	terminal = strings.TrimPrefix(last.Content(src), "@")
+	if terminal == "" {
+		return "", "", false
+	}
+	identity = csharpCompactTypeIdentity(typeNode.Content(src))
+	return identity, terminal, identity != ""
+}
+
+func csharpCompactTypeIdentity(text string) string {
+	text = strings.NewReplacer(" ", "", "\t", "", "\r", "", "\n", "").Replace(text)
+	parts := strings.Split(text, ".")
+	for i := range parts {
+		parts[i] = strings.TrimPrefix(parts[i], "@")
+	}
+	return strings.Join(parts, ".")
+}
+
+func csharpDirectChildOfType(node *sitter.Node, kind string) *sitter.Node {
+	if node == nil {
+		return nil
+	}
+	for i, count := 0, int(node.NamedChildCount()); i < count; i++ {
+		child := node.NamedChild(i)
+		if child != nil && child.Type() == kind {
+			return child
+		}
+	}
+	return nil
+}
+
+// csharpEFConfigureMethod accepts only the direct, unambiguous Configure
+// implementation for the same T named by IEntityTypeConfiguration<T>:
+// void Configure(EntityTypeBuilder<T> receiver) with a block body.
+func csharpEFConfigureMethod(decl *sitter.Node, src []byte, entityIdentity string) (*sitter.Node, string, bool) {
+	body := decl.ChildByFieldName("body")
+	if body == nil {
+		body = csharpDirectChildOfType(decl, "declaration_list")
+	}
+	if body == nil {
+		return nil, "", false
+	}
+	var method *sitter.Node
+	receiver := ""
+	for i, count := 0, int(body.NamedChildCount()); i < count; i++ {
+		candidate := body.NamedChild(i)
+		if candidate == nil || candidate.Type() != "method_declaration" {
+			continue
+		}
+		candidateIdentity, candidateReceiver, valid := csharpEFConfigureSignature(candidate, src)
+		if !valid || candidateIdentity != entityIdentity {
+			continue
+		}
+		if method != nil {
+			return nil, "", false
+		}
+		method, receiver = candidate, candidateReceiver
+	}
+	return method, receiver, method != nil
+}
+
+func csharpEFConfigureSignature(method *sitter.Node, src []byte) (entityIdentity, receiver string, ok bool) {
+	name := method.ChildByFieldName("name")
+	if name == nil || name.Content(src) != "Configure" {
+		return "", "", false
+	}
+	returns := method.ChildByFieldName("returns")
+	if returns == nil {
+		returns = method.ChildByFieldName("type")
+	}
+	if returns == nil || returns.Content(src) != "void" {
+		return "", "", false
+	}
+	parameters := method.ChildByFieldName("parameters")
+	if parameters == nil || parameters.NamedChildCount() != 1 {
+		return "", "", false
+	}
+	parameter := parameters.NamedChild(0)
+	if parameter == nil || parameter.Type() != "parameter" {
+		return "", "", false
+	}
+	parameterType := parameter.ChildByFieldName("type")
+	arg, matched := csharpEFGenericTypeArgument(parameterType, src, "EntityTypeBuilder")
+	if !matched {
+		return "", "", false
+	}
+	identity, _, named := csharpEFNamedType(arg, src)
+	if !named {
+		return "", "", false
+	}
+	parameterName := parameter.ChildByFieldName("name")
+	if parameterName == nil || parameterName.Type() != "identifier" {
+		return "", "", false
+	}
+	block := method.ChildByFieldName("body")
+	if block == nil || block.Type() != "block" {
+		return "", "", false
+	}
+	return identity, strings.TrimPrefix(parameterName.Content(src), "@"), true
+}
+
+// stampCSharpEFConfig records only a mapping proved by an exact
+// IEntityTypeConfiguration<T> implementation and its matching Configure
+// method. Scalar keys remain for the resolver compatibility contract.
+func stampCSharpEFConfig(decl *sitter.Node, src []byte, meta map[string]any) {
+	entity, identity, ok := csharpEFConfigEntity(decl, src)
+	if !ok {
+		return
+	}
+	configure, _, ok := csharpEFConfigureMethod(decl, src, identity)
+	if !ok {
 		return
 	}
 	meta["ef_config_entity"] = entity
-	table, schema, relation := csharpEFConfigTableCall(decl, src)
+	table, schema, relation := csharpEFConfigTableCall(configure, src)
 	if table == "" {
 		return
 	}
@@ -168,91 +565,164 @@ func stampCSharpEFConfig(decl *sitter.Node, src []byte, meta map[string]any) {
 	}
 }
 
-// csharpEFConfigTableCall finds the first ToTable(...) / ToView(...)
-// invocation in the declaration's subtree whose receiver is a PLAIN
-// IDENTIFIER outside any lambda, and returns its literal name/schema
-// arguments. Both restrictions are misattribution guards, not
-// conveniences: a ToTable inside a lambda is an owned-type mapping
-// (`builder.OwnsOne(c => c.Slot, s => s.ToTable(...))`) naming the
-// OWNED type's table, and a ToTable chained onto another call
-// (`builder.OwnsOne(...).ToTable(...)`) hangs off a builder for a
-// different entity. Refusing those loses the rare
-// `builder.HasAnnotation(...).ToTable(...)` chain — a miss, never a
-// wrong edge.
+// csharpEFConfigTableCall scans only the validated Configure body and
+// credits direct calls on its EntityTypeBuilder<T> parameter. Calls are
+// visited in source order and the last valid mapping wins, matching EF.
 func csharpEFConfigTableCall(decl *sitter.Node, src []byte) (table, schema, relation string) {
-	var walk func(n *sitter.Node, inLambda bool) bool
-	walk = func(n *sitter.Node, inLambda bool) bool {
-		if n == nil {
-			return true
-		}
-		switch n.Type() {
-		case "lambda_expression", "anonymous_method_expression":
-			inLambda = true
-		case "invocation_expression":
-			if !inLambda {
-				if t, s, r, ok := csharpEFTableViewArgs(n, src); ok {
-					if fn := n.ChildByFieldName("function"); fn != nil {
-						if recv := fn.ChildByFieldName("expression"); recv != nil && recv.Type() == "identifier" {
-							table, schema, relation = t, s, r
-							return false
-						}
-					}
-				}
-			}
-		}
-		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
-			if !walk(n.NamedChild(i), inLambda) {
-				return false
-			}
-		}
-		return true
+	method := decl
+	if method == nil {
+		return "", "", ""
 	}
-	walk(decl, false)
+	if method.Type() != "method_declaration" {
+		_, identity, valid := csharpEFConfigEntity(method, src)
+		if !valid {
+			return "", "", ""
+		}
+		method, _, valid = csharpEFConfigureMethod(method, src, identity)
+		if !valid {
+			return "", "", ""
+		}
+	}
+	_, receiver, valid := csharpEFConfigureSignature(method, src)
+	if !valid {
+		return "", "", ""
+	}
+	body := method.ChildByFieldName("body")
+	csharpWalkEFInvocations(body, func(inv *sitter.Node) {
+		t, s, r, matched := csharpEFTableViewArgs(inv, src)
+		if !matched {
+			return
+		}
+		fn := inv.ChildByFieldName("function")
+		if !csharpEFDirectReceiver(fn, src, receiver) {
+			return
+		}
+		table, schema, relation = t, s, r
+	})
 	return table, schema, relation
 }
 
-// csharpEFTableViewArgs recognises an invocation node as a
-// ToTable/ToView call with a literal name and returns its arguments.
-// The first argument must itself be a string literal — the
-// lambda-only overloads configure without naming, so a non-literal
-// first argument is not a table fact.
-func csharpEFTableViewArgs(n *sitter.Node, src []byte) (table, schema, relation string, ok bool) {
-	if n.Type() != "invocation_expression" {
-		return "", "", "", false
+type csharpEFArgument struct {
+	name  string
+	value *sitter.Node
+}
+
+func csharpEFArguments(inv *sitter.Node, src []byte) ([]csharpEFArgument, bool) {
+	if inv == nil {
+		return nil, false
 	}
-	fn := n.ChildByFieldName("function")
-	if fn == nil || fn.Type() != "member_access_expression" {
-		return "", "", "", false
+	list := inv.ChildByFieldName("arguments")
+	if list == nil {
+		return nil, false
 	}
-	name := ""
-	if nm := fn.ChildByFieldName("name"); nm != nil {
-		name = nm.Content(src)
-	}
-	if name != "ToTable" && name != "ToView" {
-		return "", "", "", false
-	}
-	args := n.ChildByFieldName("arguments")
-	if args == nil {
-		return "", "", "", false
-	}
-	var lits []string
-	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
-		a := args.NamedChild(i)
-		if a == nil {
+	args := make([]csharpEFArgument, 0, list.NamedChildCount())
+	for i, count := 0, int(list.NamedChildCount()); i < count; i++ {
+		node := list.NamedChild(i)
+		if node == nil {
+			return nil, false
+		}
+		if node.Type() != "argument" {
+			args = append(args, csharpEFArgument{value: node})
 			continue
 		}
-		lit := csharpAttrPositionalString(a.Content(src))
-		if i == 0 && lit == "" {
-			return "", "", "", false
+		name := ""
+		nameNode := node.ChildByFieldName("name")
+		for j, children := 0, int(node.NamedChildCount()); j < children; j++ {
+			child := node.NamedChild(j)
+			if child != nil && child.Type() == "name_colon" {
+				nameNode = child
+			}
 		}
-		lits = append(lits, lit)
+		if nameNode != nil {
+			name = csharpEFNameColon(nameNode, src)
+			if name == "" {
+				return nil, false
+			}
+		}
+		value := node.ChildByFieldName("value")
+		if value == nil {
+			value = node.ChildByFieldName("expression")
+		}
+		if value == nil && node.NamedChildCount() != 0 {
+			value = node.NamedChild(int(node.NamedChildCount()) - 1)
+		}
+		if value == nil || nameNode != nil && value.Equal(nameNode) {
+			return nil, false
+		}
+		args = append(args, csharpEFArgument{name: name, value: value})
 	}
-	if len(lits) == 0 || lits[0] == "" {
+	return args, true
+}
+
+func csharpEFNameColon(node *sitter.Node, src []byte) string {
+	if node == nil {
+		return ""
+	}
+	if name := node.ChildByFieldName("name"); name != nil {
+		return strings.TrimPrefix(name.Content(src), "@")
+	}
+	if node.NamedChildCount() != 0 {
+		return strings.TrimPrefix(node.NamedChild(0).Content(src), "@")
+	}
+	return strings.TrimPrefix(strings.TrimSuffix(strings.TrimSpace(node.Content(src)), ":"), "@")
+}
+
+// csharpEFTableViewArgs recognises literal ToTable/ToView name and schema
+// arguments, including C# name:/schema: argument syntax. A dynamic schema
+// is refused because treating it as the default schema would be wrong.
+func csharpEFTableViewArgs(inv *sitter.Node, src []byte) (table, schema, relation string, ok bool) {
+	fn, name, valid := csharpEFMemberCall(inv, src)
+	if !valid || name != "ToTable" && name != "ToView" {
 		return "", "", "", false
 	}
-	table = lits[0]
-	if len(lits) > 1 {
-		schema = lits[1]
+	_ = fn
+	args, valid := csharpEFArguments(inv, src)
+	if !valid {
+		return "", "", "", false
+	}
+	var tableNode, schemaNode *sitter.Node
+	tableSet, schemaSet := false, false
+	position := 0
+	for _, arg := range args {
+		switch arg.name {
+		case "":
+			switch position {
+			case 0:
+				tableNode, tableSet = arg.value, true
+			case 1:
+				schemaNode, schemaSet = arg.value, true
+			default:
+				return "", "", "", false
+			}
+			position++
+		case "name":
+			if tableSet {
+				return "", "", "", false
+			}
+			tableNode, tableSet = arg.value, true
+		case "schema":
+			if schemaSet {
+				return "", "", "", false
+			}
+			schemaNode, schemaSet = arg.value, true
+		default:
+			return "", "", "", false
+		}
+	}
+	if !tableSet || tableNode == nil {
+		return "", "", "", false
+	}
+	table, valid = csharpDecodeStringLiteral(tableNode.Content(src))
+	if !valid || table == "" {
+		return "", "", "", false
+	}
+	if schemaSet {
+		if !csharpEFStaticNull(schemaNode, src) {
+			schema, valid = csharpDecodeStringLiteral(schemaNode.Content(src))
+			if !valid {
+				return "", "", "", false
+			}
+		}
 	}
 	relation = "table"
 	if name == "ToView" {
@@ -261,14 +731,6 @@ func csharpEFTableViewArgs(n *sitter.Node, src []byte) (table, schema, relation 
 	return table, schema, relation, true
 }
 
-// csharpEFEntityGenericArg matches the Entity<T> generic-name link of
-// a modelBuilder fluent chain.
-var csharpEFEntityGenericArg = regexp.MustCompile(`^Entity\s*<\s*([^<>,]+?)\s*>$`)
-
-// csharpEFSubjectChangers are the fluent links that return a builder
-// for a DIFFERENT entity (owned types, navigations): a ToTable past
-// one of these names that other entity's table, so the chain walk
-// refuses rather than crediting T.
 var csharpEFSubjectChangers = map[string]bool{
 	"OwnsOne": true, "OwnsMany": true,
 	"HasOne": true, "HasMany": true,
@@ -276,96 +738,352 @@ var csharpEFSubjectChangers = map[string]bool{
 	"Navigation": true, "ComplexProperty": true,
 }
 
-// csharpEFEntityFromChain walks a ToTable/ToView call's receiver
-// chain (`modelBuilder.Entity<T>().HasKey(...).ToTable(...)`) down to
-// the Entity<T> link and returns T's final name segment, or "" when
-// the chain never names an entity — or passes through a
-// subject-changing link (`Entity<T>().OwnsOne(...).ToTable(...)` is
-// the owned type's table-splitting spelling, not T's table).
+// csharpEFEntityFromChain retains the existing helper contract; context
+// extraction uses the rooted variant so only the ModelBuilder parameter
+// can establish Entity<T>.
 func csharpEFEntityFromChain(fn *sitter.Node, src []byte) string {
+	return csharpEFEntityFromChainRoot(fn, src, "")
+}
+
+func csharpEFEntityFromChainRoot(fn *sitter.Node, src []byte, root string) string {
+	if fn == nil || fn.Type() != "member_access_expression" {
+		return ""
+	}
 	expr := fn.ChildByFieldName("expression")
-	for expr != nil {
-		switch expr.Type() {
-		case "invocation_expression":
-			expr = expr.ChildByFieldName("function")
-		case "member_access_expression":
-			if nm := expr.ChildByFieldName("name"); nm != nil {
-				txt := nm.Content(src)
-				if nm.Type() == "generic_name" {
-					if m := csharpEFEntityGenericArg.FindStringSubmatch(txt); len(m) >= 2 {
-						entity := strings.TrimSpace(m[1])
-						if i := strings.LastIndexByte(entity, '.'); i >= 0 {
-							entity = entity[i+1:]
-						}
-						return strings.TrimPrefix(entity, "@")
-					}
-					// OwnsOne<Address>(...) spells the subject change as a
-					// generic name — strip the argument list before the check.
-					if i := strings.IndexByte(txt, '<'); i >= 0 {
-						txt = strings.TrimSpace(txt[:i])
-					}
-				}
-				if csharpEFSubjectChangers[txt] {
-					return ""
-				}
-			}
-			expr = expr.ChildByFieldName("expression")
-		default:
+	for expr != nil && expr.Type() == "invocation_expression" {
+		callFn := expr.ChildByFieldName("function")
+		if callFn == nil || callFn.Type() != "member_access_expression" {
 			return ""
 		}
+		nameNode := callFn.ChildByFieldName("name")
+		if nameNode == nil {
+			return ""
+		}
+		name := csharpEFMemberName(nameNode, src)
+		if arg, entityCall := csharpEFGenericTypeArgument(nameNode, src, "Entity"); entityCall {
+			arguments := expr.ChildByFieldName("arguments")
+			if arguments == nil || arguments.NamedChildCount() != 0 {
+				return ""
+			}
+			base := callFn.ChildByFieldName("expression")
+			if base == nil || base.Type() != "identifier" {
+				return ""
+			}
+			baseName := strings.TrimPrefix(base.Content(src), "@")
+			if root != "" && baseName != root {
+				return ""
+			}
+			_, entity, named := csharpEFNamedType(arg, src)
+			if !named {
+				return ""
+			}
+			return entity
+		}
+		if csharpEFSubjectChangers[name] {
+			return ""
+		}
+		expr = callFn.ChildByFieldName("expression")
 	}
 	return ""
 }
 
-// stampCSharpEFFluent records the OnModelCreating inline fluent
-// mapping facts on the file node as Meta["ef_fluent"], one
-// "entity|table|schema|relation|line" entry per Entity<T> chain that
-// ends in a literal ToTable/ToView — line is the call's own line, so
-// the resolver's edge evidence points at the mapping statement rather
-// than the file top. Only OnModelCreating bodies are
-// scanned: that is where EF looks, and a helper method reached from
-// there is a cross-file/cross-method chase the extractor stays out
-// of. The resolver joins entries to entity class nodes by name, same
-// as the config-class stamps.
-func stampCSharpEFFluent(root *sitter.Node, src []byte, fileNode *graph.Node) {
-	var entries []string
-	seen := map[string]bool{}
-	walkNodes(root, func(n *sitter.Node) {
-		if n.Type() != "method_declaration" {
+func csharpEFMemberName(node *sitter.Node, src []byte) string {
+	if node == nil {
+		return ""
+	}
+	if node.Type() == "generic_name" {
+		name := node.ChildByFieldName("name")
+		if name == nil && node.NamedChildCount() != 0 {
+			name = node.NamedChild(0)
+		}
+		if name != nil && name.Type() == "identifier" {
+			return strings.TrimPrefix(name.Content(src), "@")
+		}
+		return ""
+	}
+	if node.Type() != "identifier" {
+		return ""
+	}
+	return strings.TrimPrefix(node.Content(src), "@")
+}
+
+func csharpEFMemberCall(inv *sitter.Node, src []byte) (*sitter.Node, string, bool) {
+	if inv == nil || inv.Type() != "invocation_expression" {
+		return nil, "", false
+	}
+	fn := inv.ChildByFieldName("function")
+	if fn == nil || fn.Type() != "member_access_expression" {
+		return nil, "", false
+	}
+	name := csharpEFMemberName(fn.ChildByFieldName("name"), src)
+	return fn, name, name != ""
+}
+
+func csharpEFDirectReceiver(fn *sitter.Node, src []byte, expected string) bool {
+	if fn == nil || fn.Type() != "member_access_expression" {
+		return false
+	}
+	receiver := fn.ChildByFieldName("expression")
+	return receiver != nil && receiver.Type() == "identifier" &&
+		strings.TrimPrefix(receiver.Content(src), "@") == expected
+}
+
+func csharpWalkEFInvocations(root *sitter.Node, visit func(*sitter.Node)) {
+	var walk func(*sitter.Node)
+	walk = func(node *sitter.Node) {
+		if node == nil {
 			return
 		}
-		if nm := n.ChildByFieldName("name"); nm == nil || nm.Content(src) != "OnModelCreating" {
-			return
+		if node != root {
+			switch node.Type() {
+			case "lambda_expression", "anonymous_method_expression", "local_function_statement", "method_declaration":
+				return
+			}
 		}
-		body := n.ChildByFieldName("body")
-		if body == nil {
-			return
+		if node.Type() == "invocation_expression" {
+			visit(node)
 		}
-		walkAST(body, func(inv *sitter.Node) bool {
-			table, schema, relation, ok := csharpEFTableViewArgs(inv, src)
-			if !ok {
-				return true
-			}
-			entity := csharpEFEntityFromChain(inv.ChildByFieldName("function"), src)
-			if entity == "" {
-				return true
-			}
-			entry := entity + "|" + table + "|" + schema + "|" + relation +
-				"|" + strconv.Itoa(int(inv.StartPoint().Row)+1)
-			if !seen[entry] {
-				seen[entry] = true
-				entries = append(entries, entry)
-			}
+		for i, count := 0, int(node.NamedChildCount()); i < count; i++ {
+			walk(node.NamedChild(i))
+		}
+	}
+	walk(root)
+}
+
+func csharpEFDbContextClass(decl *sitter.Node, src []byte) (string, bool) {
+	if decl == nil || decl.Type() != "class_declaration" {
+		return "", false
+	}
+	baseList := csharpDirectChildOfType(decl, "base_list")
+	if baseList == nil {
+		return "", false
+	}
+	isContext := false
+	for i, count := 0, int(baseList.NamedChildCount()); i < count; i++ {
+		identity, terminal, named := csharpEFNamedType(baseList.NamedChild(i), src)
+		if !named || terminal != "DbContext" {
+			continue
+		}
+		if identity == "DbContext" || identity == "Microsoft.EntityFrameworkCore.DbContext" ||
+			identity == "global::Microsoft.EntityFrameworkCore.DbContext" {
+			isContext = true
+		}
+	}
+	name := decl.ChildByFieldName("name")
+	if !isContext || name == nil || name.Type() != "identifier" {
+		return "", false
+	}
+	return strings.TrimPrefix(name.Content(src), "@"), true
+}
+
+func csharpEFOnModelCreating(decl *sitter.Node, src []byte) (*sitter.Node, string, bool) {
+	body := decl.ChildByFieldName("body")
+	if body == nil {
+		body = csharpDirectChildOfType(decl, "declaration_list")
+	}
+	if body == nil {
+		return nil, "", false
+	}
+	var found *sitter.Node
+	receiver := ""
+	for i, count := 0, int(body.NamedChildCount()); i < count; i++ {
+		method := body.NamedChild(i)
+		candidateReceiver, valid := csharpEFOnModelCreatingSignature(method, src)
+		if !valid {
+			continue
+		}
+		if found != nil {
+			return nil, "", false
+		}
+		found, receiver = method, candidateReceiver
+	}
+	return found, receiver, found != nil
+}
+
+func csharpEFOnModelCreatingSignature(method *sitter.Node, src []byte) (string, bool) {
+	if method == nil || method.Type() != "method_declaration" {
+		return "", false
+	}
+	name := method.ChildByFieldName("name")
+	if name == nil || name.Type() != "identifier" || name.Content(src) != "OnModelCreating" {
+		return "", false
+	}
+	returns := method.ChildByFieldName("returns")
+	if returns == nil {
+		returns = method.ChildByFieldName("type")
+	}
+	if returns == nil || returns.Content(src) != "void" || !csharpEFHasDirectToken(method, src, "override") {
+		return "", false
+	}
+	parameters := method.ChildByFieldName("parameters")
+	if parameters == nil || parameters.NamedChildCount() != 1 {
+		return "", false
+	}
+	parameter := parameters.NamedChild(0)
+	if parameter == nil || parameter.Type() != "parameter" {
+		return "", false
+	}
+	identity, terminal, named := csharpEFNamedType(parameter.ChildByFieldName("type"), src)
+	if !named || terminal != "ModelBuilder" || identity != "ModelBuilder" && identity != "Microsoft.EntityFrameworkCore.ModelBuilder" && identity != "global::Microsoft.EntityFrameworkCore.ModelBuilder" {
+		return "", false
+	}
+	parameterName := parameter.ChildByFieldName("name")
+	body := method.ChildByFieldName("body")
+	if parameterName == nil || parameterName.Type() != "identifier" || body == nil || body.Type() != "block" {
+		return "", false
+	}
+	return strings.TrimPrefix(parameterName.Content(src), "@"), true
+}
+
+func csharpEFHasDirectToken(node *sitter.Node, src []byte, token string) bool {
+	for i, count := 0, int(node.ChildCount()); i < count; i++ {
+		child := node.Child(i)
+		if child != nil && child.Content(src) == token {
 			return true
+		}
+	}
+	return false
+}
+
+func csharpEFApplyConfiguration(inv *sitter.Node, src []byte, receiver string) (string, bool) {
+	fn, name, valid := csharpEFMemberCall(inv, src)
+	if !valid || name != "ApplyConfiguration" || !csharpEFDirectReceiver(fn, src, receiver) {
+		return "", false
+	}
+	args, valid := csharpEFArguments(inv, src)
+	if !valid || len(args) != 1 || args[0].name != "" && args[0].name != "configuration" {
+		return "", false
+	}
+	creation := args[0].value
+	if creation == nil || creation.Type() != "object_creation_expression" {
+		return "", false
+	}
+	_, config, named := csharpEFNamedType(creation.ChildByFieldName("type"), src)
+	return config, named
+}
+
+func csharpEFApplyAssembly(inv *sitter.Node, src []byte, receiver, context string) bool {
+	fn, name, valid := csharpEFMemberCall(inv, src)
+	if !valid || name != "ApplyConfigurationsFromAssembly" || !csharpEFDirectReceiver(fn, src, receiver) {
+		return false
+	}
+	args, valid := csharpEFArguments(inv, src)
+	if !valid {
+		return false
+	}
+	var assembly, predicate *sitter.Node
+	assemblySet, predicateSet, position := false, false, 0
+	for _, arg := range args {
+		switch arg.name {
+		case "":
+			if position == 0 {
+				assembly, assemblySet = arg.value, true
+			} else if position == 1 {
+				predicate, predicateSet = arg.value, true
+			} else {
+				return false
+			}
+			position++
+		case "assembly":
+			if assemblySet {
+				return false
+			}
+			assembly, assemblySet = arg.value, true
+		case "predicate":
+			if predicateSet {
+				return false
+			}
+			predicate, predicateSet = arg.value, true
+		default:
+			return false
+		}
+	}
+	if !assemblySet || predicateSet && !csharpEFStaticNull(predicate, src) {
+		return false
+	}
+	return csharpEFCurrentAssembly(assembly, src, context)
+}
+
+func csharpEFCurrentAssembly(expr *sitter.Node, src []byte, context string) bool {
+	if expr == nil || expr.Type() != "member_access_expression" {
+		return false
+	}
+	name := expr.ChildByFieldName("name")
+	typeof := expr.ChildByFieldName("expression")
+	if name == nil || name.Type() != "identifier" || name.Content(src) != "Assembly" || typeof == nil || typeof.Type() != "typeof_expression" {
+		return false
+	}
+	typeNode := typeof.ChildByFieldName("type")
+	if typeNode == nil && typeof.NamedChildCount() == 1 {
+		typeNode = typeof.NamedChild(0)
+	}
+	identity, _, named := csharpEFNamedType(typeNode, src)
+	return named && identity == context
+}
+
+func csharpEFStaticNull(node *sitter.Node, src []byte) bool {
+	return node != nil && node.Type() == "null_literal" && strings.TrimSpace(node.Content(src)) == "null"
+}
+
+// stampCSharpEFFluent records lexical EF actions in source order. Each
+// map uses the persisted structured contract: context/kind/line/ordinal,
+// plus mapping or configuration fields appropriate to the action kind.
+func stampCSharpEFFluent(root *sitter.Node, src []byte, fileNode *graph.Node) {
+	actions := make([]map[string]any, 0)
+	walkNodes(root, func(decl *sitter.Node) {
+		context, valid := csharpEFDbContextClass(decl, src)
+		if !valid {
+			return
+		}
+		method, receiver, valid := csharpEFOnModelCreating(decl, src)
+		if !valid {
+			return
+		}
+		body := method.ChildByFieldName("body")
+		csharpWalkEFInvocations(body, func(inv *sitter.Node) {
+			if table, schema, relation, matched := csharpEFTableViewArgs(inv, src); matched {
+				entity := csharpEFEntityFromChainRoot(inv.ChildByFieldName("function"), src, receiver)
+				if entity != "" {
+					actions = append(actions, map[string]any{
+						"context":  context,
+						"kind":     "mapping",
+						"line":     int(inv.StartPoint().Row) + 1,
+						"ordinal":  len(actions),
+						"entity":   entity,
+						"table":    table,
+						"schema":   schema,
+						"relation": relation,
+					})
+					return
+				}
+			}
+			if config, matched := csharpEFApplyConfiguration(inv, src, receiver); matched {
+				actions = append(actions, map[string]any{
+					"context": context,
+					"kind":    "apply_configuration",
+					"line":    int(inv.StartPoint().Row) + 1,
+					"ordinal": len(actions),
+					"config":  config,
+				})
+				return
+			}
+			if csharpEFApplyAssembly(inv, src, receiver, context) {
+				actions = append(actions, map[string]any{
+					"context": context,
+					"kind":    "apply_assembly",
+					"line":    int(inv.StartPoint().Row) + 1,
+					"ordinal": len(actions),
+				})
+			}
 		})
 	})
-	if len(entries) == 0 {
+	if len(actions) == 0 {
 		return
 	}
 	if fileNode.Meta == nil {
 		fileNode.Meta = map[string]any{}
 	}
-	fileNode.Meta["ef_fluent"] = entries
+	fileNode.Meta["ef_fluent"] = actions
 }
 
 // emitCSharpORMEdges materialises the KindTable node + EdgeModelsTable

--- a/internal/parser/languages/csharp_orm.go
+++ b/internal/parser/languages/csharp_orm.go
@@ -1,0 +1,122 @@
+package languages
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+	sitter "github.com/zzet/gortex/internal/parser/tsitter"
+)
+
+// detectCSharpORMModel inspects a C# class/record for a [Table]
+// attribute (System.ComponentModel.DataAnnotations.Schema — the EF
+// Core mapping attribute, shared by Dapper.Contrib) and emits an
+// EdgeModelsTable to a synthetic KindTable node when one is found.
+//
+// Only the attribute form is decided at extraction time: EF's other
+// two table-name sources — DbSet<T> property-name convention and
+// fluent ToTable(...) configuration — live in files other than the
+// entity's, so they are joined by a resolver pass over stamped facts,
+// not here. A class with no [Table] attribute emits nothing.
+func detectCSharpORMModel(classNode *sitter.Node, src []byte, classID, filePath string) []*graph.Edge {
+	if classNode == nil {
+		return nil
+	}
+	tableName := ""
+	schema := ""
+	for _, ann := range csharpCollectAttributes(classNode, src) {
+		if !csharpIsTableAttr(ann.name) {
+			continue
+		}
+		name := csharpAttrPositionalString(ann.args)
+		if name == "" {
+			continue
+		}
+		tableName = name
+		schema = javaAnnotationStringArg(ann.args, "Schema")
+		break
+	}
+	if tableName == "" {
+		return nil
+	}
+	qualified := tableName
+	if schema != "" {
+		qualified = schema + "." + tableName
+	}
+	tableID := ormTableNodeID(qualified)
+	meta := map[string]any{
+		"orm":        "efcore",
+		"binding":    "attribute",
+		"table_name": tableName,
+		"derivation": "override",
+	}
+	if schema != "" {
+		meta["schema"] = schema
+	}
+	return []*graph.Edge{
+		{
+			From:     classID,
+			To:       tableID,
+			Kind:     graph.EdgeModelsTable,
+			FilePath: filePath,
+			Line:     int(classNode.StartPoint().Row) + 1,
+			Origin:   graph.OriginASTResolved,
+			Meta:     meta,
+		},
+	}
+}
+
+// csharpIsTableAttr reports whether an attribute name denotes [Table].
+// C# lets the attribute appear qualified (Schema.Table, or the full
+// namespace path) and with the explicit Attribute suffix, so compare
+// the final dotted segment against both spellings.
+func csharpIsTableAttr(name string) bool {
+	if i := strings.LastIndexByte(name, '.'); i >= 0 {
+		name = name[i+1:]
+	}
+	return name == "Table" || name == "TableAttribute"
+}
+
+// csharpAttrPositionalStringArg matches a leading (optionally
+// verbatim) string literal — [Table("name", ...)]'s table name is the
+// attribute's first positional argument, unlike JPA's key=value form.
+var csharpAttrPositionalStringArg = regexp.MustCompile(`^\s*@?"([^"]*)"`)
+
+// csharpAttrPositionalString extracts the first positional string
+// literal from an attribute's verbatim argument text. Non-literal
+// firsts (nameof(...), constants) return "" — fail-open, no guess.
+func csharpAttrPositionalString(args string) string {
+	m := csharpAttrPositionalStringArg.FindStringSubmatch(args)
+	if len(m) < 2 {
+		return ""
+	}
+	return strings.TrimSpace(m[1])
+}
+
+// emitCSharpORMEdges materialises the KindTable node + EdgeModelsTable
+// edges for a C# type, mirroring emitJavaORMEdges: the per-file table
+// node dedup happens in one place.
+func emitCSharpORMEdges(classNode *sitter.Node, src []byte, classID, filePath string, result *parser.ExtractionResult) {
+	for _, e := range detectCSharpORMModel(classNode, src, classID, filePath) {
+		if e == nil {
+			continue
+		}
+		if !ormTableNodeAlreadyEmitted(result, e.To) {
+			schema, _ := e.Meta["schema"].(string)
+			result.Nodes = append(result.Nodes, &graph.Node{
+				ID:       e.To,
+				Kind:     graph.KindTable,
+				Name:     e.Meta["table_name"].(string),
+				FilePath: filePath,
+				Language: "csharp",
+				Meta: map[string]any{
+					"dialect": "orm",
+					"schema":  schema,
+					"source":  "csharp-orm",
+				},
+			})
+		}
+		result.Edges = append(result.Edges, e)
+	}
+}

--- a/internal/parser/languages/csharp_orm.go
+++ b/internal/parser/languages/csharp_orm.go
@@ -165,23 +165,6 @@ func csharpIsTableAttr(name string) bool {
 	return name == "Table" || name == "TableAttribute"
 }
 
-// csharpAttrPositionalString extracts and decodes the first positional
-// string literal from an attribute's verbatim argument text. Only C#
-// regular and verbatim literals are accepted; constants, interpolated
-// strings, raw strings, UTF-8 literals, and malformed escapes fail open.
-func csharpAttrPositionalString(args string) string {
-	text := strings.TrimSpace(args)
-	value, consumed, ok := csharpDecodeStringLiteralPrefix(text)
-	if !ok {
-		return ""
-	}
-	rest := strings.TrimSpace(text[consumed:])
-	if rest != "" && rest[0] != ',' {
-		return ""
-	}
-	return value
-}
-
 // csharpDecodeStringLiteral decodes one complete C# regular or verbatim
 // string literal. It intentionally rejects newer raw/interpolated/UTF-8
 // spellings: accepting a prefix of one of those would manufacture a table
@@ -738,13 +721,6 @@ var csharpEFSubjectChangers = map[string]bool{
 	"Navigation": true, "ComplexProperty": true,
 }
 
-// csharpEFEntityFromChain retains the existing helper contract; context
-// extraction uses the rooted variant so only the ModelBuilder parameter
-// can establish Entity<T>.
-func csharpEFEntityFromChain(fn *sitter.Node, src []byte) string {
-	return csharpEFEntityFromChainRoot(fn, src, "")
-}
-
 func csharpEFEntityFromChainRoot(fn *sitter.Node, src []byte, root string) string {
 	if fn == nil || fn.Type() != "member_access_expression" {
 		return ""
@@ -976,11 +952,12 @@ func csharpEFApplyAssembly(inv *sitter.Node, src []byte, receiver, context strin
 	for _, arg := range args {
 		switch arg.name {
 		case "":
-			if position == 0 {
+			switch position {
+			case 0:
 				assembly, assemblySet = arg.value, true
-			} else if position == 1 {
+			case 1:
 				predicate, predicateSet = arg.value, true
-			} else {
+			default:
 				return false
 			}
 			position++

--- a/internal/parser/languages/csharp_orm.go
+++ b/internal/parser/languages/csharp_orm.go
@@ -161,51 +161,144 @@ func csharpEFConfigTableCall(decl *sitter.Node, src []byte) (table, schema, rela
 		if table != "" {
 			return false
 		}
-		if n.Type() != "invocation_expression" {
+		t, s, r, ok := csharpEFTableViewArgs(n, src)
+		if !ok {
 			return true
 		}
-		fn := n.ChildByFieldName("function")
-		if fn == nil || fn.Type() != "member_access_expression" {
-			return true
-		}
-		name := ""
-		if nm := fn.ChildByFieldName("name"); nm != nil {
-			name = nm.Content(src)
-		}
-		if name != "ToTable" && name != "ToView" {
-			return true
-		}
-		args := n.ChildByFieldName("arguments")
-		if args == nil {
-			return true
-		}
-		var lits []string
-		for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
-			a := args.NamedChild(i)
-			if a == nil {
-				continue
-			}
-			lit := csharpAttrPositionalString(a.Content(src))
-			if i == 0 && lit == "" {
-				return true
-			}
-			lits = append(lits, lit)
-		}
-		if len(lits) == 0 || lits[0] == "" {
-			return true
-		}
-		table = lits[0]
-		if len(lits) > 1 {
-			schema = lits[1]
-		}
-		if name == "ToView" {
-			relation = "view"
-		} else {
-			relation = "table"
-		}
+		table, schema, relation = t, s, r
 		return false
 	})
 	return table, schema, relation
+}
+
+// csharpEFTableViewArgs recognises an invocation node as a
+// ToTable/ToView call with a literal name and returns its arguments.
+// The first argument must itself be a string literal — the
+// lambda-only overloads configure without naming, so a non-literal
+// first argument is not a table fact.
+func csharpEFTableViewArgs(n *sitter.Node, src []byte) (table, schema, relation string, ok bool) {
+	if n.Type() != "invocation_expression" {
+		return "", "", "", false
+	}
+	fn := n.ChildByFieldName("function")
+	if fn == nil || fn.Type() != "member_access_expression" {
+		return "", "", "", false
+	}
+	name := ""
+	if nm := fn.ChildByFieldName("name"); nm != nil {
+		name = nm.Content(src)
+	}
+	if name != "ToTable" && name != "ToView" {
+		return "", "", "", false
+	}
+	args := n.ChildByFieldName("arguments")
+	if args == nil {
+		return "", "", "", false
+	}
+	var lits []string
+	for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
+		a := args.NamedChild(i)
+		if a == nil {
+			continue
+		}
+		lit := csharpAttrPositionalString(a.Content(src))
+		if i == 0 && lit == "" {
+			return "", "", "", false
+		}
+		lits = append(lits, lit)
+	}
+	if len(lits) == 0 || lits[0] == "" {
+		return "", "", "", false
+	}
+	table = lits[0]
+	if len(lits) > 1 {
+		schema = lits[1]
+	}
+	relation = "table"
+	if name == "ToView" {
+		relation = "view"
+	}
+	return table, schema, relation, true
+}
+
+// csharpEFEntityGenericArg matches the Entity<T> generic-name link of
+// a modelBuilder fluent chain.
+var csharpEFEntityGenericArg = regexp.MustCompile(`^Entity\s*<\s*([^<>,]+?)\s*>$`)
+
+// csharpEFEntityFromChain walks a ToTable/ToView call's receiver
+// chain (`modelBuilder.Entity<T>().HasKey(...).ToTable(...)`) down to
+// the Entity<T> link and returns T's final name segment, or "" when
+// the chain never names an entity.
+func csharpEFEntityFromChain(fn *sitter.Node, src []byte) string {
+	expr := fn.ChildByFieldName("expression")
+	for expr != nil {
+		switch expr.Type() {
+		case "invocation_expression":
+			expr = expr.ChildByFieldName("function")
+		case "member_access_expression":
+			if nm := expr.ChildByFieldName("name"); nm != nil && nm.Type() == "generic_name" {
+				if m := csharpEFEntityGenericArg.FindStringSubmatch(nm.Content(src)); len(m) >= 2 {
+					entity := strings.TrimSpace(m[1])
+					if i := strings.LastIndexByte(entity, '.'); i >= 0 {
+						entity = entity[i+1:]
+					}
+					return strings.TrimPrefix(entity, "@")
+				}
+			}
+			expr = expr.ChildByFieldName("expression")
+		default:
+			return ""
+		}
+	}
+	return ""
+}
+
+// stampCSharpEFFluent records the OnModelCreating inline fluent
+// mapping facts on the file node as Meta["ef_fluent"], one
+// "entity|table|schema|relation" entry per Entity<T> chain that ends
+// in a literal ToTable/ToView. Only OnModelCreating bodies are
+// scanned: that is where EF looks, and a helper method reached from
+// there is a cross-file/cross-method chase the extractor stays out
+// of. The resolver joins entries to entity class nodes by name, same
+// as the config-class stamps.
+func stampCSharpEFFluent(root *sitter.Node, src []byte, fileNode *graph.Node) {
+	var entries []string
+	seen := map[string]bool{}
+	walkNodes(root, func(n *sitter.Node) {
+		if n.Type() != "method_declaration" {
+			return
+		}
+		if nm := n.ChildByFieldName("name"); nm == nil || nm.Content(src) != "OnModelCreating" {
+			return
+		}
+		body := n.ChildByFieldName("body")
+		if body == nil {
+			return
+		}
+		walkAST(body, func(inv *sitter.Node) bool {
+			table, schema, relation, ok := csharpEFTableViewArgs(inv, src)
+			if !ok {
+				return true
+			}
+			entity := csharpEFEntityFromChain(inv.ChildByFieldName("function"), src)
+			if entity == "" {
+				return true
+			}
+			entry := entity + "|" + table + "|" + schema + "|" + relation
+			if !seen[entry] {
+				seen[entry] = true
+				entries = append(entries, entry)
+			}
+			return true
+		})
+	})
+	if len(entries) == 0 {
+		return
+	}
+	if fileNode.Meta == nil {
+		fileNode.Meta = map[string]any{}
+	}
+	fileNode.Meta["ef_fluent"] = entries
 }
 
 // emitCSharpORMEdges materialises the KindTable node + EdgeModelsTable

--- a/internal/parser/languages/csharp_orm.go
+++ b/internal/parser/languages/csharp_orm.go
@@ -2,6 +2,7 @@ package languages
 
 import (
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -81,6 +82,10 @@ func csharpIsTableAttr(name string) bool {
 // csharpAttrPositionalStringArg matches a leading (optionally
 // verbatim) string literal — [Table("name", ...)]'s table name is the
 // attribute's first positional argument, unlike JPA's key=value form.
+// Known limits, accepted for the fixed-cost regex: an escaped quote
+// truncates the name (`"a\"b"` → `a\` — table names with quotes do
+// not survive real databases either), and a C#11 raw string literal
+// ("""...""") matches its empty prefix and is skipped as unnamed.
 var csharpAttrPositionalStringArg = regexp.MustCompile(`^\s*@?"([^"]*)"`)
 
 // csharpAttrPositionalString extracts the first positional string
@@ -126,15 +131,28 @@ func stampCSharpEFConfig(decl *sitter.Node, src []byte, meta map[string]any) {
 	if baseList == nil {
 		return
 	}
-	m := csharpEFConfigIfaceArg.FindStringSubmatch(baseList.Content(src))
-	if len(m) < 2 {
+	// A class may implement IEntityTypeConfiguration<A> AND <B> (legal,
+	// two Configure overloads). A single-entity stamp cannot say whose
+	// ToTable the body scan found, so more than one distinct T refuses.
+	matches := csharpEFConfigIfaceArg.FindAllStringSubmatch(baseList.Content(src), -1)
+	if len(matches) == 0 {
 		return
 	}
-	entity := strings.TrimSpace(m[1])
-	if i := strings.LastIndexByte(entity, '.'); i >= 0 {
-		entity = entity[i+1:]
+	entity := ""
+	for _, m := range matches {
+		cand := strings.TrimSpace(m[1])
+		if i := strings.LastIndexByte(cand, '.'); i >= 0 {
+			cand = cand[i+1:]
+		}
+		cand = strings.TrimPrefix(cand, "@")
+		if cand == "" {
+			continue
+		}
+		if entity != "" && cand != entity {
+			return
+		}
+		entity = cand
 	}
-	entity = strings.TrimPrefix(entity, "@")
 	if entity == "" {
 		return
 	}
@@ -150,24 +168,46 @@ func stampCSharpEFConfig(decl *sitter.Node, src []byte, meta map[string]any) {
 	}
 }
 
-// csharpEFConfigTableCall finds the first builder.ToTable(...) or
-// builder.ToView(...) invocation in the declaration's subtree and
-// returns its literal name/schema arguments. The first argument must
-// itself be a string literal — the lambda-only ToTable overloads
-// configure without naming, so a non-literal first argument returns
-// nothing rather than fishing a string out of a nested lambda.
+// csharpEFConfigTableCall finds the first ToTable(...) / ToView(...)
+// invocation in the declaration's subtree whose receiver is a PLAIN
+// IDENTIFIER outside any lambda, and returns its literal name/schema
+// arguments. Both restrictions are misattribution guards, not
+// conveniences: a ToTable inside a lambda is an owned-type mapping
+// (`builder.OwnsOne(c => c.Slot, s => s.ToTable(...))`) naming the
+// OWNED type's table, and a ToTable chained onto another call
+// (`builder.OwnsOne(...).ToTable(...)`) hangs off a builder for a
+// different entity. Refusing those loses the rare
+// `builder.HasAnnotation(...).ToTable(...)` chain — a miss, never a
+// wrong edge.
 func csharpEFConfigTableCall(decl *sitter.Node, src []byte) (table, schema, relation string) {
-	walkAST(decl, func(n *sitter.Node) bool {
-		if table != "" {
-			return false
-		}
-		t, s, r, ok := csharpEFTableViewArgs(n, src)
-		if !ok {
+	var walk func(n *sitter.Node, inLambda bool) bool
+	walk = func(n *sitter.Node, inLambda bool) bool {
+		if n == nil {
 			return true
 		}
-		table, schema, relation = t, s, r
-		return false
-	})
+		switch n.Type() {
+		case "lambda_expression", "anonymous_method_expression":
+			inLambda = true
+		case "invocation_expression":
+			if !inLambda {
+				if t, s, r, ok := csharpEFTableViewArgs(n, src); ok {
+					if fn := n.ChildByFieldName("function"); fn != nil {
+						if recv := fn.ChildByFieldName("expression"); recv != nil && recv.Type() == "identifier" {
+							table, schema, relation = t, s, r
+							return false
+						}
+					}
+				}
+			}
+		}
+		for i, _nc := 0, int(n.NamedChildCount()); i < _nc; i++ {
+			if !walk(n.NamedChild(i), inLambda) {
+				return false
+			}
+		}
+		return true
+	}
+	walk(decl, false)
 	return table, schema, relation
 }
 
@@ -225,10 +265,23 @@ func csharpEFTableViewArgs(n *sitter.Node, src []byte) (table, schema, relation 
 // a modelBuilder fluent chain.
 var csharpEFEntityGenericArg = regexp.MustCompile(`^Entity\s*<\s*([^<>,]+?)\s*>$`)
 
+// csharpEFSubjectChangers are the fluent links that return a builder
+// for a DIFFERENT entity (owned types, navigations): a ToTable past
+// one of these names that other entity's table, so the chain walk
+// refuses rather than crediting T.
+var csharpEFSubjectChangers = map[string]bool{
+	"OwnsOne": true, "OwnsMany": true,
+	"HasOne": true, "HasMany": true,
+	"WithOne": true, "WithMany": true,
+	"Navigation": true, "ComplexProperty": true,
+}
+
 // csharpEFEntityFromChain walks a ToTable/ToView call's receiver
 // chain (`modelBuilder.Entity<T>().HasKey(...).ToTable(...)`) down to
 // the Entity<T> link and returns T's final name segment, or "" when
-// the chain never names an entity.
+// the chain never names an entity — or passes through a
+// subject-changing link (`Entity<T>().OwnsOne(...).ToTable(...)` is
+// the owned type's table-splitting spelling, not T's table).
 func csharpEFEntityFromChain(fn *sitter.Node, src []byte) string {
 	expr := fn.ChildByFieldName("expression")
 	for expr != nil {
@@ -236,13 +289,24 @@ func csharpEFEntityFromChain(fn *sitter.Node, src []byte) string {
 		case "invocation_expression":
 			expr = expr.ChildByFieldName("function")
 		case "member_access_expression":
-			if nm := expr.ChildByFieldName("name"); nm != nil && nm.Type() == "generic_name" {
-				if m := csharpEFEntityGenericArg.FindStringSubmatch(nm.Content(src)); len(m) >= 2 {
-					entity := strings.TrimSpace(m[1])
-					if i := strings.LastIndexByte(entity, '.'); i >= 0 {
-						entity = entity[i+1:]
+			if nm := expr.ChildByFieldName("name"); nm != nil {
+				txt := nm.Content(src)
+				if nm.Type() == "generic_name" {
+					if m := csharpEFEntityGenericArg.FindStringSubmatch(txt); len(m) >= 2 {
+						entity := strings.TrimSpace(m[1])
+						if i := strings.LastIndexByte(entity, '.'); i >= 0 {
+							entity = entity[i+1:]
+						}
+						return strings.TrimPrefix(entity, "@")
 					}
-					return strings.TrimPrefix(entity, "@")
+					// OwnsOne<Address>(...) spells the subject change as a
+					// generic name — strip the argument list before the check.
+					if i := strings.IndexByte(txt, '<'); i >= 0 {
+						txt = strings.TrimSpace(txt[:i])
+					}
+				}
+				if csharpEFSubjectChangers[txt] {
+					return ""
 				}
 			}
 			expr = expr.ChildByFieldName("expression")
@@ -255,8 +319,10 @@ func csharpEFEntityFromChain(fn *sitter.Node, src []byte) string {
 
 // stampCSharpEFFluent records the OnModelCreating inline fluent
 // mapping facts on the file node as Meta["ef_fluent"], one
-// "entity|table|schema|relation" entry per Entity<T> chain that ends
-// in a literal ToTable/ToView. Only OnModelCreating bodies are
+// "entity|table|schema|relation|line" entry per Entity<T> chain that
+// ends in a literal ToTable/ToView — line is the call's own line, so
+// the resolver's edge evidence points at the mapping statement rather
+// than the file top. Only OnModelCreating bodies are
 // scanned: that is where EF looks, and a helper method reached from
 // there is a cross-file/cross-method chase the extractor stays out
 // of. The resolver joins entries to entity class nodes by name, same
@@ -284,7 +350,8 @@ func stampCSharpEFFluent(root *sitter.Node, src []byte, fileNode *graph.Node) {
 			if entity == "" {
 				return true
 			}
-			entry := entity + "|" + table + "|" + schema + "|" + relation
+			entry := entity + "|" + table + "|" + schema + "|" + relation +
+				"|" + strconv.Itoa(int(inv.StartPoint().Row)+1)
 			if !seen[entry] {
 				seen[entry] = true
 				entries = append(entries, entry)

--- a/internal/parser/languages/csharp_orm.go
+++ b/internal/parser/languages/csharp_orm.go
@@ -94,6 +94,120 @@ func csharpAttrPositionalString(args string) string {
 	return strings.TrimSpace(m[1])
 }
 
+// csharpEFConfigIfaceArg pulls the single type argument out of an
+// IEntityTypeConfiguration<T> base-list entry. Text-level on purpose:
+// the base list is one short line, and the extractor needs only T's
+// name — qualification is stripped after the match.
+var csharpEFConfigIfaceArg = regexp.MustCompile(`IEntityTypeConfiguration\s*<\s*([^<>,]+?)\s*>`)
+
+// stampCSharpEFConfig detects an EF Core entity-configuration class —
+// one implementing IEntityTypeConfiguration<T> — and stamps the facts
+// a resolver pass needs to join fluent table mapping to the entity:
+//
+//	ef_config_entity    T's final name segment (always, when detected)
+//	ef_config_table     first ToTable/ToView string arg (when present)
+//	ef_config_relation  "table" or "view" (with ef_config_table)
+//	ef_config_schema    second string arg (when present)
+//
+// The entity class, the config class, and the DbContext registration
+// live in different files, so the extractor only records what this
+// file proves; the cross-file join happens at resolve time.
+func stampCSharpEFConfig(decl *sitter.Node, src []byte, meta map[string]any) {
+	if decl == nil {
+		return
+	}
+	var baseList *sitter.Node
+	for i, _nc := 0, int(decl.ChildCount()); i < _nc; i++ {
+		if c := decl.Child(i); c != nil && c.Type() == "base_list" {
+			baseList = c
+			break
+		}
+	}
+	if baseList == nil {
+		return
+	}
+	m := csharpEFConfigIfaceArg.FindStringSubmatch(baseList.Content(src))
+	if len(m) < 2 {
+		return
+	}
+	entity := strings.TrimSpace(m[1])
+	if i := strings.LastIndexByte(entity, '.'); i >= 0 {
+		entity = entity[i+1:]
+	}
+	entity = strings.TrimPrefix(entity, "@")
+	if entity == "" {
+		return
+	}
+	meta["ef_config_entity"] = entity
+	table, schema, relation := csharpEFConfigTableCall(decl, src)
+	if table == "" {
+		return
+	}
+	meta["ef_config_table"] = table
+	meta["ef_config_relation"] = relation
+	if schema != "" {
+		meta["ef_config_schema"] = schema
+	}
+}
+
+// csharpEFConfigTableCall finds the first builder.ToTable(...) or
+// builder.ToView(...) invocation in the declaration's subtree and
+// returns its literal name/schema arguments. The first argument must
+// itself be a string literal — the lambda-only ToTable overloads
+// configure without naming, so a non-literal first argument returns
+// nothing rather than fishing a string out of a nested lambda.
+func csharpEFConfigTableCall(decl *sitter.Node, src []byte) (table, schema, relation string) {
+	walkAST(decl, func(n *sitter.Node) bool {
+		if table != "" {
+			return false
+		}
+		if n.Type() != "invocation_expression" {
+			return true
+		}
+		fn := n.ChildByFieldName("function")
+		if fn == nil || fn.Type() != "member_access_expression" {
+			return true
+		}
+		name := ""
+		if nm := fn.ChildByFieldName("name"); nm != nil {
+			name = nm.Content(src)
+		}
+		if name != "ToTable" && name != "ToView" {
+			return true
+		}
+		args := n.ChildByFieldName("arguments")
+		if args == nil {
+			return true
+		}
+		var lits []string
+		for i, _nc := 0, int(args.NamedChildCount()); i < _nc; i++ {
+			a := args.NamedChild(i)
+			if a == nil {
+				continue
+			}
+			lit := csharpAttrPositionalString(a.Content(src))
+			if i == 0 && lit == "" {
+				return true
+			}
+			lits = append(lits, lit)
+		}
+		if len(lits) == 0 || lits[0] == "" {
+			return true
+		}
+		table = lits[0]
+		if len(lits) > 1 {
+			schema = lits[1]
+		}
+		if name == "ToView" {
+			relation = "view"
+		} else {
+			relation = "table"
+		}
+		return false
+	})
+	return table, schema, relation
+}
+
 // emitCSharpORMEdges materialises the KindTable node + EdgeModelsTable
 // edges for a C# type, mirroring emitJavaORMEdges: the per-file table
 // node dedup happens in one place.

--- a/internal/parser/languages/csharp_orm_test.go
+++ b/internal/parser/languages/csharp_orm_test.go
@@ -73,6 +73,71 @@ public class BinItem
 	assert.Equal(t, "audit", tableNode.Meta["schema"])
 }
 
+func TestCSharpORM_ConfigClassStampsEntityAndTable(t *testing.T) {
+	src := `using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Probe.Data.Config;
+
+public class WidgetConfig : IEntityTypeConfiguration<Widget>
+{
+    public void Configure(EntityTypeBuilder<Widget> builder)
+    {
+        builder.ToTable("widgets_v2", "sales");
+        builder.HasKey(w => w.Id);
+    }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Config/WidgetConfig.cs", src)
+	cfg := fix.nodesByID["Config/WidgetConfig.cs::WidgetConfig"]
+	require.NotNil(t, cfg)
+	assert.Equal(t, "Widget", cfg.Meta["ef_config_entity"])
+	assert.Equal(t, "widgets_v2", cfg.Meta["ef_config_table"])
+	assert.Equal(t, "sales", cfg.Meta["ef_config_schema"])
+	assert.Equal(t, "table", cfg.Meta["ef_config_relation"])
+}
+
+func TestCSharpORM_ConfigClassToViewStampsViewRelation(t *testing.T) {
+	src := `namespace Probe.Data.Config;
+
+public class TallyConfig : Microsoft.EntityFrameworkCore.IEntityTypeConfiguration<Domain.CrateTally>
+{
+    public void Configure(EntityTypeBuilder<Domain.CrateTally> builder)
+    {
+        builder.ToView("crate_tallies");
+    }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Config/TallyConfig.cs", src)
+	cfg := fix.nodesByID["Config/TallyConfig.cs::TallyConfig"]
+	require.NotNil(t, cfg)
+	assert.Equal(t, "CrateTally", cfg.Meta["ef_config_entity"],
+		"qualified iface and qualified entity arg both reduce to final segments")
+	assert.Equal(t, "crate_tallies", cfg.Meta["ef_config_table"])
+	assert.Equal(t, "view", cfg.Meta["ef_config_relation"])
+	_, hasSchema := cfg.Meta["ef_config_schema"]
+	assert.False(t, hasSchema, "no schema arg, no schema stamp")
+}
+
+func TestCSharpORM_ConfigClassWithoutToTableStampsEntityOnly(t *testing.T) {
+	src := `namespace Probe.Data.Config;
+
+public class GadgetConfig : IEntityTypeConfiguration<Gadget>
+{
+    public void Configure(EntityTypeBuilder<Gadget> builder)
+    {
+        builder.HasIndex(g => g.Serial);
+    }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Config/GadgetConfig.cs", src)
+	cfg := fix.nodesByID["Config/GadgetConfig.cs::GadgetConfig"]
+	require.NotNil(t, cfg)
+	assert.Equal(t, "Gadget", cfg.Meta["ef_config_entity"])
+	_, hasTable := cfg.Meta["ef_config_table"]
+	assert.False(t, hasTable, "no ToTable/ToView call, no table stamp")
+}
+
 func TestCSharpORM_PlainClassIgnored(t *testing.T) {
 	src := `namespace Probe.Core;
 

--- a/internal/parser/languages/csharp_orm_test.go
+++ b/internal/parser/languages/csharp_orm_test.go
@@ -138,6 +138,108 @@ public class GadgetConfig : IEntityTypeConfiguration<Gadget>
 	assert.False(t, hasTable, "no ToTable/ToView call, no table stamp")
 }
 
+func TestCSharpORM_ConfigOwnedTypeLambdaToTableNotStamped(t *testing.T) {
+	src := `namespace Probe.Data.Config;
+
+public class CrateSlotConfig : IEntityTypeConfiguration<CrateSlot>
+{
+    public void Configure(EntityTypeBuilder<CrateSlot> builder)
+    {
+        builder.OwnsOne(c => c.Slot, s => s.ToTable("slot_rows"));
+    }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Config/CrateSlotConfig.cs", src)
+	cfg := fix.nodesByID["Config/CrateSlotConfig.cs::CrateSlotConfig"]
+	require.NotNil(t, cfg)
+	assert.Equal(t, "CrateSlot", cfg.Meta["ef_config_entity"])
+	_, hasTable := cfg.Meta["ef_config_table"]
+	assert.False(t, hasTable,
+		"an owned-type ToTable inside a lambda names the OWNED type's table, not T's — must not stamp")
+}
+
+func TestCSharpORM_ConfigChainedOwnsOneToTableNotStamped(t *testing.T) {
+	src := `namespace Probe.Data.Config;
+
+public class ParcelConfig : IEntityTypeConfiguration<Parcel>
+{
+    public void Configure(EntityTypeBuilder<Parcel> builder)
+    {
+        builder.OwnsOne(p => p.Stub).ToTable("stub_rows");
+    }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Config/ParcelConfig.cs", src)
+	cfg := fix.nodesByID["Config/ParcelConfig.cs::ParcelConfig"]
+	require.NotNil(t, cfg)
+	assert.Equal(t, "Parcel", cfg.Meta["ef_config_entity"])
+	_, hasTable := cfg.Meta["ef_config_table"]
+	assert.False(t, hasTable,
+		"ToTable on an OwnsOne return names the owned type's table — the receiver is not the entity builder")
+}
+
+func TestCSharpORM_ConfigDualInterfaceRefusesEntirely(t *testing.T) {
+	src := `namespace Probe.Data.Config;
+
+public class PairConfig : IEntityTypeConfiguration<Drum>, IEntityTypeConfiguration<Spool>
+{
+    public void Configure(EntityTypeBuilder<Drum> builder)
+    {
+        builder.HasKey(d => d.Id);
+    }
+
+    public void Configure(EntityTypeBuilder<Spool> builder)
+    {
+        builder.ToTable("spool_rows");
+    }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Config/PairConfig.cs", src)
+	cfg := fix.nodesByID["Config/PairConfig.cs::PairConfig"]
+	require.NotNil(t, cfg)
+	_, hasEntity := cfg.Meta["ef_config_entity"]
+	assert.False(t, hasEntity,
+		"two IEntityTypeConfiguration<T> arguments: a single-entity stamp cannot say whose ToTable it found — refuse")
+}
+
+func TestCSharpORM_ConfigLambdaOnlyToTableNotStamped(t *testing.T) {
+	src := `namespace Probe.Data.Config;
+
+public class VaultConfig : IEntityTypeConfiguration<Vault>
+{
+    public void Configure(EntityTypeBuilder<Vault> builder)
+    {
+        builder.ToTable(tb => tb.HasComment("keyless vault"));
+    }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Config/VaultConfig.cs", src)
+	cfg := fix.nodesByID["Config/VaultConfig.cs::VaultConfig"]
+	require.NotNil(t, cfg)
+	assert.Equal(t, "Vault", cfg.Meta["ef_config_entity"])
+	_, hasTable := cfg.Meta["ef_config_table"]
+	assert.False(t, hasTable, "lambda-only ToTable overload names no table — the string inside the lambda is a comment")
+}
+
+func TestCSharpORM_InlineChainedOwnsOneNotStamped(t *testing.T) {
+	src := `namespace Probe.Data;
+
+public class ShipContext : DbContext
+{
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Parcel>().OwnsOne(p => p.Stub).ToTable("stub_split");
+        modelBuilder.Entity<Parcel>().ToTable("parcels_main");
+    }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Data/ShipContext.cs", src)
+	fileNode := fix.nodesByID["Data/ShipContext.cs"]
+	require.NotNil(t, fileNode)
+	assert.Equal(t, []string{"Parcel|parcels_main||table|8"}, fileNode.Meta["ef_fluent"],
+		"the OwnsOne chain's ToTable names the OWNED type's table — the walk must stop at subject-changing links")
+}
+
 func TestCSharpORM_OnModelCreatingFluentFileStamp(t *testing.T) {
 	src := `using Microsoft.EntityFrameworkCore;
 
@@ -160,10 +262,10 @@ public class ProbeContext : DbContext
 	fileNode := fix.nodesByID["Data/ProbeContext.cs"]
 	require.NotNil(t, fileNode)
 	assert.Equal(t, []string{
-		"Widget|widget_master|core|table",
-		"Gadget|gadget_view||view",
+		"Widget|widget_master|core|table|11",
+		"Gadget|gadget_view||view|13",
 	}, fileNode.Meta["ef_fluent"],
-		"one entry per Entity<T> chain ending in a literal ToTable/ToView; chains without one stamp nothing")
+		"one entry per Entity<T> chain ending in a literal ToTable/ToView, line-stamped; chains without one stamp nothing")
 }
 
 func TestCSharpORM_FluentOutsideOnModelCreatingNotStamped(t *testing.T) {
@@ -182,6 +284,39 @@ public class MapHelper
 	require.NotNil(t, fileNode)
 	_, has := fileNode.Meta["ef_fluent"]
 	assert.False(t, has, "only OnModelCreating bodies are scanned in v1")
+}
+
+func TestCSharpORM_NameofTableArgRefused(t *testing.T) {
+	src := `using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Probe.Core.Domain;
+
+[Table(nameof(SlateBin))]
+public class SlateBin
+{
+    public int Id { get; set; }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Models/SlateBin.cs", src)
+	assert.Empty(t, fix.edgesByKind[graph.EdgeModelsTable],
+		"a non-literal table name (nameof, constants) stamps nothing — fail-open, no guess")
+}
+
+func TestCSharpORM_VerbatimStringAndAttributeSuffix(t *testing.T) {
+	src := `using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Probe.Core.Domain;
+
+[TableAttribute(@"vault_rows")]
+public class VaultRow
+{
+    public int Id { get; set; }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Models/VaultRow.cs", src)
+	models := fix.edgesByKind[graph.EdgeModelsTable]
+	require.Len(t, models, 1, "the explicit Attribute suffix and a verbatim string are both ordinary spellings")
+	assert.Equal(t, "db::orm::vault_rows", models[0].To)
 }
 
 func TestCSharpORM_PlainClassIgnored(t *testing.T) {

--- a/internal/parser/languages/csharp_orm_test.go
+++ b/internal/parser/languages/csharp_orm_test.go
@@ -1,0 +1,86 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func runCSharpExtractFixtureORM(t *testing.T, filePath, src string) *extractedFixture {
+	t.Helper()
+	result, err := NewCSharpExtractor().Extract(filePath, []byte(src))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return foldFixture(result)
+}
+
+func TestCSharpORM_TableAttributeOverride(t *testing.T) {
+	src := `using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Probe.Core.Domain;
+
+[Table("stock_crates")]
+public class StockCrate
+{
+    public int Id { get; set; }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Models/StockCrate.cs", src)
+	models := fix.edgesByKind[graph.EdgeModelsTable]
+	require.Len(t, models, 1, "StockCrate should produce a models_table edge from [Table]")
+	assert.Equal(t, "Models/StockCrate.cs::StockCrate", models[0].From)
+	assert.Equal(t, "db::orm::stock_crates", models[0].To)
+	assert.Equal(t, "efcore", models[0].Meta["orm"])
+	assert.Equal(t, "attribute", models[0].Meta["binding"])
+	assert.Equal(t, "stock_crates", models[0].Meta["table_name"])
+	assert.Equal(t, "override", models[0].Meta["derivation"])
+
+	tableNode := fix.nodesByID["db::orm::stock_crates"]
+	require.NotNil(t, tableNode, "the KindTable node must be materialised alongside the edge")
+	assert.Equal(t, graph.KindTable, tableNode.Kind)
+	assert.Equal(t, "stock_crates", tableNode.Name)
+	assert.Equal(t, "orm", tableNode.Meta["dialect"])
+	assert.Equal(t, "csharp-orm", tableNode.Meta["source"])
+	assert.Equal(t, "", tableNode.Meta["schema"])
+}
+
+func TestCSharpORM_TableAttributeWithSchema(t *testing.T) {
+	src := `using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Probe.Core.Domain;
+
+[Table("bin_items", Schema = "audit")]
+public class BinItem
+{
+    public int Id { get; set; }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Models/BinItem.cs", src)
+	models := fix.edgesByKind[graph.EdgeModelsTable]
+	require.Len(t, models, 1)
+	assert.Equal(t, "db::orm::audit.bin_items", models[0].To)
+	assert.Equal(t, "bin_items", models[0].Meta["table_name"])
+	assert.Equal(t, "audit", models[0].Meta["schema"])
+	assert.Equal(t, "override", models[0].Meta["derivation"])
+
+	tableNode := fix.nodesByID["db::orm::audit.bin_items"]
+	require.NotNil(t, tableNode)
+	assert.Equal(t, "bin_items", tableNode.Name)
+	assert.Equal(t, "audit", tableNode.Meta["schema"])
+}
+
+func TestCSharpORM_PlainClassIgnored(t *testing.T) {
+	src := `namespace Probe.Core;
+
+public class PlainService
+{
+    public void Handle() { }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Services/PlainService.cs", src)
+	assert.Empty(t, fix.edgesByKind[graph.EdgeModelsTable])
+}

--- a/internal/parser/languages/csharp_orm_test.go
+++ b/internal/parser/languages/csharp_orm_test.go
@@ -236,7 +236,16 @@ public class ShipContext : DbContext
 	fix := runCSharpExtractFixtureORM(t, "Data/ShipContext.cs", src)
 	fileNode := fix.nodesByID["Data/ShipContext.cs"]
 	require.NotNil(t, fileNode)
-	assert.Equal(t, []string{"Parcel|parcels_main||table|8"}, fileNode.Meta["ef_fluent"],
+	assert.Equal(t, []map[string]any{{
+		"context":  "ShipContext",
+		"kind":     "mapping",
+		"line":     8,
+		"ordinal":  0,
+		"entity":   "Parcel",
+		"table":    "parcels_main",
+		"schema":   "",
+		"relation": "table",
+	}}, fileNode.Meta["ef_fluent"],
 		"the OwnsOne chain's ToTable names the OWNED type's table — the walk must stop at subject-changing links")
 }
 
@@ -261,11 +270,29 @@ public class ProbeContext : DbContext
 	fix := runCSharpExtractFixtureORM(t, "Data/ProbeContext.cs", src)
 	fileNode := fix.nodesByID["Data/ProbeContext.cs"]
 	require.NotNil(t, fileNode)
-	assert.Equal(t, []string{
-		"Widget|widget_master|core|table|11",
-		"Gadget|gadget_view||view|13",
+	assert.Equal(t, []map[string]any{
+		{
+			"context":  "ProbeContext",
+			"kind":     "mapping",
+			"line":     11,
+			"ordinal":  0,
+			"entity":   "Widget",
+			"table":    "widget_master",
+			"schema":   "core",
+			"relation": "table",
+		},
+		{
+			"context":  "ProbeContext",
+			"kind":     "mapping",
+			"line":     13,
+			"ordinal":  1,
+			"entity":   "Gadget",
+			"table":    "gadget_view",
+			"schema":   "",
+			"relation": "view",
+		},
 	}, fileNode.Meta["ef_fluent"],
-		"one entry per Entity<T> chain ending in a literal ToTable/ToView, line-stamped; chains without one stamp nothing")
+		"one structured action per Entity<T> chain ending in a literal ToTable/ToView")
 }
 
 func TestCSharpORM_FluentOutsideOnModelCreatingNotStamped(t *testing.T) {
@@ -317,6 +344,156 @@ public class VaultRow
 	models := fix.edgesByKind[graph.EdgeModelsTable]
 	require.Len(t, models, 1, "the explicit Attribute suffix and a verbatim string are both ordinary spellings")
 	assert.Equal(t, "db::orm::vault_rows", models[0].To)
+}
+
+func TestCSharpORM_AttributeMetadataDecodesSupportedLiterals(t *testing.T) {
+	src := `using System.ComponentModel.DataAnnotations.Schema;
+
+[Table("order\u005frows", Schema = @"audit")]
+public class Order
+{
+    public int Id { get; set; }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Models/Order.cs", src)
+	entity := fix.nodesByID["Models/Order.cs::Order"]
+	require.NotNil(t, entity)
+	assert.Equal(t, "order_rows", entity.Meta["ef_attribute_table"])
+	assert.Equal(t, "audit", entity.Meta["ef_attribute_schema"])
+}
+
+func TestCSharpORM_ConfigNamedArgumentsLastCallWins(t *testing.T) {
+	src := `public class WidgetConfig : IEntityTypeConfiguration<Widget>
+{
+    public void Configure(EntityTypeBuilder<Widget> builder)
+    {
+        builder.ToTable(name: "first_widgets", schema: "archive");
+        builder.ToView(schema: null, name: @"final_widgets");
+    }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Config/WidgetConfig.cs", src)
+	cfg := fix.nodesByID["Config/WidgetConfig.cs::WidgetConfig"]
+	require.NotNil(t, cfg)
+	assert.Equal(t, "Widget", cfg.Meta["ef_config_entity"])
+	assert.Equal(t, "final_widgets", cfg.Meta["ef_config_table"])
+	assert.Equal(t, "view", cfg.Meta["ef_config_relation"])
+	_, hasSchema := cfg.Meta["ef_config_schema"]
+	assert.False(t, hasSchema)
+}
+
+func TestCSharpORM_ConfigRequiresExactInterfaceAndMatchingConfigure(t *testing.T) {
+	src := `public class LookalikeConfig : AlmostIEntityTypeConfiguration<Widget>
+{
+    public void Configure(EntityTypeBuilder<Widget> builder)
+    {
+        builder.ToTable("wrong_one");
+    }
+}
+
+public class MismatchedConfig : IEntityTypeConfiguration<Widget>
+{
+    public void Configure(EntityTypeBuilder<Gadget> builder)
+    {
+        builder.ToTable("wrong_two");
+    }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Config/InvalidConfigs.cs", src)
+	for _, id := range []string{"Config/InvalidConfigs.cs::LookalikeConfig", "Config/InvalidConfigs.cs::MismatchedConfig"} {
+		cfg := fix.nodesByID[id]
+		require.NotNil(t, cfg)
+		_, stamped := cfg.Meta["ef_config_entity"]
+		assert.False(t, stamped, id)
+	}
+}
+
+func TestCSharpORM_OnModelCreatingRequiresExactContextSignatureAndReceiver(t *testing.T) {
+	src := `public class NotAContext : DbContextish
+{
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Widget>().ToTable("wrong_base");
+    }
+}
+
+public class MissingOverrideContext : DbContext
+{
+    protected void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Widget>().ToTable("wrong_signature");
+    }
+}
+
+public class ExactContext : DbContext
+{
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        otherBuilder.Entity<Widget>().ToTable("wrong_receiver");
+        modelBuilder.Entity<Widget>().ToTable("widgets");
+    }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Data/ExactContext.cs", src)
+	fileNode := fix.nodesByID["Data/ExactContext.cs"]
+	require.NotNil(t, fileNode)
+	actions, ok := fileNode.Meta["ef_fluent"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, actions, 1)
+	assert.Equal(t, "ExactContext", actions[0]["context"])
+	assert.Equal(t, "Widget", actions[0]["entity"])
+	assert.Equal(t, "widgets", actions[0]["table"])
+}
+
+func TestCSharpORM_ApplyConfigurationActionsPreserveOrder(t *testing.T) {
+	src := `public class ApplyContext : DbContext
+{
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Widget>().ToTable("widgets");
+        modelBuilder.ApplyConfiguration(configuration: new WidgetConfig());
+        modelBuilder.Entity<Widget>().ToView("widget_view");
+    }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Data/ApplyContext.cs", src)
+	fileNode := fix.nodesByID["Data/ApplyContext.cs"]
+	require.NotNil(t, fileNode)
+	actions, ok := fileNode.Meta["ef_fluent"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, actions, 3)
+	assert.Equal(t, "mapping", actions[0]["kind"])
+	assert.Equal(t, 0, actions[0]["ordinal"])
+	assert.Equal(t, "apply_configuration", actions[1]["kind"])
+	assert.Equal(t, "WidgetConfig", actions[1]["config"])
+	assert.Equal(t, 1, actions[1]["ordinal"])
+	assert.Equal(t, "mapping", actions[2]["kind"])
+	assert.Equal(t, 2, actions[2]["ordinal"])
+}
+
+func TestCSharpORM_ApplyAssemblyRequiresCurrentContextAndNullPredicate(t *testing.T) {
+	src := `public class ScanContext : DbContext
+{
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(ScanContext).Assembly);
+        modelBuilder.ApplyConfigurationsFromAssembly(assembly: typeof(ScanContext).Assembly, predicate: null);
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(OtherContext).Assembly);
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(ScanContext).Assembly, type => true);
+    }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Data/ScanContext.cs", src)
+	fileNode := fix.nodesByID["Data/ScanContext.cs"]
+	require.NotNil(t, fileNode)
+	actions, ok := fileNode.Meta["ef_fluent"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, actions, 2)
+	for ordinal, action := range actions {
+		assert.Equal(t, "ScanContext", action["context"])
+		assert.Equal(t, "apply_assembly", action["kind"])
+		assert.Equal(t, ordinal, action["ordinal"])
+	}
 }
 
 func TestCSharpORM_PlainClassIgnored(t *testing.T) {

--- a/internal/parser/languages/csharp_orm_test.go
+++ b/internal/parser/languages/csharp_orm_test.go
@@ -138,6 +138,52 @@ public class GadgetConfig : IEntityTypeConfiguration<Gadget>
 	assert.False(t, hasTable, "no ToTable/ToView call, no table stamp")
 }
 
+func TestCSharpORM_OnModelCreatingFluentFileStamp(t *testing.T) {
+	src := `using Microsoft.EntityFrameworkCore;
+
+namespace Probe.Data;
+
+public class ProbeContext : DbContext
+{
+    public DbSet<Widget> Widgets { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Widget>().ToTable("widget_master", "core");
+        modelBuilder.Entity<Domain.Gadget>().HasKey(g => g.Id);
+        modelBuilder.Entity<Domain.Gadget>().ToView("gadget_view");
+        modelBuilder.Entity<Sprocket>().HasIndex(s => s.Serial);
+    }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Data/ProbeContext.cs", src)
+	fileNode := fix.nodesByID["Data/ProbeContext.cs"]
+	require.NotNil(t, fileNode)
+	assert.Equal(t, []string{
+		"Widget|widget_master|core|table",
+		"Gadget|gadget_view||view",
+	}, fileNode.Meta["ef_fluent"],
+		"one entry per Entity<T> chain ending in a literal ToTable/ToView; chains without one stamp nothing")
+}
+
+func TestCSharpORM_FluentOutsideOnModelCreatingNotStamped(t *testing.T) {
+	src := `namespace Probe.Data;
+
+public class MapHelper
+{
+    public void Wire(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Widget>().ToTable("widgets_elsewhere");
+    }
+}
+`
+	fix := runCSharpExtractFixtureORM(t, "Data/MapHelper.cs", src)
+	fileNode := fix.nodesByID["Data/MapHelper.cs"]
+	require.NotNil(t, fileNode)
+	_, has := fileNode.Meta["ef_fluent"]
+	assert.False(t, has, "only OnModelCreating bodies are scanned in v1")
+}
+
 func TestCSharpORM_PlainClassIgnored(t *testing.T) {
 	src := `namespace Probe.Core;
 

--- a/internal/resolver/csharp_efcore_models.go
+++ b/internal/resolver/csharp_efcore_models.go
@@ -2,6 +2,8 @@ package resolver
 
 import (
 	"regexp"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -26,8 +28,8 @@ import (
 // than adding a second edge, and an entity a fluent fact claimed never
 // falls through to the DbSet convention. Within the fluent tier an
 // inline OnModelCreating entry beats a config class (EF applies
-// OnModelCreating statements after ApplyConfiguration); two
-// same-tier facts that disagree drop the entity entirely.
+// OnModelCreating statements after ApplyConfiguration); two facts in
+// the WINNING tier that disagree drop the entity entirely.
 //
 // Facts join to entity classes by unique class name within the same
 // boundary — an ambiguous name (two classes called Widget) skips
@@ -55,6 +57,9 @@ func ResolveCSharpEFCoreModels(g graph.Store) int {
 		if n == nil {
 			continue
 		}
+		// File nodes skip the language gate deliberately: they carry no
+		// Language, and only the C# extractor mints ef_fluent — key
+		// presence is the filter.
 		if n.Kind == graph.KindFile {
 			fluents = append(fluents, csharpEFInlineFactsFromFile(n)...)
 			continue
@@ -77,6 +82,15 @@ func ResolveCSharpEFCoreModels(g graph.Store) int {
 	if len(dbsets) == 0 && len(fluents) == 0 {
 		return 0
 	}
+	// Node scans are map-ordered; sort every fact list before first-wins
+	// logic so edge content and evidence sites are deterministic across
+	// runs (the mediatr/gin sibling idiom).
+	sort.Slice(dbsets, func(i, j int) bool {
+		if dbsets[i].entity != dbsets[j].entity {
+			return dbsets[i].entity < dbsets[j].entity
+		}
+		return dbsets[i].siteID < dbsets[j].siteID
+	})
 
 	// Entities that already model a table: the attribute binding was
 	// decided at extraction, and a prior run of this pass already
@@ -115,6 +129,13 @@ func ResolveCSharpEFCoreModels(g graph.Store) int {
 			meta["relation"] = f.relation
 		}
 		if es := edgesByFrom[cls.ID]; len(es) > 0 {
+			// Rewire in place. The edge keeps its FilePath/Line (the
+			// entity's own file): the edge's From side is the model, and
+			// anchoring evidence there survives re-extraction of the
+			// fact file. The superseded attribute's table node is
+			// deliberately left behind even if nothing points at it any
+			// more — same call go_orm's override rewire makes; a table
+			// node is cheap and another entity may share it.
 			e := es[0]
 			if e.To == tableID {
 				continue
@@ -200,34 +221,48 @@ type csharpEFFluentFact struct {
 }
 
 // csharpEFMergeFluentFacts reduces the fluent facts to at most one per
-// entity name: inline OnModelCreating entries beat config classes, and
-// two same-tier facts that disagree on the mapping drop the entity —
-// refusing beats guessing.
+// entity name. Two-phase so the verdict never depends on arrival order
+// (facts come off a map-ordered node scan): the inline OnModelCreating
+// tier wins outright when present — a disagreement in the config tier
+// below it is irrelevant — and only the WINNING tier's facts are
+// checked for conflicts; two of those that disagree on the mapping
+// drop the entity, refusing over guessing. Agreeing duplicates keep
+// the lowest-siteID fact, so the retained evidence site is
+// deterministic too.
 func csharpEFMergeFluentFacts(fluents []csharpEFFluentFact) []csharpEFFluentFact {
-	merged := map[string]csharpEFFluentFact{}
-	dropped := map[string]bool{}
+	byEntity := map[string][]csharpEFFluentFact{}
 	var order []string
 	for _, f := range fluents {
-		cur, ok := merged[f.entity]
-		if !ok {
-			merged[f.entity] = f
+		if _, ok := byEntity[f.entity]; !ok {
 			order = append(order, f.entity)
-			continue
 		}
-		if f.inline != cur.inline {
-			if f.inline {
-				merged[f.entity] = f
-			}
-			continue
-		}
-		if f.table != cur.table || f.schema != cur.schema || f.relation != cur.relation {
-			dropped[f.entity] = true
-		}
+		byEntity[f.entity] = append(byEntity[f.entity], f)
 	}
+	sort.Strings(order)
 	var out []csharpEFFluentFact
-	for _, name := range order {
-		if !dropped[name] {
-			out = append(out, merged[name])
+	for _, entity := range order {
+		facts := byEntity[entity]
+		// Winning tier: inline when any inline fact exists.
+		tier := facts[:0:0]
+		for _, f := range facts {
+			if f.inline {
+				tier = append(tier, f)
+			}
+		}
+		if len(tier) == 0 {
+			tier = facts
+		}
+		sort.Slice(tier, func(i, j int) bool { return tier[i].siteID < tier[j].siteID })
+		winner := tier[0]
+		conflict := false
+		for _, f := range tier[1:] {
+			if f.table != winner.table || f.schema != winner.schema || f.relation != winner.relation {
+				conflict = true
+				break
+			}
+		}
+		if !conflict {
+			out = append(out, winner)
 		}
 	}
 	return out
@@ -254,8 +289,9 @@ func csharpEFConfigFactFromNode(n *graph.Node) (csharpEFFluentFact, bool) {
 }
 
 // csharpEFInlineFactsFromFile parses the ef_fluent
-// "entity|table|schema|relation" entries off a file node. Meta lists
-// round-trip through persistence as []any, so both shapes decode.
+// "entity|table|schema|relation|line" entries off a file node. Meta
+// lists round-trip through persistence as []any, so both shapes
+// decode.
 func csharpEFInlineFactsFromFile(n *graph.Node) []csharpEFFluentFact {
 	if n.Meta == nil {
 		return nil
@@ -273,14 +309,18 @@ func csharpEFInlineFactsFromFile(n *graph.Node) []csharpEFFluentFact {
 	}
 	var out []csharpEFFluentFact
 	for _, entry := range entries {
-		parts := strings.SplitN(entry, "|", 4)
-		if len(parts) != 4 || parts[0] == "" || parts[1] == "" {
+		parts := strings.SplitN(entry, "|", 5)
+		if len(parts) != 5 || parts[0] == "" || parts[1] == "" {
 			continue
+		}
+		line, err := strconv.Atoi(parts[4])
+		if err != nil || line < 1 {
+			line = 1
 		}
 		out = append(out, csharpEFFluentFact{
 			entity: parts[0], table: parts[1], schema: parts[2], relation: parts[3],
 			inline: true,
-			siteID: n.ID, filePath: n.FilePath, line: 1,
+			siteID: n.ID, filePath: n.FilePath, line: line,
 		})
 	}
 	return out

--- a/internal/resolver/csharp_efcore_models.go
+++ b/internal/resolver/csharp_efcore_models.go
@@ -16,47 +16,135 @@ import (
 //     (verbatim — not a pluralization of the class name), and the
 //     property lives on the DbContext, not the entity.
 //
+//   - Fluent configuration: an IEntityTypeConfiguration<T> class's
+//     ToTable/ToView (stamped as ef_config_* class meta) or an
+//     OnModelCreating Entity<T>() chain (stamped as ef_fluent file
+//     meta) names the table from yet another file.
+//
+// Precedence is fluent > attribute > dbset: a fluent fact REWIRES an
+// existing attribute edge in place (go_orm's override model) rather
+// than adding a second edge, and an entity a fluent fact claimed never
+// falls through to the DbSet convention. Within the fluent tier an
+// inline OnModelCreating entry beats a config class (EF applies
+// OnModelCreating statements after ApplyConfiguration); two
+// same-tier facts that disagree drop the entity entirely.
+//
 // Facts join to entity classes by unique class name within the same
 // boundary — an ambiguous name (two classes called Widget) skips
 // rather than guesses. An entity that already carries a models_table
-// edge (attribute-bound at extraction, or a previous run of this
-// pass) is left alone, which is also what makes the pass idempotent.
+// edge at its final target is left alone, which is also what makes
+// the pass idempotent.
 //
-// Returns the number of edges synthesized.
+// Returns the number of edges synthesized or rewired.
 func ResolveCSharpEFCoreModels(g graph.Store) int {
 	if g == nil {
 		return 0
 	}
 	classesByName := map[string][]*graph.Node{}
 	var dbsets []csharpDbSetFact
-	for _, n := range nodesByKindsOrAll(g, graph.KindType, graph.KindField) {
-		if n == nil || !strings.EqualFold(n.Language, "csharp") {
+	var fluents []csharpEFFluentFact
+	for _, n := range nodesByKindsOrAll(g, graph.KindType, graph.KindField, graph.KindFile) {
+		if n == nil {
+			continue
+		}
+		if n.Kind == graph.KindFile {
+			fluents = append(fluents, csharpEFInlineFactsFromFile(n)...)
+			continue
+		}
+		if !strings.EqualFold(n.Language, "csharp") {
 			continue
 		}
 		switch n.Kind {
 		case graph.KindType:
 			classesByName[n.Name] = append(classesByName[n.Name], n)
+			if f, ok := csharpEFConfigFactFromNode(n); ok {
+				fluents = append(fluents, f)
+			}
 		case graph.KindField:
 			if f, ok := csharpDbSetFactFromNode(n); ok {
 				dbsets = append(dbsets, f)
 			}
 		}
 	}
-	if len(dbsets) == 0 {
+	if len(dbsets) == 0 && len(fluents) == 0 {
 		return 0
 	}
 
-	// Entities that already model a table keep their edge: the
-	// attribute binding was decided at extraction with the entity's own
-	// file as evidence, and a prior run of this pass already landed.
+	// Entities that already model a table: the attribute binding was
+	// decided at extraction, and a prior run of this pass already
+	// landed. Fluent facts may rewire these; the DbSet leg never
+	// touches them.
 	mapped := map[string]bool{}
+	edgesByFrom := map[string][]*graph.Edge{}
 	for e := range g.EdgesByKind(graph.EdgeModelsTable) {
 		if e != nil {
 			mapped[e.From] = true
+			edgesByFrom[e.From] = append(edgesByFrom[e.From], e)
 		}
 	}
 
 	resolved := 0
+
+	// Fluent tier first, so its claims shadow the DbSet convention.
+	var reindex []graph.EdgeReindex
+	for _, f := range csharpEFMergeFluentFacts(fluents) {
+		cands := sameBoundaryCandidates(g, f.siteID, classesByName[f.entity])
+		if len(cands) != 1 {
+			continue
+		}
+		cls := cands[0]
+		tableID := csharpEFTableNodeID(f.table, f.schema)
+		meta := map[string]any{
+			"orm":        "efcore",
+			"binding":    "fluent",
+			"table_name": f.table,
+			"derivation": "override",
+		}
+		if f.schema != "" {
+			meta["schema"] = f.schema
+		}
+		if f.relation != "" {
+			meta["relation"] = f.relation
+		}
+		if es := edgesByFrom[cls.ID]; len(es) > 0 {
+			e := es[0]
+			if e.To == tableID {
+				continue
+			}
+			csharpEFEnsureTableNode(g, tableID, f.table, f.schema, f.filePath)
+			oldTo := e.To
+			e.To = tableID
+			e.Origin = graph.OriginASTInferred
+			e.Confidence = ConfidenceTyped
+			e.ConfidenceLabel = graph.ConfidenceLabelFor(graph.EdgeModelsTable, ConfidenceTyped)
+			e.Meta = meta
+			StampSynthesizedTyped(e, SynthCSharpEFCoreModels)
+			reindex = append(reindex, graph.EdgeReindex{Edge: e, OldTo: oldTo})
+			resolved++
+			continue
+		}
+		if mapped[cls.ID] {
+			continue
+		}
+		mapped[cls.ID] = true
+		csharpEFEnsureTableNode(g, tableID, f.table, f.schema, f.filePath)
+		e := &graph.Edge{
+			From: cls.ID, To: tableID, Kind: graph.EdgeModelsTable,
+			FilePath:        f.filePath,
+			Line:            f.line,
+			Origin:          graph.OriginASTInferred,
+			Confidence:      ConfidenceTyped,
+			ConfidenceLabel: graph.ConfidenceLabelFor(graph.EdgeModelsTable, ConfidenceTyped),
+			Meta:            meta,
+		}
+		StampSynthesizedTyped(e, SynthCSharpEFCoreModels)
+		g.AddEdge(e)
+		resolved++
+	}
+	if len(reindex) > 0 {
+		g.ReindexEdges(reindex)
+	}
+
 	for _, f := range dbsets {
 		cands := sameBoundaryCandidates(g, f.siteID, classesByName[f.entity])
 		if len(cands) != 1 {
@@ -67,21 +155,8 @@ func ResolveCSharpEFCoreModels(g graph.Store) int {
 			continue
 		}
 		mapped[cls.ID] = true
-		tableID := "db::orm::" + f.table
-		if g.GetNode(tableID) == nil {
-			g.AddNode(&graph.Node{
-				ID:       tableID,
-				Kind:     graph.KindTable,
-				Name:     f.table,
-				FilePath: f.filePath,
-				Language: "csharp",
-				Meta: map[string]any{
-					"dialect": "orm",
-					"schema":  "",
-					"source":  "csharp-orm",
-				},
-			})
-		}
+		tableID := csharpEFTableNodeID(f.table, "")
+		csharpEFEnsureTableNode(g, tableID, f.table, "", f.filePath)
 		e := &graph.Edge{
 			From: cls.ID, To: tableID, Kind: graph.EdgeModelsTable,
 			FilePath:        f.filePath,
@@ -101,6 +176,135 @@ func ResolveCSharpEFCoreModels(g graph.Store) int {
 		resolved++
 	}
 	return resolved
+}
+
+// csharpEFFluentFact is one fluent table naming: from a config class
+// (inline=false) or an OnModelCreating entry (inline=true).
+type csharpEFFluentFact struct {
+	entity   string
+	table    string
+	schema   string
+	relation string
+	inline   bool
+	siteID   string
+	filePath string
+	line     int
+}
+
+// csharpEFMergeFluentFacts reduces the fluent facts to at most one per
+// entity name: inline OnModelCreating entries beat config classes, and
+// two same-tier facts that disagree on the mapping drop the entity —
+// refusing beats guessing.
+func csharpEFMergeFluentFacts(fluents []csharpEFFluentFact) []csharpEFFluentFact {
+	merged := map[string]csharpEFFluentFact{}
+	dropped := map[string]bool{}
+	var order []string
+	for _, f := range fluents {
+		cur, ok := merged[f.entity]
+		if !ok {
+			merged[f.entity] = f
+			order = append(order, f.entity)
+			continue
+		}
+		if f.inline != cur.inline {
+			if f.inline {
+				merged[f.entity] = f
+			}
+			continue
+		}
+		if f.table != cur.table || f.schema != cur.schema || f.relation != cur.relation {
+			dropped[f.entity] = true
+		}
+	}
+	var out []csharpEFFluentFact
+	for _, name := range order {
+		if !dropped[name] {
+			out = append(out, merged[name])
+		}
+	}
+	return out
+}
+
+// csharpEFConfigFactFromNode reads the ef_config_* stamps off an
+// IEntityTypeConfiguration<T> class node. A config class without a
+// literal ToTable/ToView carries no table fact.
+func csharpEFConfigFactFromNode(n *graph.Node) (csharpEFFluentFact, bool) {
+	if n.Meta == nil {
+		return csharpEFFluentFact{}, false
+	}
+	entity, _ := n.Meta["ef_config_entity"].(string)
+	table, _ := n.Meta["ef_config_table"].(string)
+	if entity == "" || table == "" {
+		return csharpEFFluentFact{}, false
+	}
+	schema, _ := n.Meta["ef_config_schema"].(string)
+	relation, _ := n.Meta["ef_config_relation"].(string)
+	return csharpEFFluentFact{
+		entity: entity, table: table, schema: schema, relation: relation,
+		siteID: n.ID, filePath: n.FilePath, line: n.StartLine,
+	}, true
+}
+
+// csharpEFInlineFactsFromFile parses the ef_fluent
+// "entity|table|schema|relation" entries off a file node. Meta lists
+// round-trip through persistence as []any, so both shapes decode.
+func csharpEFInlineFactsFromFile(n *graph.Node) []csharpEFFluentFact {
+	if n.Meta == nil {
+		return nil
+	}
+	var entries []string
+	switch v := n.Meta["ef_fluent"].(type) {
+	case []string:
+		entries = v
+	case []any:
+		for _, x := range v {
+			if s, ok := x.(string); ok {
+				entries = append(entries, s)
+			}
+		}
+	}
+	var out []csharpEFFluentFact
+	for _, entry := range entries {
+		parts := strings.SplitN(entry, "|", 4)
+		if len(parts) != 4 || parts[0] == "" || parts[1] == "" {
+			continue
+		}
+		out = append(out, csharpEFFluentFact{
+			entity: parts[0], table: parts[1], schema: parts[2], relation: parts[3],
+			inline: true,
+			siteID: n.ID, filePath: n.FilePath, line: 1,
+		})
+	}
+	return out
+}
+
+// csharpEFTableNodeID mirrors the db::<dialect>::<schema>.<table>
+// convention the other ORM passes share.
+func csharpEFTableNodeID(table, schema string) string {
+	if schema != "" {
+		return "db::orm::" + schema + "." + table
+	}
+	return "db::orm::" + table
+}
+
+// csharpEFEnsureTableNode mints the KindTable node when the store does
+// not already hold it.
+func csharpEFEnsureTableNode(g graph.Store, tableID, table, schema, filePath string) {
+	if g.GetNode(tableID) != nil {
+		return
+	}
+	g.AddNode(&graph.Node{
+		ID:       tableID,
+		Kind:     graph.KindTable,
+		Name:     table,
+		FilePath: filePath,
+		Language: "csharp",
+		Meta: map[string]any{
+			"dialect": "orm",
+			"schema":  schema,
+			"source":  "csharp-orm",
+		},
+	})
 }
 
 // csharpDbSetFact is one DbSet<T> property: the entity it names, the

--- a/internal/resolver/csharp_efcore_models.go
+++ b/internal/resolver/csharp_efcore_models.go
@@ -1,0 +1,154 @@
+package resolver
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// ResolveCSharpEFCoreModels joins the EF Core mapping facts the C#
+// extractor stamps into models_table edges. The extractor decides only
+// the in-file form — a [Table] attribute on the entity itself; the two
+// cross-file forms land here:
+//
+//   - DbSet<T> convention: EF names the table after the DbSet PROPERTY
+//     (verbatim — not a pluralization of the class name), and the
+//     property lives on the DbContext, not the entity.
+//
+// Facts join to entity classes by unique class name within the same
+// boundary — an ambiguous name (two classes called Widget) skips
+// rather than guesses. An entity that already carries a models_table
+// edge (attribute-bound at extraction, or a previous run of this
+// pass) is left alone, which is also what makes the pass idempotent.
+//
+// Returns the number of edges synthesized.
+func ResolveCSharpEFCoreModels(g graph.Store) int {
+	if g == nil {
+		return 0
+	}
+	classesByName := map[string][]*graph.Node{}
+	var dbsets []csharpDbSetFact
+	for _, n := range nodesByKindsOrAll(g, graph.KindType, graph.KindField) {
+		if n == nil || !strings.EqualFold(n.Language, "csharp") {
+			continue
+		}
+		switch n.Kind {
+		case graph.KindType:
+			classesByName[n.Name] = append(classesByName[n.Name], n)
+		case graph.KindField:
+			if f, ok := csharpDbSetFactFromNode(n); ok {
+				dbsets = append(dbsets, f)
+			}
+		}
+	}
+	if len(dbsets) == 0 {
+		return 0
+	}
+
+	// Entities that already model a table keep their edge: the
+	// attribute binding was decided at extraction with the entity's own
+	// file as evidence, and a prior run of this pass already landed.
+	mapped := map[string]bool{}
+	for e := range g.EdgesByKind(graph.EdgeModelsTable) {
+		if e != nil {
+			mapped[e.From] = true
+		}
+	}
+
+	resolved := 0
+	for _, f := range dbsets {
+		cands := sameBoundaryCandidates(g, f.siteID, classesByName[f.entity])
+		if len(cands) != 1 {
+			continue
+		}
+		cls := cands[0]
+		if mapped[cls.ID] {
+			continue
+		}
+		mapped[cls.ID] = true
+		tableID := "db::orm::" + f.table
+		if g.GetNode(tableID) == nil {
+			g.AddNode(&graph.Node{
+				ID:       tableID,
+				Kind:     graph.KindTable,
+				Name:     f.table,
+				FilePath: f.filePath,
+				Language: "csharp",
+				Meta: map[string]any{
+					"dialect": "orm",
+					"schema":  "",
+					"source":  "csharp-orm",
+				},
+			})
+		}
+		e := &graph.Edge{
+			From: cls.ID, To: tableID, Kind: graph.EdgeModelsTable,
+			FilePath:        f.filePath,
+			Line:            f.line,
+			Origin:          graph.OriginASTInferred,
+			Confidence:      ConfidenceTyped,
+			ConfidenceLabel: graph.ConfidenceLabelFor(graph.EdgeModelsTable, ConfidenceTyped),
+			Meta: map[string]any{
+				"orm":        "efcore",
+				"binding":    "dbset",
+				"table_name": f.table,
+				"derivation": "convention",
+			},
+		}
+		StampSynthesizedTyped(e, SynthCSharpEFCoreModels)
+		g.AddEdge(e)
+		resolved++
+	}
+	return resolved
+}
+
+// csharpDbSetFact is one DbSet<T> property: the entity it names, the
+// table EF derives (the property name, verbatim), and the property's
+// site as edge evidence.
+type csharpDbSetFact struct {
+	entity   string
+	table    string
+	siteID   string
+	filePath string
+	line     int
+}
+
+// csharpDbSetType matches a (possibly qualified) DbSet<T> property
+// type and captures T.
+var csharpDbSetType = regexp.MustCompile(`^(?:[A-Za-z_][\w.]*\.)?DbSet<(.+)>\??$`)
+
+// csharpDbSetFactFromNode recognises a C# property node whose type is
+// DbSet<T>. A nested-generic argument (DbSet<Pair<A,B>>) is not an
+// entity registration and returns no fact.
+func csharpDbSetFactFromNode(n *graph.Node) (csharpDbSetFact, bool) {
+	if n.Meta == nil {
+		return csharpDbSetFact{}, false
+	}
+	if k, _ := n.Meta["kind"].(string); k != "property" {
+		return csharpDbSetFact{}, false
+	}
+	ft, _ := n.Meta["field_type"].(string)
+	m := csharpDbSetType.FindStringSubmatch(strings.TrimSpace(ft))
+	if len(m) < 2 {
+		return csharpDbSetFact{}, false
+	}
+	entity := strings.TrimSpace(m[1])
+	if strings.ContainsAny(entity, "<>,") {
+		return csharpDbSetFact{}, false
+	}
+	if i := strings.LastIndexByte(entity, '.'); i >= 0 {
+		entity = entity[i+1:]
+	}
+	entity = strings.TrimPrefix(entity, "@")
+	if entity == "" || n.Name == "" {
+		return csharpDbSetFact{}, false
+	}
+	return csharpDbSetFact{
+		entity:   entity,
+		table:    n.Name,
+		siteID:   n.ID,
+		filePath: n.FilePath,
+		line:     n.StartLine,
+	}, true
+}

--- a/internal/resolver/csharp_efcore_models.go
+++ b/internal/resolver/csharp_efcore_models.go
@@ -739,12 +739,6 @@ func csharpEFActionsFromFile(n *graph.Node) []csharpEFAction {
 	return out
 }
 
-// csharpEFInlineFactsFromFile is retained as the narrow decoder entry point
-// used by focused tests; actions now include mapping and activation sites.
-func csharpEFInlineFactsFromFile(n *graph.Node) []csharpEFAction {
-	return csharpEFActionsFromFile(n)
-}
-
 func csharpEFLegacyAction(n *graph.Node, entry string, ordinal int) (csharpEFAction, bool) {
 	parts := strings.SplitN(entry, "|", 5)
 	if len(parts) != 5 || parts[0] == "" || parts[1] == "" {

--- a/internal/resolver/csharp_efcore_models.go
+++ b/internal/resolver/csharp_efcore_models.go
@@ -115,7 +115,7 @@ func ResolveCSharpEFCoreModels(g graph.Store) int {
 			continue
 		}
 		cls := cands[0]
-		tableID := csharpEFTableNodeID(f.table, f.schema)
+		tableID := csharpEFTableNodeID(cls.RepoPrefix, f.table, f.schema)
 		meta := map[string]any{
 			"orm":        "efcore",
 			"binding":    "fluent",
@@ -140,7 +140,7 @@ func ResolveCSharpEFCoreModels(g graph.Store) int {
 			if e.To == tableID {
 				continue
 			}
-			csharpEFEnsureTableNode(g, tableID, f.table, f.schema, f.filePath)
+			csharpEFEnsureTableNode(g, tableID, f.table, f.schema, f.filePath, cls.RepoPrefix)
 			oldTo := e.To
 			e.To = tableID
 			e.Origin = graph.OriginASTInferred
@@ -156,7 +156,7 @@ func ResolveCSharpEFCoreModels(g graph.Store) int {
 			continue
 		}
 		mapped[cls.ID] = true
-		csharpEFEnsureTableNode(g, tableID, f.table, f.schema, f.filePath)
+		csharpEFEnsureTableNode(g, tableID, f.table, f.schema, f.filePath, cls.RepoPrefix)
 		e := &graph.Edge{
 			From: cls.ID, To: tableID, Kind: graph.EdgeModelsTable,
 			FilePath:        f.filePath,
@@ -184,8 +184,8 @@ func ResolveCSharpEFCoreModels(g graph.Store) int {
 			continue
 		}
 		mapped[cls.ID] = true
-		tableID := csharpEFTableNodeID(f.table, "")
-		csharpEFEnsureTableNode(g, tableID, f.table, "", f.filePath)
+		tableID := csharpEFTableNodeID(cls.RepoPrefix, f.table, "")
+		csharpEFEnsureTableNode(g, tableID, f.table, "", f.filePath, cls.RepoPrefix)
 		e := &graph.Edge{
 			From: cls.ID, To: tableID, Kind: graph.EdgeModelsTable,
 			FilePath:        f.filePath,
@@ -327,26 +327,36 @@ func csharpEFInlineFactsFromFile(n *graph.Node) []csharpEFFluentFact {
 }
 
 // csharpEFTableNodeID mirrors the db::<dialect>::<schema>.<table>
-// convention the other ORM passes share.
-func csharpEFTableNodeID(table, schema string) string {
+// convention the other ORM passes share. In a workspace store, ingest
+// prefixes every extraction ID with the repo — the extractor-minted
+// db::orm:: nodes included — so resolver-minted IDs carry the joined
+// entity's RepoPrefix to keep one logical table one identity
+// regardless of which binding path named it. RepoPrefix is empty in a
+// single-repo store and the ID stays bare, same as extraction.
+func csharpEFTableNodeID(repoPrefix, table, schema string) string {
+	id := "db::orm::" + table
 	if schema != "" {
-		return "db::orm::" + schema + "." + table
+		id = "db::orm::" + schema + "." + table
 	}
-	return "db::orm::" + table
+	if repoPrefix != "" {
+		id = repoPrefix + "/" + id
+	}
+	return id
 }
 
 // csharpEFEnsureTableNode mints the KindTable node when the store does
 // not already hold it.
-func csharpEFEnsureTableNode(g graph.Store, tableID, table, schema, filePath string) {
+func csharpEFEnsureTableNode(g graph.Store, tableID, table, schema, filePath, repoPrefix string) {
 	if g.GetNode(tableID) != nil {
 		return
 	}
 	g.AddNode(&graph.Node{
-		ID:       tableID,
-		Kind:     graph.KindTable,
-		Name:     table,
-		FilePath: filePath,
-		Language: "csharp",
+		ID:         tableID,
+		Kind:       graph.KindTable,
+		Name:       table,
+		FilePath:   filePath,
+		Language:   "csharp",
+		RepoPrefix: repoPrefix,
 		Meta: map[string]any{
 			"dialect": "orm",
 			"schema":  schema,

--- a/internal/resolver/csharp_efcore_models.go
+++ b/internal/resolver/csharp_efcore_models.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -9,59 +10,51 @@ import (
 	"github.com/zzet/gortex/internal/graph"
 )
 
-// ResolveCSharpEFCoreModels joins the EF Core mapping facts the C#
-// extractor stamps into models_table edges. The extractor decides only
-// the in-file form — a [Table] attribute on the entity itself; the two
-// cross-file forms land here:
-//
-//   - DbSet<T> convention: EF names the table after the DbSet PROPERTY
-//     (verbatim — not a pluralization of the class name), and the
-//     property lives on the DbContext, not the entity.
-//
-//   - Fluent configuration: an IEntityTypeConfiguration<T> class's
-//     ToTable/ToView (stamped as ef_config_* class meta) or an
-//     OnModelCreating Entity<T>() chain (stamped as ef_fluent file
-//     meta) names the table from yet another file.
-//
-// Precedence is fluent > attribute > dbset: a fluent fact REWIRES an
-// existing attribute edge in place (go_orm's override model) rather
-// than adding a second edge, and an entity a fluent fact claimed never
-// falls through to the DbSet convention. Within the fluent tier an
-// inline OnModelCreating entry beats a config class (EF applies
-// OnModelCreating statements after ApplyConfiguration); two facts in
-// the WINNING tier that disagree drop the entity entirely.
-//
-// Facts join to entity classes by unique class name within the same
-// boundary — an ambiguous name (two classes called Widget) skips
-// rather than guesses. An entity that already carries a models_table
-// edge at its final target is left alone, which is also what makes
-// the pass idempotent.
-//
-// Scoped (incremental) invocations run through frameworkScopedStore
-// with no bespoke scopedFn: the pass only sees nodes in the changed
-// frontier, so a cross-file join whose other half did not change joins
-// nothing — fail-open, never wrong. The one transient window: a fluent
-// fact whose file is out of scope cannot shadow the DbSet convention,
-// so an incremental run may land the convention name until the next
-// full settle rewires it. Full resolves see everything.
-//
-// Returns the number of edges synthesized or rewired.
+const (
+	csharpEFActionMapping            = "mapping"
+	csharpEFActionApplyConfiguration = "apply_configuration"
+	csharpEFActionApplyAssembly      = "apply_assembly"
+)
+
+type csharpEFDecisionState uint8
+
+const (
+	csharpEFUnclaimed csharpEFDecisionState = iota
+	csharpEFWinner
+	csharpEFRejected
+)
+
+// ResolveCSharpEFCoreModels is the full/cold entry point. Incremental callers
+// use ResolveCSharpEFCoreModelsScoped so a configuration-only edit reconciles
+// the complete projection for every entity in the changed repository.
 func ResolveCSharpEFCoreModels(g graph.Store) int {
+	return ResolveCSharpEFCoreModelsScoped(g, nil)
+}
+
+// ResolveCSharpEFCoreModelsScoped joins ordered EF Core OnModelCreating actions
+// with configuration definitions, entity attributes, and DbSet conventions.
+// A non-nil scope is repository-bounded but still reads every current
+// models_table sibling for each affected entity, enabling deletion, reversion,
+// and duplicate coalescing.
+func ResolveCSharpEFCoreModelsScoped(g graph.Store, scope map[string]bool) int {
 	if g == nil {
 		return 0
 	}
-	classesByName := map[string][]*graph.Node{}
+
+	nodes := csharpEFNodesForScope(g, scope)
+	classesByKey := map[string][]*graph.Node{}
+	configsByKey := map[string][]csharpEFConfigFact{}
+	configsByBoundary := map[string][]csharpEFConfigFact{}
+	entitiesByID := map[string]*graph.Node{}
+	var actions []csharpEFAction
 	var dbsets []csharpDbSetFact
-	var fluents []csharpEFFluentFact
-	for _, n := range nodesByKindsOrAll(g, graph.KindType, graph.KindField, graph.KindFile) {
+
+	for _, n := range nodes {
 		if n == nil {
 			continue
 		}
-		// File nodes skip the language gate deliberately: they carry no
-		// Language, and only the C# extractor mints ef_fluent — key
-		// presence is the filter.
 		if n.Kind == graph.KindFile {
-			fluents = append(fluents, csharpEFInlineFactsFromFile(n)...)
+			actions = append(actions, csharpEFActionsFromFile(n)...)
 			continue
 		}
 		if !strings.EqualFold(n.Language, "csharp") {
@@ -69,270 +62,738 @@ func ResolveCSharpEFCoreModels(g graph.Store) int {
 		}
 		switch n.Kind {
 		case graph.KindType:
-			classesByName[n.Name] = append(classesByName[n.Name], n)
-			if f, ok := csharpEFConfigFactFromNode(n); ok {
-				fluents = append(fluents, f)
+			entitiesByID[n.ID] = n
+			nameKey := csharpEFNameKey(n.RepoPrefix, n.WorkspaceID, n.Name)
+			classesByKey[nameKey] = append(classesByKey[nameKey], n)
+			if cfg, ok := csharpEFConfigFactFromNode(n); ok {
+				key := csharpEFNameKey(cfg.repoPrefix, cfg.workspaceID, cfg.name)
+				configsByKey[key] = append(configsByKey[key], cfg)
+				boundary := csharpEFBoundaryKey(cfg.repoPrefix, cfg.workspaceID)
+				configsByBoundary[boundary] = append(configsByBoundary[boundary], cfg)
 			}
 		case graph.KindField:
-			if f, ok := csharpDbSetFactFromNode(n); ok {
-				dbsets = append(dbsets, f)
+			if fact, ok := csharpDbSetFactFromNode(n); ok {
+				dbsets = append(dbsets, fact)
 			}
 		}
 	}
-	if len(dbsets) == 0 && len(fluents) == 0 {
+
+	for key := range configsByKey {
+		sort.Slice(configsByKey[key], func(i, j int) bool {
+			return configsByKey[key][i].siteID < configsByKey[key][j].siteID
+		})
+	}
+	for key := range configsByBoundary {
+		sort.Slice(configsByBoundary[key], func(i, j int) bool {
+			return configsByBoundary[key][i].siteID < configsByBoundary[key][j].siteID
+		})
+	}
+
+	decisions := csharpEFReduceActions(actions, classesByKey, configsByKey, configsByBoundary)
+	dbsetsByEntity := csharpEFResolveDbSets(dbsets, classesByKey)
+
+	entityIDs := make([]string, 0, len(entitiesByID))
+	for id := range entitiesByID {
+		entityIDs = append(entityIDs, id)
+	}
+	sort.Strings(entityIDs)
+	outgoing := g.GetOutEdgesByNodeIDs(entityIDs)
+	currentByEntity := map[string][]*graph.Edge{}
+	affected := map[string]bool{}
+	for _, id := range entityIDs {
+		entity := entitiesByID[id]
+		if _, ok := csharpEFAttributeMapping(entity); ok {
+			affected[id] = true
+		}
+		for _, edge := range outgoing[id] {
+			if csharpEFOwnsModelsTableEdge(edge) {
+				currentByEntity[id] = append(currentByEntity[id], edge)
+				affected[id] = true
+			}
+		}
+	}
+	for id := range decisions {
+		affected[id] = true
+	}
+	for id := range dbsetsByEntity {
+		affected[id] = true
+	}
+
+	var removeEdges []*graph.Edge
+	addEdges := map[graph.EdgeIdentity]*graph.Edge{}
+	addNodes := map[string]*graph.Node{}
+	changed := 0
+	orderedAffected := make([]string, 0, len(affected))
+	for id := range affected {
+		orderedAffected = append(orderedAffected, id)
+	}
+	sort.Strings(orderedAffected)
+
+	for _, entityID := range orderedAffected {
+		entity := entitiesByID[entityID]
+		if entity == nil {
+			continue
+		}
+		current := currentByEntity[entityID]
+		sort.Slice(current, func(i, j int) bool {
+			return csharpEFEdgeOrderKey(current[i]) < csharpEFEdgeOrderKey(current[j])
+		})
+		desired := csharpEFDesiredProjection(entity, decisions[entityID], dbsetsByEntity[entityID], current)
+		if len(current) == 1 && desired != nil && csharpEFEdgesEqual(current[0], desired) {
+			continue
+		}
+		if len(current) == 0 && desired == nil {
+			continue
+		}
+		removeEdges = append(removeEdges, current...)
+		if desired != nil {
+			addEdges[graph.EdgeIdentityFor(desired)] = desired
+			if g.GetNode(desired.To) == nil {
+				if table := csharpEFTableNodeForEdge(entity, desired); table != nil {
+					addNodes[table.ID] = table
+				}
+			}
+		}
+		changed++
+	}
+
+	if changed == 0 {
 		return 0
 	}
-	// Node scans are map-ordered; sort every fact list before first-wins
-	// logic so edge content and evidence sites are deterministic across
-	// runs (the mediatr/gin sibling idiom).
-	sort.Slice(dbsets, func(i, j int) bool {
-		if dbsets[i].entity != dbsets[j].entity {
-			return dbsets[i].entity < dbsets[j].entity
-		}
-		return dbsets[i].siteID < dbsets[j].siteID
+	nodeBatch := make([]*graph.Node, 0, len(addNodes))
+	for _, node := range addNodes {
+		nodeBatch = append(nodeBatch, node)
+	}
+	sort.Slice(nodeBatch, func(i, j int) bool { return nodeBatch[i].ID < nodeBatch[j].ID })
+	edgeBatch := make([]*graph.Edge, 0, len(addEdges))
+	for _, edge := range addEdges {
+		edgeBatch = append(edgeBatch, edge)
+	}
+	sort.Slice(edgeBatch, func(i, j int) bool {
+		return csharpEFEdgeOrderKey(edgeBatch[i]) < csharpEFEdgeOrderKey(edgeBatch[j])
 	})
 
-	// Entities that already model a table: the attribute binding was
-	// decided at extraction, and a prior run of this pass already
-	// landed. Fluent facts may rewire these; the DbSet leg never
-	// touches them.
-	mapped := map[string]bool{}
-	edgesByFrom := map[string][]*graph.Edge{}
-	for e := range g.EdgesByKind(graph.EdgeModelsTable) {
-		if e != nil {
-			mapped[e.From] = true
-			edgesByFrom[e.From] = append(edgesByFrom[e.From], e)
+	// Full framework runs wrap legacy functions in frameworkEdgeBatchStore.
+	// This resolver performs one replacement and has no staged AddEdge writes;
+	// unwrap the facade so Graph/SQLite retain exact, atomic replacement.
+	replacementStore := g
+	if batch, ok := g.(*frameworkEdgeBatchStore); ok {
+		batch.flush()
+		if batch.readCache != nil && len(nodeBatch) > 0 {
+			batch.readCache.invalidateNodes()
 		}
+		replacementStore = batch.Store
 	}
-
-	resolved := 0
-
-	// Fluent tier first, so its claims shadow the DbSet convention.
-	var reindex []graph.EdgeReindex
-	for _, f := range csharpEFMergeFluentFacts(fluents) {
-		cands := sameBoundaryCandidates(g, f.siteID, classesByName[f.entity])
-		if len(cands) != 1 {
-			continue
-		}
-		cls := cands[0]
-		tableID := csharpEFTableNodeID(cls.RepoPrefix, f.table, f.schema)
-		meta := map[string]any{
-			"orm":        "efcore",
-			"binding":    "fluent",
-			"table_name": f.table,
-			"derivation": "override",
-		}
-		if f.schema != "" {
-			meta["schema"] = f.schema
-		}
-		if f.relation != "" {
-			meta["relation"] = f.relation
-		}
-		if es := edgesByFrom[cls.ID]; len(es) > 0 {
-			// Rewire in place. The edge keeps its FilePath/Line (the
-			// entity's own file): the edge's From side is the model, and
-			// anchoring evidence there survives re-extraction of the
-			// fact file. The superseded attribute's table node is
-			// deliberately left behind even if nothing points at it any
-			// more — same call go_orm's override rewire makes; a table
-			// node is cheap and another entity may share it.
-			e := es[0]
-			if e.To == tableID {
-				continue
-			}
-			csharpEFEnsureTableNode(g, tableID, f.table, f.schema, f.filePath, cls.RepoPrefix)
-			oldTo := e.To
-			e.To = tableID
-			e.Origin = graph.OriginASTInferred
-			e.Confidence = ConfidenceTyped
-			e.ConfidenceLabel = graph.ConfidenceLabelFor(graph.EdgeModelsTable, ConfidenceTyped)
-			e.Meta = meta
-			StampSynthesizedTyped(e, SynthCSharpEFCoreModels)
-			reindex = append(reindex, graph.EdgeReindex{Edge: e, OldTo: oldTo})
-			resolved++
-			continue
-		}
-		if mapped[cls.ID] {
-			continue
-		}
-		mapped[cls.ID] = true
-		csharpEFEnsureTableNode(g, tableID, f.table, f.schema, f.filePath, cls.RepoPrefix)
-		e := &graph.Edge{
-			From: cls.ID, To: tableID, Kind: graph.EdgeModelsTable,
-			FilePath:        f.filePath,
-			Line:            f.line,
-			Origin:          graph.OriginASTInferred,
-			Confidence:      ConfidenceTyped,
-			ConfidenceLabel: graph.ConfidenceLabelFor(graph.EdgeModelsTable, ConfidenceTyped),
-			Meta:            meta,
-		}
-		StampSynthesizedTyped(e, SynthCSharpEFCoreModels)
-		g.AddEdge(e)
-		resolved++
+	_, err := graph.ReplaceDerivedContracts(replacementStore, graph.DerivedContractReplacement{
+		RemoveEdges: removeEdges,
+		Nodes:       nodeBatch,
+		Edges:       edgeBatch,
+	})
+	if err != nil {
+		return 0
 	}
-	if len(reindex) > 0 {
-		g.ReindexEdges(reindex)
-	}
-
-	for _, f := range dbsets {
-		cands := sameBoundaryCandidates(g, f.siteID, classesByName[f.entity])
-		if len(cands) != 1 {
-			continue
-		}
-		cls := cands[0]
-		if mapped[cls.ID] {
-			continue
-		}
-		mapped[cls.ID] = true
-		tableID := csharpEFTableNodeID(cls.RepoPrefix, f.table, "")
-		csharpEFEnsureTableNode(g, tableID, f.table, "", f.filePath, cls.RepoPrefix)
-		e := &graph.Edge{
-			From: cls.ID, To: tableID, Kind: graph.EdgeModelsTable,
-			FilePath:        f.filePath,
-			Line:            f.line,
-			Origin:          graph.OriginASTInferred,
-			Confidence:      ConfidenceTyped,
-			ConfidenceLabel: graph.ConfidenceLabelFor(graph.EdgeModelsTable, ConfidenceTyped),
-			Meta: map[string]any{
-				"orm":        "efcore",
-				"binding":    "dbset",
-				"table_name": f.table,
-				"derivation": "convention",
-			},
-		}
-		StampSynthesizedTyped(e, SynthCSharpEFCoreModels)
-		g.AddEdge(e)
-		resolved++
-	}
-	return resolved
+	return changed
 }
 
-// csharpEFFluentFact is one fluent table naming: from a config class
-// (inline=false) or an OnModelCreating entry (inline=true).
-type csharpEFFluentFact struct {
-	entity   string
-	table    string
-	schema   string
-	relation string
-	inline   bool
-	siteID   string
-	filePath string
-	line     int
-}
-
-// csharpEFMergeFluentFacts reduces the fluent facts to at most one per
-// entity name. Two-phase so the verdict never depends on arrival order
-// (facts come off a map-ordered node scan): the inline OnModelCreating
-// tier wins outright when present — a disagreement in the config tier
-// below it is irrelevant — and only the WINNING tier's facts are
-// checked for conflicts; two of those that disagree on the mapping
-// drop the entity, refusing over guessing. Agreeing duplicates keep
-// the lowest-siteID fact, so the retained evidence site is
-// deterministic too.
-func csharpEFMergeFluentFacts(fluents []csharpEFFluentFact) []csharpEFFluentFact {
-	byEntity := map[string][]csharpEFFluentFact{}
-	var order []string
-	for _, f := range fluents {
-		if _, ok := byEntity[f.entity]; !ok {
-			order = append(order, f.entity)
-		}
-		byEntity[f.entity] = append(byEntity[f.entity], f)
+func csharpEFNodesForScope(g graph.Store, scope map[string]bool) []*graph.Node {
+	if scope == nil {
+		return nodesByKindsOrAll(g, graph.KindType, graph.KindField, graph.KindFile)
 	}
-	sort.Strings(order)
-	var out []csharpEFFluentFact
-	for _, entity := range order {
-		facts := byEntity[entity]
-		// Winning tier: inline when any inline fact exists.
-		tier := facts[:0:0]
-		for _, f := range facts {
-			if f.inline {
-				tier = append(tier, f)
-			}
-		}
-		if len(tier) == 0 {
-			tier = facts
-		}
-		sort.Slice(tier, func(i, j int) bool { return tier[i].siteID < tier[j].siteID })
-		winner := tier[0]
-		conflict := false
-		for _, f := range tier[1:] {
-			if f.table != winner.table || f.schema != winner.schema || f.relation != winner.relation {
-				conflict = true
-				break
-			}
-		}
-		if !conflict {
-			out = append(out, winner)
+	prefixes := frameworkScopePrefixes(scope)
+	var out []*graph.Node
+	for node := range graph.NodesInScopeSeq(g, prefixes, nil, graph.KindType, graph.KindField, graph.KindFile) {
+		if node != nil {
+			out = append(out, node)
 		}
 	}
 	return out
 }
 
-// csharpEFConfigFactFromNode reads the ef_config_* stamps off an
-// IEntityTypeConfiguration<T> class node. A config class without a
-// literal ToTable/ToView carries no table fact.
-func csharpEFConfigFactFromNode(n *graph.Node) (csharpEFFluentFact, bool) {
-	if n.Meta == nil {
-		return csharpEFFluentFact{}, false
+type csharpEFMapping struct {
+	entity      string
+	table       string
+	schema      string
+	relation    string
+	context     string
+	siteID      string
+	filePath    string
+	line        int
+	repoPrefix  string
+	workspaceID string
+	sources     []string
+	contexts    []string
+}
+
+type csharpEFAction struct {
+	kind        string
+	context     string
+	config      string
+	ordinal     int
+	line        int
+	siteID      string
+	filePath    string
+	repoPrefix  string
+	workspaceID string
+	mapping     csharpEFMapping
+}
+
+type csharpEFConfigFact struct {
+	name        string
+	siteID      string
+	repoPrefix  string
+	workspaceID string
+	mapping     csharpEFMapping
+}
+
+type csharpEFDecision struct {
+	state   csharpEFDecisionState
+	mapping csharpEFMapping
+}
+
+func csharpEFReduceActions(
+	actions []csharpEFAction,
+	classesByKey map[string][]*graph.Node,
+	configsByKey map[string][]csharpEFConfigFact,
+	configsByBoundary map[string][]csharpEFConfigFact,
+) map[string]csharpEFDecision {
+	byContext := map[string][]csharpEFAction{}
+	for _, action := range actions {
+		key := csharpEFBoundaryKey(action.repoPrefix, action.workspaceID) + "\x00" + action.context
+		byContext[key] = append(byContext[key], action)
+	}
+	contextKeys := make([]string, 0, len(byContext))
+	for key := range byContext {
+		contextKeys = append(contextKeys, key)
+	}
+	sort.Strings(contextKeys)
+
+	perEntity := map[string][]csharpEFDecision{}
+	for _, contextKey := range contextKeys {
+		stream := byContext[contextKey]
+		sort.SliceStable(stream, func(i, j int) bool {
+			if stream[i].ordinal != stream[j].ordinal {
+				return stream[i].ordinal < stream[j].ordinal
+			}
+			if stream[i].line != stream[j].line {
+				return stream[i].line < stream[j].line
+			}
+			return stream[i].kind < stream[j].kind
+		})
+		current := map[string]csharpEFDecision{}
+		for _, action := range stream {
+			switch action.kind {
+			case csharpEFActionMapping:
+				if id, mapping, ok := csharpEFResolveMapping(action.mapping, classesByKey); ok {
+					current[id] = csharpEFDecision{state: csharpEFWinner, mapping: mapping}
+				}
+			case csharpEFActionApplyConfiguration:
+				key := csharpEFNameKey(action.repoPrefix, action.workspaceID, action.config)
+				configs := configsByKey[key]
+				if len(configs) != 1 {
+					continue
+				}
+				mapping := csharpEFActivateConfig(configs[0], action)
+				if id, resolved, ok := csharpEFResolveMapping(mapping, classesByKey); ok {
+					current[id] = csharpEFDecision{state: csharpEFWinner, mapping: resolved}
+				}
+			case csharpEFActionApplyAssembly:
+				boundary := csharpEFBoundaryKey(action.repoPrefix, action.workspaceID)
+				atEvent := map[string][]csharpEFMapping{}
+				for _, config := range configsByBoundary[boundary] {
+					mapping := csharpEFActivateConfig(config, action)
+					if id, resolved, ok := csharpEFResolveMapping(mapping, classesByKey); ok {
+						atEvent[id] = append(atEvent[id], resolved)
+					}
+				}
+				for entityID, mappings := range atEvent {
+					current[entityID] = csharpEFMergeMappings(mappings)
+				}
+			}
+		}
+		for entityID, decision := range current {
+			perEntity[entityID] = append(perEntity[entityID], decision)
+		}
+	}
+
+	out := map[string]csharpEFDecision{}
+	for entityID, decisions := range perEntity {
+		if len(decisions) == 0 {
+			continue
+		}
+		merged := decisions[0]
+		for _, decision := range decisions[1:] {
+			if merged.state == csharpEFRejected || decision.state == csharpEFRejected ||
+				!csharpEFMappingEqual(merged.mapping, decision.mapping) {
+				merged = csharpEFDecision{state: csharpEFRejected}
+				continue
+			}
+			merged.mapping = csharpEFCombineMappingEvidence(merged.mapping, decision.mapping)
+		}
+		out[entityID] = merged
+	}
+	return out
+}
+
+func csharpEFMergeMappings(mappings []csharpEFMapping) csharpEFDecision {
+	if len(mappings) == 0 {
+		return csharpEFDecision{state: csharpEFUnclaimed}
+	}
+	sort.Slice(mappings, func(i, j int) bool {
+		return csharpEFMappingEvidenceKey(mappings[i]) < csharpEFMappingEvidenceKey(mappings[j])
+	})
+	winner := mappings[0]
+	for _, mapping := range mappings[1:] {
+		if !csharpEFMappingEqual(winner, mapping) {
+			return csharpEFDecision{state: csharpEFRejected}
+		}
+		winner = csharpEFCombineMappingEvidence(winner, mapping)
+	}
+	return csharpEFDecision{state: csharpEFWinner, mapping: winner}
+}
+
+func csharpEFResolveMapping(
+	mapping csharpEFMapping,
+	classesByKey map[string][]*graph.Node,
+) (string, csharpEFMapping, bool) {
+	key := csharpEFNameKey(mapping.repoPrefix, mapping.workspaceID, mapping.entity)
+	candidates := classesByKey[key]
+	if len(candidates) != 1 {
+		return "", csharpEFMapping{}, false
+	}
+	entity := candidates[0]
+	mapping.entity = entity.Name
+	return entity.ID, mapping, true
+}
+
+func csharpEFActivateConfig(config csharpEFConfigFact, action csharpEFAction) csharpEFMapping {
+	mapping := config.mapping
+	mapping.context = action.context
+	mapping.contexts = []string{action.context}
+	mapping.siteID = action.siteID
+	mapping.filePath = action.filePath
+	mapping.line = action.line
+	mapping.repoPrefix = action.repoPrefix
+	mapping.workspaceID = action.workspaceID
+	mapping.sources = csharpEFUniqueStrings([]string{config.siteID, csharpEFActionSource(action)})
+	return mapping
+}
+
+func csharpEFResolveDbSets(
+	facts []csharpDbSetFact,
+	classesByKey map[string][]*graph.Node,
+) map[string][]csharpDbSetFact {
+	out := map[string][]csharpDbSetFact{}
+	sort.Slice(facts, func(i, j int) bool { return facts[i].siteID < facts[j].siteID })
+	for _, fact := range facts {
+		key := csharpEFNameKey(fact.repoPrefix, fact.workspaceID, fact.entity)
+		candidates := classesByKey[key]
+		if len(candidates) != 1 {
+			continue
+		}
+		out[candidates[0].ID] = append(out[candidates[0].ID], fact)
+	}
+	return out
+}
+
+func csharpEFDesiredProjection(
+	entity *graph.Node,
+	decision csharpEFDecision,
+	dbsets []csharpDbSetFact,
+	current []*graph.Edge,
+) *graph.Edge {
+	attribute, hasAttribute := csharpEFAttributeMapping(entity)
+	switch decision.state {
+	case csharpEFWinner:
+		return csharpEFProjectionEdge(entity, decision.mapping, "fluent", "override")
+	case csharpEFRejected:
+		// An activated same-boundary conflict claims the entity but has no
+		// defensible target. Drop the projection entirely; do not expose the
+		// lower-precedence attribute or DbSet as if it were the runtime winner.
+		return nil
+	default:
+		if hasAttribute {
+			return csharpEFAttributeEdge(entity, attribute, current)
+		}
+		mapping, ok := csharpEFDbSetMapping(dbsets)
+		if !ok {
+			return nil
+		}
+		return csharpEFProjectionEdge(entity, mapping, "dbset", "convention")
+	}
+}
+
+func csharpEFDbSetMapping(facts []csharpDbSetFact) (csharpEFMapping, bool) {
+	if len(facts) == 0 {
+		return csharpEFMapping{}, false
+	}
+	sort.Slice(facts, func(i, j int) bool { return facts[i].siteID < facts[j].siteID })
+	first := facts[0]
+	for _, fact := range facts[1:] {
+		if fact.table != first.table {
+			return csharpEFMapping{}, false
+		}
+	}
+	sources := make([]string, 0, len(facts))
+	for _, fact := range facts {
+		sources = append(sources, fact.siteID)
+	}
+	return csharpEFMapping{
+		entity: first.entity, table: first.table,
+		siteID: first.siteID, filePath: first.filePath, line: first.line,
+		repoPrefix: first.repoPrefix, workspaceID: first.workspaceID,
+		sources: csharpEFUniqueStrings(sources),
+	}, true
+}
+
+func csharpEFProjectionEdge(entity *graph.Node, mapping csharpEFMapping, binding, derivation string) *graph.Edge {
+	tableID := csharpEFTableNodeID(entity.RepoPrefix, mapping.table, mapping.schema)
+	meta := map[string]any{
+		"orm":        "efcore",
+		"binding":    binding,
+		"table_name": mapping.table,
+		"derivation": derivation,
+	}
+	if mapping.schema != "" {
+		meta["schema"] = mapping.schema
+	}
+	if mapping.relation != "" {
+		meta["relation"] = mapping.relation
+	}
+	if sources := csharpEFUniqueStrings(mapping.sources); len(sources) > 0 {
+		meta["ef_sources"] = strings.Join(sources, "\x1f")
+	}
+	if contexts := csharpEFUniqueStrings(mapping.contexts); len(contexts) > 0 {
+		meta["ef_contexts"] = strings.Join(contexts, "\x1f")
+	}
+	filePath := mapping.filePath
+	line := mapping.line
+	if filePath == "" {
+		filePath = entity.FilePath
+	}
+	if line < 1 {
+		line = entity.StartLine
+	}
+	edge := &graph.Edge{
+		From: entity.ID, To: tableID, Kind: graph.EdgeModelsTable,
+		FilePath:        filePath,
+		Line:            line,
+		Origin:          graph.OriginASTInferred,
+		Confidence:      ConfidenceTyped,
+		ConfidenceLabel: graph.ConfidenceLabelFor(graph.EdgeModelsTable, ConfidenceTyped),
+		Meta:            meta,
+	}
+	StampSynthesizedTyped(edge, SynthCSharpEFCoreModels)
+	return edge
+}
+
+func csharpEFAttributeMapping(entity *graph.Node) (csharpEFMapping, bool) {
+	if entity == nil || entity.Meta == nil {
+		return csharpEFMapping{}, false
+	}
+	table, _ := entity.Meta["ef_attribute_table"].(string)
+	if table == "" {
+		return csharpEFMapping{}, false
+	}
+	schema, _ := entity.Meta["ef_attribute_schema"].(string)
+	return csharpEFMapping{
+		entity: entity.Name, table: table, schema: schema,
+		siteID: entity.ID, filePath: entity.FilePath, line: entity.StartLine,
+		repoPrefix: entity.RepoPrefix, workspaceID: entity.WorkspaceID,
+	}, true
+}
+
+func csharpEFAttributeEdge(entity *graph.Node, mapping csharpEFMapping, current []*graph.Edge) *graph.Edge {
+	tableID := csharpEFTableNodeID(entity.RepoPrefix, mapping.table, mapping.schema)
+	for _, edge := range current {
+		if edge == nil || edge.To != tableID || edge.Meta == nil {
+			continue
+		}
+		binding, _ := edge.Meta["binding"].(string)
+		if binding == "attribute" {
+			return cloneFrameworkEdge(edge)
+		}
+	}
+	meta := map[string]any{
+		"orm":        "efcore",
+		"binding":    "attribute",
+		"table_name": mapping.table,
+		"derivation": "override",
+	}
+	if mapping.schema != "" {
+		meta["schema"] = mapping.schema
+	}
+	return &graph.Edge{
+		From: entity.ID, To: tableID, Kind: graph.EdgeModelsTable,
+		FilePath:        entity.FilePath,
+		Line:            entity.StartLine,
+		Origin:          graph.OriginASTInferred,
+		Confidence:      ConfidenceTyped,
+		ConfidenceLabel: graph.ConfidenceLabelFor(graph.EdgeModelsTable, ConfidenceTyped),
+		Meta:            meta,
+	}
+}
+
+func csharpEFTableNodeForEdge(entity *graph.Node, edge *graph.Edge) *graph.Node {
+	if entity == nil || edge == nil || edge.Meta == nil {
+		return nil
+	}
+	table, _ := edge.Meta["table_name"].(string)
+	if table == "" {
+		return nil
+	}
+	schema, _ := edge.Meta["schema"].(string)
+	return &graph.Node{
+		ID:          edge.To,
+		Kind:        graph.KindTable,
+		Name:        table,
+		FilePath:    edge.FilePath,
+		Language:    "csharp",
+		RepoPrefix:  entity.RepoPrefix,
+		WorkspaceID: entity.WorkspaceID,
+		Meta: map[string]any{
+			"dialect": "orm",
+			"schema":  schema,
+			"source":  "csharp-orm",
+		},
+	}
+}
+
+func csharpEFOwnsModelsTableEdge(edge *graph.Edge) bool {
+	if edge == nil || edge.Kind != graph.EdgeModelsTable || edge.Meta == nil {
+		return false
+	}
+	orm, _ := edge.Meta["orm"].(string)
+	synth, _ := edge.Meta[MetaSynthesizedBy].(string)
+	return orm == "efcore" || synth == SynthCSharpEFCoreModels
+}
+
+func csharpEFEdgesEqual(a, b *graph.Edge) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.From == b.From && a.To == b.To && a.Kind == b.Kind &&
+		a.FilePath == b.FilePath && a.Line == b.Line && a.Origin == b.Origin &&
+		a.Confidence == b.Confidence && a.ConfidenceLabel == b.ConfidenceLabel &&
+		reflect.DeepEqual(a.Meta, b.Meta)
+}
+
+func csharpEFMappingEqual(a, b csharpEFMapping) bool {
+	return a.table == b.table && a.schema == b.schema && a.relation == b.relation
+}
+
+func csharpEFCombineMappingEvidence(a, b csharpEFMapping) csharpEFMapping {
+	if csharpEFMappingEvidenceKey(b) < csharpEFMappingEvidenceKey(a) {
+		a, b = b, a
+	}
+	a.sources = csharpEFUniqueStrings(append(append([]string(nil), a.sources...), b.sources...))
+	a.contexts = csharpEFUniqueStrings(append(append([]string(nil), a.contexts...), b.contexts...))
+	return a
+}
+
+func csharpEFMappingEvidenceKey(mapping csharpEFMapping) string {
+	return mapping.filePath + "\x00" + strconv.Itoa(mapping.line) + "\x00" + mapping.siteID
+}
+
+func csharpEFEdgeOrderKey(edge *graph.Edge) string {
+	if edge == nil {
+		return ""
+	}
+	return edge.From + "\x00" + edge.To + "\x00" + string(edge.Kind) + "\x00" + edge.FilePath + "\x00" + strconv.Itoa(edge.Line)
+}
+
+func csharpEFBoundaryKey(repoPrefix, workspaceID string) string {
+	return repoPrefix + "\x00" + workspaceID
+}
+
+func csharpEFNameKey(repoPrefix, workspaceID, name string) string {
+	return csharpEFBoundaryKey(repoPrefix, workspaceID) + "\x00" + csharpEFBareName(name)
+}
+
+func csharpEFBareName(name string) string {
+	name = strings.TrimSpace(strings.TrimPrefix(name, "global::"))
+	if i := strings.LastIndexByte(name, '.'); i >= 0 {
+		name = name[i+1:]
+	}
+	return strings.TrimPrefix(name, "@")
+}
+
+func csharpEFUniqueStrings(values []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func csharpEFActionSource(action csharpEFAction) string {
+	return action.siteID + "#" + action.context + "#" + strconv.Itoa(action.ordinal)
+}
+
+func csharpEFConfigFactFromNode(n *graph.Node) (csharpEFConfigFact, bool) {
+	if n == nil || n.Meta == nil {
+		return csharpEFConfigFact{}, false
 	}
 	entity, _ := n.Meta["ef_config_entity"].(string)
 	table, _ := n.Meta["ef_config_table"].(string)
 	if entity == "" || table == "" {
-		return csharpEFFluentFact{}, false
+		return csharpEFConfigFact{}, false
 	}
 	schema, _ := n.Meta["ef_config_schema"].(string)
 	relation, _ := n.Meta["ef_config_relation"].(string)
-	return csharpEFFluentFact{
-		entity: entity, table: table, schema: schema, relation: relation,
+	mapping := csharpEFMapping{
+		entity: csharpEFBareName(entity), table: table, schema: schema, relation: relation,
 		siteID: n.ID, filePath: n.FilePath, line: n.StartLine,
+		repoPrefix: n.RepoPrefix, workspaceID: n.WorkspaceID,
+		sources: []string{n.ID},
+	}
+	return csharpEFConfigFact{
+		name: csharpEFBareName(n.Name), siteID: n.ID,
+		repoPrefix: n.RepoPrefix, workspaceID: n.WorkspaceID,
+		mapping: mapping,
 	}, true
 }
 
-// csharpEFInlineFactsFromFile parses the ef_fluent
-// "entity|table|schema|relation|line" entries off a file node. Meta
-// lists round-trip through persistence as []any, so both shapes
-// decode.
-func csharpEFInlineFactsFromFile(n *graph.Node) []csharpEFFluentFact {
-	if n.Meta == nil {
+func csharpEFActionsFromFile(n *graph.Node) []csharpEFAction {
+	if n == nil || n.Meta == nil {
 		return nil
 	}
-	var entries []string
-	switch v := n.Meta["ef_fluent"].(type) {
-	case []string:
-		entries = v
-	case []any:
-		for _, x := range v {
-			if s, ok := x.(string); ok {
-				entries = append(entries, s)
-			}
+	value := n.Meta["ef_fluent"]
+	var out []csharpEFAction
+	appendMap := func(index int, raw map[string]any) {
+		kind, _ := raw["kind"].(string)
+		kind = strings.ToLower(strings.TrimSpace(kind))
+		context, _ := raw["context"].(string)
+		if context == "" {
+			context = n.ID
 		}
-	}
-	var out []csharpEFFluentFact
-	for _, entry := range entries {
-		parts := strings.SplitN(entry, "|", 5)
-		if len(parts) != 5 || parts[0] == "" || parts[1] == "" {
-			continue
-		}
-		line, err := strconv.Atoi(parts[4])
-		if err != nil || line < 1 {
+		line, ok := csharpEFMetaInt(raw["line"])
+		if !ok || line < 1 {
 			line = 1
 		}
-		out = append(out, csharpEFFluentFact{
-			entity: parts[0], table: parts[1], schema: parts[2], relation: parts[3],
-			inline: true,
-			siteID: n.ID, filePath: n.FilePath, line: line,
-		})
+		ordinal, ok := csharpEFMetaInt(raw["ordinal"])
+		if !ok {
+			ordinal = index
+		}
+		action := csharpEFAction{
+			kind: kind, context: context, ordinal: ordinal, line: line,
+			siteID: n.ID, filePath: n.FilePath,
+			repoPrefix: n.RepoPrefix, workspaceID: n.WorkspaceID,
+		}
+		switch kind {
+		case csharpEFActionMapping:
+			action.mapping = csharpEFMapping{
+				entity:   csharpEFBareName(csharpEFString(raw["entity"])),
+				table:    csharpEFString(raw["table"]),
+				schema:   csharpEFString(raw["schema"]),
+				relation: csharpEFString(raw["relation"]),
+				context:  context, contexts: []string{context},
+				siteID: n.ID, filePath: n.FilePath, line: line,
+				repoPrefix: n.RepoPrefix, workspaceID: n.WorkspaceID,
+				sources: []string{csharpEFActionSource(action)},
+			}
+			if action.mapping.entity == "" || action.mapping.table == "" {
+				return
+			}
+		case csharpEFActionApplyConfiguration:
+			action.config = csharpEFBareName(csharpEFString(raw["config"]))
+			if action.config == "" {
+				return
+			}
+		case csharpEFActionApplyAssembly:
+		default:
+			return
+		}
+		out = append(out, action)
+	}
+
+	switch entries := value.(type) {
+	case []map[string]any:
+		for i, entry := range entries {
+			appendMap(i, entry)
+		}
+	case []any:
+		for i, entry := range entries {
+			if raw, ok := entry.(map[string]any); ok {
+				appendMap(i, raw)
+				continue
+			}
+			if legacy, ok := entry.(string); ok {
+				if action, ok := csharpEFLegacyAction(n, legacy, i); ok {
+					out = append(out, action)
+				}
+			}
+		}
+	case []string:
+		for i, entry := range entries {
+			if action, ok := csharpEFLegacyAction(n, entry, i); ok {
+				out = append(out, action)
+			}
+		}
 	}
 	return out
 }
 
-// csharpEFTableNodeID mirrors the db::<dialect>::<schema>.<table>
-// convention the other ORM passes share. In a workspace store, ingest
-// prefixes every extraction ID with the repo — the extractor-minted
-// db::orm:: nodes included — so resolver-minted IDs carry the joined
-// entity's RepoPrefix to keep one logical table one identity
-// regardless of which binding path named it. RepoPrefix is empty in a
-// single-repo store and the ID stays bare, same as extraction.
+// csharpEFInlineFactsFromFile is retained as the narrow decoder entry point
+// used by focused tests; actions now include mapping and activation sites.
+func csharpEFInlineFactsFromFile(n *graph.Node) []csharpEFAction {
+	return csharpEFActionsFromFile(n)
+}
+
+func csharpEFLegacyAction(n *graph.Node, entry string, ordinal int) (csharpEFAction, bool) {
+	parts := strings.SplitN(entry, "|", 5)
+	if len(parts) != 5 || parts[0] == "" || parts[1] == "" {
+		return csharpEFAction{}, false
+	}
+	line, err := strconv.Atoi(parts[4])
+	if err != nil || line < 1 {
+		line = 1
+	}
+	action := csharpEFAction{
+		kind: csharpEFActionMapping, context: n.ID, ordinal: ordinal, line: line,
+		siteID: n.ID, filePath: n.FilePath,
+		repoPrefix: n.RepoPrefix, workspaceID: n.WorkspaceID,
+	}
+	action.mapping = csharpEFMapping{
+		entity: csharpEFBareName(parts[0]), table: parts[1], schema: parts[2], relation: parts[3],
+		context: action.context, contexts: []string{action.context},
+		siteID: n.ID, filePath: n.FilePath, line: line,
+		repoPrefix: n.RepoPrefix, workspaceID: n.WorkspaceID,
+		sources: []string{csharpEFActionSource(action)},
+	}
+	return action, true
+}
+
+func csharpEFMetaInt(value any) (int, bool) {
+	switch v := value.(type) {
+	case int:
+		return v, true
+	case int32:
+		return int(v), true
+	case int64:
+		return int(v), true
+	case float32:
+		return int(v), true
+	case float64:
+		return int(v), true
+	case string:
+		n, err := strconv.Atoi(v)
+		return n, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func csharpEFString(value any) string {
+	text, _ := value.(string)
+	return strings.TrimSpace(text)
+}
+
 func csharpEFTableNodeID(repoPrefix, table, schema string) string {
 	id := "db::orm::" + table
 	if schema != "" {
@@ -344,73 +805,54 @@ func csharpEFTableNodeID(repoPrefix, table, schema string) string {
 	return id
 }
 
-// csharpEFEnsureTableNode mints the KindTable node when the store does
-// not already hold it.
+// csharpEFEnsureTableNode remains for sibling tests and callers that construct
+// one table eagerly; the reconciler itself batches table nodes atomically.
 func csharpEFEnsureTableNode(g graph.Store, tableID, table, schema, filePath, repoPrefix string) {
 	if g.GetNode(tableID) != nil {
 		return
 	}
 	g.AddNode(&graph.Node{
-		ID:         tableID,
-		Kind:       graph.KindTable,
-		Name:       table,
-		FilePath:   filePath,
-		Language:   "csharp",
-		RepoPrefix: repoPrefix,
-		Meta: map[string]any{
-			"dialect": "orm",
-			"schema":  schema,
-			"source":  "csharp-orm",
-		},
+		ID: tableID, Kind: graph.KindTable, Name: table,
+		FilePath: filePath, Language: "csharp", RepoPrefix: repoPrefix,
+		Meta: map[string]any{"dialect": "orm", "schema": schema, "source": "csharp-orm"},
 	})
 }
 
-// csharpDbSetFact is one DbSet<T> property: the entity it names, the
-// table EF derives (the property name, verbatim), and the property's
-// site as edge evidence.
 type csharpDbSetFact struct {
-	entity   string
-	table    string
-	siteID   string
-	filePath string
-	line     int
+	entity      string
+	table       string
+	siteID      string
+	filePath    string
+	line        int
+	repoPrefix  string
+	workspaceID string
 }
 
-// csharpDbSetType matches a (possibly qualified) DbSet<T> property
-// type and captures T.
 var csharpDbSetType = regexp.MustCompile(`^(?:[A-Za-z_][\w.]*\.)?DbSet<(.+)>\??$`)
 
-// csharpDbSetFactFromNode recognises a C# property node whose type is
-// DbSet<T>. A nested-generic argument (DbSet<Pair<A,B>>) is not an
-// entity registration and returns no fact.
 func csharpDbSetFactFromNode(n *graph.Node) (csharpDbSetFact, bool) {
-	if n.Meta == nil {
+	if n == nil || n.Meta == nil {
 		return csharpDbSetFact{}, false
 	}
-	if k, _ := n.Meta["kind"].(string); k != "property" {
+	if kind, _ := n.Meta["kind"].(string); kind != "property" {
 		return csharpDbSetFact{}, false
 	}
-	ft, _ := n.Meta["field_type"].(string)
-	m := csharpDbSetType.FindStringSubmatch(strings.TrimSpace(ft))
-	if len(m) < 2 {
+	fieldType, _ := n.Meta["field_type"].(string)
+	match := csharpDbSetType.FindStringSubmatch(strings.TrimSpace(fieldType))
+	if len(match) < 2 {
 		return csharpDbSetFact{}, false
 	}
-	entity := strings.TrimSpace(m[1])
+	entity := strings.TrimSpace(match[1])
 	if strings.ContainsAny(entity, "<>,") {
 		return csharpDbSetFact{}, false
 	}
-	if i := strings.LastIndexByte(entity, '.'); i >= 0 {
-		entity = entity[i+1:]
-	}
-	entity = strings.TrimPrefix(entity, "@")
+	entity = csharpEFBareName(entity)
 	if entity == "" || n.Name == "" {
 		return csharpDbSetFact{}, false
 	}
 	return csharpDbSetFact{
-		entity:   entity,
-		table:    n.Name,
-		siteID:   n.ID,
-		filePath: n.FilePath,
-		line:     n.StartLine,
+		entity: entity, table: n.Name,
+		siteID: n.ID, filePath: n.FilePath, line: n.StartLine,
+		repoPrefix: n.RepoPrefix, workspaceID: n.WorkspaceID,
 	}, true
 }

--- a/internal/resolver/csharp_efcore_models.go
+++ b/internal/resolver/csharp_efcore_models.go
@@ -35,6 +35,14 @@ import (
 // edge at its final target is left alone, which is also what makes
 // the pass idempotent.
 //
+// Scoped (incremental) invocations run through frameworkScopedStore
+// with no bespoke scopedFn: the pass only sees nodes in the changed
+// frontier, so a cross-file join whose other half did not change joins
+// nothing — fail-open, never wrong. The one transient window: a fluent
+// fact whose file is out of scope cannot shadow the DbSet convention,
+// so an incremental run may land the convention name until the next
+// full settle rewires it. Full resolves see everything.
+//
 // Returns the number of edges synthesized or rewired.
 func ResolveCSharpEFCoreModels(g graph.Store) int {
 	if g == nil {

--- a/internal/resolver/csharp_efcore_models_test.go
+++ b/internal/resolver/csharp_efcore_models_test.go
@@ -9,356 +9,326 @@ import (
 	"github.com/zzet/gortex/internal/graph"
 )
 
-// efModelsTableEdges collects every models_table edge in the store.
 func efModelsTableEdges(g graph.Store) []*graph.Edge {
 	var out []*graph.Edge
-	for e := range g.EdgesByKind(graph.EdgeModelsTable) {
-		if e != nil {
-			out = append(out, e)
+	for edge := range g.EdgesByKind(graph.EdgeModelsTable) {
+		if edge != nil {
+			out = append(out, edge)
 		}
 	}
 	return out
 }
 
-// TestResolveCSharpEFCoreModels_DbSetConventionBindsPropertyName pins
-// EF's actual convention: the table name is the DbSet PROPERTY name,
-// verbatim — not a pluralization of the entity class name.
-func TestResolveCSharpEFCoreModels_DbSetConventionBindsPropertyName(t *testing.T) {
-	g := buildCSharpResolverGraph(t, map[string]string{
-		"Domain/Widget.cs": `namespace App.Domain;
-
-public class Widget
-{
-    public int Id { get; set; }
-}
-`,
-		"Data/ProbeContext.cs": `using Microsoft.EntityFrameworkCore;
-
-namespace App.Data;
-
-public class ProbeContext : DbContext
-{
-    public DbSet<Widget> StockWidgets { get; set; }
-}
-`,
-	})
-	n := ResolveCSharpEFCoreModels(g)
-	assert.Equal(t, 1, n)
-
-	models := efModelsTableEdges(g)
-	require.Len(t, models, 1)
-	e := models[0]
-	assert.Equal(t, "Domain/Widget.cs::Widget", e.From)
-	assert.Equal(t, "db::orm::StockWidgets", e.To,
-		"table = DbSet property name verbatim, never a pluralized class name")
-	assert.Equal(t, "efcore", e.Meta["orm"])
-	assert.Equal(t, "dbset", e.Meta["binding"])
-	assert.Equal(t, "StockWidgets", e.Meta["table_name"])
-	assert.Equal(t, "convention", e.Meta["derivation"])
-
-	tableNode := g.GetNode("db::orm::StockWidgets")
-	require.NotNil(t, tableNode, "the KindTable node is minted with the edge")
-	assert.Equal(t, graph.KindTable, tableNode.Kind)
-	assert.Equal(t, "orm", tableNode.Meta["dialect"])
-	assert.Equal(t, "csharp-orm", tableNode.Meta["source"])
-
-	assert.Equal(t, 0, ResolveCSharpEFCoreModels(g), "second run is a no-op")
-	assert.Len(t, efModelsTableEdges(g), 1, "idempotent: no duplicate edges")
-}
-
-// TestResolveCSharpEFCoreModels_FluentConfigRewiresAttributeEdge: the
-// precedence is fluent > attribute — a config class's ToTable rewires
-// the extractor's attribute edge in place, go_orm's override model.
-func TestResolveCSharpEFCoreModels_FluentConfigRewiresAttributeEdge(t *testing.T) {
-	g := buildCSharpResolverGraph(t, map[string]string{
-		"Domain/Widget.cs": `using System.ComponentModel.DataAnnotations.Schema;
-
-namespace App.Domain;
-
-[Table("attr_widgets")]
-public class Widget
-{
-    public int Id { get; set; }
-}
-`,
-		"Config/WidgetConfig.cs": `using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata.Builders;
-
-namespace App.Config;
-
-public class WidgetConfig : IEntityTypeConfiguration<Widget>
-{
-    public void Configure(EntityTypeBuilder<Widget> builder)
-    {
-        builder.ToTable("fluent_widgets", "sales");
-    }
-}
-`,
-	})
-	n := ResolveCSharpEFCoreModels(g)
-	assert.Equal(t, 1, n, "the rewire counts as resolution work")
-
-	models := efModelsTableEdges(g)
-	require.Len(t, models, 1, "rewired in place — never a second edge")
-	e := models[0]
-	assert.Equal(t, "Domain/Widget.cs::Widget", e.From)
-	assert.Equal(t, "db::orm::sales.fluent_widgets", e.To)
-	assert.Equal(t, "fluent", e.Meta["binding"])
-	assert.Equal(t, "fluent_widgets", e.Meta["table_name"])
-	assert.Equal(t, "sales", e.Meta["schema"])
-	assert.Equal(t, "override", e.Meta["derivation"])
-	require.NotNil(t, g.GetNode("db::orm::sales.fluent_widgets"))
-
-	assert.Equal(t, 0, ResolveCSharpEFCoreModels(g), "second run is a no-op")
-	assert.Len(t, efModelsTableEdges(g), 1)
-}
-
-// TestResolveCSharpEFCoreModels_InlineFluentBeatsDbSet: an
-// OnModelCreating Entity<T>().ToTable wins over the DbSet property
-// convention for the same entity — one edge, fluent-bound; a ToView
-// carries relation=view.
-func TestResolveCSharpEFCoreModels_InlineFluentBeatsDbSet(t *testing.T) {
-	g := buildCSharpResolverGraph(t, map[string]string{
-		"Domain/Gadget.cs": `namespace App.Domain;
-
-public class Gadget
-{
-    public int Id { get; set; }
-}
-`,
-		"Domain/CrateTally.cs": `namespace App.Domain;
-
-public class CrateTally
-{
-    public int Total { get; set; }
-}
-`,
-		"Data/ProbeContext.cs": `using Microsoft.EntityFrameworkCore;
-
-namespace App.Data;
-
-public class ProbeContext : DbContext
-{
-    public DbSet<Gadget> Gadgets { get; set; }
-    public DbSet<CrateTally> Tallies { get; set; }
-
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        modelBuilder.Entity<Gadget>().ToTable("gadget_rows");
-        modelBuilder.Entity<CrateTally>().ToView("crate_tallies");
-    }
-}
-`,
-	})
-	n := ResolveCSharpEFCoreModels(g)
-	assert.Equal(t, 2, n)
-
-	byFrom := map[string]*graph.Edge{}
-	for _, e := range efModelsTableEdges(g) {
-		require.NotContains(t, byFrom, e.From, "one edge per entity")
-		byFrom[e.From] = e
+func efModelEdgesFrom(g graph.Store, entityID string) []*graph.Edge {
+	var out []*graph.Edge
+	for _, edge := range efModelsTableEdges(g) {
+		if edge.From == entityID {
+			out = append(out, edge)
+		}
 	}
-	require.Len(t, byFrom, 2)
-
-	ge := byFrom["Domain/Gadget.cs::Gadget"]
-	require.NotNil(t, ge)
-	assert.Equal(t, "db::orm::gadget_rows", ge.To, "fluent beats the DbSet convention name")
-	assert.Equal(t, "fluent", ge.Meta["binding"])
-	assert.Equal(t, "override", ge.Meta["derivation"])
-
-	te := byFrom["Domain/CrateTally.cs::CrateTally"]
-	require.NotNil(t, te)
-	assert.Equal(t, "db::orm::crate_tallies", te.To)
-	assert.Equal(t, "view", te.Meta["relation"])
+	return out
 }
 
-// TestCSharpEFMergeFluentFacts_OrderIndependent: the merge's verdict
-// for an entity must not depend on fact arrival order — facts come off
-// a map-ordered node scan, so every permutation of the same set must
-// produce the same result.
-func TestCSharpEFMergeFluentFacts_OrderIndependent(t *testing.T) {
-	configA := csharpEFFluentFact{entity: "Widget", table: "w1", siteID: "a.cs::AConfig"}
-	configB := csharpEFFluentFact{entity: "Widget", table: "w2", siteID: "b.cs::BConfig"}
-	inline := csharpEFFluentFact{entity: "Widget", table: "w3", inline: true, siteID: "ctx.cs"}
+func efOnlyModelEdgeFrom(t *testing.T, g graph.Store, entityID string) *graph.Edge {
+	t.Helper()
+	edges := efModelEdgesFrom(g, entityID)
+	require.Len(t, edges, 1)
+	return edges[0]
+}
 
-	perms := [][]csharpEFFluentFact{
-		{configA, configB, inline},
-		{configA, inline, configB},
-		{inline, configA, configB},
-		{inline, configB, configA},
-		{configB, inline, configA},
-		{configB, configA, inline},
+func efAddEntity(
+	g graph.Store,
+	id, repoPrefix, workspaceID, name string,
+	attributeTable, attributeSchema string,
+) *graph.Node {
+	meta := map[string]any{}
+	if attributeTable != "" {
+		meta["ef_attribute_table"] = attributeTable
+		if attributeSchema != "" {
+			meta["ef_attribute_schema"] = attributeSchema
+		}
 	}
-	for i, p := range perms {
-		out := csharpEFMergeFluentFacts(p)
-		require.Len(t, out, 1, "perm %d: inline tier wins outright — config disagreement below it is irrelevant", i)
-		assert.Equal(t, "w3", out[0].table, "perm %d", i)
-		assert.True(t, out[0].inline, "perm %d", i)
+	node := &graph.Node{
+		ID: id, Kind: graph.KindType, Name: name,
+		FilePath: id, Language: "csharp", RepoPrefix: repoPrefix,
+		WorkspaceID: workspaceID, StartLine: 3, Meta: meta,
 	}
+	g.AddNode(node)
+	return node
+}
 
-	// No inline tier: the config disagreement drops the entity, both orders.
-	for i, p := range [][]csharpEFFluentFact{{configA, configB}, {configB, configA}} {
-		assert.Empty(t, csharpEFMergeFluentFacts(p), "conflict perm %d", i)
+func efAddConfig(
+	g graph.Store,
+	id, repoPrefix, workspaceID, name, entity, table, schema, relation string,
+) *graph.Node {
+	node := &graph.Node{
+		ID: id, Kind: graph.KindType, Name: name,
+		FilePath: id, Language: "csharp", RepoPrefix: repoPrefix,
+		WorkspaceID: workspaceID, StartLine: 8,
+		Meta: map[string]any{
+			"ef_config_entity": entity, "ef_config_table": table,
+			"ef_config_schema": schema, "ef_config_relation": relation,
+		},
 	}
+	g.AddNode(node)
+	return node
+}
 
-	// Agreeing same-tier facts: kept, and the retained site is the
-	// deterministic (lowest-siteID) one regardless of order.
-	configA2 := csharpEFFluentFact{entity: "Widget", table: "w1", siteID: "z.cs::ZConfig"}
-	agreeA := csharpEFFluentFact{entity: "Widget", table: "w1", siteID: "a.cs::AConfig"}
-	for i, p := range [][]csharpEFFluentFact{{configA2, agreeA}, {agreeA, configA2}} {
-		out := csharpEFMergeFluentFacts(p)
-		require.Len(t, out, 1, "agree perm %d", i)
-		assert.Equal(t, "a.cs::AConfig", out[0].siteID, "agree perm %d: lowest siteID wins deterministically", i)
+func efAddDbSet(g graph.Store, id, repoPrefix, workspaceID, entity, property string) *graph.Node {
+	node := &graph.Node{
+		ID: id, Kind: graph.KindField, Name: property,
+		FilePath: id, Language: "csharp", RepoPrefix: repoPrefix,
+		WorkspaceID: workspaceID, StartLine: 6,
+		Meta: map[string]any{"kind": "property", "field_type": "DbSet<" + entity + ">"},
+	}
+	g.AddNode(node)
+	return node
+}
+
+func efAddActionFile(g graph.Store, id, repoPrefix, workspaceID string, actions any) *graph.Node {
+	node := &graph.Node{
+		ID: id, Kind: graph.KindFile, Name: id, FilePath: id,
+		Language: "csharp", RepoPrefix: repoPrefix, WorkspaceID: workspaceID,
+		Meta: map[string]any{"ef_fluent": actions},
+	}
+	g.AddNode(node)
+	return node
+}
+
+func efMappingAction(context, entity, table, schema, relation string, ordinal, line int) map[string]any {
+	return map[string]any{
+		"context": context, "kind": csharpEFActionMapping,
+		"line": line, "ordinal": ordinal,
+		"entity": entity, "table": table, "schema": schema, "relation": relation,
 	}
 }
 
-// TestResolveCSharpEFCoreModels_InlineBeatsConfigClass: within the
-// fluent tier, an OnModelCreating inline entry beats a config class —
-// EF applies OnModelCreating statements after ApplyConfiguration.
-func TestResolveCSharpEFCoreModels_InlineBeatsConfigClass(t *testing.T) {
-	g := buildCSharpResolverGraph(t, map[string]string{
-		"Domain/Gadget.cs": `namespace App.Domain;
-
-public class Gadget
-{
-    public int Id { get; set; }
-}
-`,
-		"Config/GadgetConfig.cs": `using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata.Builders;
-
-namespace App.Config;
-
-public class GadgetConfig : IEntityTypeConfiguration<Gadget>
-{
-    public void Configure(EntityTypeBuilder<Gadget> builder)
-    {
-        builder.ToTable("cfg_gadgets");
-    }
-}
-`,
-		"Data/ProbeContext.cs": `using Microsoft.EntityFrameworkCore;
-
-namespace App.Data;
-
-public class ProbeContext : DbContext
-{
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        modelBuilder.Entity<Gadget>().ToTable("inline_gadgets");
-    }
-}
-`,
-	})
-	assert.Equal(t, 1, ResolveCSharpEFCoreModels(g))
-	models := efModelsTableEdges(g)
-	require.Len(t, models, 1)
-	assert.Equal(t, "db::orm::inline_gadgets", models[0].To)
-}
-
-// TestResolveCSharpEFCoreModels_EfFluentAnySliceDecodes: meta lists
-// round-trip through persistence as []any — the pass must decode both
-// shapes, not just the in-process []string.
-func TestResolveCSharpEFCoreModels_EfFluentAnySliceDecodes(t *testing.T) {
-	g := buildCSharpResolverGraph(t, map[string]string{
-		"Domain/Gadget.cs": `namespace App.Domain;
-
-public class Gadget
-{
-    public int Id { get; set; }
-}
-`,
-		"Data/ProbeContext.cs": `using Microsoft.EntityFrameworkCore;
-
-namespace App.Data;
-
-public class ProbeContext : DbContext
-{
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        modelBuilder.Entity<Gadget>().ToTable("gadget_rows");
-    }
-}
-`,
-	})
-	fileNode := g.GetNode("Data/ProbeContext.cs")
-	require.NotNil(t, fileNode)
-	entries, ok := fileNode.Meta["ef_fluent"].([]string)
-	require.True(t, ok, "extractor stamps []string in-process")
-	anyEntries := make([]any, len(entries))
-	for i, e := range entries {
-		anyEntries[i] = e
+func efApplyConfigAction(context, config string, ordinal, line int) map[string]any {
+	return map[string]any{
+		"context": context, "kind": csharpEFActionApplyConfiguration,
+		"line": line, "ordinal": ordinal, "config": config,
 	}
-	fileNode.Meta["ef_fluent"] = anyEntries
-
-	assert.Equal(t, 1, ResolveCSharpEFCoreModels(g))
-	models := efModelsTableEdges(g)
-	require.Len(t, models, 1)
-	assert.Equal(t, "db::orm::gadget_rows", models[0].To)
-	assert.Greater(t, models[0].Line, 1, "edge evidence carries the mapping statement's line, not the file top")
 }
 
-// TestResolveCSharpEFCoreModels_RepoPrefixedStoreSpelling: in a
-// workspace store, ingest prefixes every extraction ID with the repo —
-// including the extractor-minted db::orm:: table nodes. Edges the
-// RESOLVER mints must use the same spelling, or one logical table
-// splits into a bare and a prefixed identity depending on which
-// binding path named it.
-func TestResolveCSharpEFCoreModels_RepoPrefixedStoreSpelling(t *testing.T) {
+func efApplyAssemblyAction(context string, ordinal, line int) map[string]any {
+	return map[string]any{
+		"context": context, "kind": csharpEFActionApplyAssembly,
+		"line": line, "ordinal": ordinal,
+	}
+}
+
+func efAddOwnedProjection(g graph.Store, entity *graph.Node, table, schema, relation, binding string) *graph.Edge {
+	tableID := csharpEFTableNodeID(entity.RepoPrefix, table, schema)
+	csharpEFEnsureTableNode(g, tableID, table, schema, entity.FilePath, entity.RepoPrefix)
+	edge := &graph.Edge{
+		From: entity.ID, To: tableID, Kind: graph.EdgeModelsTable,
+		FilePath: entity.FilePath, Line: entity.StartLine,
+		Meta: map[string]any{
+			"orm": "efcore", "binding": binding,
+			"table_name": table, "schema": schema, "relation": relation,
+		},
+	}
+	g.AddEdge(edge)
+	return edge
+}
+
+func TestResolveCSharpEFCoreModels_DbSetConventionIsIdempotent(t *testing.T) {
 	g := graph.New()
-	g.AddNode(&graph.Node{
-		ID: "probe/Domain\\Widget.cs::Widget", Kind: graph.KindType, Name: "Widget",
-		FilePath: "probe/Domain\\Widget.cs", Language: "csharp", RepoPrefix: "probe",
-	})
-	g.AddNode(&graph.Node{
-		ID: "probe/Data\\Ctx.cs::ProbeContext", Kind: graph.KindType, Name: "ProbeContext",
-		FilePath: "probe/Data\\Ctx.cs", Language: "csharp", RepoPrefix: "probe",
-	})
-	g.AddNode(&graph.Node{
-		ID: "probe/Data\\Ctx.cs::ProbeContext.StockWidgets", Kind: graph.KindField, Name: "StockWidgets",
-		FilePath: "probe/Data\\Ctx.cs", Language: "csharp", RepoPrefix: "probe", StartLine: 7,
-		Meta: map[string]any{"kind": "property", "field_type": "DbSet<Widget>", "receiver": "ProbeContext"},
-	})
-
-	assert.Equal(t, 1, ResolveCSharpEFCoreModels(g))
-	models := efModelsTableEdges(g)
-	require.Len(t, models, 1)
-	assert.Equal(t, "probe/db::orm::StockWidgets", models[0].To,
-		"resolver-minted table IDs carry the entity's repo prefix, matching the ingest spelling")
-	tableNode := g.GetNode("probe/db::orm::StockWidgets")
-	require.NotNil(t, tableNode)
-	assert.Equal(t, "probe", tableNode.RepoPrefix)
+	entity := efAddEntity(g, "Domain/Widget.cs::Widget", "", "", "Widget", "", "")
+	efAddDbSet(g, "Data/Ctx.cs::Ctx.StockWidgets", "", "", "Widget", "StockWidgets")
+	require.Equal(t, 1, ResolveCSharpEFCoreModels(g))
+	edge := efOnlyModelEdgeFrom(t, g, entity.ID)
+	assert.Equal(t, "db::orm::StockWidgets", edge.To)
+	assert.Equal(t, "dbset", edge.Meta["binding"])
+	assert.Equal(t, "StockWidgets", edge.Meta["table_name"])
+	assert.Equal(t, "convention", edge.Meta["derivation"])
+	require.NotNil(t, g.GetNode("db::orm::StockWidgets"))
+	assert.Equal(t, 0, ResolveCSharpEFCoreModels(g))
+	assert.Len(t, efModelEdgesFrom(g, entity.ID), 1)
 }
 
-// TestResolveCSharpEFCoreModels_AmbiguousEntityNameSkips: the join is
-// by unique class name — two classes sharing the entity's name means
-// the pass refuses to guess and emits nothing.
-func TestResolveCSharpEFCoreModels_AmbiguousEntityNameSkips(t *testing.T) {
-	g := buildCSharpResolverGraph(t, map[string]string{
-		"Domain/Widget.cs": `namespace App.Domain;
-
-public class Widget
-{
-    public int Id { get; set; }
+func TestResolveCSharpEFCoreModels_UnusedConfigurationIsInert(t *testing.T) {
+	g := graph.New()
+	entity := efAddEntity(g, "Domain/Widget.cs::Widget", "", "", "Widget", "", "")
+	efAddConfig(g, "Config/WidgetConfig.cs::WidgetConfig", "", "", "WidgetConfig", "Widget", "fluent_widgets", "", "table")
+	efAddDbSet(g, "Data/Ctx.cs::Ctx.Widgets", "", "", "Widget", "Widgets")
+	require.Equal(t, 1, ResolveCSharpEFCoreModels(g))
+	edge := efOnlyModelEdgeFrom(t, g, entity.ID)
+	assert.Equal(t, "db::orm::Widgets", edge.To)
+	assert.Equal(t, "dbset", edge.Meta["binding"])
 }
-`,
-		"Legacy/Widget.cs": `namespace App.Legacy;
 
-public class Widget
-{
-    public string Tag { get; set; }
+func TestResolveCSharpEFCoreModels_ActivationAndInlineFollowSourceOrder(t *testing.T) {
+	tests := []struct {
+		name    string
+		actions []map[string]any
+		want    string
+	}{
+		{"configuration then inline", []map[string]any{
+			efApplyConfigAction("Ctx", "WidgetConfig", 0, 10),
+			efMappingAction("Ctx", "Widget", "inline_widgets", "", "table", 1, 11),
+		}, "inline_widgets"},
+		{"inline then configuration", []map[string]any{
+			efMappingAction("Ctx", "Widget", "inline_widgets", "", "table", 0, 10),
+			efApplyConfigAction("Ctx", "WidgetConfig", 1, 11),
+		}, "config_widgets"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := graph.New()
+			entity := efAddEntity(g, "Domain/Widget.cs::Widget", "", "", "Widget", "", "")
+			efAddConfig(g, "Config/WidgetConfig.cs::WidgetConfig", "", "", "WidgetConfig", "Widget", "config_widgets", "", "table")
+			efAddActionFile(g, "Data/Ctx.cs", "", "", tt.actions)
+			require.Equal(t, 1, ResolveCSharpEFCoreModels(g))
+			edge := efOnlyModelEdgeFrom(t, g, entity.ID)
+			assert.Equal(t, "db::orm::"+tt.want, edge.To)
+			assert.Equal(t, "fluent", edge.Meta["binding"])
+		})
+	}
 }
-`,
-		"Data/ProbeContext.cs": `using Microsoft.EntityFrameworkCore;
 
-namespace App.Data;
-
-public class ProbeContext : DbContext
-{
-    public DbSet<Widget> Widgets { get; set; }
+func TestResolveCSharpEFCoreModels_AssemblyAgreementCoalesces(t *testing.T) {
+	g := graph.New()
+	entity := efAddEntity(g, "Domain/Widget.cs::Widget", "", "", "Widget", "", "")
+	efAddConfig(g, "Config/A.cs::AConfig", "", "", "AConfig", "Widget", "widgets", "sales", "table")
+	efAddConfig(g, "Config/B.cs::BConfig", "", "", "BConfig", "Widget", "widgets", "sales", "table")
+	efAddActionFile(g, "Data/Ctx.cs", "", "", []map[string]any{efApplyAssemblyAction("Ctx", 0, 10)})
+	require.Equal(t, 1, ResolveCSharpEFCoreModels(g))
+	edge := efOnlyModelEdgeFrom(t, g, entity.ID)
+	assert.Equal(t, "db::orm::sales.widgets", edge.To)
+	assert.Equal(t, "fluent", edge.Meta["binding"])
+	assert.Equal(t, 0, ResolveCSharpEFCoreModels(g))
 }
-`,
-	})
+
+func TestResolveCSharpEFCoreModels_AssemblyConflictBlocksFallbackUntilLaterOverride(t *testing.T) {
+	g := graph.New()
+	entity := efAddEntity(g, "Domain/Widget.cs::Widget", "", "", "Widget", "attribute_widgets", "")
+	efAddOwnedProjection(g, entity, "attribute_widgets", "", "table", "attribute")
+	efAddDbSet(g, "Data/Ctx.cs::Ctx.Widgets", "", "", "Widget", "Widgets")
+	efAddConfig(g, "Config/A.cs::AConfig", "", "", "AConfig", "Widget", "widgets_a", "", "table")
+	efAddConfig(g, "Config/B.cs::BConfig", "", "", "BConfig", "Widget", "widgets_b", "", "table")
+	file := efAddActionFile(g, "Data/Ctx.cs", "", "", []map[string]any{efApplyAssemblyAction("Ctx", 0, 10)})
+	require.Equal(t, 1, ResolveCSharpEFCoreModels(g))
+	assert.Empty(t, efModelEdgesFrom(g, entity.ID), "rejection blocks both attribute and DbSet fallback")
+	file.Meta["ef_fluent"] = []map[string]any{
+		efApplyAssemblyAction("Ctx", 0, 10),
+		efMappingAction("Ctx", "Widget", "later_widgets", "", "view", 1, 11),
+	}
+	require.Equal(t, 1, ResolveCSharpEFCoreModels(g))
+	edge := efOnlyModelEdgeFrom(t, g, entity.ID)
+	assert.Equal(t, "db::orm::later_widgets", edge.To)
+	assert.Equal(t, "view", edge.Meta["relation"])
+}
+
+func TestResolveCSharpEFCoreModels_ExactRepositoryWorkspaceAndEntityBoundary(t *testing.T) {
+	g := graph.New()
+	entityA := efAddEntity(g, "repo-a/ws-1/Widget.cs::Widget", "repo-a", "ws-1", "Widget", "", "")
+	entityB := efAddEntity(g, "repo-b/ws-1/Widget.cs::Widget", "repo-b", "ws-1", "Widget", "", "")
+	entityC := efAddEntity(g, "repo-a/ws-2/Widget.cs::Widget", "repo-a", "ws-2", "Widget", "", "")
+	efAddActionFile(g, "repo-a/ws-1/Ctx.cs", "repo-a", "ws-1", []map[string]any{efMappingAction("Ctx", "Widget", "widgets_a", "", "table", 0, 10)})
+	efAddActionFile(g, "repo-b/ws-1/Ctx.cs", "repo-b", "ws-1", []map[string]any{efMappingAction("Ctx", "Widget", "widgets_b", "", "table", 0, 10)})
+	efAddActionFile(g, "repo-a/ws-2/Ctx.cs", "repo-a", "ws-2", []map[string]any{efMappingAction("Ctx", "Widget", "widgets_c", "", "table", 0, 10)})
+	require.Equal(t, 3, ResolveCSharpEFCoreModels(g))
+	assert.Equal(t, "repo-a/db::orm::widgets_a", efOnlyModelEdgeFrom(t, g, entityA.ID).To)
+	assert.Equal(t, "repo-b/db::orm::widgets_b", efOnlyModelEdgeFrom(t, g, entityB.ID).To)
+	assert.Equal(t, "repo-a/db::orm::widgets_c", efOnlyModelEdgeFrom(t, g, entityC.ID).To)
+}
+
+func TestResolveCSharpEFCoreModels_AmbiguousEntityWithinBoundaryIsRejected(t *testing.T) {
+	g := graph.New()
+	efAddEntity(g, "repo-a/Domain/Widget.cs::Widget", "repo-a", "ws", "Widget", "", "")
+	efAddEntity(g, "repo-a/Legacy/Widget.cs::Widget", "repo-a", "ws", "Widget", "", "")
+	efAddActionFile(g, "repo-a/Data/Ctx.cs", "repo-a", "ws", []map[string]any{efMappingAction("Ctx", "Widget", "widgets", "", "table", 0, 10)})
 	assert.Equal(t, 0, ResolveCSharpEFCoreModels(g))
 	assert.Empty(t, efModelsTableEdges(g))
+}
+
+func TestResolveCSharpEFCoreModelsScoped_ConfigOnlyChangeReconcilesOneRepository(t *testing.T) {
+	g := graph.New()
+	entityA := efAddEntity(g, "repo-a/Domain/Widget.cs::Widget", "repo-a", "ws", "Widget", "", "")
+	configA := efAddConfig(g, "repo-a/Config/WidgetConfig.cs::WidgetConfig", "repo-a", "ws", "WidgetConfig", "Widget", "widgets_a", "", "table")
+	efAddActionFile(g, "repo-a/Data/Ctx.cs", "repo-a", "ws", []map[string]any{efApplyConfigAction("Ctx", "WidgetConfig", 0, 10)})
+	entityB := efAddEntity(g, "repo-b/Domain/Widget.cs::Widget", "repo-b", "ws", "Widget", "", "")
+	efAddConfig(g, "repo-b/Config/WidgetConfig.cs::WidgetConfig", "repo-b", "ws", "WidgetConfig", "Widget", "widgets_b", "", "table")
+	efAddActionFile(g, "repo-b/Data/Ctx.cs", "repo-b", "ws", []map[string]any{efApplyConfigAction("Ctx", "WidgetConfig", 0, 10)})
+	require.Equal(t, 2, ResolveCSharpEFCoreModels(g))
+	configA.Meta["ef_config_table"] = "widgets_a_v2"
+	require.Equal(t, 1, ResolveCSharpEFCoreModelsScoped(g, map[string]bool{"repo-a": true}))
+	assert.Equal(t, "repo-a/db::orm::widgets_a_v2", efOnlyModelEdgeFrom(t, g, entityA.ID).To)
+	assert.Equal(t, "repo-b/db::orm::widgets_b", efOnlyModelEdgeFrom(t, g, entityB.ID).To)
+	assert.Equal(t, 0, ResolveCSharpEFCoreModelsScoped(g, map[string]bool{"repo-a": true}))
+}
+
+func TestResolveCSharpEFCoreModels_RemovalRestoresAttributeOrDbSetAndDeletesOtherwise(t *testing.T) {
+	t.Run("attribute", func(t *testing.T) {
+		g := graph.New()
+		entity := efAddEntity(g, "repo-a/Domain/Widget.cs::Widget", "repo-a", "ws", "Widget", "attribute_widgets", "catalog")
+		efAddConfig(g, "repo-a/Config/WidgetConfig.cs::WidgetConfig", "repo-a", "ws", "WidgetConfig", "Widget", "fluent_widgets", "sales", "table")
+		file := efAddActionFile(g, "repo-a/Data/Ctx.cs", "repo-a", "ws", []map[string]any{efApplyConfigAction("Ctx", "WidgetConfig", 0, 10)})
+		require.Equal(t, 1, ResolveCSharpEFCoreModels(g))
+		assert.Equal(t, "repo-a/db::orm::sales.fluent_widgets", efOnlyModelEdgeFrom(t, g, entity.ID).To)
+		file.Meta["ef_fluent"] = []map[string]any{}
+		require.Equal(t, 1, ResolveCSharpEFCoreModelsScoped(g, map[string]bool{"repo-a": true}))
+		edge := efOnlyModelEdgeFrom(t, g, entity.ID)
+		assert.Equal(t, "repo-a/db::orm::catalog.attribute_widgets", edge.To)
+		assert.Equal(t, "attribute", edge.Meta["binding"])
+	})
+	t.Run("dbset", func(t *testing.T) {
+		g := graph.New()
+		entity := efAddEntity(g, "repo-a/Domain/Widget.cs::Widget", "repo-a", "ws", "Widget", "", "")
+		efAddConfig(g, "repo-a/Config/WidgetConfig.cs::WidgetConfig", "repo-a", "ws", "WidgetConfig", "Widget", "fluent_widgets", "", "table")
+		efAddDbSet(g, "repo-a/Data/Ctx.cs::Ctx.Widgets", "repo-a", "ws", "Widget", "Widgets")
+		file := efAddActionFile(g, "repo-a/Data/Ctx.cs", "repo-a", "ws", []map[string]any{efApplyConfigAction("Ctx", "WidgetConfig", 0, 10)})
+		require.Equal(t, 1, ResolveCSharpEFCoreModels(g))
+		assert.Equal(t, "repo-a/db::orm::fluent_widgets", efOnlyModelEdgeFrom(t, g, entity.ID).To)
+		file.Meta["ef_fluent"] = []map[string]any{}
+		require.Equal(t, 1, ResolveCSharpEFCoreModelsScoped(g, map[string]bool{"repo-a": true}))
+		edge := efOnlyModelEdgeFrom(t, g, entity.ID)
+		assert.Equal(t, "repo-a/db::orm::Widgets", edge.To)
+		assert.Equal(t, "dbset", edge.Meta["binding"])
+	})
+	t.Run("no fallback", func(t *testing.T) {
+		g := graph.New()
+		entity := efAddEntity(g, "repo-a/Domain/Widget.cs::Widget", "repo-a", "ws", "Widget", "", "")
+		efAddConfig(g, "repo-a/Config/WidgetConfig.cs::WidgetConfig", "repo-a", "ws", "WidgetConfig", "Widget", "fluent_widgets", "", "table")
+		file := efAddActionFile(g, "repo-a/Data/Ctx.cs", "repo-a", "ws", []map[string]any{efApplyConfigAction("Ctx", "WidgetConfig", 0, 10)})
+		require.Equal(t, 1, ResolveCSharpEFCoreModels(g))
+		file.Meta["ef_fluent"] = []map[string]any{}
+		require.Equal(t, 1, ResolveCSharpEFCoreModelsScoped(g, map[string]bool{"repo-a": true}))
+		assert.Empty(t, efModelEdgesFrom(g, entity.ID))
+	})
+}
+
+func TestResolveCSharpEFCoreModels_DuplicateSiblingProjectionsCoalesce(t *testing.T) {
+	g := graph.New()
+	entity := efAddEntity(g, "repo-a/Domain/Widget.cs::Widget", "repo-a", "ws", "Widget", "", "")
+	efAddConfig(g, "repo-a/Config/WidgetConfig.cs::WidgetConfig", "repo-a", "ws", "WidgetConfig", "Widget", "widgets", "", "table")
+	efAddActionFile(g, "repo-a/Data/Ctx.cs", "repo-a", "ws", []map[string]any{efApplyConfigAction("Ctx", "WidgetConfig", 0, 10)})
+	require.Equal(t, 1, ResolveCSharpEFCoreModels(g))
+	efAddOwnedProjection(g, entity, "stale_widgets", "", "table", "fluent")
+	require.Len(t, efModelEdgesFrom(g, entity.ID), 2)
+	require.Equal(t, 1, ResolveCSharpEFCoreModelsScoped(g, map[string]bool{"repo-a": true}))
+	edge := efOnlyModelEdgeFrom(t, g, entity.ID)
+	assert.Equal(t, "repo-a/db::orm::widgets", edge.To)
+	assert.Equal(t, 0, ResolveCSharpEFCoreModelsScoped(g, map[string]bool{"repo-a": true}))
+}
+
+func TestResolveCSharpEFCoreModels_ToTableToViewSameTargetIsSemanticReplacement(t *testing.T) {
+	g := graph.New()
+	entity := efAddEntity(g, "repo-a/Domain/Tally.cs::Tally", "repo-a", "ws", "Tally", "", "")
+	file := efAddActionFile(g, "repo-a/Data/Ctx.cs", "repo-a", "ws", []any{
+		efMappingAction("Ctx", "Tally", "tallies", "", "table", 0, 10),
+	})
+	require.Equal(t, 1, ResolveCSharpEFCoreModels(g))
+	before := efOnlyModelEdgeFrom(t, g, entity.ID)
+	assert.Equal(t, "repo-a/db::orm::tallies", before.To)
+	assert.Equal(t, "table", before.Meta["relation"])
+	file.Meta["ef_fluent"] = []any{
+		efMappingAction("Ctx", "Tally", "tallies", "", "view", 0, 10),
+	}
+	require.Equal(t, 1, ResolveCSharpEFCoreModelsScoped(g, map[string]bool{"repo-a": true}))
+	after := efOnlyModelEdgeFrom(t, g, entity.ID)
+	assert.Equal(t, before.To, after.To)
+	assert.Equal(t, "view", after.Meta["relation"])
+	assert.Equal(t, 0, ResolveCSharpEFCoreModelsScoped(g, map[string]bool{"repo-a": true}))
 }

--- a/internal/resolver/csharp_efcore_models_test.go
+++ b/internal/resolver/csharp_efcore_models_test.go
@@ -172,6 +172,132 @@ public class ProbeContext : DbContext
 	assert.Equal(t, "view", te.Meta["relation"])
 }
 
+// TestCSharpEFMergeFluentFacts_OrderIndependent: the merge's verdict
+// for an entity must not depend on fact arrival order — facts come off
+// a map-ordered node scan, so every permutation of the same set must
+// produce the same result.
+func TestCSharpEFMergeFluentFacts_OrderIndependent(t *testing.T) {
+	configA := csharpEFFluentFact{entity: "Widget", table: "w1", siteID: "a.cs::AConfig"}
+	configB := csharpEFFluentFact{entity: "Widget", table: "w2", siteID: "b.cs::BConfig"}
+	inline := csharpEFFluentFact{entity: "Widget", table: "w3", inline: true, siteID: "ctx.cs"}
+
+	perms := [][]csharpEFFluentFact{
+		{configA, configB, inline},
+		{configA, inline, configB},
+		{inline, configA, configB},
+		{inline, configB, configA},
+		{configB, inline, configA},
+		{configB, configA, inline},
+	}
+	for i, p := range perms {
+		out := csharpEFMergeFluentFacts(p)
+		require.Len(t, out, 1, "perm %d: inline tier wins outright — config disagreement below it is irrelevant", i)
+		assert.Equal(t, "w3", out[0].table, "perm %d", i)
+		assert.True(t, out[0].inline, "perm %d", i)
+	}
+
+	// No inline tier: the config disagreement drops the entity, both orders.
+	for i, p := range [][]csharpEFFluentFact{{configA, configB}, {configB, configA}} {
+		assert.Empty(t, csharpEFMergeFluentFacts(p), "conflict perm %d", i)
+	}
+
+	// Agreeing same-tier facts: kept, and the retained site is the
+	// deterministic (lowest-siteID) one regardless of order.
+	configA2 := csharpEFFluentFact{entity: "Widget", table: "w1", siteID: "z.cs::ZConfig"}
+	agreeA := csharpEFFluentFact{entity: "Widget", table: "w1", siteID: "a.cs::AConfig"}
+	for i, p := range [][]csharpEFFluentFact{{configA2, agreeA}, {agreeA, configA2}} {
+		out := csharpEFMergeFluentFacts(p)
+		require.Len(t, out, 1, "agree perm %d", i)
+		assert.Equal(t, "a.cs::AConfig", out[0].siteID, "agree perm %d: lowest siteID wins deterministically", i)
+	}
+}
+
+// TestResolveCSharpEFCoreModels_InlineBeatsConfigClass: within the
+// fluent tier, an OnModelCreating inline entry beats a config class —
+// EF applies OnModelCreating statements after ApplyConfiguration.
+func TestResolveCSharpEFCoreModels_InlineBeatsConfigClass(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Domain/Gadget.cs": `namespace App.Domain;
+
+public class Gadget
+{
+    public int Id { get; set; }
+}
+`,
+		"Config/GadgetConfig.cs": `using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace App.Config;
+
+public class GadgetConfig : IEntityTypeConfiguration<Gadget>
+{
+    public void Configure(EntityTypeBuilder<Gadget> builder)
+    {
+        builder.ToTable("cfg_gadgets");
+    }
+}
+`,
+		"Data/ProbeContext.cs": `using Microsoft.EntityFrameworkCore;
+
+namespace App.Data;
+
+public class ProbeContext : DbContext
+{
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Gadget>().ToTable("inline_gadgets");
+    }
+}
+`,
+	})
+	assert.Equal(t, 1, ResolveCSharpEFCoreModels(g))
+	models := efModelsTableEdges(g)
+	require.Len(t, models, 1)
+	assert.Equal(t, "db::orm::inline_gadgets", models[0].To)
+}
+
+// TestResolveCSharpEFCoreModels_EfFluentAnySliceDecodes: meta lists
+// round-trip through persistence as []any — the pass must decode both
+// shapes, not just the in-process []string.
+func TestResolveCSharpEFCoreModels_EfFluentAnySliceDecodes(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Domain/Gadget.cs": `namespace App.Domain;
+
+public class Gadget
+{
+    public int Id { get; set; }
+}
+`,
+		"Data/ProbeContext.cs": `using Microsoft.EntityFrameworkCore;
+
+namespace App.Data;
+
+public class ProbeContext : DbContext
+{
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Gadget>().ToTable("gadget_rows");
+    }
+}
+`,
+	})
+	fileNode := g.GetNode("Data/ProbeContext.cs")
+	require.NotNil(t, fileNode)
+	entries, ok := fileNode.Meta["ef_fluent"].([]string)
+	require.True(t, ok, "extractor stamps []string in-process")
+	anyEntries := make([]any, len(entries))
+	for i, e := range entries {
+		anyEntries[i] = e
+	}
+	fileNode.Meta["ef_fluent"] = anyEntries
+
+	assert.Equal(t, 1, ResolveCSharpEFCoreModels(g))
+	models := efModelsTableEdges(g)
+	require.Len(t, models, 1)
+	assert.Equal(t, "db::orm::gadget_rows", models[0].To)
+	assert.Greater(t, models[0].Line, 1, "edge evidence carries the mapping statement's line, not the file top")
+}
+
 // TestResolveCSharpEFCoreModels_AmbiguousEntityNameSkips: the join is
 // by unique class name — two classes sharing the entity's name means
 // the pass refuses to guess and emits nothing.

--- a/internal/resolver/csharp_efcore_models_test.go
+++ b/internal/resolver/csharp_efcore_models_test.go
@@ -1,0 +1,100 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// efModelsTableEdges collects every models_table edge in the store.
+func efModelsTableEdges(g graph.Store) []*graph.Edge {
+	var out []*graph.Edge
+	for e := range g.EdgesByKind(graph.EdgeModelsTable) {
+		if e != nil {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// TestResolveCSharpEFCoreModels_DbSetConventionBindsPropertyName pins
+// EF's actual convention: the table name is the DbSet PROPERTY name,
+// verbatim — not a pluralization of the entity class name.
+func TestResolveCSharpEFCoreModels_DbSetConventionBindsPropertyName(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Domain/Widget.cs": `namespace App.Domain;
+
+public class Widget
+{
+    public int Id { get; set; }
+}
+`,
+		"Data/ProbeContext.cs": `using Microsoft.EntityFrameworkCore;
+
+namespace App.Data;
+
+public class ProbeContext : DbContext
+{
+    public DbSet<Widget> StockWidgets { get; set; }
+}
+`,
+	})
+	n := ResolveCSharpEFCoreModels(g)
+	assert.Equal(t, 1, n)
+
+	models := efModelsTableEdges(g)
+	require.Len(t, models, 1)
+	e := models[0]
+	assert.Equal(t, "Domain/Widget.cs::Widget", e.From)
+	assert.Equal(t, "db::orm::StockWidgets", e.To,
+		"table = DbSet property name verbatim, never a pluralized class name")
+	assert.Equal(t, "efcore", e.Meta["orm"])
+	assert.Equal(t, "dbset", e.Meta["binding"])
+	assert.Equal(t, "StockWidgets", e.Meta["table_name"])
+	assert.Equal(t, "convention", e.Meta["derivation"])
+
+	tableNode := g.GetNode("db::orm::StockWidgets")
+	require.NotNil(t, tableNode, "the KindTable node is minted with the edge")
+	assert.Equal(t, graph.KindTable, tableNode.Kind)
+	assert.Equal(t, "orm", tableNode.Meta["dialect"])
+	assert.Equal(t, "csharp-orm", tableNode.Meta["source"])
+
+	assert.Equal(t, 0, ResolveCSharpEFCoreModels(g), "second run is a no-op")
+	assert.Len(t, efModelsTableEdges(g), 1, "idempotent: no duplicate edges")
+}
+
+// TestResolveCSharpEFCoreModels_AmbiguousEntityNameSkips: the join is
+// by unique class name — two classes sharing the entity's name means
+// the pass refuses to guess and emits nothing.
+func TestResolveCSharpEFCoreModels_AmbiguousEntityNameSkips(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Domain/Widget.cs": `namespace App.Domain;
+
+public class Widget
+{
+    public int Id { get; set; }
+}
+`,
+		"Legacy/Widget.cs": `namespace App.Legacy;
+
+public class Widget
+{
+    public string Tag { get; set; }
+}
+`,
+		"Data/ProbeContext.cs": `using Microsoft.EntityFrameworkCore;
+
+namespace App.Data;
+
+public class ProbeContext : DbContext
+{
+    public DbSet<Widget> Widgets { get; set; }
+}
+`,
+	})
+	assert.Equal(t, 0, ResolveCSharpEFCoreModels(g))
+	assert.Empty(t, efModelsTableEdges(g))
+}

--- a/internal/resolver/csharp_efcore_models_test.go
+++ b/internal/resolver/csharp_efcore_models_test.go
@@ -66,6 +66,112 @@ public class ProbeContext : DbContext
 	assert.Len(t, efModelsTableEdges(g), 1, "idempotent: no duplicate edges")
 }
 
+// TestResolveCSharpEFCoreModels_FluentConfigRewiresAttributeEdge: the
+// precedence is fluent > attribute — a config class's ToTable rewires
+// the extractor's attribute edge in place, go_orm's override model.
+func TestResolveCSharpEFCoreModels_FluentConfigRewiresAttributeEdge(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Domain/Widget.cs": `using System.ComponentModel.DataAnnotations.Schema;
+
+namespace App.Domain;
+
+[Table("attr_widgets")]
+public class Widget
+{
+    public int Id { get; set; }
+}
+`,
+		"Config/WidgetConfig.cs": `using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace App.Config;
+
+public class WidgetConfig : IEntityTypeConfiguration<Widget>
+{
+    public void Configure(EntityTypeBuilder<Widget> builder)
+    {
+        builder.ToTable("fluent_widgets", "sales");
+    }
+}
+`,
+	})
+	n := ResolveCSharpEFCoreModels(g)
+	assert.Equal(t, 1, n, "the rewire counts as resolution work")
+
+	models := efModelsTableEdges(g)
+	require.Len(t, models, 1, "rewired in place — never a second edge")
+	e := models[0]
+	assert.Equal(t, "Domain/Widget.cs::Widget", e.From)
+	assert.Equal(t, "db::orm::sales.fluent_widgets", e.To)
+	assert.Equal(t, "fluent", e.Meta["binding"])
+	assert.Equal(t, "fluent_widgets", e.Meta["table_name"])
+	assert.Equal(t, "sales", e.Meta["schema"])
+	assert.Equal(t, "override", e.Meta["derivation"])
+	require.NotNil(t, g.GetNode("db::orm::sales.fluent_widgets"))
+
+	assert.Equal(t, 0, ResolveCSharpEFCoreModels(g), "second run is a no-op")
+	assert.Len(t, efModelsTableEdges(g), 1)
+}
+
+// TestResolveCSharpEFCoreModels_InlineFluentBeatsDbSet: an
+// OnModelCreating Entity<T>().ToTable wins over the DbSet property
+// convention for the same entity — one edge, fluent-bound; a ToView
+// carries relation=view.
+func TestResolveCSharpEFCoreModels_InlineFluentBeatsDbSet(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Domain/Gadget.cs": `namespace App.Domain;
+
+public class Gadget
+{
+    public int Id { get; set; }
+}
+`,
+		"Domain/CrateTally.cs": `namespace App.Domain;
+
+public class CrateTally
+{
+    public int Total { get; set; }
+}
+`,
+		"Data/ProbeContext.cs": `using Microsoft.EntityFrameworkCore;
+
+namespace App.Data;
+
+public class ProbeContext : DbContext
+{
+    public DbSet<Gadget> Gadgets { get; set; }
+    public DbSet<CrateTally> Tallies { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Gadget>().ToTable("gadget_rows");
+        modelBuilder.Entity<CrateTally>().ToView("crate_tallies");
+    }
+}
+`,
+	})
+	n := ResolveCSharpEFCoreModels(g)
+	assert.Equal(t, 2, n)
+
+	byFrom := map[string]*graph.Edge{}
+	for _, e := range efModelsTableEdges(g) {
+		require.NotContains(t, byFrom, e.From, "one edge per entity")
+		byFrom[e.From] = e
+	}
+	require.Len(t, byFrom, 2)
+
+	ge := byFrom["Domain/Gadget.cs::Gadget"]
+	require.NotNil(t, ge)
+	assert.Equal(t, "db::orm::gadget_rows", ge.To, "fluent beats the DbSet convention name")
+	assert.Equal(t, "fluent", ge.Meta["binding"])
+	assert.Equal(t, "override", ge.Meta["derivation"])
+
+	te := byFrom["Domain/CrateTally.cs::CrateTally"]
+	require.NotNil(t, te)
+	assert.Equal(t, "db::orm::crate_tallies", te.To)
+	assert.Equal(t, "view", te.Meta["relation"])
+}
+
 // TestResolveCSharpEFCoreModels_AmbiguousEntityNameSkips: the join is
 // by unique class name — two classes sharing the entity's name means
 // the pass refuses to guess and emits nothing.

--- a/internal/resolver/csharp_efcore_models_test.go
+++ b/internal/resolver/csharp_efcore_models_test.go
@@ -298,6 +298,38 @@ public class ProbeContext : DbContext
 	assert.Greater(t, models[0].Line, 1, "edge evidence carries the mapping statement's line, not the file top")
 }
 
+// TestResolveCSharpEFCoreModels_RepoPrefixedStoreSpelling: in a
+// workspace store, ingest prefixes every extraction ID with the repo —
+// including the extractor-minted db::orm:: table nodes. Edges the
+// RESOLVER mints must use the same spelling, or one logical table
+// splits into a bare and a prefixed identity depending on which
+// binding path named it.
+func TestResolveCSharpEFCoreModels_RepoPrefixedStoreSpelling(t *testing.T) {
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID: "probe/Domain\\Widget.cs::Widget", Kind: graph.KindType, Name: "Widget",
+		FilePath: "probe/Domain\\Widget.cs", Language: "csharp", RepoPrefix: "probe",
+	})
+	g.AddNode(&graph.Node{
+		ID: "probe/Data\\Ctx.cs::ProbeContext", Kind: graph.KindType, Name: "ProbeContext",
+		FilePath: "probe/Data\\Ctx.cs", Language: "csharp", RepoPrefix: "probe",
+	})
+	g.AddNode(&graph.Node{
+		ID: "probe/Data\\Ctx.cs::ProbeContext.StockWidgets", Kind: graph.KindField, Name: "StockWidgets",
+		FilePath: "probe/Data\\Ctx.cs", Language: "csharp", RepoPrefix: "probe", StartLine: 7,
+		Meta: map[string]any{"kind": "property", "field_type": "DbSet<Widget>", "receiver": "ProbeContext"},
+	})
+
+	assert.Equal(t, 1, ResolveCSharpEFCoreModels(g))
+	models := efModelsTableEdges(g)
+	require.Len(t, models, 1)
+	assert.Equal(t, "probe/db::orm::StockWidgets", models[0].To,
+		"resolver-minted table IDs carry the entity's repo prefix, matching the ingest spelling")
+	tableNode := g.GetNode("probe/db::orm::StockWidgets")
+	require.NotNil(t, tableNode)
+	assert.Equal(t, "probe", tableNode.RepoPrefix)
+}
+
 // TestResolveCSharpEFCoreModels_AmbiguousEntityNameSkips: the join is
 // by unique class name — two classes sharing the entity's name means
 // the pass refuses to guess and emits nothing.

--- a/internal/resolver/framework_synth.go
+++ b/internal/resolver/framework_synth.go
@@ -948,7 +948,7 @@ func defaultFrameworkSynthesizers() []FrameworkSynthesizer {
 		// into the models_table layer. Position-independent: it reads
 		// only its own stamps and models_table itself, and no other
 		// pass consumes models_table during synthesis.
-		synthFunc{name: SynthCSharpEFCoreModels, fn: ResolveCSharpEFCoreModels},
+		synthFunc{name: SynthCSharpEFCoreModels, fn: ResolveCSharpEFCoreModels, scopedFn: ResolveCSharpEFCoreModelsScoped},
 		// Sidekiq job dispatch: Worker.perform_async(...) → the worker's
 		// perform, namespace-aware. Include-gated, typed tier.
 		synthFunc{name: SynthSidekiq, fn: ResolveSidekiqCalls},

--- a/internal/resolver/framework_synth.go
+++ b/internal/resolver/framework_synth.go
@@ -111,6 +111,7 @@ const (
 	SynthMediatR             = "mediatr-dispatch"
 	SynthCSharpIfaceDispatch = "csharp-iface-dispatch"
 	SynthCSharpDIIfaces      = "csharp-di-implemented-interfaces"
+	SynthCSharpEFCoreModels  = "csharp-efcore-models"
 	SynthSidekiq             = "sidekiq-dispatch"
 	SynthLaravelEvent        = "laravel-event"
 	SynthFnPointerDispatch   = "fn-pointer-dispatch"
@@ -239,6 +240,7 @@ var frameworkSynthLanguageFamilies = map[string][]string{
 	SynthMediatR:             {"dotnet"},
 	SynthCSharpIfaceDispatch: {"dotnet"},
 	SynthCSharpDIIfaces:      {"dotnet"},
+	SynthCSharpEFCoreModels:  {"dotnet"},
 	SynthSidekiq:             {"ruby"},
 	SynthLaravelEvent:        {"php"},
 	SynthFnPointerDispatch:   {"c"},
@@ -941,6 +943,7 @@ func defaultFrameworkSynthesizers() []FrameworkSynthesizer {
 		// find_usages / get_callers result. After the implements-producing
 		// passes so the impl fan-out is complete.
 		synthFunc{name: SynthCSharpIfaceDispatch, fn: ResolveCSharpInterfaceDispatch, scopedFn: ResolveCSharpInterfaceDispatchScoped},
+		synthFunc{name: SynthCSharpEFCoreModels, fn: ResolveCSharpEFCoreModels},
 		// Sidekiq job dispatch: Worker.perform_async(...) → the worker's
 		// perform, namespace-aware. Include-gated, typed tier.
 		synthFunc{name: SynthSidekiq, fn: ResolveSidekiqCalls},

--- a/internal/resolver/framework_synth.go
+++ b/internal/resolver/framework_synth.go
@@ -943,6 +943,11 @@ func defaultFrameworkSynthesizers() []FrameworkSynthesizer {
 		// find_usages / get_callers result. After the implements-producing
 		// passes so the impl fan-out is complete.
 		synthFunc{name: SynthCSharpIfaceDispatch, fn: ResolveCSharpInterfaceDispatch, scopedFn: ResolveCSharpInterfaceDispatchScoped},
+		// csharp-efcore-models joins the extractor's EF Core facts
+		// (attribute models_table edges, ef_config_*/ef_fluent stamps)
+		// into the models_table layer. Position-independent: it reads
+		// only its own stamps and models_table itself, and no other
+		// pass consumes models_table during synthesis.
 		synthFunc{name: SynthCSharpEFCoreModels, fn: ResolveCSharpEFCoreModels},
 		// Sidekiq job dispatch: Worker.perform_async(...) → the worker's
 		// perform, namespace-aware. Include-gated, typed tier.


### PR DESCRIPTION
Builds on #680 and preserves @pbednarcik original EF Core attribution work while addressing every requested-change finding from the review.

## What changed

- Activate IEntityTypeConfiguration mappings only through supported ApplyConfiguration or current-assembly ApplyConfigurationsFromAssembly sites, preserving source order and failing open when activation cannot be proven.
- Reconcile the complete models_table projection per repository/entity boundary, including stale-edge removal, legacy duplicate coalescing, full semantic comparison, reversible attribute attribution, and conflict claims that block DbSet fallback.
- Restrict fluent scanning to valid DbContext.OnModelCreating and IEntityTypeConfiguration<T>.Configure methods and their exact builder receivers; support named name/schema arguments and last-call-wins behavior.
- Persist ef_fluent as structured metadata and decode supported regular/verbatim C# literals while rejecting unsupported or ambiguous forms.
- Add a global post-extraction policy epoch so warm stores restage every affected ORM ecosystem, with a real SQLite close/reopen regression.
- Add focused regressions for activation, ordering, scoped reconciliation, removal/restoration, duplicate handling, repository isolation, conflicts, named arguments, literal decoding, structured metadata, and warm-store upgrades.

## Validation

- go build -buildvcs=false ./...
- go vet -buildvcs=false ./internal/graph/store_sqlite/... ./internal/indexer/... ./internal/parser/languages/... ./internal/resolver/...
- go test ./internal/parser/languages
- go test ./internal/resolver
- go test ./internal/indexer -count=1
- go test -buildvcs=false ./internal/graph/store_sqlite
- go test -race -buildvcs=false ./internal/parser/languages/... ./internal/resolver/... ./internal/indexer/...
- focused race test for the changed SQLite metadata encoding path

A repository-wide test run encountered one transient TempDir cleanup race in internal/mcp; both the exact failing test and the complete internal/mcp package passed immediately on clean reruns.