### PR TITLE
`batch_symbols` JSON callers/callees cap at 9 and did not say so

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -281,7 +281,7 @@ over a very large tree, or `ask` against a slow local model.
 | Tool | Description |
 |------|-------------|
 | `get_symbol_source` | Source code of a single symbol (80% fewer tokens than Read). Returns `tokens_saved` per call. `compress_bodies` stubs bodies (with an optional `keep` subset); `max_lines` salience-truncates to a control-flow skeleton |
-| `batch_symbols` | Multiple symbols with source/callers/callees in one call |
+| `batch_symbols` | Multiple symbols with source and a capped 1-hop callers/callees sample (`callers_truncated` / `callees_truncated` mark a cut; full neighbourhood is `get_callers` / `get_call_chain`) |
 | `find_import_path` | Correct import path for a symbol |
 | `explain_change_impact` | Risk-tiered blast radius with affected processes. A zero-edge target carries the same per-symbol `likely_unused` / `possible_extraction_gap` / `coverage_incomplete` caveat as `get_callers` |
 | `get_recent_changes` | Files/symbols changed since timestamp. Rows are clamped to the session workspace and narrowed further by `repo`/`project`/`scope`; each multi-repo row names its `repo` |

--- a/internal/mcp/batch_symbols_neighbourhood_truncation_test.go
+++ b/internal/mcp/batch_symbols_neighbourhood_truncation_test.go
@@ -1,0 +1,164 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// batch_symbols walks 1-hop callers/callees with a hard-coded Limit:10.
+// BFS counts the seed, so the id lists cap at nine. Truncated is
+// computed and must ride on the JSON entry; a total must not, because
+// TotalNodes is the capped subgraph (seed+9), not the neighbourhood.
+
+func TestBatchSymbols_CallersTruncatedFlag(t *testing.T) {
+	t.Parallel()
+
+	t.Run("15_callers_flag_true_len_9", func(t *testing.T) {
+		t.Parallel()
+		entry := batchSymbolsEntry(t, graphWithCallers(t, 15), "lib.go::Hub")
+		callers := mustStringSlice(t, entry["callers"])
+		assert.Equal(t, 9, len(callers), "Limit 10 includes the seed")
+		assert.Equal(t, true, entry["callers_truncated"], "capped list must carry callers_truncated")
+		assertNoInventedTotal(t, entry)
+	})
+
+	t.Run("8_callers_flag_absent_len_8", func(t *testing.T) {
+		t.Parallel()
+		entry := batchSymbolsEntry(t, graphWithCallers(t, 8), "lib.go::Hub")
+		callers := mustStringSlice(t, entry["callers"])
+		assert.Equal(t, 8, len(callers))
+		_, flagged := entry["callers_truncated"]
+		assert.False(t, flagged, "complete under-cap page must not grow a truncated key")
+		assertNoInventedTotal(t, entry)
+	})
+
+	t.Run("15_callees_flag_true_len_9", func(t *testing.T) {
+		t.Parallel()
+		entry := batchSymbolsEntry(t, graphWithCallees(t, 15), "lib.go::Hub")
+		callees := mustStringSlice(t, entry["callees"])
+		assert.Equal(t, 9, len(callees), "Limit 10 includes the seed")
+		assert.Equal(t, true, entry["callees_truncated"], "capped list must carry callees_truncated")
+		assertNoInventedTotal(t, entry)
+	})
+
+	t.Run("8_callees_flag_absent_len_8", func(t *testing.T) {
+		t.Parallel()
+		entry := batchSymbolsEntry(t, graphWithCallees(t, 8), "lib.go::Hub")
+		callees := mustStringSlice(t, entry["callees"])
+		assert.Equal(t, 8, len(callees))
+		_, flagged := entry["callees_truncated"]
+		assert.False(t, flagged, "complete under-cap page must not grow a truncated key")
+		assertNoInventedTotal(t, entry)
+	})
+}
+
+func TestBatchSymbols_GCXOmitsNeighbourhood(t *testing.T) {
+	t.Parallel()
+	g := graphWithCallers(t, 15)
+	srv := newBatchSymbolsServer(t, g)
+	res := callTool(t, srv, "batch_symbols", map[string]any{
+		"ids":    []any{"lib.go::Hub"},
+		"format": "gcx",
+	})
+	require.False(t, res.IsError, "%s", toolResultText(res))
+	text := toolResultText(res)
+	assert.NotContains(t, text, "callers", "GCX batch_symbols encoder drops the neighbourhood lists")
+	assert.NotContains(t, text, "callers_truncated")
+}
+
+func graphWithCallers(t *testing.T, n int) *graph.Graph {
+	t.Helper()
+	g := graph.New()
+	target := hubNode()
+	g.AddNode(target)
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("c%d.go::Caller%d", i, i)
+		g.AddNode(&graph.Node{
+			ID: id, Kind: graph.KindFunction, Name: fmt.Sprintf("Caller%d", i),
+			FilePath: fmt.Sprintf("c%d.go", i), Language: "go",
+			StartLine: 1, EndLine: 5,
+		})
+		g.AddEdge(&graph.Edge{
+			From: id, To: target.ID, Kind: graph.EdgeCalls,
+			FilePath: fmt.Sprintf("c%d.go", i), Line: 2,
+			Origin: graph.OriginLSPResolved,
+		})
+	}
+	return g
+}
+
+func graphWithCallees(t *testing.T, n int) *graph.Graph {
+	t.Helper()
+	g := graph.New()
+	target := hubNode()
+	g.AddNode(target)
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("d%d.go::Callee%d", i, i)
+		g.AddNode(&graph.Node{
+			ID: id, Kind: graph.KindFunction, Name: fmt.Sprintf("Callee%d", i),
+			FilePath: fmt.Sprintf("d%d.go", i), Language: "go",
+			StartLine: 1, EndLine: 5,
+		})
+		g.AddEdge(&graph.Edge{
+			From: target.ID, To: id, Kind: graph.EdgeCalls,
+			FilePath: "lib.go", Line: 2,
+			Origin: graph.OriginLSPResolved,
+		})
+	}
+	return g
+}
+
+func hubNode() *graph.Node {
+	return &graph.Node{
+		ID: "lib.go::Hub", Kind: graph.KindFunction, Name: "Hub",
+		FilePath: "lib.go", Language: "go", StartLine: 1, EndLine: 3,
+	}
+}
+
+func newBatchSymbolsServer(t *testing.T, g *graph.Graph) *Server {
+	t.Helper()
+	eng := query.NewEngine(g)
+	eng.SetSearch(search.NewNull())
+	return NewServer(eng, g, nil, nil, zap.NewNop(), nil)
+}
+
+func batchSymbolsEntry(t *testing.T, g *graph.Graph, id string) map[string]any {
+	t.Helper()
+	srv := newBatchSymbolsServer(t, g)
+	res := callTool(t, srv, "batch_symbols", map[string]any{"ids": []any{id}})
+	require.False(t, res.IsError, "%s", toolResultText(res))
+	var batchResp map[string]any
+	require.NoError(t, json.Unmarshal([]byte(res.Content[0].(mcplib.TextContent).Text), &batchResp))
+	syms, ok := batchResp["symbols"].([]any)
+	require.True(t, ok)
+	require.Len(t, syms, 1)
+	entry, ok := syms[0].(map[string]any)
+	require.True(t, ok)
+	return entry
+}
+
+func mustStringSlice(t *testing.T, raw any) []any {
+	t.Helper()
+	require.NotNil(t, raw)
+	out, ok := raw.([]any)
+	require.True(t, ok, "expected id list, got %T", raw)
+	return out
+}
+
+func assertNoInventedTotal(t *testing.T, entry map[string]any) {
+	t.Helper()
+	for _, k := range []string{"callers_total", "callees_total", "caller_total", "callee_total", "total_nodes"} {
+		_, present := entry[k]
+		assert.False(t, present, "must not emit %s — TotalNodes is the page size, not the neighbourhood", k)
+	}
+}

--- a/internal/mcp/tools_coding.go
+++ b/internal/mcp/tools_coding.go
@@ -77,7 +77,7 @@ func (s *Server) registerCodingTools() {
 
 	s.addTool(
 		mcp.NewTool("batch_symbols",
-			mcp.WithDescription("Returns signatures, source code, callers, and callees for multiple symbols in one call. Use instead of calling get_symbol_source or get_symbol multiple times — saves 60% round-trip overhead."),
+			mcp.WithDescription("Returns signatures, source code, and a capped 1-hop callers/callees sample for multiple symbols in one call. `callers_truncated` / `callees_truncated` mark a cut; use get_callers / get_call_chain for the full neighbourhood. Use instead of calling get_symbol_source or get_symbol multiple times — saves 60% round-trip overhead."),
 			mcp.WithString("ids", mcp.Required(), mcp.Description("Comma-separated list of symbol IDs")),
 			mcp.WithBoolean("include_source", mcp.Description("Include source code for each symbol (default: false)")),
 			mcp.WithNumber("context_lines", mcp.Description("Extra lines above/below source (default: 3, only if include_source)")),
@@ -1236,6 +1236,11 @@ func (s *Server) handleBatchSymbols(ctx context.Context, req mcp.CallToolRequest
 			if len(callerIDs) > 0 {
 				entry["callers"] = callerIDs
 			}
+			// Stamp the cut. Do not emit a total: TotalNodes is the
+			// capped subgraph (seed+9), not the neighbourhood.
+			if callers.Truncated {
+				entry["callers_truncated"] = true
+			}
 
 			// Callees (depth 1).
 			callees := s.engineFor(ctx).GetCallChain(node.ID, query.QueryOptions{Depth: 1, Limit: 10, Detail: "brief", WorkspaceID: sessWS})
@@ -1247,6 +1252,9 @@ func (s *Server) handleBatchSymbols(ctx context.Context, req mcp.CallToolRequest
 			}
 			if len(calleeIDs) > 0 {
 				entry["callees"] = calleeIDs
+			}
+			if callees.Truncated {
+				entry["callees_truncated"] = true
 			}
 		}
 


### PR DESCRIPTION
`handleBatchSymbols` walks the 1-hop neighbourhood with a hard-coded
`Limit: 10` (`tools_coding.go`). BFS counts the seed against that limit,
so the id lists cap at nine. `SubGraph.Truncated` was already computed
(`engine.go:1636`) and then discarded — the JSON response was just
`callers: [...]` / `callees: [...]`.

The cap stays. The JSON entry now carries `callers_truncated` /
`callees_truncated` when the cut binds. Complete under-cap pages (8
callers, 8 callees) grow no new key.

No `*_total`. On this path `TotalNodes` is `len(allNodes)` after the cap
(`engine.go:1634`), so a `TotalNodes - 1` figure would report 9 on a
15-caller graph — the page size, not the neighbourhood.

Full callers/callees remain `get_callers` / `get_call_chain`. GCX
(`encodeBatchSymbols`) still omits the lists; this stamp is the JSON
wire.

```
HEAD:    15 callers → 9 ids, no flag
this PR: 15 callers → 9 ids, callers_truncated=true
         8 callers  → 8 ids, no flag
```

`go test ./internal/mcp -run TestBatchSymbols_CallersTruncatedFlag -v`
