### PR TITLE
fix(mcp): resolve superseded failed mutation receipts on later success

### DIFF
--- a/internal/mcp/edit_serialization.go
+++ b/internal/mcp/edit_serialization.go
@@ -171,12 +171,42 @@ func (s *Server) trackMutationTicket(ticket *indexer.MutationTicket) *mutationRe
 		receipt.result = result
 		receipt.completed = true
 		receipt.mu.Unlock()
+		if result.Err == nil && result.Reindexed {
+			s.resolveSupersededFailedReceipts(receipt)
+		}
 		close(receipt.done)
 		time.AfterFunc(mutationReceiptRetention, func() {
 			s.mutationReceipts.Delete(receipt.id)
 		})
 	}()
 	return receipt
+}
+
+// resolveSupersededFailedReceipts drops terminally failed receipts for a path
+// once a later generation of the same path has been applied successfully. The
+// graph then reflects newer bytes than the failed generation ever wrote, so
+// the stale failure no longer describes a real freshness gap — keeping it
+// would only fail freshness barriers that waiting cannot heal, because a
+// terminal error never completes differently. Pending receipts and failures
+// at or above the succeeded generation are left untouched.
+func (s *Server) resolveSupersededFailedReceipts(succeeded *mutationReceipt) {
+	succeededPath := filepath.Clean(succeeded.path)
+	s.mutationReceipts.Range(func(key, value any) bool {
+		other, ok := value.(*mutationReceipt)
+		if !ok || other == succeeded {
+			return true
+		}
+		if other.generation >= succeeded.generation || filepath.Clean(other.path) != succeededPath {
+			return true
+		}
+		other.mu.RLock()
+		terminalFailure := other.completed && (other.result.Err != nil || !other.result.Reindexed)
+		other.mu.RUnlock()
+		if terminalFailure {
+			s.mutationReceipts.Delete(key)
+		}
+		return true
+	})
 }
 
 func (r *mutationReceipt) outcome(pending bool) mutationReindexOutcome {
@@ -313,16 +343,19 @@ waitLoop:
 	}
 
 	issues := make([]string, 0, len(receipts))
+	hasTerminalFailure := false
 	for _, receipt := range receipts {
 		select {
 		case <-receipt.done:
 			outcome := receipt.outcome(false)
 			switch {
 			case outcome.Err != nil:
+				hasTerminalFailure = true
 				issues = append(issues, fmt.Sprintf(
 					"failed receipt=%s repo=%q path=%q generation=%d error=%q",
 					receipt.id, receipt.repo, receipt.path, receipt.generation, outcome.Err.Error()))
 			case !outcome.Reindexed:
+				hasTerminalFailure = true
 				issues = append(issues, fmt.Sprintf(
 					"failed receipt=%s repo=%q path=%q generation=%d error=%q",
 					receipt.id, receipt.repo, receipt.path, receipt.generation, "reindex not confirmed"))
@@ -351,6 +384,11 @@ waitLoop:
 			message += "; "
 		}
 		message += issue
+	}
+	if hasTerminalFailure {
+		message += "; terminally failed generations do not recover by waiting — " +
+			"they clear when a later mutation of the same path succeeds or when " +
+			"the receipt retention lapses"
 	}
 	return fmt.Errorf("%s", message)
 }

--- a/internal/mcp/edit_serialization.go
+++ b/internal/mcp/edit_serialization.go
@@ -172,7 +172,7 @@ func (s *Server) trackMutationTicket(ticket *indexer.MutationTicket) *mutationRe
 		receipt.completed = true
 		receipt.mu.Unlock()
 		if result.Err == nil && result.Reindexed {
-			s.resolveSupersededFailedReceipts(receipt)
+			s.resolveSupersededFailedReceipts(receipt.path, receipt.generation, result)
 		}
 		close(receipt.done)
 		time.AfterFunc(mutationReceiptRetention, func() {
@@ -182,29 +182,40 @@ func (s *Server) trackMutationTicket(ticket *indexer.MutationTicket) *mutationRe
 	return receipt
 }
 
-// resolveSupersededFailedReceipts drops terminally failed receipts for a path
-// once a later generation of the same path has been applied successfully. The
-// graph then reflects newer bytes than the failed generation ever wrote, so
-// the stale failure no longer describes a real freshness gap — keeping it
-// would only fail freshness barriers that waiting cannot heal, because a
-// terminal error never completes differently. Pending receipts and failures
-// at or above the succeeded generation are left untouched.
-func (s *Server) resolveSupersededFailedReceipts(succeeded *mutationReceipt) {
-	succeededPath := filepath.Clean(succeeded.path)
-	s.mutationReceipts.Range(func(key, value any) bool {
+// resolveSupersededFailedReceipts resolves terminally failed receipts for a
+// path once a later generation of the same path has been applied
+// successfully. The graph then reflects newer bytes than the failed
+// generation ever wrote, so the stale failure no longer describes a real
+// freshness gap — keeping it would only fail freshness barriers that waiting
+// cannot heal, because a terminal error never completes differently.
+//
+// The failed receipt is resolved in place rather than deleted: the
+// mutation-commit ledger refreshes its graph half through
+// mutationReceiptState, and a deleted receipt would leave that record
+// reading "pending" forever. Stamping the superseding apply mirrors how
+// completeMutationWaiters resolves earlier waiters with the later apply's
+// result. Pending receipts and failures at or above the succeeded
+// generation are left untouched. The succeeded result is passed by value so
+// the sweep holds no lock besides the receipt it is stamping.
+func (s *Server) resolveSupersededFailedReceipts(succeededPath string, succeededGeneration uint64, applied indexer.MutationResult) {
+	cleanPath := filepath.Clean(succeededPath)
+	s.mutationReceipts.Range(func(_, value any) bool {
 		other, ok := value.(*mutationReceipt)
-		if !ok || other == succeeded {
+		if !ok {
 			return true
 		}
-		if other.generation >= succeeded.generation || filepath.Clean(other.path) != succeededPath {
+		if other.generation >= succeededGeneration || filepath.Clean(other.path) != cleanPath {
 			return true
 		}
-		other.mu.RLock()
-		terminalFailure := other.completed && (other.result.Err != nil || !other.result.Reindexed)
-		other.mu.RUnlock()
-		if terminalFailure {
-			s.mutationReceipts.Delete(key)
+		other.mu.Lock()
+		if other.completed && (other.result.Err != nil || !other.result.Reindexed) {
+			other.result = indexer.MutationResult{
+				RequestedGeneration: other.generation,
+				AppliedGeneration:   applied.AppliedGeneration,
+				Reindexed:           true,
+			}
 		}
+		other.mu.Unlock()
 		return true
 	})
 }

--- a/internal/mcp/mutation_freshness_test.go
+++ b/internal/mcp/mutation_freshness_test.go
@@ -123,21 +123,26 @@ func TestMutationFreshnessSuccessResolvesSupersededFailures(t *testing.T) {
 	})
 
 	succeeded := pendingFreshnessReceipt(s, "receipt-success", "repo-a", "/repo-a/file.go", 9)
-	completeFreshnessReceipt(succeeded, indexer.MutationResult{
+	appliedResult := indexer.MutationResult{
 		RequestedGeneration: 9,
 		AppliedGeneration:   9,
 		Reindexed:           true,
-	})
-	s.resolveSupersededFailedReceipts(succeeded)
+	}
+	completeFreshnessReceipt(succeeded, appliedResult)
+	s.resolveSupersededFailedReceipts("/repo-a/file.go", 9, appliedResult)
 
-	if _, loaded := s.mutationReceipts.Load("receipt-stale-failed"); loaded {
-		t.Fatal("superseded failed receipt survived a later successful generation")
+	if _, loaded := s.mutationReceipts.Load("receipt-stale-failed"); !loaded {
+		t.Fatal("superseded receipt was deleted; it must stay queryable for the mutation-commit ledger")
 	}
-	if _, loaded := s.mutationReceipts.Load("receipt-other-path"); !loaded {
-		t.Fatal("failure on an unrelated path was dropped")
+	resolved := stale.outcome(false)
+	if resolved.Err != nil || !resolved.Reindexed || resolved.AppliedGeneration != 9 {
+		t.Fatalf("superseded failure was not resolved in place: %+v", resolved)
 	}
-	if _, loaded := s.mutationReceipts.Load("receipt-newer-failed"); !loaded {
-		t.Fatal("failure newer than the succeeded generation was dropped")
+	if outcome := otherPath.outcome(false); outcome.Err == nil {
+		t.Fatal("failure on an unrelated path was resolved")
+	}
+	if outcome := newer.outcome(false); outcome.Err == nil {
+		t.Fatal("failure newer than the succeeded generation was resolved")
 	}
 
 	err := s.awaitMutationFreshnessForRepos(context.Background(), "repo-a")
@@ -178,11 +183,40 @@ func TestTrackMutationTicketResolvesSupersededFailures(t *testing.T) {
 	close(done)
 	<-receipt.done
 
-	if _, loaded := s.mutationReceipts.Load("receipt-stale-failed"); loaded {
-		t.Fatal("stale failed receipt not resolved after a successful ticket")
+	if _, loaded := s.mutationReceipts.Load("receipt-stale-failed"); !loaded {
+		t.Fatal("stale receipt was deleted; it must stay queryable for the mutation-commit ledger")
+	}
+	resolved := stale.outcome(false)
+	if resolved.Err != nil || !resolved.Reindexed || resolved.AppliedGeneration != 5 {
+		t.Fatalf("stale failed receipt not resolved after a successful ticket: %+v", resolved)
 	}
 	if _, loaded := s.mutationReceipts.Load(receipt.id); !loaded {
 		t.Fatal("successful receipt itself was dropped before retention")
+	}
+}
+
+func TestMutationFreshnessSuccessKeepsPendingSamePathReceipts(t *testing.T) {
+	s := &Server{mutationSafetyWait: time.Millisecond}
+	inflight := pendingFreshnessReceipt(s, "receipt-inflight", "repo-a", "/repo-a/file.go", 4)
+
+	appliedResult := indexer.MutationResult{
+		RequestedGeneration: 9,
+		AppliedGeneration:   9,
+		Reindexed:           true,
+	}
+	succeeded := pendingFreshnessReceipt(s, "receipt-success", "repo-a", "/repo-a/file.go", 9)
+	completeFreshnessReceipt(succeeded, appliedResult)
+	s.resolveSupersededFailedReceipts("/repo-a/file.go", 9, appliedResult)
+
+	if _, loaded := s.mutationReceipts.Load("receipt-inflight"); !loaded {
+		t.Fatal("a still-pending receipt for the same path was dropped by the resolve")
+	}
+	if outcome := inflight.outcome(true); outcome.Pending != true {
+		t.Fatalf("a still-pending receipt was marked completed by the resolve: %+v", outcome)
+	}
+	err := s.awaitMutationFreshnessForRepos(context.Background(), "repo-a")
+	if err == nil || !strings.Contains(err.Error(), "receipt-inflight") {
+		t.Fatalf("barrier no longer reports the in-flight receipt: %v", err)
 	}
 }
 

--- a/internal/mcp/mutation_freshness_test.go
+++ b/internal/mcp/mutation_freshness_test.go
@@ -104,6 +104,88 @@ func TestMutationFreshnessTerminalFailureFailsClosed(t *testing.T) {
 	}
 }
 
+func TestMutationFreshnessSuccessResolvesSupersededFailures(t *testing.T) {
+	s := &Server{mutationSafetyWait: time.Millisecond}
+	stale := pendingFreshnessReceipt(s, "receipt-stale-failed", "repo-a", "/repo-a/file.go", 6)
+	completeFreshnessReceipt(stale, indexer.MutationResult{
+		RequestedGeneration: 6,
+		Err:                 errors.New("context deadline exceeded"),
+	})
+	otherPath := pendingFreshnessReceipt(s, "receipt-other-path", "repo-a", "/repo-a/other.go", 7)
+	completeFreshnessReceipt(otherPath, indexer.MutationResult{
+		RequestedGeneration: 7,
+		Err:                 errors.New("unrelated failure"),
+	})
+	newer := pendingFreshnessReceipt(s, "receipt-newer-failed", "repo-a", "/repo-a/file.go", 12)
+	completeFreshnessReceipt(newer, indexer.MutationResult{
+		RequestedGeneration: 12,
+		Err:                 errors.New("later failure"),
+	})
+
+	succeeded := pendingFreshnessReceipt(s, "receipt-success", "repo-a", "/repo-a/file.go", 9)
+	completeFreshnessReceipt(succeeded, indexer.MutationResult{
+		RequestedGeneration: 9,
+		AppliedGeneration:   9,
+		Reindexed:           true,
+	})
+	s.resolveSupersededFailedReceipts(succeeded)
+
+	if _, loaded := s.mutationReceipts.Load("receipt-stale-failed"); loaded {
+		t.Fatal("superseded failed receipt survived a later successful generation")
+	}
+	if _, loaded := s.mutationReceipts.Load("receipt-other-path"); !loaded {
+		t.Fatal("failure on an unrelated path was dropped")
+	}
+	if _, loaded := s.mutationReceipts.Load("receipt-newer-failed"); !loaded {
+		t.Fatal("failure newer than the succeeded generation was dropped")
+	}
+
+	err := s.awaitMutationFreshnessForRepos(context.Background(), "repo-a")
+	if err == nil {
+		t.Fatal("remaining failures did not fail closed")
+	}
+	message := err.Error()
+	if strings.Contains(message, "receipt-stale-failed") {
+		t.Fatalf("freshness error still reports the superseded receipt: %s", message)
+	}
+	for _, want := range []string{
+		"receipt-other-path",
+		"receipt-newer-failed",
+		"do not recover by waiting",
+	} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("freshness error %q does not contain %q", message, want)
+		}
+	}
+}
+
+func TestTrackMutationTicketResolvesSupersededFailures(t *testing.T) {
+	s := &Server{}
+	stale := pendingFreshnessReceipt(s, "receipt-stale-failed", "", "/repo/file.go", 3)
+	completeFreshnessReceipt(stale, indexer.MutationResult{
+		RequestedGeneration: 3,
+		Err:                 errors.New("context deadline exceeded"),
+	})
+
+	done := make(chan indexer.MutationResult, 1)
+	ticket := &indexer.MutationTicket{Path: "/repo/file.go", Generation: 5, Done: done}
+	receipt := s.trackMutationTicket(ticket)
+	done <- indexer.MutationResult{
+		RequestedGeneration: 5,
+		AppliedGeneration:   5,
+		Reindexed:           true,
+	}
+	close(done)
+	<-receipt.done
+
+	if _, loaded := s.mutationReceipts.Load("receipt-stale-failed"); loaded {
+		t.Fatal("stale failed receipt not resolved after a successful ticket")
+	}
+	if _, loaded := s.mutationReceipts.Load(receipt.id); !loaded {
+		t.Fatal("successful receipt itself was dropped before retention")
+	}
+}
+
 func TestMutationReposForSymbolIDsUnresolvedWidensBarrier(t *testing.T) {
 	g := graph.New()
 	g.AddNode(&graph.Node{


### PR DESCRIPTION
## Summary

Fixes the rolling repo-wide `change.detect` lockout described in #692.

A mutation whose disk write succeeded but whose graph ingest failed leaves a terminally failed receipt in `Server.mutationReceipts`. `awaitMutationFreshnessForRepos` then refuses `change.detect`/`change.impact` for the whole repository until the receipt's 10-minute retention lapses — even though waiting can never heal a terminal failure. Under load, each failed ingest of an actively edited file re-arms the barrier for another retention window, so agents observe a seemingly permanent, uncleareable lockout.

## Change

- `trackMutationTicket`: when a ticket completes successfully (`Err == nil && Reindexed`), call the new `resolveSupersededFailedReceipts`, which drops **terminally failed** receipts for the **same path** with a **lower generation**. The graph then reflects newer bytes than the failed generation ever wrote, so the stale failure no longer describes a real freshness gap. Pending receipts and failures at or above the succeeded generation are untouched, as are failures on other paths.
- Barrier error message: when a terminal failure is reported, append that terminally failed generations do not recover by waiting and clear on a later successful mutation of the path or on retention expiry. (Existing tests assert substrings, so this is additive.)

## Tests

- `TestMutationFreshnessSuccessResolvesSupersededFailures`: success resolves an older failed receipt for the same path; failures on another path and failures newer than the success survive and still fail the barrier; the superseded receipt no longer appears in the error.
- `TestTrackMutationTicketResolvesSupersededFailures`: end-to-end through `trackMutationTicket` — a successful ticket for the path removes the stale failed receipt and keeps its own receipt for retention.
- Deleting the resolve call makes the end-to-end test fail (verified), so the tests bind the behavior.

## Verification

- `go vet ./internal/mcp/`: clean.
- Focused freshness tests pass on Windows and on Linux (`golang:1.26` container).
- Full `./internal/mcp` suite in the Linux container: `TestDetectChanges_EchoesMeasuredScope` and `TestFileMutationsReindexSynchronouslyAcrossConsecutiveEdits` fail **identically with and without this patch** (both pass in isolation), so they appear to be pre-existing load-sensitive failures, not regressions from this change.

## Scope (explicit, so #692 stays open)

- `workspace_admin.reindex` goes through `multiIndexer.IncrementalReindexRepo` and never touches `s.mutationReceipts`, so a scoped reindex of the file still does not resolve a failed receipt. Not addressed here.
- Under sustained load where every successive ingest also fails, nothing here clears anything — the resolve only runs on a success. This converts "blocked until retention" into "blocked until the next success", not the full rolling-lockout fix. Retry-with-backoff and degrade-instead-of-refuse remain open in #692.
- As of the review follow-up, superseded failures are resolved **in place** (stamped with the superseding apply) rather than deleted, so `change.receipt` keeps reporting truthfully.

## Notes

The reproduction and measurements behind this are in #692 (including the correction comment with the retention/in-memory analysis). The other asks in that issue — an explicit reconcile operation, degrade-instead-of-refuse, and printing a queryable id in the refusal — are intentionally left out of this PR since they involve API-surface decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


