### PR TITLE
indexer: pin the retarget-frontier discard to full-coverage batches

### DIFF
--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -1689,7 +1689,7 @@ func (mi *MultiIndexer) runGlobalGraphPassesTopologyHeld(
 	// a scoped re-projection under ResolveMutex.
 	if scanPrefixes == nil {
 		mi.discardRetargetedTestCallFiles(nil)
-    }
+	}
 	passStart("entrypoint_hierarchy")
 	ctrlStart := time.Now()
 	// Seeds from already-stamped entry points, so cost is O(seed

--- a/internal/indexer/multi_global_passes_test.go
+++ b/internal/indexer/multi_global_passes_test.go
@@ -225,3 +225,98 @@ func TestMultiIndexer_TrackRepoCtx_NoBatch_RunsGlobalPassesInline(t *testing.T) 
 	assert.Greater(t, countEdges(g, graph.EdgeImplements), 0,
 		"non-batched TrackRepoCtx must emit EdgeImplements inline")
 }
+
+// setupForeignRepoRetargetFrontier builds the state where the scoped batch
+// projection and the frontier discard disagree: two repos cold-indexed,
+// repo-b's test call restubbed with its projection evicted (repo-b itself
+// unchanged), then rebound by repo-a's resolver. Per-repo resolvers are
+// never SetScope'd, so repo-a's ResolveAll walks the whole shared graph and
+// parks repo-b/main_test.go on repo-a's frontier — a caller a scoped
+// {repo-a} projection will never walk (it reads only repo-a's calls edges).
+func setupForeignRepoRetargetFrontier(t *testing.T) (*MultiIndexer, graph.Store) {
+	t.Helper()
+	repoA := filepath.Join(t.TempDir(), "repo-a")
+	require.NoError(t, os.MkdirAll(repoA, 0o755))
+	writeFile(t, filepath.Join(repoA, "go.mod"), "module example.com/repo-a\n\ngo 1.22\n")
+	writeFile(t, filepath.Join(repoA, "main.go"), "package main\n\nfunc Alpha() {}\n")
+	repoB := filepath.Join(t.TempDir(), "repo-b")
+	require.NoError(t, os.MkdirAll(repoB, 0o755))
+	writeFile(t, filepath.Join(repoB, "go.mod"), "module example.com/repo-b\n\ngo 1.22\n")
+	writeFile(t, filepath.Join(repoB, "main.go"), "package main\n\nfunc Beta() {}\n")
+	writeFile(t, filepath.Join(repoB, "main_test.go"),
+		"package main\n\nimport \"testing\"\n\nfunc TestBeta(t *testing.T) { Beta() }\n")
+
+	tmpCfg := filepath.Join(t.TempDir(), "config.yaml")
+	gc := &config.GlobalConfig{
+		Repos: []config.RepoEntry{
+			{Path: repoA, Name: "repo-a"},
+			{Path: repoB, Name: "repo-b"},
+		},
+	}
+	gc.SetConfigPath(tmpCfg)
+	require.NoError(t, gc.Save())
+	cm, err := config.NewConfigManager(tmpCfg)
+	require.NoError(t, err)
+
+	g := graph.New()
+	mi := NewMultiIndexer(g, newTestRegistry(), search.NewNull(), cm, zap.NewNop())
+	_, err = mi.IndexAll()
+	require.NoError(t, err)
+	require.NotNil(t,
+		findEdge(g, graph.EdgeTests, "repo-b/main_test.go::TestBeta", "repo-b/main.go::Beta"),
+		"fixture: cold index must project repo-b's test call")
+
+	// Restub: evict the projection and put the call back to unresolved —
+	// the post-restub graph state, with repo-b untouched on disk.
+	require.True(t, g.RemoveEdge("repo-b/main_test.go::TestBeta", "repo-b/main.go::Beta", graph.EdgeTests))
+	require.True(t, g.RemoveEdge("repo-b/main_test.go::TestBeta", "repo-b/main.go::Beta", graph.EdgeCalls))
+	g.AddEdge(&graph.Edge{From: "repo-b/main_test.go::TestBeta", To: graph.UnresolvedMarker + "Beta",
+		Kind: graph.EdgeCalls, FilePath: "repo-b/main_test.go", Line: 5})
+
+	// repo-a's resolver rebinds it — the same call indexCtxRaw and
+	// RunDeferredPasses make.
+	mi.indexers["repo-a"].resolver.ResolveAll()
+	require.NotNil(t,
+		findEdge(g, graph.EdgeCalls, "repo-b/main_test.go::TestBeta", "repo-b/main.go::Beta"),
+		"fixture: repo-a's unscoped ResolveAll must rebind repo-b's call")
+	return mi, g
+}
+
+// A scoped batch projects by the repo of the calls edge but discards
+// per-indexer frontiers whole, so a repo-b caller parked on repo-a's
+// frontier is neither projected nor carried to the next save. The
+// projection must end up either emitted or still deferred on a frontier —
+// never gone.
+func TestScopedGlobalPassKeepsForeignRepoRetargetFrontier(t *testing.T) {
+	mi, g := setupForeignRepoRetargetFrontier(t)
+	mi.runGlobalGraphPasses(context.Background(), map[string]struct{}{"repo-a": {}}, false)
+	if findEdge(g, graph.EdgeTests, "repo-b/main_test.go::TestBeta", "repo-b/main.go::Beta") != nil {
+		return // projected outright — even better than deferred
+	}
+	for _, idx := range mi.indexers {
+		for _, f := range idx.resolver.TakeRetargetedTestCallFiles() {
+			if f == "repo-b/main_test.go" {
+				return // deferred — the next save's scoped pass reconciles it
+			}
+		}
+	}
+	t.Fatalf("scoped batch permanently lost repo-b's test projection: " +
+		"not projected, and no retarget frontier carries repo-b/main_test.go")
+}
+
+// The surviving discard, pinned: a full-coverage batch projection is
+// graph-wide, so every per-repo frontier must be empty afterwards — the
+// perf win of the cold-path discard, without the unsafe scoped case.
+func TestFullCoverageGlobalPassDiscardsAllRetargetFrontiers(t *testing.T) {
+	mi, g := setupForeignRepoRetargetFrontier(t)
+	mi.runGlobalGraphPasses(context.Background(), nil, false)
+	if findEdge(g, graph.EdgeTests, "repo-b/main_test.go::TestBeta", "repo-b/main.go::Beta") == nil {
+		t.Fatalf("full-coverage batch must project the rebound test call")
+	}
+	for prefix, idx := range mi.indexers {
+		if files := idx.resolver.TakeRetargetedTestCallFiles(); len(files) != 0 {
+			t.Fatalf("full-coverage batch left %d file(s) parked on %s's frontier: %v",
+				len(files), prefix, files)
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #679, closing the round-3 review's remaining ask: the surviving discard in `runGlobalGraphPassesTopologyHeld` had no coverage, which is how the scoped-batch loss slipped in in the first place.

Two regression tests over that call site, plus one formatting byte:

1. **`TestScopedGlobalPassKeepsForeignRepoRetargetFrontier`** - your end-to-end reproduction as a fixture: two repos cold-indexed through `IndexAll`, repo-b's test call restubbed with its projection evicted (repo-b unchanged), rebound by repo-a's unscoped per-repo `ResolveAll` (which parks `repo-b/main_test.go` on repo-a's frontier), then `runGlobalGraphPasses({repo-a})`. The test accepts either outcome that preserves the projection - emitted outright, or still parked on a frontier for the next save - and fails only on the permanent-loss shape. Restoring the unconditional discard fails it with exactly that shape.
2. **`TestFullCoverageGlobalPassDiscardsAllRetargetFrontiers`** - the pin you asked for: after a `scanPrefixes == nil` batch, the rebound call is projected and every per-repo frontier is empty. Short-circuiting the discard fails it with `[repo-b/main_test.go]` parked on repo-a's frontier.
3. The suggestion-applied gate landed with a space-indented closing brace (`multi.go:1692`); retabbed so the tree is gofmt-clean again.

Verified: both tests green at head and neuter-audited in both directions as above; build, `go vet`, `staticcheck` clean; full `internal/indexer` suite fail-set identical to a clean-main control in the same shell (my usual Windows environmental set, empty diff); the frontier test family is green under `-race`.
