### PR TITLE
graph: untangle the eviction-receipt doc comments

### DIFF
--- a/internal/graph/mutation_receipt.go
+++ b/internal/graph/mutation_receipt.go
@@ -26,9 +26,15 @@ type MutationReceipt struct {
 	// ChangedFiles contains exact source files for added edges. Resolved edges
 	// belong here so cross-repository materialization still observes them, but
 	// they must not trigger another same-repository unresolved-edge pass.
-	ChangedFiles     []string `json:"changed_files,omitempty"`
-	UnresolvedFiles  []string `json:"unresolved_files,omitempty"`
-	DefinitionFiles  []string `json:"definition_files,omitempty"`
+	ChangedFiles    []string `json:"changed_files,omitempty"`
+	UnresolvedFiles []string `json:"unresolved_files,omitempty"`
+	DefinitionFiles []string `json:"definition_files,omitempty"`
+	// TargetNames is descriptive only: it records the Name/QualName of every
+	// added node for observability, and nothing in resolution consumes it —
+	// the name frontier reads EvictedNames, the file frontier reads
+	// DefinitionFiles. The backends deliberately diverge on its contents (the
+	// graph accumulator records non-referenceable added-node names, SQLite
+	// does not); keep that divergence out of any correctness contract.
 	TargetNames      []string `json:"target_names,omitempty"`
 	TargetIDs        []string `json:"target_ids,omitempty"`
 	ImportCandidates []string `json:"import_candidates,omitempty"`

--- a/internal/graph/stub.go
+++ b/internal/graph/stub.go
@@ -356,6 +356,30 @@ func IsReferenceableSymbol(k NodeKind) bool {
 // UnresolvedNameCandidateIDsForName is `import::<path>`.
 const ImportStubNamePrefix = "import::"
 
+// EvictedNodeNeedsResolutionFrontier reports whether evicting a node of this
+// kind can change resolution even though ReceiptNamesForEvictedSymbol offers
+// no stub key for it. Exactly one kind qualifies: a file node is an import
+// candidate - relative imports, Lua requires and Godot res:// paths all bind
+// to one - so removing it can collapse an ambiguity for a pending import
+// elsewhere, while the import specifier it would be parked under is not
+// derivable from the file. Its file still has to reach the definition
+// frontier, because ResolutionRelevant=false is the one verdict that skips
+// the catch-up pass outright.
+//
+// Every other nameless kind really is neutral. Nothing binds by name to an
+// import, param, local or module node, so an eviction that touches only those
+// creates no resolution work.
+//
+// In production the neutral branch is a per-node skip, never a receipt-level
+// verdict: ResolutionRelevant=false is unreachable for a real eviction,
+// because every file reindex evicts its own file node and that node lands in
+// the KindFile branch above. The
+// Test*MutationReceiptEvictFilesNonreferenceableOnlyStaysNeutral pair pins a
+// receipt shape production never produces.
+func EvictedNodeNeedsResolutionFrontier(kind NodeKind) bool {
+	return kind == KindFile
+}
+
 // ReceiptNamesForEvictedSymbol maps one evicted node to the receipt
 // target names under which pending references to it may be parked, and
 // reports whether that mapping is exact. This is the single authority
@@ -387,23 +411,6 @@ const ImportStubNamePrefix = "import::"
 // ambiguity, and it is bounded by the same rule as every other name — a
 // pending stub that could rebind is only reachable by name, never by the
 // file frontier.
-// EvictedNodeNeedsResolutionFrontier reports whether evicting a node of this
-// kind can change resolution even though ReceiptNamesForEvictedSymbol offers
-// no stub key for it. Exactly one kind qualifies: a file node is an import
-// candidate - relative imports, Lua requires and Godot res:// paths all bind
-// to one - so removing it can collapse an ambiguity for a pending import
-// elsewhere, while the import specifier it would be parked under is not
-// derivable from the file. Its file still has to reach the definition
-// frontier, because ResolutionRelevant=false is the one verdict that skips
-// the catch-up pass outright.
-//
-// Every other nameless kind really is neutral. Nothing binds by name to an
-// import, param, local or module node, so an eviction that touches only those
-// creates no resolution work.
-func EvictedNodeNeedsResolutionFrontier(kind NodeKind) bool {
-	return kind == KindFile
-}
-
 func ReceiptNamesForEvictedSymbol(kind NodeKind, name, qualName string) (names []string, exact bool) {
 	switch {
 	case IsReferenceableSymbol(kind):


### PR DESCRIPTION
Follow-ups from the #678 approval, comments only - no behavior change.

1. **`stub.go` carried one fused doc block.** `ReceiptNamesForEvictedSymbol`'s contract (including its fall-through paragraph about the nil-exact approximation) sat on top of `EvictedNodeNeedsResolutionFrontier`, and `ReceiptNamesForEvictedSymbol` itself was left undocumented. Split, so each half sits on the function it describes.
2. **The production reachability fact is now stated** on `EvictedNodeNeedsResolutionFrontier`: `ResolutionRelevant=false` is unreachable for a real eviction, because every file reindex evicts its own file node - so the neutral branch survives as a per-node skip, not a receipt-level verdict, and the `Test*MutationReceiptEvictFilesNonreferenceableOnlyStaysNeutral` pair pins a receipt shape production never produces.
3. **`TargetNames` is documented as descriptive-only**: nothing in resolution consumes it (the name frontier reads `EvictedNames`, the file frontier reads `DefinitionFiles`), and the deliberate backend divergence is named - the graph accumulator records non-referenceable added-node names, SQLite does not - so it stays out of any correctness contract.

Verified: gofmt, `go vet`, `staticcheck` clean; `internal/graph` suite green.
