### PR TITLE
graph: dedupe the property-test model by node ID

### DIFF
--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -410,6 +410,7 @@ func genMultiRepoGraph(t *rapid.T) (*Graph, map[string][]string) {
 
 	expected := make(map[string][]string) // prefix → node IDs
 	var allNodeIDs []string
+	seenIDs := make(map[string]bool)
 	kinds := []NodeKind{KindFunction, KindType, KindMethod, KindVariable}
 
 	for _, prefix := range prefixes {
@@ -421,8 +422,13 @@ func genMultiRepoGraph(t *rapid.T) (*Graph, map[string][]string) {
 			kind := kinds[rapid.IntRange(0, len(kinds)-1).Draw(t, "kind")]
 			n := makeRepoNode(id, name, kind, file, "go", prefix)
 			g.AddNode(n)
-			expected[prefix] = append(expected[prefix], id)
-			allNodeIDs = append(allNodeIDs, id)
+			// AddNode upserts by ID, so a drawn (name, file) collision must
+			// also appear only once in the expected model.
+			if !seenIDs[id] {
+				seenIDs[id] = true
+				expected[prefix] = append(expected[prefix], id)
+				allNodeIDs = append(allNodeIDs, id)
+			}
 		}
 	}
 


### PR DESCRIPTION
`TestPropertyPerRepoIndexCorrectness` can fail on an unlucky rapid seed: when the generator draws a (name, file) collision inside one repo, two generated nodes mint the same node ID. The expected model kept the duplicate ID twice, but `AddNode` upserts by ID, so `GetRepoNodes` returns the deduplicated set and the compare fails.

A saved failfile reproduces identically at older heads, so it is a pre-existing test-model bug, not a regression - product behavior (upsert) is correct. The model now records each ID once; reproduced RED with the failfile, green after, plus fresh-seed runs.
