### PR TITLE
savings: book the retrieval half of the ledger

### DIFF
--- a/cmd/gortex/doctor_runtime.go
+++ b/cmd/gortex/doctor_runtime.go
@@ -549,9 +549,10 @@ func printSavings(w io.Writer, sv doctorSavings) {
 			}
 		}
 	}
-	fmt.Fprintln(w, "    note: only the read-family tools write here (saved = whole-file tokens −")
-	fmt.Fprintln(w, "          returned). explore / search / relations / trace record nothing, and")
-	fmt.Fprintln(w, "          reading a whole file records 0 — so this describes those calls only.")
+	fmt.Fprintln(w, "    note: saved = whole-file tokens − returned. The read-family tools book the")
+	fmt.Fprintln(w, "          one file they stand in for; explore / search / relations / trace book")
+	fmt.Fprintln(w, "          the files their page cites, each credited once per session. Reading a")
+	fmt.Fprintln(w, "          whole file still records 0 — it displaces nothing.")
 	fmt.Fprintln(w)
 }
 

--- a/cmd/gortex/savings.go
+++ b/cmd/gortex/savings.go
@@ -40,10 +40,13 @@ sessions: Today, Last 7 days, and All time. Each bucket shows a 16-cell
 saved/total bar, percentage saved, raw token counts, and the USD value of
 the tokens avoided (priced against popular models).
 
-Savings accumulate every time a source-reading MCP tool — read_file,
+Savings accumulate on two shapes of call. A read-family tool — read_file,
 get_file_summary, get_editing_context, get_symbol_source, batch_symbols,
-smart_context — returns a summary, symbol, or compressed view that stands
-in for a full-file read. The ledger lives in the machine-global sidecar
+smart_context — books the whole file its response stands in for. A
+retrieval tool — explore, the search / relations / trace families,
+get_repo_outline, get_artifact and friends — books the set of files its
+page cites, each file credited at most once per session so a re-query
+never mints savings twice. The ledger lives in the machine-global sidecar
 database (~/.gortex/sidecar.sqlite); flat-file ledgers from older
 releases (savings.json / savings.jsonl under the cache dir) are imported
 once and renamed *.bak.
@@ -265,14 +268,14 @@ func emitSavingsDashboard(snap savings.File, buckets []savings.Bucket, modelTota
 	_, headlineModel := pickHeadlineCost(costs, savingsModel)
 	fmt.Println()
 	if snap.Totals.CallsCounted == 0 {
-		hint := "savings record when the agent reads code through gortex (read_file, get_file_summary, get_editing_context, get_symbol_source, smart_context, …)"
+		hint := "savings record when the agent reads or locates code through gortex (read_file, get_symbol_source, search_symbols, find_usages, explore, …)"
 		if tty {
 			fmt.Println("  " + progress.StyleHint.Render("◌  no source-reading tool calls recorded yet"))
 			fmt.Println("     " + progress.Caption(hint))
 			fmt.Println()
 		} else {
 			fmt.Println("No source-reading tool calls recorded yet.")
-			fmt.Println("Savings record when the agent reads code through gortex (read_file, get_file_summary, get_editing_context, get_symbol_source, smart_context, ...).")
+			fmt.Println("Savings record when the agent reads or locates code through gortex (read_file, get_symbol_source, search_symbols, find_usages, explore, ...).")
 		}
 		return
 	}

--- a/docs/savings.md
+++ b/docs/savings.md
@@ -2,9 +2,21 @@
 
 Gortex tracks how many tokens it saves compared to naive file reads — per-call, per-session, and cumulative across restarts:
 
-- **Per-call:** every source-reading tool — `read_file`, `get_file_summary`, `get_editing_context`, `get_symbol_source`, `batch_symbols` (with `include_source`), `smart_context` — books an observation server-side: tokens actually returned vs the full-file read the response stands in for. The per-call value is deliberately not echoed in responses (agents don't act on it and it would burn tokens on every reply); it lands in the ledger.
+- **Per-call:** two shapes of call book an observation server-side. The per-call value is deliberately not echoed in responses (agents don't act on it and it would burn tokens on every reply); it lands in the ledger.
+  - **Read-family** — `read_file`, `get_file_summary`, `get_editing_context`, `get_symbol_source`, `batch_symbols` (with `include_source`), `smart_context`: tokens actually returned vs the *one* full file the response stands in for.
+  - **Retrieval** — `explore`, `context_closure`, `prefetch_context`, `get_repo_outline`, `get_artifact`, the `search_*` family, the relations family (`find_usages`, `get_callers`, `get_dependencies`, `get_dependents`, `find_implementations`, …), the trace family (`get_call_chain`, `flow_between`, `taint_paths`, `walk_graph`, …), `nav`, `suggest_pattern`: tokens returned vs the *set* of whole files the page cites. These are the calls that replace a grep-then-read sweep, so their counterfactual is the files the caller would otherwise have opened.
+
 - **Session-level:** `graph_stats` returns a `token_savings` object with `calls_counted`, `tokens_returned`, `tokens_saved`, `efficiency_ratio`.
 - **Cumulative (cross-session):** `graph_stats` also returns `cumulative_savings` when persistence is wired — includes `first_seen`, `last_updated`, and `cost_avoided_usd` per model — Anthropic (Opus/Sonnet/Haiku), OpenAI (GPT-5, GPT-4.1, GPT-4o, o3/o4-mini), Google Gemini (3.x and 2.5), DeepSeek, and Zhipu GLM (5.x and 4.5/4.6/4.7 tiers). Backed by the machine-global sidecar database (`~/.gortex/sidecar.sqlite` — the same file that holds notes/memories): `savings_totals` carries top-line + per-repo + per-language aggregates and `savings_events` one session-tagged row per call, powering the windowed buckets and the per-tool breakdown. Each observation commits transactionally, so the ledger survives SIGKILLed MCP servers and concurrent writer processes. Flat-file ledgers from older releases (`~/.gortex/cache/savings.json` + `savings.jsonl`) are imported once on first open and renamed `*.bak`.
+
+### What the retrieval baseline deliberately does not claim
+
+A retrieval page names more files than its caller would have opened, and naming a file twice does not save reading it twice. Two limits keep the number honest, and both under-report on purpose — the ledger's failure mode must be "Gortex looks worse than it is", never "Gortex invented savings":
+
+- **Once per session, per file.** A file's whole-file baseline is credited at most once per MCP session, whichever call surfaces it first — read-family or retrieval. A repeated search over the same corner of the repo books nothing. This bounds everything a session can ever claim to the cost of reading its repo once.
+- **Capped per call.** At most 8 distinct cited files are credited by any single call. A 50-hit `find_usages` page does not mean the caller would have opened 50 files; it would have opened the few hits it cared about, and we cannot know which.
+
+A call that credits no new file books nothing at all, rather than a zero-baseline row: we did not measure that call's counterfactual, so we do not assert one. Reading a whole file through `read_file` still books `saved = 0` — it displaces nothing — which is why a healthy ledger shows read_file at 0% next to the retrieval tools that carry the real savings.
 
 `gortex savings` renders a three-bucket dashboard:
 

--- a/internal/mcp/facade_tools.go
+++ b/internal/mcp/facade_tools.go
@@ -1111,6 +1111,11 @@ func (s *Server) invokeFacadeSpec(ctx context.Context, req mcpgo.CallToolRequest
 	forwarded.Params.RawArguments = nil
 	result, err = legacy.handler(ctx, forwarded)
 	if err == nil {
+		// Book the retrieval half of the savings ledger under the LEGACY tool
+		// name, so a facade call and a direct legacy call land in the same
+		// per-tool bucket. Runs before decoration: the baseline is what the
+		// handler actually retrieved, not the riders bolted on afterwards.
+		s.recordRetrievalSavings(ctx, spec.Legacy, result)
 		result = s.decorateFacadeFreshness(spec.Legacy, forwarded, result)
 	}
 	result = decorateFacadeResultIdentity(result, spec)

--- a/internal/mcp/overlay.go
+++ b/internal/mcp/overlay.go
@@ -172,6 +172,14 @@ func (s *Server) wrapToolHandlerMode(h mcpserver.ToolHandlerFunc, injectOverlay 
 			qStart = time.Now()
 		}
 		res, hErr := h(ctx, req)
+		// Book the retrieval half of the savings ledger for a DIRECT legacy
+		// call. Facade calls do not reach here under their legacy name — the
+		// facade holds the unwrapped handler (prepareTool) and books in
+		// invokeFacadeSpec — and facade names are not in the allow-list, so
+		// the two paths cannot double-count.
+		if hErr == nil {
+			s.recordRetrievalSavings(ctx, req.Params.Name, res)
+		}
 		// Opt-in usage telemetry: count this tool invocation by name only —
 		// never arguments or results. nil-safe, consent-gated, and fail-silent,
 		// so a disabled or absent recorder adds nothing to the dispatch path.

--- a/internal/mcp/savings_retrieval.go
+++ b/internal/mcp/savings_retrieval.go
@@ -1,0 +1,340 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	toon "github.com/toon-format/toon-go"
+
+	"github.com/zzet/gortex/internal/tokens"
+)
+
+// Retrieval savings — the second half of the ledger.
+//
+// The original recording sites (read_file, get_file_summary,
+// get_editing_context, get_symbol_source, batch_symbols, smart_context) all
+// answer the same question: "this response stands in for reading ONE whole
+// file, how much did that save?". That model leaves out every tool whose whole
+// point is to replace a grep-then-read sweep across SEVERAL files — explore,
+// search, relations, trace — which is where the agent actually stops paying
+// for raw file reads. Those tools booked nothing at all, so a session that
+// navigated entirely through the graph showed a flat ledger.
+//
+// This file generalises the same counterfactual from one file to the file SET
+// a retrieval page stands in for:
+//
+//	returned = tokens of the page actually shipped
+//	fullFile = Σ over the distinct files the page cites of that file's
+//	           whole-file token estimate
+//
+// with two deliberate limits that keep the number honest:
+//
+//  1. Per session, a file's whole-file baseline is credited AT MOST ONCE
+//     (creditedFile below). The counterfactual agent that already opened a
+//     file does not pay to open it again, so neither may we. This bounds
+//     everything a session can ever claim to the cost of reading its repo
+//     once.
+//  2. Per call, at most retrievalBaselineMaxFiles distinct files are credited.
+//     A 50-hit find_usages page does not mean the caller would have opened 50
+//     files — it would have opened the few hits it cared about. We cannot know
+//     which, so we credit the conservative end of the range.
+//
+// Both limits under-report on purpose. The ledger's failure mode must be
+// "Gortex looks worse than it is", never "Gortex invented savings".
+
+// retrievalBaselineMaxFiles caps how many distinct cited files one retrieval
+// call may credit. Retrieval pages cite far more files than their caller would
+// have opened: search_symbols defaults to 20 hits and find_usages to 50, but an
+// agent following either typically opens a handful before it has its answer.
+// Crediting every cited file would let one call mint a six-figure baseline; the
+// cap keeps a single observation the same order of magnitude as the read-family
+// observations it sits beside in the ledger.
+const retrievalBaselineMaxFiles = 8
+
+// maxRetrievalCitationScan bounds how much of a response is swept for
+// citations, so a pathological page cannot turn accounting into a hot loop.
+// Mirrors maxFreshnessSweep, which bounds the same sweep for the freshness
+// rider.
+const maxRetrievalCitationScan = 256
+
+// retrievalCitationColumns are the GCX1 column names that carry a
+// repo-relative file path. Deliberately excludes path_abs / *_abs: absolute
+// columns name the same file as their relative sibling and would be dropped by
+// the absolute-path filter anyway, but naming them here would suggest they are
+// a second citation.
+var retrievalCitationColumns = map[string]bool{
+	"path": true, "file": true, "file_path": true, "filepath": true,
+	"from_path": true, "to_path": true, "relative_path": true,
+}
+
+// retrievalSavingsTools is the allow-list of legacy tool names whose response
+// displaces raw file reading and therefore has a defensible whole-file
+// baseline. Membership is a judgement about the counterfactual, so it is
+// explicit rather than inferred:
+//
+//   - The six tools that already book their own observation are ABSENT. They
+//     record inside their handler with a baseline they measure exactly; adding
+//     them here would double-count.
+//   - export_context is ABSENT: it delegates its whole retrieval to
+//     handleSmartContext, which books the observation.
+//   - The response.* re-cut tools (ctx_peek / ctx_slice / ctx_grep /
+//     ctx_stats) are ABSENT: they re-cut a page the originating tool already
+//     shipped, so the file was displaced once, not twice.
+//   - Metadata, control, and write tools are ABSENT: nothing about their
+//     output stands in for reading a file.
+var retrievalSavingsTools = map[string]bool{
+	// explore — the mandated first call of a task. Ships ranked targets with
+	// full symbol bodies and redacted source windows.
+	"explore":          true,
+	"context_closure":  true,
+	"prefetch_context": true,
+	"get_repo_outline": true,
+
+	// search — the declared grep replacement.
+	"search_symbols":   true,
+	"search_text":      true,
+	"search_ast":       true,
+	"search_artifacts": true,
+	"winnow_symbols":   true,
+
+	// read — the paths that serve file bytes without booking themselves.
+	"get_artifact": true,
+
+	// relations — "use instead of Grep to find every reference".
+	"find_usages":          true,
+	"get_callers":          true,
+	"get_dependencies":     true,
+	"get_dependents":       true,
+	"find_implementations": true,
+	"find_declaration":     true,
+	"find_overrides":       true,
+	"find_import_path":     true,
+	"check_references":     true,
+	"get_class_hierarchy":  true,
+	"get_cluster":          true,
+
+	// trace — path and flow pages, each row a real location the caller would
+	// otherwise have had to open the file to find.
+	"get_call_chain": true,
+	"get_cfg":        true,
+	"flow_between":   true,
+	"taint_paths":    true,
+	"trace_path":     true,
+	"walk_graph":     true,
+	"graph_query":    true,
+
+	// change/session paths that serve real source bodies.
+	"nav":             true,
+	"suggest_pattern": true,
+}
+
+// recordRetrievalSavings books the file-set baseline for one retrieval call.
+// tool is the LEGACY tool name (the facade forwards under it, so the ledger's
+// per-tool breakdown stays comparable across surfaces). No-ops for every tool
+// outside retrievalSavingsTools, for error results, and for responses that
+// cite no file the session has not already been credited for.
+func (s *Server) recordRetrievalSavings(ctx context.Context, tool string, res *mcp.CallToolResult) {
+	if s == nil || res == nil || res.IsError || !retrievalSavingsTools[tool] {
+		return
+	}
+	payload, ok := singleTextContent(res)
+	if !ok || payload == "" {
+		return
+	}
+	s.recordFileSetBaselineSavings(ctx, tool, citedFilesFromResult(payload), payload)
+}
+
+// recordFileSetBaselineSavings is recordFileBaselineSavings generalised from
+// one file to the set a page stands in for: same resolve/stat/estimate
+// discipline per file, summed into a single observation so one call books one
+// row. Files already credited to this session, and files past the per-call cap,
+// contribute nothing.
+func (s *Server) recordFileSetBaselineSavings(ctx context.Context, tool string, relPaths []string, payload string) {
+	if len(relPaths) == 0 || payload == "" {
+		return
+	}
+	stats := s.tokenStatsFor(ctx)
+	if stats == nil {
+		return
+	}
+	var (
+		fullFile int64
+		credited int
+		language string
+		attrPath string
+	)
+	for _, rel := range relPaths {
+		if credited >= retrievalBaselineMaxFiles {
+			break
+		}
+		abs, err := s.resolveGraphPath(rel)
+		if err != nil {
+			continue
+		}
+		info, err := os.Stat(abs)
+		if err != nil || info.IsDir() || info.Size() == 0 {
+			continue
+		}
+		// Claim the file before counting it: a file already credited to this
+		// session was already paid for by whichever call surfaced it first.
+		if !stats.creditFile(abs) {
+			continue
+		}
+		fullFile += int64(tokens.EstimateFromSample(int(info.Size()), fileHeadSample(abs)))
+		credited++
+		if attrPath == "" {
+			attrPath = rel
+			language = s.detectLanguageForPath(ctx, abs, rel)
+		}
+	}
+	if credited == 0 || fullFile <= 0 {
+		return
+	}
+	stats.record(s.fileAttributionNode(attrPath, language), tool, tokens.CachedCountInt64(payload), fullFile)
+}
+
+// baselineSampleBytes bounds the calibration read per credited file. The
+// existing recorders can hand EstimateFromSample a slice of the very file they
+// are pricing; a retrieval page cannot — its own text is a dense citation table
+// whose chars-per-token ratio is nothing like the source it stands in for, and
+// calibrating on it would mis-price every baseline. So read a bounded head of
+// each file instead. Files at or under this size are counted exactly.
+const baselineSampleBytes = 8192
+
+// fileHeadSample returns up to baselineSampleBytes of a file, for use as the
+// chars-per-token calibration sample for that same file. Returns "" on any
+// read error, which makes EstimateFromSample fall back to its chars/4
+// heuristic rather than skipping the file.
+func fileHeadSample(abs string) string {
+	f, err := os.Open(abs)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = f.Close() }()
+	buf := make([]byte, baselineSampleBytes)
+	n, err := f.Read(buf)
+	if n <= 0 || (err != nil && err != io.EOF) {
+		return ""
+	}
+	return string(buf[:n])
+}
+
+// citedFilesFromResult extracts the distinct repo-relative files a tool
+// response cites, across every wire format Gortex emits. Absolute paths are
+// skipped: they name the same file as their relative sibling column (path_abs
+// next to path), and an absolute path outside any tracked repo is not a
+// citation this ledger can attribute.
+func citedFilesFromResult(payload string) []string {
+	text := strings.TrimSpace(payload)
+	if text == "" {
+		return nil
+	}
+	seen := make(map[string]bool)
+	out := make([]string, 0, 8)
+	add := func(p string) {
+		p = strings.TrimSpace(p)
+		if p == "" || filepath.IsAbs(p) || seen[p] || len(out) >= maxRetrievalCitationScan {
+			return
+		}
+		seen[p] = true
+		out = append(out, p)
+	}
+	if strings.HasPrefix(text, "GCX1") {
+		collectGCXCitedPaths(text, add)
+		return out
+	}
+	switch text[0] {
+	case '{':
+		var asObj map[string]any
+		if json.Unmarshal([]byte(text), &asObj) == nil {
+			for _, p := range collectGraphFilePaths(asObj) {
+				add(p)
+			}
+			return out
+		}
+	case '[':
+		var asArr []any
+		if json.Unmarshal([]byte(text), &asArr) == nil {
+			for _, p := range collectGraphFilePaths(asArr) {
+				add(p)
+			}
+			return out
+		}
+	}
+	// TOON is the third wire format Gortex emits, and it is the DEFAULT shape
+	// of several retrieval tools (search_text, get_repo_outline, nav). Decoding
+	// it costs a parse of a payload we already hold; a decode failure just
+	// means this call books nothing.
+	if len(text) <= maxToonCitationBytes {
+		if decoded, derr := toon.Decode([]byte(text)); derr == nil {
+			for _, p := range collectGraphFilePaths(decoded) {
+				add(p)
+			}
+		}
+	}
+	return out
+}
+
+// maxToonCitationBytes bounds the TOON decode attempt so a very large text
+// response cannot turn accounting into the expensive part of the call.
+const maxToonCitationBytes = 1 << 20
+
+// collectGCXCitedPaths walks the GCX1 compact wire format: one or more blocks,
+// each a `GCX1 tool=… fields=a,b,c …` header followed by tab-separated rows.
+// Path columns are located by name from the header, so a schema change adds or
+// drops citations rather than silently shifting them by one column.
+func collectGCXCitedPaths(text string, add func(string)) {
+	var cols []int
+	width := 0
+	for _, line := range strings.Split(text, "\n") {
+		if strings.HasPrefix(line, "GCX1") {
+			cols, width = gcxPathColumns(line)
+			continue
+		}
+		if len(cols) == 0 || line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Split(line, "\t")
+		// A line that does not carry the block's full column count is not a
+		// row: GCX1 payloads can be followed by prose riders (the momentum
+		// note, a warming banner), and reading column N out of a sentence
+		// would credit a "file" that never existed.
+		if len(fields) != width {
+			continue
+		}
+		for _, idx := range cols {
+			add(fields[idx])
+		}
+	}
+}
+
+// gcxPathColumns returns the indexes of the path-bearing columns declared by a
+// GCX1 header line, in column order, together with the block's total column
+// count.
+func gcxPathColumns(header string) ([]int, int) {
+	spec := ""
+	for _, tok := range strings.Fields(header) {
+		if rest, ok := strings.CutPrefix(tok, "fields="); ok {
+			spec = rest
+			break
+		}
+	}
+	if spec == "" {
+		return nil, 0
+	}
+	names := strings.Split(spec, ",")
+	var cols []int
+	for i, name := range names {
+		if retrievalCitationColumns[strings.TrimSpace(name)] {
+			cols = append(cols, i)
+		}
+	}
+	sort.Ints(cols)
+	return cols, len(names)
+}

--- a/internal/mcp/savings_retrieval_test.go
+++ b/internal/mcp/savings_retrieval_test.go
@@ -1,0 +1,290 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/savings"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// newRetrievalSavingsServer indexes a repo of several non-trivial Go files.
+// The read-family fixtures elsewhere in this package use a single 30-byte
+// file, which cannot exercise a file-SET baseline: the point of these tests is
+// that one retrieval page stands in for several whole files, so the fixture
+// has to have several.
+func newRetrievalSavingsServer(t *testing.T, files int) (*Server, *savings.Store, string) {
+	t.Helper()
+	// These tests drive the facade names an agent actually calls, so the
+	// session must be on the facade-v1 surface rather than the legacy default.
+	t.Setenv("GORTEX_TOOLS", "facade-v1")
+	dir := filepath.Join(t.TempDir(), "myrepo")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	for i := range files {
+		var b strings.Builder
+		fmt.Fprintf(&b, "package myrepo\n\nimport \"strings\"\n\n")
+		for j := range 12 {
+			fmt.Fprintf(&b, `
+// Widget%d%d walks the shared registry and normalises every entry it is
+// handed, returning the joined form plus whether anything matched at all.
+func Widget%d%d(key string, depth int) (string, bool) {
+	if key == "" {
+		return "", false
+	}
+	parts := make([]string, 0, depth)
+	for i := 0; i < depth; i++ {
+		parts = append(parts, strings.ToLower(strings.TrimSpace(key)))
+	}
+	return strings.Join(parts, "/"), len(parts) > 0
+}
+`, i, j, i, j)
+		}
+		require.NoError(t, os.WriteFile(filepath.Join(dir, fmt.Sprintf("mod%d.go", i)), []byte(b.String()), 0o644))
+	}
+
+	tmpCfg := filepath.Join(t.TempDir(), "config.yaml")
+	gc := &config.GlobalConfig{Repos: []config.RepoEntry{{Path: dir, Name: "myrepo"}}}
+	gc.SetConfigPath(tmpCfg)
+	require.NoError(t, gc.Save())
+	cm, err := config.NewConfigManager(tmpCfg)
+	require.NoError(t, err)
+
+	reg := parser.NewRegistry()
+	reg.Register(languages.NewGoExtractor())
+	g := graph.New()
+	mi := indexer.NewMultiIndexer(g, reg, search.NewNull(), cm, zap.NewNop())
+	_, err = mi.IndexAll()
+	require.NoError(t, err)
+
+	srv := NewServer(query.NewEngine(g), g, nil, nil, zap.NewNop(), nil, MultiRepoOptions{
+		ConfigManager: cm,
+		MultiIndexer:  mi,
+	})
+	store, err := savings.Open("")
+	require.NoError(t, err)
+	srv.InitSavings(store, "")
+	return srv, store, dir
+}
+
+func ledgerByTool(t *testing.T, store *savings.Store) map[string]int64 {
+	t.Helper()
+	totals, err := store.ToolTotals(time.Time{})
+	require.NoError(t, err)
+	out := make(map[string]int64, len(totals))
+	for _, row := range totals {
+		out[row.Tool] = row.TokensSaved
+	}
+	return out
+}
+
+// The user-visible bug: an agent that navigates entirely through the facade —
+// search, relations, trace — saw a flat ledger, because none of those
+// operations reached a recording site. Each must now book its file-set
+// baseline under its LEGACY tool name, so the facade and the legacy surface
+// land in the same per-tool bucket.
+func TestFacadeRetrievalOperationsRecordSavings(t *testing.T) {
+	srv, store, _ := newRetrievalSavingsServer(t, 4)
+	ctx := context.Background()
+
+	res := callToolByName(t, srv, ctx, "search", map[string]any{
+		"operation": "symbols", "query": "Widget",
+	})
+	require.False(t, res.IsError, "search.symbols must succeed: %s", textOfResult(t, res))
+
+	byTool := ledgerByTool(t, store)
+	require.Contains(t, byTool, "search_symbols",
+		"search.symbols must book under its legacy tool name, got %v", byTool)
+	require.Greater(t, byTool["search_symbols"], int64(0),
+		"a search page citing whole files it stands in for must book real savings")
+}
+
+// relations.usages is documented as the replacement for grepping a symbol's
+// call sites. It cites files the caller would otherwise have opened, so it
+// carries the same baseline as any other retrieval page.
+func TestFacadeRelationsRecordsSavings(t *testing.T) {
+	srv, store, _ := newRetrievalSavingsServer(t, 3)
+	ctx := context.Background()
+
+	res := callToolByName(t, srv, ctx, "relations", map[string]any{
+		"operation": "usages", "target": map[string]any{"symbol": "myrepo/mod0.go::Widget00"},
+	})
+	require.False(t, res.IsError, "relations.usages must succeed: %s", textOfResult(t, res))
+	require.Greater(t, ledgerByTool(t, store)["find_usages"], int64(0))
+}
+
+// A file's whole-file baseline is the cost of reading it ONCE. An agent that
+// searches the same corner of the repo twice did not avoid reading those files
+// twice, so the second page must book nothing — otherwise a polling or
+// re-querying client mints savings out of nothing, the same failure the
+// not-modified guards exist to prevent on the read-family tools.
+func TestRetrievalSavingsCreditsEachFileOncePerSession(t *testing.T) {
+	srv, store, _ := newRetrievalSavingsServer(t, 3)
+	ctx := WithSessionID(context.Background(), "session-repeat")
+
+	first := callToolByName(t, srv, ctx, "search", map[string]any{"operation": "symbols", "query": "Widget"})
+	require.False(t, first.IsError)
+	afterFirst := ledgerByTool(t, store)["search_symbols"]
+	require.Greater(t, afterFirst, int64(0), "the first page must book the files it surfaced")
+
+	second := callToolByName(t, srv, ctx, "search", map[string]any{"operation": "symbols", "query": "Widget"})
+	require.False(t, second.IsError)
+	require.Equal(t, afterFirst, ledgerByTool(t, store)["search_symbols"],
+		"a repeat page over already-surfaced files must add no savings")
+}
+
+// The two halves of the ledger must not bill the same file twice. A read-family
+// call already charges the whole file as its counterfactual; a later retrieval
+// page that merely cites that file has displaced nothing further.
+func TestReadFamilyBaselineBlocksLaterRetrievalCredit(t *testing.T) {
+	srv, store, _ := newRetrievalSavingsServer(t, 1)
+	ctx := WithSessionID(context.Background(), "session-shared")
+
+	read := callToolByName(t, srv, ctx, "read", map[string]any{
+		"operation": "file", "target": map[string]any{"file": "mod0.go"},
+	})
+	require.False(t, read.IsError, "read.file must succeed: %s", textOfResult(t, read))
+	require.Contains(t, ledgerByTool(t, store), "read_file")
+
+	found := callToolByName(t, srv, ctx, "search", map[string]any{"operation": "symbols", "query": "Widget"})
+	require.False(t, found.IsError)
+	require.NotContains(t, ledgerByTool(t, store), "search_symbols",
+		"the only cited file was already billed by read_file; the search must add nothing")
+}
+
+// Sessions are the unit of the credited-file set: two agents working the same
+// repo have each genuinely avoided their own reads, so the second session must
+// be credited even though the first already surfaced the same files.
+func TestRetrievalSavingsCreditIsPerSession(t *testing.T) {
+	srv, store, _ := newRetrievalSavingsServer(t, 2)
+	args := map[string]any{"operation": "symbols", "query": "Widget"}
+
+	first := callToolByName(t, srv, WithSessionID(context.Background(), "A"), "search", args)
+	require.False(t, first.IsError)
+	afterA := ledgerByTool(t, store)["search_symbols"]
+	require.Greater(t, afterA, int64(0))
+
+	second := callToolByName(t, srv, WithSessionID(context.Background(), "B"), "search", args)
+	require.False(t, second.IsError)
+	require.Greater(t, ledgerByTool(t, store)["search_symbols"], afterA,
+		"a second session avoided its own reads and must be credited for them")
+}
+
+// The per-call cap is the guard against a wide page minting a baseline nobody
+// would have paid: a 50-hit usages page does not mean the caller would have
+// opened 50 files. Credit stops at retrievalBaselineMaxFiles distinct files.
+func TestRetrievalBaselineCapsFilesPerCall(t *testing.T) {
+	files := retrievalBaselineMaxFiles + 6
+	srv, _, dir := newRetrievalSavingsServer(t, files)
+	ctx := WithSessionID(context.Background(), "session-cap")
+
+	cited := make([]string, 0, files)
+	for i := range files {
+		cited = append(cited, filepath.Join("myrepo", fmt.Sprintf("mod%d.go", i)))
+	}
+	srv.recordFileSetBaselineSavings(ctx, "search_symbols", cited, "a retrieval page")
+
+	credited := 0
+	for i := range files {
+		abs := filepath.Join(dir, fmt.Sprintf("mod%d.go", i))
+		// creditFile returns false for a file already claimed by the call above.
+		if !srv.tokenStatsFor(ctx).creditFile(abs) {
+			credited++
+		}
+	}
+	require.Equal(t, retrievalBaselineMaxFiles, credited,
+		"exactly the cap may be credited, however many files the page cites")
+}
+
+// A tool outside the retrieval allow-list must never book, however many files
+// its output happens to name — the allow-list is the judgement about which
+// responses actually displace a file read.
+func TestRetrievalSavingsIgnoresNonRetrievalTools(t *testing.T) {
+	srv, store, _ := newRetrievalSavingsServer(t, 2)
+	ctx := context.Background()
+
+	res := callToolByName(t, srv, ctx, "workspace", map[string]any{"operation": "repos"})
+	require.False(t, res.IsError, "workspace.repos must succeed: %s", textOfResult(t, res))
+	require.Empty(t, ledgerByTool(t, store),
+		"a workspace listing displaces no file read and must book nothing")
+}
+
+// citedFilesFromResult is the one place a response is turned back into the set
+// of files it stands in for, across all three wire formats Gortex emits. A
+// format it cannot read books nothing, which is why every format matters.
+func TestCitedFilesFromResult_WireFormats(t *testing.T) {
+	t.Run("gcx1 locates path columns by name across blocks", func(t *testing.T) {
+		payload := strings.Join([]string{
+			"GCX1 tool=get_call_chain.nodes fields=id,kind,name,path,path_abs,line total=2",
+			"repo/a.go::F\tfunction\tF\trepo/a.go\t/abs/repo/a.go\t6",
+			"repo/b.go::G\tfunction\tG\trepo/b.go\t/abs/repo/b.go\t9",
+			"GCX1 tool=get_call_chain.edges fields=from,to,kind,line,file_path count=1",
+			"repo/a.go::F\trepo/b.go::G\tcalls\t12\trepo/c.go",
+		}, "\n")
+		require.Equal(t, []string{"repo/a.go", "repo/b.go", "repo/c.go"}, citedFilesFromResult(payload))
+	})
+
+	t.Run("gcx1 comment and blank lines are not rows", func(t *testing.T) {
+		payload := "GCX1 tool=search_symbols fields=id,path total=1\n# 1 result(s)\n\nrepo/a.go::F\trepo/a.go"
+		require.Equal(t, []string{"repo/a.go"}, citedFilesFromResult(payload))
+	})
+
+	t.Run("prose riders after a block are not rows", func(t *testing.T) {
+		payload := strings.Join([]string{
+			"GCX1 tool=search_symbols fields=path,kind,name total=1",
+			"repo/a.go\tfunction\tF",
+			"(Session note: graph read #6. Every location returned so far is real and citeable.)",
+		}, "\n")
+		require.Equal(t, []string{"repo/a.go"}, citedFilesFromResult(payload))
+	})
+
+	t.Run("json object and array", func(t *testing.T) {
+		require.Equal(t, []string{"repo/a.go", "repo/b.go"},
+			citedFilesFromResult(`{"hits":[{"path":"repo/a.go"},{"file":"repo/b.go"}]}`))
+		require.Equal(t, []string{"repo/a.go"},
+			citedFilesFromResult(`[{"file_path":"repo/a.go"}]`))
+	})
+
+	t.Run("toon", func(t *testing.T) {
+		payload := "count: 2\nmatches[2]:\n  - line: 3\n    path: repo/a.go\n  - line: 7\n    path: repo/b.go\nquery: x"
+		require.Equal(t, []string{"repo/a.go", "repo/b.go"}, citedFilesFromResult(payload))
+	})
+
+	t.Run("absolute paths are not citations", func(t *testing.T) {
+		payload := "GCX1 tool=search_symbols fields=id,path,path_abs total=1\nx\t/abs/only.go\t/abs/only.go"
+		require.Empty(t, citedFilesFromResult(payload))
+	})
+
+	t.Run("unparseable payloads book nothing", func(t *testing.T) {
+		require.Empty(t, citedFilesFromResult("some prose with no structure at all"))
+		require.Empty(t, citedFilesFromResult(""))
+	})
+}
+
+// creditFile is the single choke point that stops a file being billed twice.
+func TestTokenStatsCreditFile(t *testing.T) {
+	ts := &tokenStats{}
+	require.True(t, ts.creditFile("/repo/a.go"), "first claim wins")
+	require.False(t, ts.creditFile("/repo/a.go"), "second claim on the same file is refused")
+	require.True(t, ts.creditFile("/repo/b.go"), "a different file is independent")
+	require.False(t, ts.creditFile(""), "an empty path is never creditable")
+
+	full := &tokenStats{creditedFiles: make(map[string]struct{}, maxCreditedFiles)}
+	for i := range maxCreditedFiles {
+		full.creditedFiles[fmt.Sprintf("/f/%d.go", i)] = struct{}{}
+	}
+	require.False(t, full.creditFile("/f/overflow.go"), "a saturated set stops crediting rather than growing")
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -825,6 +825,44 @@ type tokenStats struct {
 	repoPath       string      // forwarded to savings for per-repo aggregation
 	sessionID      string      // rides on persisted events; "" for the shared default
 	clientName     string      // MCP client app (claude-code / cursor / …) from initialize; rides on events
+	// creditedFiles is the set of absolute file paths whose whole-file
+	// baseline this session has already claimed, so a retrieval page can
+	// never bill the same file twice (see savings_retrieval.go). The
+	// counterfactual agent that already opened a file does not pay to open
+	// it again; without this set, N searches over the same hot file would
+	// mint N whole-file baselines. Bounded by maxCreditedFiles: a session
+	// that has been shown that many distinct files has already been credited
+	// for more than any real counterfactual would have read.
+	creditedFiles map[string]struct{}
+}
+
+// maxCreditedFiles bounds the per-session credited-file set. Well above any
+// plausible session's working set, and small enough that the map stays
+// negligible next to the graph the same daemon holds.
+const maxCreditedFiles = 8192
+
+// creditFile claims a file's whole-file baseline for this session. absPath is
+// the RESOLVED absolute path, so a repo-prefixed citation ("repo/util.go") and
+// the bare relative path a direct read used ("util.go") collapse to the same
+// key. Returns true when the caller may count the file, false when this
+// session has already been credited for it (or the set is full).
+func (ts *tokenStats) creditFile(absPath string) bool {
+	if ts == nil || absPath == "" {
+		return false
+	}
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	if ts.creditedFiles == nil {
+		ts.creditedFiles = make(map[string]struct{})
+	}
+	if _, done := ts.creditedFiles[absPath]; done {
+		return false
+	}
+	if len(ts.creditedFiles) >= maxCreditedFiles {
+		return false
+	}
+	ts.creditedFiles[absPath] = struct{}{}
+	return true
 }
 
 // setClientName records the MCP client app on the session's tokenStats so

--- a/internal/mcp/tools_coding.go
+++ b/internal/mcp/tools_coding.go
@@ -993,7 +993,9 @@ func (s *Server) handleGetSymbolSource(ctx context.Context, req mcp.CallToolRequ
 	// response). Aggregated stats remain available via the `savings` tool.
 	returned := tokens.CachedCountInt64(source)
 	fullFile := int64(tokens.EstimateFromSample(totalFileChars, source))
-	s.tokenStatsFor(ctx).record(s.savingsAttributionNode(node), "get_symbol_source", returned, fullFile)
+	symStats := s.tokenStatsFor(ctx)
+	symStats.creditFile(absPath)
+	symStats.record(s.savingsAttributionNode(node), "get_symbol_source", returned, fullFile)
 
 	result := map[string]any{
 		"id":         node.ID,
@@ -1266,7 +1268,9 @@ func (s *Server) handleBatchSymbols(ctx context.Context, req mcp.CallToolRequest
 					entry["from_line"] = fromLine
 					returned := tokens.CachedCountInt64(source)
 					fullFile := int64(tokens.EstimateFromSample(totalFileChars, source))
-					s.tokenStatsFor(ctx).record(s.savingsAttributionNode(node), "batch_symbols", returned, fullFile)
+					batchStats := s.tokenStatsFor(ctx)
+					batchStats.creditFile(absPath)
+					batchStats.record(s.savingsAttributionNode(node), "batch_symbols", returned, fullFile)
 				}
 			}
 		}
@@ -2168,7 +2172,9 @@ func (s *Server) handleSmartContext(ctx context.Context, req mcp.CallToolRequest
 					sourcesEmbedded++
 					returned := tokens.CachedCountInt64(source)
 					fullFile := int64(tokens.EstimateFromSample(totalFileChars, source))
-					s.tokenStatsFor(ctx).record(s.savingsAttributionNode(sym), "smart_context", returned, fullFile)
+					ctxStats := s.tokenStatsFor(ctx)
+					ctxStats.creditFile(absPath)
+					ctxStats.record(s.savingsAttributionNode(sym), "smart_context", returned, fullFile)
 				}
 			}
 		}

--- a/internal/mcp/tools_fileops.go
+++ b/internal/mcp/tools_fileops.go
@@ -637,8 +637,20 @@ func (s *Server) recordFileBaselineSavings(ctx context.Context, tool, relPath, l
 		return
 	}
 	returned := tokens.CachedCountInt64(payload)
-	fullFile := int64(tokens.EstimateFromSample(int(info.Size()), payload))
-	s.tokenStatsFor(ctx).record(s.fileAttributionNode(relPath, language), tool, returned, fullFile)
+	// Calibrate the file's token count on the FILE, not on the response.
+	// EstimateFromSample scales a byte count by the chars-per-token ratio of
+	// its sample, and the sample is only meaningful when it is "a smaller
+	// chunk of the same content" (see its doc comment). The payload here is a
+	// marshalled node list or an editing-context bundle, whose ratio is
+	// nothing like the source it is standing in for, so calibrating on it
+	// mis-priced every summary and editing-context baseline.
+	fullFile := int64(tokens.EstimateFromSample(int(info.Size()), fileHeadSample(abs)))
+	stats := s.tokenStatsFor(ctx)
+	// This charges the whole file as the counterfactual, so claim it for the
+	// session: a later retrieval page that merely cites the file must not
+	// bill it a second time (savings_retrieval.go).
+	stats.creditFile(abs)
+	stats.record(s.fileAttributionNode(relPath, language), tool, returned, fullFile)
 }
 
 // repoRelative converts an absolute path to a repo-prefixed or root-relative
@@ -1600,7 +1612,9 @@ func (s *Server) handleReadFile(ctx context.Context, req mcp.CallToolRequest) (*
 		if bodiesElided || salienceTruncated || windowed || contentTruncated {
 			fullFile = int64(tokens.EstimateFromSample(originalBytes, contentStr))
 		}
-		s.tokenStatsFor(ctx).record(s.fileAttributionNode(relPath, language), "read_file", returned, fullFile)
+		stats := s.tokenStatsFor(ctx)
+		stats.creditFile(absPath)
+		stats.record(s.fileAttributionNode(relPath, language), "read_file", returned, fullFile)
 	}
 
 	s.attachFileDependents(result, relPath)


### PR DESCRIPTION
## The report

A user on Discord: "I forced Claude to use gortex, but I didn't see my savings move." Their agent then blamed the facade — claiming `explore` / `search` / `read` are separate implementations that never call the recording tools, "intentional by design, not a bug."

That diagnosis is wrong in its mechanism and right in its conclusion. The facade forwards the same `ctx` to the same legacy handler under the legacy tool name (`facade_tools.go` `invokeFacadeSpec`), so `read(operation: "file")` does book — as `read_file`. Nothing about the facade breaks attribution.

The real problem is coverage plus a degenerate baseline, and it reproduces without any facade at all.

## Reproduced

A fresh daemon in an isolated `$HOME`, driven over real MCP frames:

| | before | after |
|---|---|---|
| recorded calls | 2 | 4 |
| tokens saved | 2,640 | 19,238 |
| ratio | 46.0% | 83.0% |
| cost avoided | $0.0132 | $0.0962 |

Same fixture repo, same six-call session (`search.symbols`, `search.text`, `relations.usages`, `trace.call_chain`, `read.file`, `read.source`).

On a small fixture, the "before" column is already flattering: with a two-file repo, the only calls that record are `read_file` (which books `saved = 0` by construction) and `get_symbol_source`, and the machine-wide ledger on my own dev box had **0 rows** across every table despite months of daily MCP use.

## Root cause

1. **Coverage.** `tokenStats.record` had five call sites yielding six tool names. 180 of the 187 facade-v1 operations reached none of them. That includes `explore` — the surface the instruction profile mandates as the first call of every task, which ships full fenced source bodies — and the entire `search` / `relations` / `trace` surface, whose stated purpose is replacing a grep-then-read sweep.
2. **Degenerate baseline.** The one tool an agent calls constantly, `read_file`, sets `fullFile := returned` unless a transform shrank the response, so an ordinary whole-file read books `saved = 0`. The tools that recorded were mostly recording zeros.

Net effect: the ledger measured the one operation that cannot save anything, and ignored the ones that do.

## The fix

Generalise the existing counterfactual from one file to the file **set** a retrieval page stands in for:

```
returned = tokens of the page actually shipped
fullFile = Σ whole-file tokens of the distinct files the page cites
```

`recordRetrievalSavings` runs at two dispatch points — `invokeFacadeSpec` for facade calls (booking under `spec.Legacy`, so both surfaces share a per-tool bucket) and the shared tool middleware for direct legacy calls. They cannot double-count: the facade holds the *unwrapped* handler, and facade names are not in the allow-list.

Citations are read back from all three wire formats Gortex emits — GCX1 (path columns located by name from the block header, with a column-count guard so prose riders like the momentum note are never mistaken for rows), JSON (via the existing `collectGraphFilePaths`), and TOON. GCX1 is the default for `claude-code` sessions and TOON is the default shape of `search_text` / `get_repo_outline` / `nav`, so skipping either would have left the same hole in a different place.

### What it deliberately does not claim

The ledger's failure mode must be "Gortex looks worse than it is", never "Gortex invented savings". Two limits, both under-reporting on purpose:

- **Once per session, per file.** A file's whole-file baseline is credited at most once, whichever call surfaces it first. A re-query over the same corner of the repo books nothing. This bounds everything a session can ever claim to the cost of reading its repo once. The read-family recorders now claim their file in the same set, so the two halves of the ledger never bill the same file twice.
- **Capped per call** at 8 distinct cited files. A 50-hit `find_usages` page does not mean the caller would have opened 50 files; it would have opened the few hits it cared about, and we cannot know which.

A call that credits no new file books **nothing at all** rather than a zero-baseline row — we did not measure that call's counterfactual, so we do not assert one.

Membership in the retrieval allow-list is a judgement about the counterfactual, so it is explicit rather than inferred. Absent by design: the six already-instrumented tools (they measure their own baseline exactly), `export_context` (it delegates to `handleSmartContext`, which books), the `response.*` re-cut tools (they re-cut a page already shipped), and every metadata / control / write tool.

### Also fixed: a mis-priced baseline

`recordFileBaselineSavings` priced a file by scaling its byte count through the chars-per-token ratio of the **response** — a marshalled node list or editing-context bundle, whose ratio is nothing like the source it stands in for. `EstimateFromSample`'s own contract says the sample must be "a smaller chunk of the same content". Every `get_file_summary` and `get_editing_context` baseline was wrong. It now calibrates on a bounded head of the file itself.

## Tests

`internal/mcp/savings_retrieval_test.go` — facade `search` / `relations` book under their legacy names; per-session per-file credit; cross-session independence; the read-family/retrieval double-bill guard; the per-call cap; the allow-list; all four wire-format shapes plus the absolute-path and prose-rider exclusions.

Every test was mutation-verified: neutering `recordRetrievalSavings` fails 4, neutering the `creditFile` dedupe fails 3, removing the cap fails 1.

`go test` and `go test -race` green on `internal/mcp`, `internal/savings`, `cmd/gortex`; `golangci-lint` clean.

## Follow-ups, not in this PR

- `get_symbol_source`, `batch_symbols` and `smart_context` record **before** their `if_none_match` check, so a polling client mints repeat observations. `read_file` / `get_file_summary` / `get_editing_context` already return before accounting; those three should match.
- `read_file`'s `returned` counts only the content string, excluding the JSON envelope and escaping it actually ships — so `tokens_returned` under-states wire cost.
- `export_context` books its observation under `smart_context`, because it delegates the whole retrieval to that handler.
- `smart_context` in `fidelity:"graded"` mode returns *more* source and books *less*: its record call is gated on `!graded`.
- Unrelated, found while validating: `relations.callers` on a Go repo with gopls attached killed the daemon with `fatal error: concurrent map writes` in `semantic/lsp.(*Provider).openDocument` (provider.go:2789), reached via `confirmSymbolRefsOnDemand`. Pre-existing on main; worth its own issue.
