### PR TITLE
fix(mcp): let a scoped reindex resolve the failed receipt for that path

### DIFF
--- a/internal/mcp/edit_serialization.go
+++ b/internal/mcp/edit_serialization.go
@@ -220,6 +220,37 @@ func (s *Server) resolveSupersededFailedReceipts(succeededPath string, succeeded
 	})
 }
 
+// resolveReindexedPathReceipts resolves terminally failed freshness receipts
+// for a path that an explicit reindex has just re-parsed. A failed ingest
+// fail-closes change.detect for the whole repository until retention lapses,
+// and reindex_repository was the obvious recovery that did not work: it
+// re-reads the file into the graph but never touched this map, so the barrier
+// kept reporting a gap the graph no longer had.
+//
+// The evidence a failed receipt is waiting for is exactly "the graph has read
+// the current bytes of this path", which a successful scoped re-parse
+// provides. Pending receipts are left alone: they describe work still in
+// flight, not a dead generation, and clearing one would hide a real gap.
+func (s *Server) resolveReindexedPathReceipts(reindexedPath string) {
+	cleanPath := filepath.Clean(reindexedPath)
+	s.mutationReceipts.Range(func(_, value any) bool {
+		receipt, ok := value.(*mutationReceipt)
+		if !ok || filepath.Clean(receipt.path) != cleanPath {
+			return true
+		}
+		receipt.mu.Lock()
+		if receipt.completed && (receipt.result.Err != nil || !receipt.result.Reindexed) {
+			receipt.result = indexer.MutationResult{
+				RequestedGeneration: receipt.generation,
+				AppliedGeneration:   receipt.generation,
+				Reindexed:           true,
+			}
+		}
+		receipt.mu.Unlock()
+		return true
+	})
+}
+
 func (r *mutationReceipt) outcome(pending bool) mutationReindexOutcome {
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/internal/mcp/edit_serialization.go
+++ b/internal/mcp/edit_serialization.go
@@ -231,11 +231,44 @@ func (s *Server) resolveSupersededFailedReceipts(succeededPath string, succeeded
 // the current bytes of this path", which a successful scoped re-parse
 // provides. Pending receipts are left alone: they describe work still in
 // flight, not a dead generation, and clearing one would hide a real gap.
-func (s *Server) resolveReindexedPathReceipts(reindexedPath string) {
+// failedReceiptsBefore snapshots the failed freshness receipts a reindex pass
+// is entitled to resolve. It MUST be called before the pass starts: a receipt
+// that fails its own ingest while the pass is running was never read by it, so
+// resolving it would certify bytes the graph never saw. Receipt IDs are the
+// bound rather than a timestamp because receipts carry no completion time.
+//
+// A nil result resolves nothing, which is the correct reading of "no snapshot
+// was taken".
+func (s *Server) failedReceiptsBefore(paths []string, root string) map[string]struct{} {
+	candidate, ok := reindexCandidatePath(paths, root)
+	if !ok {
+		return nil
+	}
+	eligible := make(map[string]struct{})
+	s.mutationReceipts.Range(func(_, value any) bool {
+		receipt, ok := value.(*mutationReceipt)
+		if !ok || filepath.Clean(receipt.path) != candidate {
+			return true
+		}
+		receipt.mu.RLock()
+		failed := receipt.completed && (receipt.result.Err != nil || !receipt.result.Reindexed)
+		receipt.mu.RUnlock()
+		if failed {
+			eligible[receipt.id] = struct{}{}
+		}
+		return true
+	})
+	return eligible
+}
+
+func (s *Server) resolveReindexedPathReceipts(reindexedPath string, eligible map[string]struct{}) {
 	cleanPath := filepath.Clean(reindexedPath)
 	s.mutationReceipts.Range(func(_, value any) bool {
 		receipt, ok := value.(*mutationReceipt)
 		if !ok || filepath.Clean(receipt.path) != cleanPath {
+			return true
+		}
+		if _, wasFailingBeforeThePass := eligible[receipt.id]; !wasFailingBeforeThePass {
 			return true
 		}
 		receipt.mu.Lock()

--- a/internal/mcp/mutation_freshness_test.go
+++ b/internal/mcp/mutation_freshness_test.go
@@ -233,9 +233,13 @@ func TestReindexedPathResolvesFailedReceiptsForThatPathOnly(t *testing.T) {
 		RequestedGeneration: 7,
 		Err:                 errors.New("unrelated failure"),
 	})
+	// Snapshot taken where production takes it: before the pass runs. The
+	// in-flight receipt below therefore appears mid-pass and is out of scope
+	// by construction, not by the completed/pending check alone.
+	eligible := s.failedReceiptsBefore([]string{"file.go"}, "/repo-a")
 	inflight := pendingFreshnessReceipt(s, "receipt-inflight", "repo-a", "/repo-a/file.go", 9)
 
-	s.resolveReindexedPathReceipts("/repo-a/file.go")
+	s.resolveReindexedPathReceipts("/repo-a/file.go", eligible)
 
 	if outcome := failed.outcome(false); outcome.Err != nil || !outcome.Reindexed {
 		t.Fatalf("a re-parsed path did not resolve its failed receipt: %+v", outcome)
@@ -291,6 +295,22 @@ func TestReindexedReceiptPathOnlyResolvesAProvenSinglePath(t *testing.T) {
 		{"a whole-repo pass resolves nothing", nil, "/repo", stale, "", false},
 		{"nothing was re-parsed", []string{"a.go"}, "/repo", &indexer.IndexResult{StaleFileCount: 0}, "", false},
 		{"the path itself failed to index", []string{"a.go"}, "/repo", &indexer.IndexResult{StaleFileCount: 1, FailedFiles: []string{"a.go"}}, "", false},
+		// The spelling production actually produces: FailedFiles is absolute
+		// while the caller asked with a relative path. Comparing the raw
+		// request alone lets this walk past the guard and stamp a file that
+		// failed to index as fresh.
+		{
+			"an absolute failed file is refused for a relative request",
+			[]string{"internal/a.go"}, "/repo",
+			&indexer.IndexResult{StaleFileCount: 1, FailedFiles: []string{filepath.Join("/repo", "internal", "a.go")}},
+			"", false,
+		},
+		{
+			"an absolute failed file is refused for an absolute request",
+			[]string{absFixture}, "/repo",
+			&indexer.IndexResult{StaleFileCount: 1, FailedFiles: []string{absFixture}},
+			"", false,
+		},
 		{"a relative path without a known root is not guessed", []string{"a.go"}, "", stale, "", false},
 		{"a missing result resolves nothing", []string{"a.go"}, "/repo", nil, "", false},
 	}
@@ -302,6 +322,78 @@ func TestReindexedReceiptPathOnlyResolvesAProvenSinglePath(t *testing.T) {
 					tc.paths, tc.root, got, ok, tc.want, tc.ok)
 			}
 		})
+	}
+}
+
+func TestReindexResolveIgnoresReceiptsThatFailedDuringThePass(t *testing.T) {
+	s := &Server{mutationSafetyWait: time.Millisecond}
+	before := pendingFreshnessReceipt(s, "receipt-before", "repo-a", "/repo-a/file.go", 6)
+	completeFreshnessReceipt(before, indexer.MutationResult{
+		RequestedGeneration: 6,
+		Err:                 errors.New("context deadline exceeded"),
+	})
+
+	eligible := s.failedReceiptsBefore([]string{"file.go"}, "/repo-a")
+
+	// A write that lands, fails its own ingest, and completes while the
+	// indexer pass is still running. The pass read the bytes as they were at
+	// its start, so its success is evidence about those bytes and about
+	// nothing written afterwards.
+	during := pendingFreshnessReceipt(s, "receipt-during", "repo-a", "/repo-a/file.go", 7)
+	completeFreshnessReceipt(during, indexer.MutationResult{
+		RequestedGeneration: 7,
+		Err:                 errors.New("ingest failed"),
+	})
+
+	s.resolveReindexedPathReceipts("/repo-a/file.go", eligible)
+
+	if outcome := before.outcome(false); outcome.Err != nil || !outcome.Reindexed {
+		t.Fatalf("the receipt the pass actually covers was not resolved: %+v", outcome)
+	}
+	if outcome := during.outcome(false); outcome.Err == nil {
+		t.Fatalf("a write that failed while the pass ran was stamped fresh: %+v", outcome)
+	}
+
+	err := s.awaitMutationFreshnessForRepos(context.Background(), "repo-a")
+	if err == nil || !strings.Contains(err.Error(), "receipt-during") {
+		t.Fatalf("the barrier stopped reporting the mid-pass failure: %v", err)
+	}
+	if strings.Contains(err.Error(), "receipt-before") {
+		t.Fatalf("the barrier still reports the resolved receipt: %v", err)
+	}
+}
+
+func TestFailedReceiptsBeforeRefusesToSnapshotAnUnattributablePass(t *testing.T) {
+	s := &Server{mutationSafetyWait: time.Millisecond}
+	failed := pendingFreshnessReceipt(s, "receipt-failed", "repo-a", "/repo-a/file.go", 6)
+	completeFreshnessReceipt(failed, indexer.MutationResult{
+		RequestedGeneration: 6,
+		Err:                 errors.New("context deadline exceeded"),
+	})
+
+	// Every shape reindexedReceiptPath also refuses. A nil snapshot has to
+	// resolve nothing on its own, so the two guards cannot drift into a state
+	// where one of them alone is what stands between a failed ingest and a
+	// fresh verdict.
+	for _, tc := range []struct {
+		name  string
+		paths []string
+		root  string
+	}{
+		{"several paths", []string{"a.go", "b.go"}, "/repo-a"},
+		{"whole-repo pass", nil, "/repo-a"},
+		{"relative path without a root", []string{"file.go"}, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if eligible := s.failedReceiptsBefore(tc.paths, tc.root); eligible != nil {
+				t.Fatalf("failedReceiptsBefore(%v, %q) = %v, want nil", tc.paths, tc.root, eligible)
+			}
+		})
+	}
+
+	s.resolveReindexedPathReceipts("/repo-a/file.go", nil)
+	if outcome := failed.outcome(false); outcome.Err == nil {
+		t.Fatalf("a nil snapshot resolved a receipt: %+v", outcome)
 	}
 }
 

--- a/internal/mcp/mutation_freshness_test.go
+++ b/internal/mcp/mutation_freshness_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -217,6 +218,90 @@ func TestMutationFreshnessSuccessKeepsPendingSamePathReceipts(t *testing.T) {
 	err := s.awaitMutationFreshnessForRepos(context.Background(), "repo-a")
 	if err == nil || !strings.Contains(err.Error(), "receipt-inflight") {
 		t.Fatalf("barrier no longer reports the in-flight receipt: %v", err)
+	}
+}
+
+func TestReindexedPathResolvesFailedReceiptsForThatPathOnly(t *testing.T) {
+	s := &Server{mutationSafetyWait: time.Millisecond}
+	failed := pendingFreshnessReceipt(s, "receipt-failed", "repo-a", "/repo-a/file.go", 6)
+	completeFreshnessReceipt(failed, indexer.MutationResult{
+		RequestedGeneration: 6,
+		Err:                 errors.New("context deadline exceeded"),
+	})
+	otherPath := pendingFreshnessReceipt(s, "receipt-other-path", "repo-a", "/repo-a/other.go", 7)
+	completeFreshnessReceipt(otherPath, indexer.MutationResult{
+		RequestedGeneration: 7,
+		Err:                 errors.New("unrelated failure"),
+	})
+	inflight := pendingFreshnessReceipt(s, "receipt-inflight", "repo-a", "/repo-a/file.go", 9)
+
+	s.resolveReindexedPathReceipts("/repo-a/file.go")
+
+	if outcome := failed.outcome(false); outcome.Err != nil || !outcome.Reindexed {
+		t.Fatalf("a re-parsed path did not resolve its failed receipt: %+v", outcome)
+	}
+	if outcome := otherPath.outcome(false); outcome.Err == nil {
+		t.Fatal("a failure on an unrelated path was resolved")
+	}
+	if outcome := inflight.outcome(true); !outcome.Pending {
+		t.Fatalf("an in-flight receipt was completed by the reindex resolve: %+v", outcome)
+	}
+	inflight.mu.RLock()
+	touched := inflight.result.Reindexed || inflight.result.AppliedGeneration != 0
+	inflight.mu.RUnlock()
+	if touched {
+		t.Fatal("the resolve stamped a result onto a receipt whose ticket is still in flight")
+	}
+
+	err := s.awaitMutationFreshnessForRepos(context.Background(), "repo-a")
+	if err == nil {
+		t.Fatal("the remaining receipts did not fail closed")
+	}
+	if strings.Contains(err.Error(), "receipt-failed") {
+		t.Fatalf("the barrier still reports the resolved receipt: %v", err)
+	}
+	for _, want := range []string{"receipt-other-path", "receipt-inflight"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("barrier %q no longer reports %q", err, want)
+		}
+	}
+}
+
+func TestReindexedReceiptPathOnlyResolvesAProvenSinglePath(t *testing.T) {
+	stale := &indexer.IndexResult{StaleFileCount: 1}
+	// A platform-real absolute path: on Windows a rooted path without a
+	// drive letter is not absolute, so a hand-written "/repo/..." would be
+	// joined rather than used as-is (harmlessly — it then matches no
+	// receipt — but it would not exercise the branch under test).
+	absFixture, absErr := filepath.Abs(filepath.Join("repo", "internal", "a.go"))
+	if absErr != nil {
+		t.Fatalf("resolving the fixture path: %v", absErr)
+	}
+	cases := []struct {
+		name   string
+		paths  []string
+		root   string
+		result *indexer.IndexResult
+		want   string
+		ok     bool
+	}{
+		{"single relative path is joined to the repo root", []string{"internal/a.go"}, "/repo", stale, filepath.Join("/repo", "internal/a.go"), true},
+		{"single absolute path is used as-is", []string{absFixture}, "/repo", stale, absFixture, true},
+		{"several paths cannot be attributed per path", []string{"a.go", "b.go"}, "/repo", stale, "", false},
+		{"a whole-repo pass resolves nothing", nil, "/repo", stale, "", false},
+		{"nothing was re-parsed", []string{"a.go"}, "/repo", &indexer.IndexResult{StaleFileCount: 0}, "", false},
+		{"the path itself failed to index", []string{"a.go"}, "/repo", &indexer.IndexResult{StaleFileCount: 1, FailedFiles: []string{"a.go"}}, "", false},
+		{"a relative path without a known root is not guessed", []string{"a.go"}, "", stale, "", false},
+		{"a missing result resolves nothing", []string{"a.go"}, "/repo", nil, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := reindexedReceiptPath(tc.paths, tc.root, tc.result)
+			if ok != tc.ok || got != tc.want {
+				t.Fatalf("reindexedReceiptPath(%v, %q) = (%q, %v), want (%q, %v)",
+					tc.paths, tc.root, got, ok, tc.want, tc.ok)
+			}
+		})
 	}
 }
 

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -1525,8 +1526,9 @@ func (s *Server) handleReindexRepository(ctx context.Context, req mcp.CallToolRe
 	pathArg := req.GetString("path", "")
 
 	var (
-		result *indexer.IndexResult
-		err    error
+		result      *indexer.IndexResult
+		err         error
+		reindexRoot string
 	)
 
 	// Multi-repo mode: route through the per-repo indexer so nodes keep
@@ -1557,6 +1559,7 @@ func (s *Server) handleReindexRepository(ctx context.Context, req mcp.CallToolRe
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
+		reindexRoot, _ = s.multiIndexer.RepoRoot(prefix)
 	} else {
 		if s.indexer == nil {
 			return mcp.NewToolResultError("reindex_repository: no indexer available"), nil
@@ -1577,6 +1580,23 @@ func (s *Server) handleReindexRepository(ctx context.Context, req mcp.CallToolRe
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
+		reindexRoot = root
+	}
+
+	// A successful scoped re-parse is exactly the evidence a terminally failed
+	// freshness receipt for that path is waiting for, so clear it here: a
+	// failed ingest otherwise fail-closes change.detect for the whole
+	// repository until retention lapses, and reindex is the recovery callers
+	// reach for first (#692).
+	//
+	// Deliberately narrow. IncrementalReindexRepo scopes the pass to the given
+	// paths, so with exactly one requested path a non-zero StaleFileCount
+	// proves that file was re-parsed. With several paths the count cannot be
+	// attributed per path, and clearing a receipt for a file that was not
+	// re-parsed would be a false green — the very thing the receipt exists to
+	// prevent — so anything wider is left alone.
+	if resolved, ok := reindexedReceiptPath(paths, reindexRoot, result); ok {
+		s.resolveReindexedPathReceipts(resolved)
 	}
 
 	s.RunAnalysis()
@@ -1602,6 +1622,32 @@ func (s *Server) handleReindexRepository(ctx context.Context, req mcp.CallToolRe
 		payload["failed_files"] = result.FailedFiles
 	}
 	return s.respondJSONOrTOON(ctx, req, payload)
+}
+
+// reindexedReceiptPath reports the absolute path whose failed freshness
+// receipts a reindex pass has earned the right to resolve, if any.
+//
+// Deliberately narrow. IncrementalReindexRepo scopes the pass to the requested
+// paths, so with exactly one requested path a non-zero StaleFileCount proves
+// that file was re-parsed. With several paths the count cannot be attributed
+// per path, and clearing a receipt for a file that was not re-parsed would be
+// a false green — the very thing the receipt exists to prevent — so anything
+// wider resolves nothing.
+func reindexedReceiptPath(paths []string, root string, result *indexer.IndexResult) (string, bool) {
+	if len(paths) != 1 || result == nil || result.StaleFileCount <= 0 {
+		return "", false
+	}
+	if slices.Contains(result.FailedFiles, paths[0]) {
+		return "", false
+	}
+	resolved := paths[0]
+	if !filepath.IsAbs(resolved) {
+		if root == "" {
+			return "", false
+		}
+		resolved = filepath.Join(root, resolved)
+	}
+	return resolved, true
 }
 
 func (s *Server) handleGetSymbol(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -1529,6 +1528,14 @@ func (s *Server) handleReindexRepository(ctx context.Context, req mcp.CallToolRe
 		result      *indexer.IndexResult
 		err         error
 		reindexRoot string
+		// eligible is snapshotted BEFORE the pass runs: only receipts that
+		// had already failed when the indexer read the file may be resolved
+		// by it. A mutation that lands mid-pass, fails its own ingest and
+		// completes before this handler returns would otherwise be stamped
+		// fresh, certifying bytes the graph never read. Using pass start as
+		// the cutoff declines some safe resolutions, which is the right way
+		// to be wrong here.
+		eligible map[string]struct{}
 	)
 
 	// Multi-repo mode: route through the per-repo indexer so nodes keep
@@ -1555,11 +1562,12 @@ func (s *Server) handleReindexRepository(ctx context.Context, req mcp.CallToolRe
 					"reindex_repository: no repository specified and the active repository is ambiguous; pass `path`"), nil
 			}
 		}
+		reindexRoot, _ = s.multiIndexer.RepoRoot(prefix)
+		eligible = s.failedReceiptsBefore(paths, reindexRoot)
 		result, err = s.multiIndexer.IncrementalReindexRepo(prefix, paths)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
-		reindexRoot, _ = s.multiIndexer.RepoRoot(prefix)
 	} else {
 		if s.indexer == nil {
 			return mcp.NewToolResultError("reindex_repository: no indexer available"), nil
@@ -1576,11 +1584,12 @@ func (s *Server) handleReindexRepository(ctx context.Context, req mcp.CallToolRe
 		if absErr != nil {
 			return mcp.NewToolResultError(absErr.Error()), nil
 		}
+		reindexRoot = root
+		eligible = s.failedReceiptsBefore(paths, reindexRoot)
 		result, err = s.indexer.IncrementalReindexPaths(root, paths)
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
-		reindexRoot = root
 	}
 
 	// A successful scoped re-parse is exactly the evidence a terminally failed
@@ -1596,7 +1605,7 @@ func (s *Server) handleReindexRepository(ctx context.Context, req mcp.CallToolRe
 	// re-parsed would be a false green — the very thing the receipt exists to
 	// prevent — so anything wider is left alone.
 	if resolved, ok := reindexedReceiptPath(paths, reindexRoot, result); ok {
-		s.resolveReindexedPathReceipts(resolved)
+		s.resolveReindexedPathReceipts(resolved, eligible)
 	}
 
 	s.RunAnalysis()
@@ -1624,6 +1633,24 @@ func (s *Server) handleReindexRepository(ctx context.Context, req mcp.CallToolRe
 	return s.respondJSONOrTOON(ctx, req, payload)
 }
 
+// reindexCandidatePath resolves the single requested path against the repo
+// root. Split out from reindexedReceiptPath so the pre-pass snapshot and the
+// post-pass resolution agree on the spelling by construction: if they ever
+// disagreed, the snapshot would bound the wrong receipts.
+func reindexCandidatePath(paths []string, root string) (string, bool) {
+	if len(paths) != 1 {
+		return "", false
+	}
+	resolved := paths[0]
+	if !filepath.IsAbs(resolved) {
+		if root == "" {
+			return "", false
+		}
+		resolved = filepath.Join(root, resolved)
+	}
+	return filepath.Clean(resolved), true
+}
+
 // reindexedReceiptPath reports the absolute path whose failed freshness
 // receipts a reindex pass has earned the right to resolve, if any.
 //
@@ -1633,19 +1660,37 @@ func (s *Server) handleReindexRepository(ctx context.Context, req mcp.CallToolRe
 // per path, and clearing a receipt for a file that was not re-parsed would be
 // a false green — the very thing the receipt exists to prevent — so anything
 // wider resolves nothing.
+//
+// Two properties worth stating because both are fail-closed by construction
+// and would be surprising to rediscover: path comparison is case-sensitive,
+// so a spelling difference on a case-insensitive filesystem silently skips a
+// resolution rather than making a wrong one; and `paths` may name a directory,
+// which returns a directory path here and then matches no receipt, because
+// receipts hold file paths and matching is exact equality. If receipt matching
+// ever became prefix-based, that second property would turn into a hole.
 func reindexedReceiptPath(paths []string, root string, result *indexer.IndexResult) (string, bool) {
 	if len(paths) != 1 || result == nil || result.StaleFileCount <= 0 {
 		return "", false
 	}
-	if slices.Contains(result.FailedFiles, paths[0]) {
+	resolved, ok := reindexCandidatePath(paths, root)
+	if !ok {
 		return "", false
 	}
-	resolved := paths[0]
-	if !filepath.IsAbs(resolved) {
-		if root == "" {
+
+	// FailedFiles carries ABSOLUTE paths (pinned by
+	// TestIncrementalReindex_FailedFileSurfacedAndRetried) while paths[0] is
+	// whatever spelling the caller passed, so the comparison has to happen
+	// after the join — checking the raw request alone lets a relative request
+	// walk straight past this guard, which is the only thing standing between
+	// a file that failed to index and a barrier that reports it fresh.
+	// StaleFileCount counts discovered-stale files INCLUDING the ones that
+	// then failed, so it cannot stand in for this check. Both spellings are
+	// compared because refusing a resolution is always the safe direction.
+	requested := filepath.Clean(paths[0])
+	for _, failed := range result.FailedFiles {
+		if clean := filepath.Clean(failed); clean == resolved || clean == requested {
 			return "", false
 		}
-		resolved = filepath.Join(root, resolved)
 	}
 	return resolved, true
 }

--- a/internal/mcp/tools_core_reindex_test.go
+++ b/internal/mcp/tools_core_reindex_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -57,6 +58,54 @@ func decodeReindexResult(t *testing.T, res *mcplib.CallToolResult) reindexResult
 // single-repo path of reindex_repository with no `paths` argument: a
 // file changed since the initial index is re-parsed, and the result
 // reports scope="repository" plus a sane node/edge/stale count.
+// TestHandleReindexRepository_ResolvesFailedReceiptForTheReparsedPath covers
+// the wiring itself: a scoped reindex of one file must clear a terminally
+// failed freshness receipt for that file, because otherwise a failed ingest
+// fail-closes change.detect for the whole repository until retention lapses
+// and reindex — the recovery callers reach for first — silently does nothing.
+func TestHandleReindexRepository_ResolvesFailedReceiptForTheReparsedPath(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "main.go")
+	require.NoError(t, os.WriteFile(target,
+		[]byte("package main\n\nfunc Main() {}\n"), 0o644))
+
+	g := graph.New()
+	idx := indexer.New(g, testRegistry(), config.Default().Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	srv := NewServer(query.NewEngine(g), g, idx, nil, zap.NewNop(), nil)
+
+	// A failed ingest for that exact path, plus one for a file the pass will
+	// not touch: only the re-parsed path may be resolved.
+	failed := pendingFreshnessReceipt(srv, "receipt-failed", "", target, 4)
+	completeFreshnessReceipt(failed, indexer.MutationResult{
+		RequestedGeneration: 4,
+		Err:                 errors.New("context deadline exceeded"),
+	})
+	untouched := pendingFreshnessReceipt(srv, "receipt-untouched", "",
+		filepath.Join(dir, "other.go"), 5)
+	completeFreshnessReceipt(untouched, indexer.MutationResult{
+		RequestedGeneration: 5,
+		Err:                 errors.New("unrelated failure"),
+	})
+
+	bumpFile(t, target, "package main\n\nfunc Main() {}\n\nfunc Extra() {}\n")
+
+	req := mcplib.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"paths": []any{target}}
+	res, err := srv.handleReindexRepository(context.Background(), req)
+	require.NoError(t, err)
+	out := decodeReindexResult(t, res)
+	require.Equal(t, 1, out.StaleFileCount, "the pass must have re-parsed the file")
+
+	if outcome := failed.outcome(false); outcome.Err != nil || !outcome.Reindexed {
+		t.Fatalf("reindex did not resolve the failed receipt for the re-parsed path: %+v", outcome)
+	}
+	if outcome := untouched.outcome(false); outcome.Err == nil {
+		t.Fatal("reindex resolved a receipt for a path it never re-parsed")
+	}
+}
+
 func TestHandleReindexRepository_WholeRepoSingleMode(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(dir, "pkg"), 0o755))


### PR DESCRIPTION
Implements **request 1 of #692**, and follows on from #693.

## The gap

A mutation whose disk write succeeded but whose graph ingest failed leaves a terminally failed freshness receipt, and that receipt fail-closes `change.detect`/`change.impact` for the **whole repository** until retention lapses.

`reindex_repository` is the recovery a caller reaches for first — and it does not work. It re-reads the file into the graph but never touches `s.mutationReceipts`, so the barrier keeps reporting a gap the graph no longer has. (Verified: `mutationReceipts` is referenced only in `edit_serialization.go` and the batch path; the reindex route never sees it.)

## The change

A successful **scoped** re-parse is exactly the evidence a failed receipt is waiting for — the graph has now read the current bytes of that path — so the handler resolves it, **in place**, the same way a superseding mutation does since #693.

**Kept deliberately narrow, and this is the part worth reviewing:**

- `IncrementalReindexRepo` scopes the pass to the requested paths, so with **exactly one** requested path a non-zero `StaleFileCount` *proves* that file was re-parsed.
- With several paths the count cannot be attributed per path → resolves nothing.
- A whole-repo pass resolves nothing either: it admits by mtime, so it makes no promise about any particular file.
- A relative path with no known repo root is not guessed at.

Clearing a receipt for a file that was **not** re-parsed would be a false green — the very thing the receipt exists to prevent — so every ambiguous case declines.

Pending receipts are untouched: they describe work still in flight, not a dead generation.

The decision lives in a pure helper (`reindexedReceiptPath`) rather than inline, so it can be tested without a live indexer.

## Tests

- a table over the decision: single relative path joined to the repo root, single absolute path used as-is, several paths, whole-repo, nothing re-parsed, the path itself in `FailedFiles`, a relative path with no known root, a missing result;
- a unit test that the resolve touches **only** the re-parsed path and leaves an in-flight receipt's `result` untouched;
- an **end-to-end** test through `handleReindexRepository` that proves the wiring, using the existing harness in `tools_core_reindex_test.go`.

**Seven mutants** each fail their test and pass restored: resolver body removed · path filter dropped · `completed` guard dropped · handler stops calling the resolver · single-path guard dropped · `FailedFiles` check dropped · empty-root guess allowed.

> Worth saying: the first pass had the decision inline in the handler, and the mutation run showed **three** mutants not binding — the handler logic had no test at all. Extracting the helper and adding the end-to-end test is what closed that; the design change came from the mutants, not from taste.

## Verification

`go build` and `go vet` clean. The full `./internal/mcp` suite shows 20 failures on this Windows workstation — **the same tests fail identically on a clean tree** (8 of them sampled A/B), so they are pre-existing environment failures, not regressions. None is in the mutation or reindex families.

## Not covered

The other asks in #692 — retry-with-backoff for a failed ingest, and degrade-instead-of-refuse in `detect` — are untouched here, and #692 should stay open for them. This PR only makes the recovery that callers already attempt actually work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
