### PR TITLE
parser: C# accessor bodies, initializers, and the implicit value parameter own their calls

### DIFF
--- a/internal/indexer/extractor_version.go
+++ b/internal/indexer/extractor_version.go
@@ -40,7 +40,7 @@ var extractorVersions = map[string]int{
 	//   "go": 2,
 	"c":      generatedParserProjectionPolicyVersion, // generated parser projection covers all strictly detected table sizes
 	"php":    2,                                      // class/interface inheritance now emits typed structural edges
-	"csharp": 17,                                     // clause-specific binder extents, offset-aware typed locals + field uses, byte-interval caller attribution, canonical base-list spellings, partial-fragment base preservation (was: canonical-identifier type-arg domain)
+	"csharp": 18,                                     // accessor bodies, property/field initializers, and the typed value parameter own their calls (was: clause-specific binder extents, offset-aware typed locals + field uses, byte-interval caller attribution, canonical base-list spellings, partial-fragment base preservation)
 	"scala":  2,                                      // explicitly instantiated generic calls emit call edges
 	"go":     3,                                      // generic instantiations are marked so indexing a func value cannot bind (was: generic calls emit call edges)
 	"cpp":    2,                                      // templated and namespace-qualified calls emit call edges

--- a/internal/indexer/extractor_version_test.go
+++ b/internal/indexer/extractor_version_test.go
@@ -229,7 +229,7 @@ func TestStaleLangsDetection(t *testing.T) {
 		}
 
 		for _, path := range []string{"src/Handler.cs", "Views/Page.razor", "Views/Page.cshtml"} {
-			want := policySalt + "|csharp@17"
+			want := policySalt + "|csharp@18"
 			if got := merkleSaltFor(path); got != want {
 				t.Errorf("C# extractor salt for %s = %q, want %q", path, got, want)
 			}

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -880,7 +880,7 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 	// `x as Foo`), static / const access (`Foo.Empty`, `typeof(Foo)`,
 	// `nameof(Foo)`), and attribute type names (`[Foo]`). Inheritance is
 	// already covered by emitCSharpBaseList, so it is not re-emitted here.
-	emitCSharpReferenceForms(root, src, filePath, fileID, result)
+	emitCSharpReferenceForms(root, src, filePath, fileID, result, funcBytes, funcLines)
 
 	// Two same-named calls on ONE line whose receivers differ make the
 	// line unattributable: member companions dedupe to a single stored
@@ -1123,7 +1123,7 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 	captureValueRefCandidates(result, root, filePath, src)
 	captureFnValueCandidates(result, root, filePath, src)
 
-	captureMediatRDispatch(result, root, filePath, src)
+	captureMediatRDispatch(result, root, filePath, src, funcBytes, funcLines)
 
 	return result, hadError, nil
 }

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -520,7 +520,7 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 			e.emitField(m, filePath, fileID, src, result, seen, fileAliases)
 
 		case m.Captures["prop.def"] != nil:
-			e.emitProperty(m, filePath, fileID, src, result, seen, fileAliases)
+			e.emitProperty(m, filePath, fileID, src, result, seen, fileAliases, funcBytes)
 
 		case m.Captures["using.def"] != nil:
 			e.emitUsing(m, filePath, fileID, result)
@@ -630,7 +630,7 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 	// type environments. Owner attribution runs once per local, call and
 	// type use — the sorted lookup keeps that from multiplying into an
 	// O(locals×functions) linear-scan product on member-heavy files.
-	funcRanges := newCSharpFuncLookup(buildFuncRanges(result), funcBytes)
+	funcRanges := newCSharpFuncLookup(csharpOwnerRanges(result, funcBytes), funcBytes)
 
 	// Build type environments in legacy precedence, scoped per enclosing
 	// method — a same-named local of a different type in a sibling method
@@ -1901,7 +1901,7 @@ func (e *CSharpExtractor) emitField(m parser.QueryResult, filePath, fileID strin
 	emitCSharpTypeUseEdges(id, fieldTypeRaw, filePath, def.StartLine+1, result)
 }
 
-func (e *CSharpExtractor) emitProperty(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen map[string]bool, fileAliases map[string]bool) {
+func (e *CSharpExtractor) emitProperty(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen map[string]bool, fileAliases map[string]bool, funcBytes map[string][2]int) {
 	def := m.Captures["prop.def"]
 	owner := csharpDirectMemberOwner(def.Node, src, "class_declaration", "struct_declaration", "interface_declaration", "record_declaration")
 	if owner.kind == "" {
@@ -1913,6 +1913,13 @@ func (e *CSharpExtractor) emitProperty(m parser.QueryResult, filePath, fileID st
 		return
 	}
 	seen[id] = true
+	// Accessor bodies, an expression body, and an initializer all live
+	// inside the declaration span — recording it makes the property a
+	// call owner (round-23 catch AC1: without an owner the funcRanges
+	// gate dropped every accessor-body call outright).
+	if def.Node != nil {
+		funcBytes[id] = [2]int{int(def.Node.StartByte()), int(def.Node.EndByte())}
+	}
 	// Interface properties are implicitly public; explicit modifiers still win.
 	isIface := owner.kind == "interface_declaration"
 	defaultVis := VisibilityPrivate
@@ -2093,6 +2100,28 @@ type csharpFuncLookup struct {
 	bytes map[string][2]int
 }
 
+// csharpOwnerRanges widens the method/constructor owner set with every
+// member that recorded byte extents but is not a KindFunction/KindMethod
+// node — properties today, any extent-carrying member kind tomorrow. A
+// member that can hold executable code must be able to OWN the calls in
+// it: the funcRanges gate drops a call whose enclosing member it cannot
+// name, which is how every accessor-body call vanished (round-23 catch
+// AC1 — 3 of the probe cell's 4 sites, the expression-bodied method
+// being the lone survivor).
+func csharpOwnerRanges(result *parser.ExtractionResult, funcBytes map[string][2]int) []funcRange {
+	ranges := buildFuncRanges(result)
+	for _, n := range result.Nodes {
+		if n.Kind != graph.KindField {
+			continue
+		}
+		if _, ok := funcBytes[n.ID]; !ok {
+			continue
+		}
+		ranges = append(ranges, funcRange{id: n.ID, startLine: n.StartLine, endLine: n.EndLine})
+	}
+	return ranges
+}
+
 func newCSharpFuncLookup(ranges []funcRange, bytes map[string][2]int) *csharpFuncLookup {
 	sorted := append([]funcRange(nil), ranges...)
 	ord := make([]int, len(sorted))
@@ -2122,10 +2151,10 @@ func newCSharpFuncLookup(ranges []funcRange, bytes map[string][2]int) *csharpFun
 // carried A's call and every consumer of the attribution read the wrong
 // member's evidence (round-5 finding 4). Falls back to the line answer
 // whenever no recorded byte extent contains the offset: extents are
-// recorded only for methods and constructors, so a member kind without
-// them (property, indexer, field initializer) sharing a line with one
-// that has them would otherwise lose its call outright rather than
-// degrade to line attribution (round-6 finding B3).
+// recorded for methods, constructors, and properties, so a member kind
+// still without them (indexer, event accessor, field initializer)
+// sharing a line with one that has them would otherwise lose its call
+// outright rather than degrade to line attribution (round-6 finding B3).
 func (l *csharpFuncLookup) enclosingAt(line, offset int) string {
 	if offset < 0 || len(l.bytes) == 0 {
 		return l.enclosing(line)

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -1883,7 +1883,7 @@ func (e *CSharpExtractor) emitField(m parser.QueryResult, filePath, fileID strin
 	// on the field it actually initializes. Initializer-less declarators
 	// record nothing — they contain no code, and keeping them out of the
 	// owner set avoids needless one-line ambiguity ties.
-	if nameCap.Node != nil {
+	if nameCap.Node != nil && !csharpHasModifier(def.Node, src, "const") {
 		if decl := nameCap.Node.Parent(); decl != nil && decl.Type() == "variable_declarator" {
 			// Grammar revisions disagree on the wrapper (equals_value_clause
 			// vs the expression hanging directly under the declarator — the
@@ -1911,6 +1911,11 @@ func (e *CSharpExtractor) emitField(m parser.QueryResult, filePath, fileID strin
 	meta := map[string]any{
 		"receiver":   owner.name,
 		"visibility": csharpVisibility(def.Node, src, defaultVis),
+	}
+	// Initialized fields are call owners; they carry scope_ns for the
+	// resolver's scoped-usings narrowing like every other owner kind.
+	if ns := csharpEnclosingNamespace(def.Node, src); ns != "" {
+		meta["scope_ns"] = ns
 	}
 	if isIface {
 		meta["iface_member"] = true
@@ -2073,6 +2078,11 @@ func (e *CSharpExtractor) emitProperty(m parser.QueryResult, filePath, fileID st
 		"receiver":   owner.name,
 		"visibility": csharpVisibility(def.Node, src, defaultVis),
 		"kind":       "property",
+	}
+	// Properties are call owners; the resolver's scoped-usings narrowing
+	// reads the caller's scope_ns, so they carry it like methods do.
+	if ns := csharpEnclosingNamespace(def.Node, src); ns != "" {
+		meta["scope_ns"] = ns
 	}
 	if isIface {
 		meta["iface_member"] = true
@@ -2302,10 +2312,11 @@ func newCSharpFuncLookup(ranges []funcRange, bytes map[string][2]int) *csharpFun
 // carried A's call and every consumer of the attribution read the wrong
 // member's evidence (round-5 finding 4). Falls back to the line answer
 // whenever no recorded byte extent contains the offset: extents are
-// recorded for methods, constructors, and properties, so a member kind
-// still without them (indexer, event accessor, field initializer)
-// sharing a line with one that has them would otherwise lose its call
-// outright rather than degrade to line attribution (round-6 finding B3).
+// recorded for methods, constructors, properties, and initialized field
+// declarators, so a member kind still without them (indexer, event
+// accessor) sharing a line with one that has them would otherwise lose
+// its call outright rather than degrade to line attribution (round-6
+// finding B3).
 func (l *csharpFuncLookup) enclosingAt(line, offset int) string {
 	if offset < 0 || len(l.bytes) == 0 {
 		return l.enclosing(line)

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -458,6 +458,10 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 	// cannot say which of two members sharing a physical line owns a
 	// call site; the byte interval can (round-5 finding 4).
 	funcBytes := make(map[string][2]int)
+	// Properties carrying a set/init accessor, recorded at emission so
+	// the deferred typing pass can seed the accessor's implicit `value`
+	// parameter with the property's declared type.
+	valueProps := make(map[string]csharpValueProp)
 	// Type IDs whose FIRST declaration spelled `partial` — the gate for
 	// preserving a later same-file fragment's base list (round-5
 	// finding 5).
@@ -520,7 +524,7 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 			e.emitField(m, filePath, fileID, src, result, seen, fileAliases, funcBytes)
 
 		case m.Captures["prop.def"] != nil:
-			e.emitProperty(m, filePath, fileID, src, result, seen, fileAliases, funcBytes)
+			e.emitProperty(m, filePath, fileID, src, result, seen, fileAliases, funcBytes, valueProps)
 
 		case m.Captures["using.def"] != nil:
 			e.emitUsing(m, filePath, fileID, result)
@@ -697,6 +701,37 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 		env[l.name] = typeName
 		if b := typedRecord(owner, l); b != nil && b.typ == "" {
 			b.typ = typeName
+		}
+	}
+	// The implicit `value` parameter of a set/init accessor carries the
+	// property's declared type — seed it like a tier-0 typed local, per
+	// accessor owner, BEFORE the local tiers so a real declaration keeps
+	// last-write precedence. Withheld when the enclosing type itself
+	// declares a member named `value`: inside that property's GETTER the
+	// name means the member, a per-owner map cannot split the accessors,
+	// and overwriting legitimate field evidence would hand the resolver
+	// a confident wrong answer — the seed refuses instead.
+	if len(valueProps) > 0 {
+		valueMembers := map[string]bool{}
+		for _, n := range result.Nodes {
+			if (n.Kind == graph.KindField || n.Kind == graph.KindConstant) && n.Name == "value" {
+				if r, _ := n.Meta["receiver"].(string); r != "" {
+					valueMembers[r] = true
+				}
+			}
+		}
+		for id, vp := range valueProps {
+			if valueMembers[vp.receiver] {
+				continue
+			}
+			if t := normalizeCSharpTypeName(vp.typ); t != "" && t != "var" {
+				env := tenvByOwner[id]
+				if env == nil {
+					env = make(typeEnv)
+					tenvByOwner[id] = env
+				}
+				env["value"] = t
+			}
 		}
 	}
 	for _, l := range locals {
@@ -1927,7 +1962,34 @@ func (e *CSharpExtractor) emitField(m parser.QueryResult, filePath, fileID strin
 	emitCSharpTypeUseEdges(id, fieldTypeRaw, filePath, def.StartLine+1, result)
 }
 
-func (e *CSharpExtractor) emitProperty(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen map[string]bool, fileAliases map[string]bool, funcBytes map[string][2]int) {
+// csharpValueProp records a set/init-carrying property so the deferred
+// typing pass can seed the accessor's implicit `value` parameter.
+type csharpValueProp struct {
+	typ      string // raw declared property type
+	receiver string // enclosing type name, for the value-member collision check
+}
+
+// csharpHasSetOrInitAccessor reports whether the property declares a set
+// or init accessor. The keyword is an anonymous child of the
+// accessor_declaration, so every child's Type is scanned, not just the
+// named ones.
+func csharpHasSetOrInitAccessor(def *sitter.Node) bool {
+	found := false
+	walkNodes(def, func(n *sitter.Node) {
+		if found || n.Type() != "accessor_declaration" {
+			return
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			if c := n.Child(i); c != nil && (c.Type() == "set" || c.Type() == "init") {
+				found = true
+				return
+			}
+		}
+	})
+	return found
+}
+
+func (e *CSharpExtractor) emitProperty(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen map[string]bool, fileAliases map[string]bool, funcBytes map[string][2]int, valueProps map[string]csharpValueProp) {
 	def := m.Captures["prop.def"]
 	owner := csharpDirectMemberOwner(def.Node, src, "class_declaration", "struct_declaration", "interface_declaration", "record_declaration")
 	if owner.kind == "" {
@@ -1969,6 +2031,9 @@ func (e *CSharpExtractor) emitProperty(m parser.QueryResult, filePath, fileID st
 		if args := csharpTypeArgsFromTypeNode(t, src, csharpUnstampableArgNames(def.Node, src, fileAliases)); args != "" {
 			meta["field_type_args"] = args
 		}
+	}
+	if propTypeRaw != "" && def.Node != nil && csharpHasSetOrInitAccessor(def.Node) {
+		valueProps[id] = csharpValueProp{typ: propTypeRaw, receiver: owner.name}
 	}
 	if doc := extractCSharpDoc(src, def.StartLine); doc != "" {
 		meta["doc"] = doc

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -1912,8 +1912,10 @@ func (e *CSharpExtractor) emitField(m parser.QueryResult, filePath, fileID strin
 		"receiver":   owner.name,
 		"visibility": csharpVisibility(def.Node, src, defaultVis),
 	}
-	// Initialized fields are call owners; they carry scope_ns for the
-	// resolver's scoped-usings narrowing like every other owner kind.
+	// Every field carries scope_ns for the resolver's scoped-usings
+	// narrowing, not only the initialized ones that are call owners: a
+	// field's TYPE reference needs the same namespace narrowing whether
+	// or not its declarator authored a call.
 	if ns := csharpEnclosingNamespace(def.Node, src); ns != "" {
 		meta["scope_ns"] = ns
 	}
@@ -1982,7 +1984,13 @@ type csharpValueProp struct {
 // csharpPropertyHasExecutableBody reports whether the fragment carries
 // any accessor block or expression body - the discriminator between a
 // C# 13 partial property's declaring part (`{ get; set; }`) and its
-// implementing part.
+// implementing part. The walk is coarse: an auto-property with a
+// block-lambda INITIALIZER (`public Func<int> F { get; } = () => { … };`)
+// would read as body-bearing because the lambda's block matches. That
+// misread is unreachable today - this predicate runs only on the
+// duplicate-declaration path, and valid C# does not permit two
+// same-name property declarations where one is such an auto-property -
+// so it is documented rather than special-cased.
 func csharpPropertyHasExecutableBody(def *sitter.Node) bool {
 	found := false
 	walkNodes(def, func(n *sitter.Node) {
@@ -2316,7 +2324,8 @@ func newCSharpFuncLookup(ranges []funcRange, bytes map[string][2]int) *csharpFun
 // declarators, so a member kind still without them (indexer, event
 // accessor) sharing a line with one that has them would otherwise lose
 // its call outright rather than degrade to line attribution (round-6
-// finding B3).
+// finding B3) - unless the line answer's own recorded bytes exclude the
+// offset, in which case the fallback is refused (see below).
 func (l *csharpFuncLookup) enclosingAt(line, offset int) string {
 	if offset < 0 || len(l.bytes) == 0 {
 		return l.enclosing(line)
@@ -2347,7 +2356,17 @@ func (l *csharpFuncLookup) enclosingAt(line, offset int) string {
 	if best != "" {
 		return best
 	}
-	return l.enclosing(line)
+	// The line fallback exists for member kinds that record NO extents
+	// at all (indexer, event accessor). If the line answer does have
+	// recorded bytes and the offset sits outside them, the offset is
+	// provably not inside that member, so handing it the call invents a
+	// false edge on a same-line neighbour - strictly worse than the drop
+	// it replaced.
+	fb := l.enclosing(line)
+	if b, ok := l.bytes[fb]; ok && (offset < b[0] || offset >= b[1]) {
+		return ""
+	}
+	return fb
 }
 
 func (l *csharpFuncLookup) enclosing(line int) string {

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -517,7 +517,7 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 			e.emitConstructor(m, filePath, fileID, src, result, seen, funcBytes)
 
 		case m.Captures["field.def"] != nil:
-			e.emitField(m, filePath, fileID, src, result, seen, fileAliases)
+			e.emitField(m, filePath, fileID, src, result, seen, fileAliases, funcBytes)
 
 		case m.Captures["prop.def"] != nil:
 			e.emitProperty(m, filePath, fileID, src, result, seen, fileAliases, funcBytes)
@@ -1825,18 +1825,44 @@ func (e *CSharpExtractor) emitConstructor(m parser.QueryResult, filePath, fileID
 	emitCSharpFunctionShape(id, def.Node, src, filePath, startLine1, result)
 }
 
-func (e *CSharpExtractor) emitField(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen map[string]bool, fileAliases map[string]bool) {
+func (e *CSharpExtractor) emitField(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen map[string]bool, fileAliases map[string]bool, funcBytes map[string][2]int) {
 	def := m.Captures["field.def"]
 	owner := csharpDirectMemberOwner(def.Node, src, "class_declaration", "struct_declaration", "interface_declaration", "record_declaration")
 	if owner.kind == "" {
 		return
 	}
-	name := m.Captures["field.name"].Text
+	nameCap := m.Captures["field.name"]
+	name := nameCap.Text
 	id := filePath + "::" + owner.name + "." + name
 	if seen[id] {
 		return
 	}
 	seen[id] = true
+	// An initializer is executable code with no method around it, so the
+	// declaring field owns its calls (round-23 catch AC1's field lane).
+	// The extent is the DECLARATOR, not the whole declaration: on a
+	// multi-declarator line (`int a = F(), b = G();`) each call must land
+	// on the field it actually initializes. Initializer-less declarators
+	// record nothing — they contain no code, and keeping them out of the
+	// owner set avoids needless one-line ambiguity ties.
+	if nameCap.Node != nil {
+		if decl := nameCap.Node.Parent(); decl != nil && decl.Type() == "variable_declarator" {
+			// Grammar revisions disagree on the wrapper (equals_value_clause
+			// vs the expression hanging directly under the declarator — the
+			// await-tier walk above tolerates both), so "has an initializer"
+			// is: any named child besides the name and a fixed-size-buffer
+			// bracketed_argument_list.
+			for i := 0; i < int(decl.NamedChildCount()); i++ {
+				c := decl.NamedChild(i)
+				if c == nil || c.StartByte() == nameCap.Node.StartByte() ||
+					c.Type() == "bracketed_argument_list" {
+					continue
+				}
+				funcBytes[id] = [2]int{int(decl.StartByte()), int(decl.EndByte())}
+				break
+			}
+		}
+	}
 	// Interface fields (C# 8+ static/const members) are implicitly public.
 	isIface := owner.kind == "interface_declaration"
 	defaultVis := VisibilityPrivate

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -703,37 +703,6 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 			b.typ = typeName
 		}
 	}
-	// The implicit `value` parameter of a set/init accessor carries the
-	// property's declared type — seed it like a tier-0 typed local, per
-	// accessor owner, BEFORE the local tiers so a real declaration keeps
-	// last-write precedence. Withheld when the enclosing type itself
-	// declares a member named `value`: inside that property's GETTER the
-	// name means the member, a per-owner map cannot split the accessors,
-	// and overwriting legitimate field evidence would hand the resolver
-	// a confident wrong answer — the seed refuses instead.
-	if len(valueProps) > 0 {
-		valueMembers := map[string]bool{}
-		for _, n := range result.Nodes {
-			if (n.Kind == graph.KindField || n.Kind == graph.KindConstant) && n.Name == "value" {
-				if r, _ := n.Meta["receiver"].(string); r != "" {
-					valueMembers[r] = true
-				}
-			}
-		}
-		for id, vp := range valueProps {
-			if valueMembers[vp.receiver] {
-				continue
-			}
-			if t := normalizeCSharpTypeName(vp.typ); t != "" && t != "var" {
-				env := tenvByOwner[id]
-				if env == nil {
-					env = make(typeEnv)
-					tenvByOwner[id] = env
-				}
-				env["value"] = t
-			}
-		}
-	}
 	for _, l := range locals {
 		owner := localOwner(l)
 		if owner == "" {
@@ -945,6 +914,34 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 	// The field-identifier emitter reuses both.
 	paramsByOwner := csharpParamNamesByOwner(result)
 	localScopes := csharpLocalScopes{}
+	// The implicit `value` parameter of a set/init accessor carries the
+	// property's declared type, and inside those accessors it is ALWAYS
+	// the parameter - a same-named member is only reachable there via
+	// this.value. Seed it as an offset-scoped record over each accessor
+	// span, never owner-wide: in the GETTER the bare name means a member
+	// (possibly inherited, possibly declared in another partial
+	// fragment), and an owner-wide seed typed those sites with the
+	// property type - a confident wrong answer. The scope registration
+	// keeps the shadow refusal and the field-identifier lane from
+	// reading the parameter as field evidence inside the accessor.
+	for id, vp := range valueProps {
+		t := normalizeCSharpTypeName(vp.typ)
+		if t == "" || t == "var" {
+			continue
+		}
+		recs := typedLocalsByOwner[id]
+		if recs == nil {
+			recs = map[string][]*csharpTypedBinding{}
+			typedLocalsByOwner[id] = recs
+		}
+		if localScopes[id] == nil {
+			localScopes[id] = map[string][]csharpLocalScope{}
+		}
+		for _, sp := range vp.spans {
+			recs["value"] = append(recs["value"], &csharpTypedBinding{typ: t, scope: sp})
+			localScopes[id]["value"] = append(localScopes[id]["value"], sp)
+		}
+	}
 	for _, l := range locals {
 		owner := localOwner(l)
 		if owner == "" {
@@ -1963,30 +1960,34 @@ func (e *CSharpExtractor) emitField(m parser.QueryResult, filePath, fileID strin
 }
 
 // csharpValueProp records a set/init-carrying property so the deferred
-// typing pass can seed the accessor's implicit `value` parameter.
+// typing pass can seed the accessor's implicit `value` parameter as an
+// offset-scoped record over each accessor's own byte extent.
 type csharpValueProp struct {
-	typ      string // raw declared property type
-	receiver string // enclosing type name, for the value-member collision check
+	typ   string // raw declared property type
+	spans []csharpLocalScope
 }
 
-// csharpHasSetOrInitAccessor reports whether the property declares a set
-// or init accessor. The keyword is an anonymous child of the
+// csharpSetInitAccessorSpans returns the byte extents of the property's
+// set and init accessor declarations - the spans where `value` IS the
+// implicit parameter (a same-named member is only reachable there via
+// this.value, so a seed scoped to these spans can never collide with
+// member evidence). The keyword is an anonymous child of the
 // accessor_declaration, so every child's Type is scanned, not just the
 // named ones.
-func csharpHasSetOrInitAccessor(def *sitter.Node) bool {
-	found := false
+func csharpSetInitAccessorSpans(def *sitter.Node) []csharpLocalScope {
+	var spans []csharpLocalScope
 	walkNodes(def, func(n *sitter.Node) {
-		if found || n.Type() != "accessor_declaration" {
+		if n.Type() != "accessor_declaration" {
 			return
 		}
 		for i := 0; i < int(n.ChildCount()); i++ {
 			if c := n.Child(i); c != nil && (c.Type() == "set" || c.Type() == "init") {
-				found = true
+				spans = append(spans, csharpLocalScope{start: int(n.StartByte()), end: int(n.EndByte())})
 				return
 			}
 		}
 	})
-	return found
+	return spans
 }
 
 func (e *CSharpExtractor) emitProperty(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen map[string]bool, fileAliases map[string]bool, funcBytes map[string][2]int, valueProps map[string]csharpValueProp) {
@@ -2032,8 +2033,10 @@ func (e *CSharpExtractor) emitProperty(m parser.QueryResult, filePath, fileID st
 			meta["field_type_args"] = args
 		}
 	}
-	if propTypeRaw != "" && def.Node != nil && csharpHasSetOrInitAccessor(def.Node) {
-		valueProps[id] = csharpValueProp{typ: propTypeRaw, receiver: owner.name}
+	if propTypeRaw != "" && def.Node != nil {
+		if spans := csharpSetInitAccessorSpans(def.Node); len(spans) > 0 {
+			valueProps[id] = csharpValueProp{typ: propTypeRaw, spans: spans}
+		}
 	}
 	if doc := extractCSharpDoc(src, def.StartLine); doc != "" {
 		meta["doc"] = doc

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -458,6 +458,12 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 	// cannot say which of two members sharing a physical line owns a
 	// call site; the byte interval can (round-5 finding 4).
 	funcBytes := make(map[string][2]int)
+	// Line spans matching funcBytes for member kinds whose NODE lines
+	// can differ from the extent that owns their code - a C# 13 partial
+	// property's node keeps the first fragment's lines while the extents
+	// belong to the implementing fragment, and a field's extent is its
+	// declarator, not the whole declaration.
+	funcLines := make(map[string][2]int)
 	// Properties carrying a set/init accessor, recorded at emission so
 	// the deferred typing pass can seed the accessor's implicit `value`
 	// parameter with the property's declared type.
@@ -521,10 +527,10 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 			e.emitConstructor(m, filePath, fileID, src, result, seen, funcBytes)
 
 		case m.Captures["field.def"] != nil:
-			e.emitField(m, filePath, fileID, src, result, seen, fileAliases, funcBytes)
+			e.emitField(m, filePath, fileID, src, result, seen, fileAliases, funcBytes, funcLines)
 
 		case m.Captures["prop.def"] != nil:
-			e.emitProperty(m, filePath, fileID, src, result, seen, fileAliases, funcBytes, valueProps)
+			e.emitProperty(m, filePath, fileID, src, result, seen, fileAliases, funcBytes, funcLines, valueProps)
 
 		case m.Captures["using.def"] != nil:
 			e.emitUsing(m, filePath, fileID, result)
@@ -634,7 +640,7 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 	// type environments. Owner attribution runs once per local, call and
 	// type use — the sorted lookup keeps that from multiplying into an
 	// O(locals×functions) linear-scan product on member-heavy files.
-	funcRanges := newCSharpFuncLookup(csharpOwnerRanges(result, funcBytes), funcBytes)
+	funcRanges := newCSharpFuncLookup(csharpOwnerRanges(result, funcBytes, funcLines), funcBytes)
 
 	// Build type environments in legacy precedence, scoped per enclosing
 	// method — a same-named local of a different type in a sibling method
@@ -1857,7 +1863,7 @@ func (e *CSharpExtractor) emitConstructor(m parser.QueryResult, filePath, fileID
 	emitCSharpFunctionShape(id, def.Node, src, filePath, startLine1, result)
 }
 
-func (e *CSharpExtractor) emitField(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen map[string]bool, fileAliases map[string]bool, funcBytes map[string][2]int) {
+func (e *CSharpExtractor) emitField(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen map[string]bool, fileAliases map[string]bool, funcBytes, funcLines map[string][2]int) {
 	def := m.Captures["field.def"]
 	owner := csharpDirectMemberOwner(def.Node, src, "class_declaration", "struct_declaration", "interface_declaration", "record_declaration")
 	if owner.kind == "" {
@@ -1891,6 +1897,7 @@ func (e *CSharpExtractor) emitField(m parser.QueryResult, filePath, fileID strin
 					continue
 				}
 				funcBytes[id] = [2]int{int(decl.StartByte()), int(decl.EndByte())}
+				funcLines[id] = [2]int{int(decl.StartPoint().Row) + 1, int(decl.EndPoint().Row) + 1}
 				break
 			}
 		}
@@ -1967,6 +1974,46 @@ type csharpValueProp struct {
 	spans []csharpLocalScope
 }
 
+// csharpPropertyHasExecutableBody reports whether the fragment carries
+// any accessor block or expression body - the discriminator between a
+// C# 13 partial property's declaring part (`{ get; set; }`) and its
+// implementing part.
+func csharpPropertyHasExecutableBody(def *sitter.Node) bool {
+	found := false
+	walkNodes(def, func(n *sitter.Node) {
+		if found {
+			return
+		}
+		switch n.Type() {
+		case "block", "arrow_expression_clause":
+			found = true
+		}
+	})
+	return found
+}
+
+// csharpRecordPropertyOwnership records one fragment's declaration span
+// as the property's call-ownership evidence: byte extents, the line
+// span (the minted node keeps the FIRST fragment's lines, so a partial
+// implementation needs its own), and the set/init spans for the value
+// seed. Re-invoked by the duplicate-declaration path when the
+// body-bearing fragment of a partial property extracts second.
+func csharpRecordPropertyOwnership(id string, node *sitter.Node, startLine, endLine int, src []byte, funcBytes, funcLines map[string][2]int, valueProps map[string]csharpValueProp) {
+	if node == nil {
+		return
+	}
+	funcBytes[id] = [2]int{int(node.StartByte()), int(node.EndByte())}
+	funcLines[id] = [2]int{startLine + 1, endLine + 1}
+	delete(valueProps, id)
+	if t := node.ChildByFieldName("type"); t != nil {
+		if raw := strings.TrimSpace(t.Content(src)); raw != "" {
+			if spans := csharpSetInitAccessorSpans(node); len(spans) > 0 {
+				valueProps[id] = csharpValueProp{typ: raw, spans: spans}
+			}
+		}
+	}
+}
+
 // csharpSetInitAccessorSpans returns the byte extents of the property's
 // set and init accessor declarations - the spans where `value` IS the
 // implicit parameter (a same-named member is only reachable there via
@@ -1990,7 +2037,7 @@ func csharpSetInitAccessorSpans(def *sitter.Node) []csharpLocalScope {
 	return spans
 }
 
-func (e *CSharpExtractor) emitProperty(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen map[string]bool, fileAliases map[string]bool, funcBytes map[string][2]int, valueProps map[string]csharpValueProp) {
+func (e *CSharpExtractor) emitProperty(m parser.QueryResult, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen map[string]bool, fileAliases map[string]bool, funcBytes, funcLines map[string][2]int, valueProps map[string]csharpValueProp) {
 	def := m.Captures["prop.def"]
 	owner := csharpDirectMemberOwner(def.Node, src, "class_declaration", "struct_declaration", "interface_declaration", "record_declaration")
 	if owner.kind == "" {
@@ -1999,6 +2046,15 @@ func (e *CSharpExtractor) emitProperty(m parser.QueryResult, filePath, fileID st
 	name := m.Captures["prop.name"].Text
 	id := filePath + "::" + owner.name + "." + name
 	if seen[id] {
+		// A same-file duplicate declaration mints no second node — but a
+		// C# 13 partial property splits declaration and implementation
+		// across fragments, and either order may extract first. The
+		// body-bearing fragment must own the extents and the value
+		// spans, or every accessor call in the implementation dies
+		// ownerless (the AC1 drop, one level up).
+		if def.Node != nil && csharpPropertyHasExecutableBody(def.Node) {
+			csharpRecordPropertyOwnership(id, def.Node, def.StartLine, def.EndLine, src, funcBytes, funcLines, valueProps)
+		}
 		return
 	}
 	seen[id] = true
@@ -2006,9 +2062,7 @@ func (e *CSharpExtractor) emitProperty(m parser.QueryResult, filePath, fileID st
 	// inside the declaration span — recording it makes the property a
 	// call owner (round-23 catch AC1: without an owner the funcRanges
 	// gate dropped every accessor-body call outright).
-	if def.Node != nil {
-		funcBytes[id] = [2]int{int(def.Node.StartByte()), int(def.Node.EndByte())}
-	}
+	csharpRecordPropertyOwnership(id, def.Node, def.StartLine, def.EndLine, src, funcBytes, funcLines, valueProps)
 	// Interface properties are implicitly public; explicit modifiers still win.
 	isIface := owner.kind == "interface_declaration"
 	defaultVis := VisibilityPrivate
@@ -2031,11 +2085,6 @@ func (e *CSharpExtractor) emitProperty(m parser.QueryResult, filePath, fileID st
 		// gate receiver evidence — csharp_base_type_args.go).
 		if args := csharpTypeArgsFromTypeNode(t, src, csharpUnstampableArgNames(def.Node, src, fileAliases)); args != "" {
 			meta["field_type_args"] = args
-		}
-	}
-	if propTypeRaw != "" && def.Node != nil {
-		if spans := csharpSetInitAccessorSpans(def.Node); len(spans) > 0 {
-			valueProps[id] = csharpValueProp{typ: propTypeRaw, spans: spans}
 		}
 	}
 	if doc := extractCSharpDoc(src, def.StartLine); doc != "" {
@@ -2202,7 +2251,7 @@ type csharpFuncLookup struct {
 // name, which is how every accessor-body call vanished (round-23 catch
 // AC1 — 3 of the probe cell's 4 sites, the expression-bodied method
 // being the lone survivor).
-func csharpOwnerRanges(result *parser.ExtractionResult, funcBytes map[string][2]int) []funcRange {
+func csharpOwnerRanges(result *parser.ExtractionResult, funcBytes, funcLines map[string][2]int) []funcRange {
 	ranges := buildFuncRanges(result)
 	for _, n := range result.Nodes {
 		if n.Kind != graph.KindField {
@@ -2211,7 +2260,15 @@ func csharpOwnerRanges(result *parser.ExtractionResult, funcBytes map[string][2]
 		if _, ok := funcBytes[n.ID]; !ok {
 			continue
 		}
-		ranges = append(ranges, funcRange{id: n.ID, startLine: n.StartLine, endLine: n.EndLine})
+		start, end := n.StartLine, n.EndLine
+		// The recorded line span wins over the node's: a partial
+		// property's node keeps the declaring fragment's lines while
+		// the code lives in the implementing fragment, and a field's
+		// extent is its declarator.
+		if ln, ok := funcLines[n.ID]; ok {
+			start, end = ln[0], ln[1]
+		}
+		ranges = append(ranges, funcRange{id: n.ID, startLine: start, endLine: end})
 	}
 	return ranges
 }

--- a/internal/parser/languages/csharp_accessor_calls_test.go
+++ b/internal/parser/languages/csharp_accessor_calls_test.go
@@ -359,3 +359,75 @@ func TestCSharpExtractor_ReferenceFormsInAccessorsOwnTheProperty(t *testing.T) {
 		assert.True(t, found, "the Send site inside the accessor must stamp its dispatch placeholder")
 	})
 }
+
+// Property and field nodes are call owners now, and the resolver's
+// scoped-usings narrowing reads the caller's scope_ns - a member kind
+// without the stamp answered the namespace question with an empty
+// scope. Same stamp methods and constructors already carry.
+func TestCSharpExtractor_PropertyAndFieldCarryScopeNS(t *testing.T) {
+	src := []byte(`namespace App.Inner {
+    public class Holder {
+        private int _seed = 1;
+        public int Prop { get; set; }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("App.cs", src)
+	require.NoError(t, err)
+
+	for _, id := range []string{"App.cs::Holder.Prop", "App.cs::Holder._seed"} {
+		var found *graph.Node
+		for _, n := range result.Nodes {
+			if n.ID == id {
+				found = n
+			}
+		}
+		require.NotNil(t, found, id)
+		assert.Equal(t, "App.Inner", found.Meta["scope_ns"], "%s must carry its enclosing namespace", id)
+	}
+}
+
+// The discriminating shape for "initializer-less declarators record
+// nothing": a bare field sharing a line with a call-bearing member. If
+// the bare declarator entered the owner set its 1-line range would tie
+// the line; staying out, the expression-bodied property owns its call
+// byte-precisely and the bare field owns nothing. Also pins two
+// expression-bodied properties sharing one line - each owns its own
+// call through its own byte span.
+func TestCSharpExtractor_OneLineNeighborsKeepTheirOwners(t *testing.T) {
+	src := []byte(`namespace App {
+    public class Crank {
+        public int Turn() { return 1; }
+        public int Spin() { return 2; }
+    }
+    public class Tight {
+        private readonly Crank _c = new Crank();
+        private int _bare; public int Q => _c.Turn();
+        public int A => _c.Turn(); public int B => _c.Spin();
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("App.cs", src)
+	require.NoError(t, err)
+
+	qEdges := callEdgesFrom(result.Edges, "App.cs::Tight.Q", "Turn")
+	require.Len(t, qEdges, 1,
+		"the property owns its call despite the bare field on its line")
+	assert.Nil(t, qEdges[0].Meta["receiver_ambiguous"],
+		"a codeless declarator must not enter the owner set - its 1-line range would tie the line and stamp a refusal on the property's call")
+	var fromBare int
+	for _, ed := range result.Edges {
+		if ed.From == "App.cs::Tight._bare" && ed.Kind == graph.EdgeCalls {
+			fromBare++
+		}
+	}
+	assert.Zero(t, fromBare, "an initializer-less declarator holds no code and owns no calls")
+	assert.Len(t, callEdgesFrom(result.Edges, "App.cs::Tight.A", "Turn"), 1,
+		"first of two same-line properties owns its own call")
+	assert.Len(t, callEdgesFrom(result.Edges, "App.cs::Tight.B", "Spin"), 1,
+		"second of two same-line properties owns its own call")
+	assert.Empty(t, callEdgesFrom(result.Edges, "App.cs::Tight.A", "Spin"),
+		"no cross-theft between same-line properties")
+}

--- a/internal/parser/languages/csharp_accessor_calls_test.go
+++ b/internal/parser/languages/csharp_accessor_calls_test.go
@@ -1,6 +1,7 @@
 package languages
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -304,4 +305,57 @@ func TestCSharpExtractor_PartialPropertyImplementationOwnsItsCalls(t *testing.T)
 		"the implementing fragment's get body owns its call")
 	assert.Len(t, callEdgesFrom(result.Edges, "App.cs::KPart.P", "Prime"), 1,
 		"the implementing fragment's set body owns its call")
+}
+
+// The reference-form and MediatR lanes attribute by their own ranges
+// lookup; keyed to methods only, an accessor body split its evidence -
+// the calls edge on the property, the instantiates edge on the FILE
+// node, and the MediatR dispatch placeholder dropped outright.
+func TestCSharpExtractor_ReferenceFormsInAccessorsOwnTheProperty(t *testing.T) {
+	src := []byte(`namespace App {
+    public class Crank {
+        public int Turn() { return 1; }
+    }
+    public class PingCmd { }
+    public class Holder {
+        private readonly object _mediator = null;
+        public int Made {
+            get { var c = new Crank(); return c.Turn(); }
+        }
+        public int Kick {
+            get { ((MediatR.IMediator)_mediator).Send(new PingCmd()); return 1; }
+        }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("App.cs", src)
+	require.NoError(t, err)
+
+	t.Run("instantiates edge owner", func(t *testing.T) {
+		var fromProp, fromFile bool
+		for _, ed := range result.Edges {
+			if ed.Kind != graph.EdgeInstantiates || !strings.Contains(ed.To, "Crank") {
+				continue
+			}
+			switch ed.From {
+			case "App.cs::Holder.Made":
+				fromProp = true
+			case "App.cs":
+				fromFile = true
+			}
+		}
+		assert.True(t, fromProp, "the accessor body's new Crank() belongs to the property")
+		assert.False(t, fromFile, "the file node is not the owner of code inside a member")
+	})
+
+	t.Run("mediatr dispatch site in an accessor", func(t *testing.T) {
+		var found bool
+		for _, ed := range result.Edges {
+			if ed.From == "App.cs::Holder.Kick" && ed.To == "unresolved::*.Handle" {
+				found = true
+			}
+		}
+		assert.True(t, found, "the Send site inside the accessor must stamp its dispatch placeholder")
+	})
 }

--- a/internal/parser/languages/csharp_accessor_calls_test.go
+++ b/internal/parser/languages/csharp_accessor_calls_test.go
@@ -271,3 +271,37 @@ func TestCSharpExtractor_SetterValueCarriesThePropertyType(t *testing.T) {
 			"the getter's value is the inherited Crank field; stamping the property type is a confident wrong answer")
 	})
 }
+
+// A C# 13 partial property splits declaration and implementation across
+// fragments, and either may extract first. The seen[] dedup mints one
+// node, but the extents (and the value spans) must come from the
+// body-bearing fragment - keyed to the declaring fragment, every
+// accessor call in the implementation died ownerless, byte-for-byte the
+// AC1 failure mode this branch exists to fix.
+func TestCSharpExtractor_PartialPropertyImplementationOwnsItsCalls(t *testing.T) {
+	src := []byte(`namespace App {
+    public class Crank {
+        public int Turn() { return 1; }
+        public void Prime(int v) { }
+    }
+    public partial class KPart {
+        private readonly Crank _crank = new Crank();
+        public partial int P { get; set; }
+    }
+    public partial class KPart {
+        public partial int P {
+            get { return _crank.Turn(); }
+            set { value.ToString(); _crank.Prime(value); }
+        }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("App.cs", src)
+	require.NoError(t, err)
+
+	assert.Len(t, callEdgesFrom(result.Edges, "App.cs::KPart.P", "Turn"), 1,
+		"the implementing fragment's get body owns its call")
+	assert.Len(t, callEdgesFrom(result.Edges, "App.cs::KPart.P", "Prime"), 1,
+		"the implementing fragment's set body owns its call")
+}

--- a/internal/parser/languages/csharp_accessor_calls_test.go
+++ b/internal/parser/languages/csharp_accessor_calls_test.go
@@ -176,18 +176,24 @@ func findCallEdge(t *testing.T, edges []*graph.Edge, fromID, method string) *gra
 	return found[0]
 }
 
-// Inside a set/init accessor `value` is the implicit parameter and its
-// type is DECLARED - it is the property type. Seeding it as typed
-// receiver evidence stamps receiver_type instead of the old
-// receiver_name:value, which invited the resolver to go looking for a
-// FIELD named value the accessor cannot mean. When the enclosing type
-// really does declare a member named value, the seed is withheld and
-// the field evidence stands - same refusal posture as the shadow index.
+// Inside a set/init accessor `value` is ALWAYS the implicit parameter -
+// a same-named member is only reachable via this.value - and its type
+// is DECLARED: it is the property type. The seed is therefore an
+// OFFSET-SCOPED record over each set/init accessor's byte extent, never
+// an owner-wide entry: in the GETTER the bare name means a member
+// (possibly inherited, possibly declared in another partial fragment),
+// and an owner-wide seed typed those sites with the property type - a
+// confident wrong answer. The scope registration also keeps the
+// field-identifier lane from minting a field-use edge for the
+// parameter.
 func TestCSharpExtractor_SetterValueCarriesThePropertyType(t *testing.T) {
 	src := []byte(`namespace App {
     public class Crank {
         public int Turn() { return 1; }
         public void Prime(int v) { }
+    }
+    public class Widget {
+        public int Spin() { return 2; }
     }
     public class Sink {
         public Crank Feed {
@@ -200,8 +206,26 @@ func TestCSharpExtractor_SetterValueCarriesThePropertyType(t *testing.T) {
     }
     public class Clash {
         private readonly Crank value = new Crank();
-        public Crank Feed {
-            set { _ = value.Turn(); }
+        public Widget Feed {
+            set { _ = value.Spin(); }
+        }
+        public Crank Show {
+            get { return value.Turn(); }
+        }
+    }
+    public class Dirty {
+        public Crank Both {
+            get { Crank value = new Crank(); return value; }
+            set { value.Prime(2); }
+        }
+    }
+    public class VBase {
+        protected Crank value = new Crank();
+    }
+    public class VDerived : VBase {
+        public Widget Feed {
+            get { _ = value.Turn(); return null; }
+            set { }
         }
     }
 }
@@ -219,9 +243,31 @@ func TestCSharpExtractor_SetterValueCarriesThePropertyType(t *testing.T) {
 		ed := findCallEdge(t, result.Edges, "App.cs::Sink.Boot", "Prime")
 		assert.Equal(t, "Crank", ed.Meta["receiver_type"])
 	})
-	t.Run("member named value withholds the seed", func(t *testing.T) {
-		ed := findCallEdge(t, result.Edges, "App.cs::Clash.Feed", "Turn")
-		assert.Nil(t, ed.Meta["receiver_type"], "a declared value member makes the name ambiguous evidence")
-		assert.Equal(t, "value", ed.Meta["receiver_name"], "the field evidence stands")
+	t.Run("member named value never beats the setter parameter", func(t *testing.T) {
+		ed := findCallEdge(t, result.Edges, "App.cs::Clash.Feed", "Spin")
+		assert.Equal(t, "Widget", ed.Meta["receiver_type"],
+			"in a set accessor value IS the parameter; the Crank field needs this.value")
+		var reads int
+		for _, r := range result.Edges {
+			if r.From == "App.cs::Clash.Feed" && r.Kind == graph.EdgeReads {
+				reads++
+			}
+		}
+		assert.Zero(t, reads, "the parameter must not mint field-use evidence")
+	})
+	t.Run("getter value means the member", func(t *testing.T) {
+		ed := findCallEdge(t, result.Edges, "App.cs::Clash.Show", "Turn")
+		assert.Nil(t, ed.Meta["receiver_type"],
+			"the seed is set/init-scoped; the getter's value is the field, left to field evidence")
+	})
+	t.Run("typed getter local named value cannot kill the seed", func(t *testing.T) {
+		ed := findCallEdge(t, result.Edges, "App.cs::Dirty.Both", "Prime")
+		assert.Equal(t, "Crank", ed.Meta["receiver_type"],
+			"the setter-span record answers Found at the setter site regardless of getter locals")
+	})
+	t.Run("inherited value member is not property-typed", func(t *testing.T) {
+		ed := findCallEdge(t, result.Edges, "App.cs::VDerived.Feed", "Turn")
+		assert.NotEqual(t, "Widget", ed.Meta["receiver_type"],
+			"the getter's value is the inherited Crank field; stamping the property type is a confident wrong answer")
 	})
 }

--- a/internal/parser/languages/csharp_accessor_calls_test.go
+++ b/internal/parser/languages/csharp_accessor_calls_test.go
@@ -131,3 +131,38 @@ func TestCSharpExtractor_PropertyInitializerCallAttributesToTheProperty(t *testi
 	assert.Len(t, callEdgesFrom(result.Edges, "App.cs::Config.Seeded", "SeedValue"), 1,
 		"property-initializer call must attribute to the property node")
 }
+
+// A field initializer is executable code with no method around it. The
+// field declarator's own byte span owns the call — per DECLARATOR, so a
+// multi-declarator line (`int a = F(), b = G();`) hands each call to
+// the field it actually initializes.
+func TestCSharpExtractor_FieldInitializerCallAttributesToItsField(t *testing.T) {
+	src := []byte(`namespace App {
+    public class Seeder {
+        public static int A() { return 1; }
+        public static int B() { return 2; }
+    }
+    public class Config {
+        private int _lone = Seeder.A();
+        private int _first = Seeder.A(), _second = Seeder.B();
+        private static readonly int Shared = Seeder.B();
+        private int _bare;
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("App.cs", src)
+	require.NoError(t, err)
+
+	for _, row := range []struct{ shape, owner, method string }{
+		{"single declarator", "App.cs::Config._lone", "A"},
+		{"first of two declarators", "App.cs::Config._first", "A"},
+		{"second of two declarators", "App.cs::Config._second", "B"},
+		{"static readonly", "App.cs::Config.Shared", "B"},
+	} {
+		t.Run(row.shape, func(t *testing.T) {
+			assert.Len(t, callEdgesFrom(result.Edges, row.owner, row.method), 1,
+				"initializer call must attribute to its own field node")
+		})
+	}
+}

--- a/internal/parser/languages/csharp_accessor_calls_test.go
+++ b/internal/parser/languages/csharp_accessor_calls_test.go
@@ -1,0 +1,133 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Calls inside property accessor bodies used to vanish outright: the
+// call-owner lookup admitted only methods and constructors, so a call
+// whose enclosing member was a property found no owner and was dropped
+// at the funcRanges gate — not misattributed, gone (round-23 catch AC1,
+// 3 of 4 sites in the probe cell). Properties now record byte extents
+// and join the owner lookup, so every accessor form owns its calls.
+//
+// Each row is one accessor shape; the assertion is the call edge FROM
+// the property node. The expression-bodied METHOD control at the bottom
+// pins the one shape that always worked, so a regression that silenced
+// calls wholesale cannot pass this test.
+func TestCSharpExtractor_AccessorBodyCallsAttributeToTheProperty(t *testing.T) {
+	src := []byte(`namespace App {
+    public class Crank {
+        public int Turn() { return 1; }
+        public void Push(int v) { }
+        public int Get() { return 2; }
+        public void Prime(int v) { }
+        public static int Spin() { return 3; }
+        public int Feed(System.Func<int> f) { return f(); }
+    }
+
+    public class GaugeFace {
+        private readonly Crank _crank = new Crank();
+        private int _stored;
+
+        public int Reading {
+            get { return _crank.Turn(); }
+            set { _stored = value + _crank.Turn(); }
+        }
+
+        public int Snapshot => _crank.Turn();
+
+        public int Flow {
+            get => _crank.Get();
+            set => _crank.Push(value);
+        }
+
+        public int Sealed {
+            get { return _crank.Get(); }
+            init { _crank.Prime(value); }
+        }
+
+        public static int Global {
+            get { return Crank.Spin(); }
+        }
+
+        public int Wrapped {
+            get { return _crank.Feed(() => _crank.Turn()); }
+        }
+
+        public int Plain { get; set; }
+
+        public int Tally() => _crank.Turn();
+    }
+
+    public class Box<T> {
+        private readonly Crank _crank = new Crank();
+        public int Item => _crank.Turn();
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("App.cs", src)
+	require.NoError(t, err)
+
+	for _, row := range []struct {
+		shape, owner, method string
+		count                int
+	}{
+		{"block get", "App.cs::GaugeFace.Reading", "Turn", 2}, // get + set both call Turn
+		{"expression-bodied property", "App.cs::GaugeFace.Snapshot", "Turn", 1},
+		{"expression-bodied get", "App.cs::GaugeFace.Flow", "Get", 1},
+		{"expression-bodied set", "App.cs::GaugeFace.Flow", "Push", 1},
+		{"init accessor", "App.cs::GaugeFace.Sealed", "Prime", 1},
+		{"static property accessor", "App.cs::GaugeFace.Global", "Spin", 1},
+		{"lambda inside accessor", "App.cs::GaugeFace.Wrapped", "Turn", 1},
+		{"generic container property", "App.cs::Box.Item", "Turn", 1},
+	} {
+		t.Run(row.shape, func(t *testing.T) {
+			edges := callEdgesFrom(result.Edges, row.owner, row.method)
+			assert.Len(t, edges, row.count,
+				"accessor-body call must attribute to the property node")
+		})
+	}
+
+	t.Run("expression-bodied method control", func(t *testing.T) {
+		require.Len(t, callEdgesFrom(result.Edges, "App.cs::GaugeFace.Tally", "Turn"), 1,
+			"the one site AC1 left alive must stay alive")
+	})
+
+	t.Run("auto-property emits no calls", func(t *testing.T) {
+		var fromPlain int
+		for _, ed := range result.Edges {
+			if ed.From == "App.cs::GaugeFace.Plain" && ed.Kind == graph.EdgeCalls {
+				fromPlain++
+			}
+		}
+		assert.Zero(t, fromPlain, "an auto-property has no body to own calls")
+	})
+}
+
+// A property with an initializer spans its `= Call()` bytes, so the
+// initializer call belongs to the property node the same way an
+// accessor-body call does.
+func TestCSharpExtractor_PropertyInitializerCallAttributesToTheProperty(t *testing.T) {
+	src := []byte(`namespace App {
+    public class Seeder {
+        public static int SeedValue() { return 7; }
+    }
+    public class Config {
+        public int Seeded { get; set; } = Seeder.SeedValue();
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("App.cs", src)
+	require.NoError(t, err)
+
+	assert.Len(t, callEdgesFrom(result.Edges, "App.cs::Config.Seeded", "SeedValue"), 1,
+		"property-initializer call must attribute to the property node")
+}

--- a/internal/parser/languages/csharp_accessor_calls_test.go
+++ b/internal/parser/languages/csharp_accessor_calls_test.go
@@ -166,3 +166,62 @@ func TestCSharpExtractor_FieldInitializerCallAttributesToItsField(t *testing.T) 
 		})
 	}
 }
+
+// findCallEdge returns the single EdgeCalls from fromID whose unresolved
+// target names method, failing the test on any other cardinality.
+func findCallEdge(t *testing.T, edges []*graph.Edge, fromID, method string) *graph.Edge {
+	t.Helper()
+	found := callEdgesFrom(edges, fromID, method)
+	require.Len(t, found, 1, "expected exactly one %s call from %s", method, fromID)
+	return found[0]
+}
+
+// Inside a set/init accessor `value` is the implicit parameter and its
+// type is DECLARED - it is the property type. Seeding it as typed
+// receiver evidence stamps receiver_type instead of the old
+// receiver_name:value, which invited the resolver to go looking for a
+// FIELD named value the accessor cannot mean. When the enclosing type
+// really does declare a member named value, the seed is withheld and
+// the field evidence stands - same refusal posture as the shadow index.
+func TestCSharpExtractor_SetterValueCarriesThePropertyType(t *testing.T) {
+	src := []byte(`namespace App {
+    public class Crank {
+        public int Turn() { return 1; }
+        public void Prime(int v) { }
+    }
+    public class Sink {
+        public Crank Feed {
+            set { _ = value.Turn(); }
+        }
+        public Crank Boot {
+            get { return null; }
+            init { value.Prime(1); }
+        }
+    }
+    public class Clash {
+        private readonly Crank value = new Crank();
+        public Crank Feed {
+            set { _ = value.Turn(); }
+        }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("App.cs", src)
+	require.NoError(t, err)
+
+	t.Run("set accessor", func(t *testing.T) {
+		ed := findCallEdge(t, result.Edges, "App.cs::Sink.Feed", "Turn")
+		assert.Equal(t, "Crank", ed.Meta["receiver_type"], "value is declared Crank by the property")
+		assert.Nil(t, ed.Meta["receiver_name"], "value is a parameter, not field evidence")
+	})
+	t.Run("init accessor", func(t *testing.T) {
+		ed := findCallEdge(t, result.Edges, "App.cs::Sink.Boot", "Prime")
+		assert.Equal(t, "Crank", ed.Meta["receiver_type"])
+	})
+	t.Run("member named value withholds the seed", func(t *testing.T) {
+		ed := findCallEdge(t, result.Edges, "App.cs::Clash.Feed", "Turn")
+		assert.Nil(t, ed.Meta["receiver_type"], "a declared value member makes the name ambiguous evidence")
+		assert.Equal(t, "value", ed.Meta["receiver_name"], "the field evidence stands")
+	})
+}

--- a/internal/parser/languages/csharp_mediatr.go
+++ b/internal/parser/languages/csharp_mediatr.go
@@ -35,7 +35,7 @@ var mediatrHandleMethods = map[string]bool{"Handle": true, "HandleAsync": true}
 
 // captureMediatRDispatch tags handler methods and stamps Send/Publish
 // placeholders. Runs at the tail of Extract so the method nodes exist.
-func captureMediatRDispatch(result *parser.ExtractionResult, root *sitter.Node, filePath string, src []byte) {
+func captureMediatRDispatch(result *parser.ExtractionResult, root *sitter.Node, filePath string, src []byte, funcBytes, funcLines map[string][2]int) {
 	if root == nil || result == nil {
 		return
 	}
@@ -83,8 +83,11 @@ func captureMediatRDispatch(result *parser.ExtractionResult, root *sitter.Node, 
 		}
 	})
 
-	// Pass 2: Send/Publish dispatch sites.
-	funcRanges := buildFuncRanges(result)
+	// Pass 2: Send/Publish dispatch sites. The widened owner set, not the
+	// methods-only one - a dispatch site inside an accessor or
+	// initializer body found no owner and the placeholder was dropped
+	// outright at the from=="" gate below.
+	funcRanges := csharpOwnerRanges(result, funcBytes, funcLines)
 	seen := map[string]bool{}
 	mediatrWalk(root, func(call *sitter.Node) {
 		if call.Type() != "invocation_expression" {

--- a/internal/parser/languages/csharp_typeuse.go
+++ b/internal/parser/languages/csharp_typeuse.go
@@ -61,11 +61,16 @@ import (
 // `local.X` are the same shape — see csharpStaticReceiverEligible, which
 // accepts an uppercase receiver outright and falls back to "is this name
 // bound to a value in this file" for scripts that have no case at all.
-func emitCSharpReferenceForms(root *sitter.Node, src []byte, filePath, fileID string, result *parser.ExtractionResult) {
+func emitCSharpReferenceForms(root *sitter.Node, src []byte, filePath, fileID string, result *parser.ExtractionResult, funcBytes, funcLines map[string][2]int) {
 	if root == nil {
 		return
 	}
-	funcRanges := buildFuncRanges(result)
+	// The widened owner set, not the methods-only one: an accessor or
+	// initializer body must attribute its type references to the same
+	// member that owns its calls, or one line of code splits its
+	// evidence between two owners (and the fileID fallback below is for
+	// top-level positions, not for code inside a member).
+	funcRanges := csharpOwnerRanges(result, funcBytes, funcLines)
 
 	// Dedup across the whole file on (owner, type, line, ref_context) so a
 	// type referenced twice in the same role on the same line emits one edge.

--- a/internal/resolver/csharp_accessor_calls_test.go
+++ b/internal/resolver/csharp_accessor_calls_test.go
@@ -1,0 +1,104 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Round-23 catch AC1, end to end: calls from property accessor bodies
+// used to vanish at the extractor's owner gate, so nothing here could
+// resolve at all. Resolution to a UNIQUE member name proves the whole
+// pipeline: the edge exists, survives every demotion pass with a
+// property-node caller, and binds. (Cross-TYPE name ambiguity is
+// refused by the static tier for method callers too - typed
+// disambiguation is the value-parameter pin's subject below.)
+func TestResolveCSharp_AccessorBodyCallsResolve(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Gauge.cs": `namespace App {
+    public class AcCrank { public int Turn() { return 1; } }
+    public class AcGauge {
+        private readonly AcCrank _crank = new AcCrank();
+        private int _stored;
+        public int Reading {
+            get { return _crank.Turn(); }
+            set { _stored = value + _crank.Turn(); }
+        }
+        public int Snapshot => _crank.Turn();
+        public int Tally() => _crank.Turn();
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	fromProp := 0
+	for _, to := range callsFrom(g, "Gauge.cs::AcGauge.Reading") {
+		if to == "Gauge.cs::AcCrank.Turn" {
+			fromProp++
+		}
+	}
+	assert.Equal(t, 2, fromProp,
+		"the get and set bodies each call Turn through the Crank-typed field")
+
+	for _, row := range []struct{ owner, want string }{
+		{"Gauge.cs::AcGauge.Snapshot", "Gauge.cs::AcCrank.Turn"},
+		{"Gauge.cs::AcGauge.Tally", "Gauge.cs::AcCrank.Turn"},
+	} {
+		resolved := false
+		for _, to := range callsFrom(g, row.owner) {
+			if to == row.want {
+				resolved = true
+			}
+		}
+		assert.True(t, resolved, "%s must resolve its Turn call to AcCrank", row.owner)
+	}
+}
+
+// The implicit `value` parameter is typed by the property declaration,
+// so a call on it resolves like a call on any typed local - to the
+// property type's method, not the decoy's.
+func TestResolveCSharp_SetterValueReceiverResolves(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Sink.cs": `namespace App {
+    public class VpCrank { public int Turn() { return 1; } }
+    public class VpDecoy { public int Turn() { return 9; } }
+    public class VpSink {
+        public VpCrank Feed {
+            set { _ = value.Turn(); }
+        }
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	resolved := false
+	for _, to := range callsFrom(g, "Sink.cs::VpSink.Feed") {
+		if to == "Sink.cs::VpCrank.Turn" {
+			resolved = true
+		}
+	}
+	assert.True(t, resolved,
+		"value is declared VpCrank by the property - its Turn call must resolve there")
+}
+
+// A field initializer call resolves from the field node that owns it.
+func TestResolveCSharp_FieldInitializerCallResolves(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{
+		"Config.cs": `namespace App {
+    public class FiSeeder { public static int Prime() { return 7; } }
+    public class FiConfig {
+        private int _seed = FiSeeder.Prime();
+    }
+}`,
+	})
+	New(g).ResolveAll()
+
+	resolved := false
+	for _, to := range callsFrom(g, "Config.cs::FiConfig._seed") {
+		if to == "Config.cs::FiSeeder.Prime" {
+			resolved = true
+		}
+	}
+	assert.True(t, resolved,
+		"the initializer's static-form call must resolve from the field node")
+}

--- a/internal/resolver/csharp_same_line_attribution_test.go
+++ b/internal/resolver/csharp_same_line_attribution_test.go
@@ -10,29 +10,40 @@ import (
 )
 
 // Byte extents are recorded for methods, constructors, properties, and
-// initialized field declarators. A member kind still WITHOUT them
-// (indexer, event accessor) sharing a source line with one that has
-// them matches no recorded extent - and answering "" there erased the
-// call outright instead of falling back to the line answer (round-6
-// finding B3). The extentless member's call must survive line-keyed;
-// every extent-carrying member must own its call BYTE-precisely, not
-// hand it to whoever shares the line (the pre-owner-widening behavior
-// this test silently tolerated).
-func TestResolveCSharp_ExtentlessMemberSharingALineKeepsItsCall(t *testing.T) {
+// initialized field declarators. Every extent-carrying member must own
+// its call BYTE-precisely, not hand it to whoever shares the line (the
+// pre-owner-widening behavior this test silently tolerated).
+//
+// A member kind still WITHOUT extents (indexer, event accessor) is the
+// hard case: its call matches no recorded extent, and the line fallback
+// answers a same-line neighbour that provably does NOT contain the call
+// - the neighbour's recorded bytes exclude the offset. Handing it the
+// call invents a false edge carrying full receiver evidence and no
+// ambiguity stamp (ambiguousAt counts ranges, and an extent-less member
+// contributes none), indistinguishable downstream from a correct edge.
+// Such calls are REFUSED instead. This deliberately trades the
+// extent-less member's recall for precision; the recall returns when
+// indexers and event accessors are emitted with extents of their own
+// (tracked follow-up). Distinct from the round-6 B3 erasure: there the
+// "" answer dropped calls whose line owner was plausible - here the
+// line owner is provably wrong.
+func TestResolveCSharp_SameLineMemberCallAttribution(t *testing.T) {
 	cases := map[string]struct {
-		src   string
-		owner string // "" = presence only: the owner stays line-keyed
+		src     string
+		call    string // authored call's target name; "" = "Take"
+		owner   string // this member owns the call byte-precisely
+		refused bool   // no member may be handed the call
 	}{
 		"property_shares_line": {src: `namespace App {
  public class BLBag { public int Take() { return 1; } }
  public class BLProp { private BLBag _b = new BLBag();
   public int Q => _b.Take(); public void M() { }
  } }`, owner: "X.cs::BLProp.Q"},
-		"indexer_shares_line": {src: `namespace App {
+		"indexer_beside_method_refused": {src: `namespace App {
  public class BLBag { public int Take() { return 1; } }
  public class BLIdx { private BLBag _b = new BLBag();
   public int this[int i] => _b.Take(); public void M() { }
- } }`},
+ } }`, refused: true},
 		"field_init_shares_line": {src: `namespace App {
  public class BLBag { public int Take() { return 1; } }
  public class BLInit { private BLBag _b = new BLBag();
@@ -43,25 +54,52 @@ func TestResolveCSharp_ExtentlessMemberSharingALineKeepsItsCall(t *testing.T) {
  public class BLCtor { private BLBag _b = new BLBag();
   public BLCtor() { } public int Q => _b.Take();
  } }`, owner: "X.cs::BLCtor.Q"},
+		// The two shapes below are NEW false-edge populations opened by
+		// the owner widening itself: the base emitted nothing for them,
+		// while widened properties made a wrong owner available.
+		"indexer_beside_property_refused": {src: `namespace App {
+ public class QBag { public int Idx() { return 1; } public int Pro() { return 2; } }
+ public class Q01 { private QBag _b = new QBag();
+  public int this[int i] => _b.Idx(); public int Q => _b.Pro();
+ } }`, call: "Idx", refused: true},
+		"indexer_beside_property_neighbour_keeps_own": {src: `namespace App {
+ public class QBag { public int Idx() { return 1; } public int Pro() { return 2; } }
+ public class Q01 { private QBag _b = new QBag();
+  public int this[int i] => _b.Idx(); public int Q => _b.Pro();
+ } }`, call: "Pro", owner: "X.cs::Q01.Q"},
+		"event_accessor_beside_property_refused": {src: `namespace App {
+ public class QBag { public int Ev() { return 1; } public int Pro() { return 2; } }
+ public class Q03 { private QBag _b = new QBag();
+  public event System.EventHandler E { add { _b.Ev(); } remove { } } public int Q => _b.Pro();
+ } }`, call: "Ev", refused: true},
+		"event_accessor_beside_property_neighbour_keeps_own": {src: `namespace App {
+ public class QBag { public int Ev() { return 1; } public int Pro() { return 2; } }
+ public class Q03 { private QBag _b = new QBag();
+  public event System.EventHandler E { add { _b.Ev(); } remove { } } public int Q => _b.Pro();
+ } }`, call: "Pro", owner: "X.cs::Q03.Q"},
 	}
 	for name, tc := range cases {
 		g := buildCSharpResolverGraph(t, map[string]string{"X.cs": tc.src})
-		found := false
+		target := tc.call
+		if target == "" {
+			target = "Take"
+		}
 		owners := map[string]int{}
 		for _, e := range g.AllEdges() {
-			if e != nil && e.Kind == graph.EdgeCalls && strings.Contains(e.To, "Take") {
-				found = true
+			if e != nil && e.Kind == graph.EdgeCalls && strings.Contains(e.To, target) {
 				owners[e.From]++
 			}
 		}
-		assert.True(t, found, "[%s] the member's call must not vanish", name)
-		if tc.owner != "" {
-			assert.NotZero(t, owners[tc.owner],
-				"[%s] the extent-carrying member owns its call byte-precisely, got owners %v", name, owners)
-			delete(owners, tc.owner)
+		if tc.refused {
 			assert.Empty(t, owners,
-				"[%s] no line-sharing member may carry a duplicate of the call", name)
+				"[%s] an extent-less member's call must be refused, not handed to a same-line neighbour, got owners %v", name, owners)
+			continue
 		}
+		assert.NotZero(t, owners[tc.owner],
+			"[%s] the extent-carrying member owns its call byte-precisely, got owners %v", name, owners)
+		delete(owners, tc.owner)
+		assert.Empty(t, owners,
+			"[%s] no line-sharing member may carry a duplicate of the call", name)
 	}
 }
 

--- a/internal/resolver/csharp_same_line_attribution_test.go
+++ b/internal/resolver/csharp_same_line_attribution_test.go
@@ -9,45 +9,59 @@ import (
 	"github.com/zzet/gortex/internal/graph"
 )
 
-// Byte extents are recorded only for methods and constructors. When a
-// member kind WITHOUT extents (property, indexer, field initializer)
-// shares a source line with one that has them, the offset matches no
-// recorded extent - and answering "" there erased the call outright
-// instead of falling back to the line answer (round-6 finding B3). The
-// call must survive; which member carries it can stay line-keyed until
-// every member kind records extents.
+// Byte extents are recorded for methods, constructors, properties, and
+// initialized field declarators. A member kind still WITHOUT them
+// (indexer, event accessor) sharing a source line with one that has
+// them matches no recorded extent - and answering "" there erased the
+// call outright instead of falling back to the line answer (round-6
+// finding B3). The extentless member's call must survive line-keyed;
+// every extent-carrying member must own its call BYTE-precisely, not
+// hand it to whoever shares the line (the pre-owner-widening behavior
+// this test silently tolerated).
 func TestResolveCSharp_ExtentlessMemberSharingALineKeepsItsCall(t *testing.T) {
-	cases := map[string]string{
-		"property_shares_line": `namespace App {
+	cases := map[string]struct {
+		src   string
+		owner string // "" = presence only: the owner stays line-keyed
+	}{
+		"property_shares_line": {src: `namespace App {
  public class BLBag { public int Take() { return 1; } }
  public class BLProp { private BLBag _b = new BLBag();
   public int Q => _b.Take(); public void M() { }
- } }`,
-		"indexer_shares_line": `namespace App {
+ } }`, owner: "X.cs::BLProp.Q"},
+		"indexer_shares_line": {src: `namespace App {
  public class BLBag { public int Take() { return 1; } }
  public class BLIdx { private BLBag _b = new BLBag();
   public int this[int i] => _b.Take(); public void M() { }
- } }`,
-		"field_init_shares_line": `namespace App {
+ } }`},
+		"field_init_shares_line": {src: `namespace App {
  public class BLBag { public int Take() { return 1; } }
  public class BLInit { private BLBag _b = new BLBag();
   private int _n = new BLBag().Take(); public void M() { }
- } }`,
-		"ctor_and_property_same_line": `namespace App {
+ } }`, owner: "X.cs::BLInit._n"},
+		"ctor_and_property_same_line": {src: `namespace App {
  public class BLBag { public int Take() { return 1; } }
  public class BLCtor { private BLBag _b = new BLBag();
   public BLCtor() { } public int Q => _b.Take();
- } }`,
+ } }`, owner: "X.cs::BLCtor.Q"},
 	}
-	for name, src := range cases {
-		g := buildCSharpResolverGraph(t, map[string]string{"X.cs": src})
+	for name, tc := range cases {
+		g := buildCSharpResolverGraph(t, map[string]string{"X.cs": tc.src})
 		found := false
+		owners := map[string]int{}
 		for _, e := range g.AllEdges() {
 			if e != nil && e.Kind == graph.EdgeCalls && strings.Contains(e.To, "Take") {
 				found = true
+				owners[e.From]++
 			}
 		}
-		assert.True(t, found, "[%s] the extentless member's call must fall back to line attribution, not vanish", name)
+		assert.True(t, found, "[%s] the member's call must not vanish", name)
+		if tc.owner != "" {
+			assert.NotZero(t, owners[tc.owner],
+				"[%s] the extent-carrying member owns its call byte-precisely, got owners %v", name, owners)
+			delete(owners, tc.owner)
+			assert.Empty(t, owners,
+				"[%s] no line-sharing member may carry a duplicate of the call", name)
+		}
 	}
 }
 

--- a/internal/semantic/tstypes/testdata/golden/apply_snapshot.json
+++ b/internal/semantic/tstypes/testdata/golden/apply_snapshot.json
@@ -202,6 +202,11 @@
     },
     {
       "NodeID": "widgets/Alpha.Part1.cs::Alpha.Sidekick",
+      "Key": "scope_ns",
+      "Value": "Widgets"
+    },
+    {
+      "NodeID": "widgets/Alpha.Part1.cs::Alpha.Sidekick",
       "Key": "semantic_source",
       "Value": "csharp-types"
     },


### PR DESCRIPTION
## What this fixes

A call inside a property accessor body was dropped outright at extraction. The call-owner lookup admits only methods and constructors, properties are field-kind nodes, and a call whose enclosing member the lookup cannot name is discarded, not misattributed. In a probe class with four authored call sites (get body, set body, expression-bodied property, expression-bodied method), exactly one survived: the expression-bodied method, the only shape that rides emitMethod. Accessors are everywhere in production C#, so this was the largest recall gap my counted fixture repo still showed. Field initializer calls and MediatR dispatch sites inside accessors died at the same gate, and instantiates edges from accessor bodies landed on the file node.

This is the fuller fix the round-6 byte-attribution work in #677 left a comment pointing at: record extents for the remaining member kinds instead of letting their calls fall through.

NOTE ON THE BASE: this branch is stacked on the #677 head (the extents machinery is its foundation). #677 has since merged - say the word if you want this rebased onto main.

## What lands

- **Properties own their calls.** emitProperty records the declaration byte span the way emitMethod and emitConstructor do, and csharpOwnerRanges widens the owner set with every extent-carrying member node. Block get/set/init bodies, expression-bodied properties AND accessors, static accessors, lambdas and local functions inside accessors, property initializers, explicit interface implementations, and the C# 13 field-keyword shape all attribute to the property node. A side effect worth naming: properties on a shared line now byte-attribute precisely instead of riding the round-6 line fallback.
- **C# 13 partial properties.** The declaration/implementation split meant the dedup kept whichever fragment extracted first as the extent owner - for the usual declaring-part-first layout that was the bodiless fragment, so every call in the implementation still died. Ownership now re-records from the body-bearing fragment, with a parallel line-span map because the minted node keeps the first fragment's lines while the code lives in the second. This is the shape source generators emit.
- **Field initializers own their calls, per DECLARATOR.** `int a = F(), b = G();` hands each call to the field it actually initializes. Initializer-less declarators stay out of the owner set (no code, and a 1-line range would tie lines needlessly - pinned via the ambiguity-stamp observable). const declarators are skipped entirely.
- **The implicit `value` parameter is typed by the property declaration** - as an offset-scoped record over each set/init accessor span, never owner-wide. Inside set/init, `value` is always the parameter (a same-named member needs this.value), so those sites get real receiver evidence; in a getter the bare name means a member, possibly inherited or declared in another partial fragment, so getter sites are left to ordinary member evidence rather than stamped with a confident wrong answer. The scope registration also keeps the field-identifier lane from reading the parameter as a field.
- **Lane consistency.** The reference-form pass (instantiates, casts, static access, attributes) and the MediatR dispatch pass consume the same widened owner set, so one line of accessor code no longer splits its evidence between two owners.
- **scope_ns on property and initialized-field nodes**, for the scoped-usings narrowing, matching every other owner kind.
- **Extractor version bump (csharp 17 to 18)** so existing stores re-extract and mint the recovered edges.

## Evidence

Every lane RED-first with committed pins (accessor matrix, per-declarator field inits, partial-property fragments, six value-parameter shapes including the inherited-member and typed-getter-local traps, owner-asserting same-line pins). On my counted fixture repo, cold store A/B against the base commit: the four-site probe class goes 1/4 to 4/4, and an 18-cell deep matrix (every accessor shape above, each with a uniquely named target asserted at exactly its authored count against the resolved callee) goes all-zeros to all-exact. Indexer and event add/remove accessor bodies stay at zero on both stores: those members are not emitted as nodes at all today, so their cells stay armed for a separate member-emission change rather than a bolt-on here. Full parser/resolver/indexer suites: fail-name sets byte-identical to clean-base controls on Windows; race pass green.

## Behavior notes, disclosed

- **More receiver_ambiguous stamps on one-line layouts.** An initialized field or a property sharing a physical line with another member now line-ties in ambiguousAt, so calls owned by extent-carrying members there carry the refusal stamp even though byte attribution names their owner precisely. Kept deliberately: the stamp exists for line-keyed consumers, and un-stamping would cut against the equal-span refusal from #677 round 4. If you would rather ambiguousAt consult offsets, that is a small follow-up.
- **Extent-less members sharing a line are refused, not misattributed** (review round). An indexer or event accessor records no bytes of its own, so its call reached the line fallback - and the widened owner set could make that fallback answer a property or initialized field that provably does NOT contain the call, minting a false edge with full receiver evidence and no ambiguity stamp where the base emitted nothing. The fallback now refuses when the line answer's recorded bytes exclude the offset (guard authored and corpus-verified in review). This also removes the pre-existing method-neighbour false edge and its read. The extent-less member's recall returns when indexers and event accessors are emitted with extents of their own - the member-emission follow-up already noted in Evidence.
- **The reference-form and MediatR lanes stay line-keyed internally** (pre-existing); they gained the widened owner set, not byte precision.
- **Downstream kind filters.** A few analysis rollups (architecture hierarchy leaf kinds, betweenness centrality's SQL pushdown, ref_facts in unscoped mode) filter callers to function/method kinds, so the recovered property-owned edges are correct in the graph but invisible to those surfaces. Left untouched here since widening them is a policy call - happy to file it separately.
- **Enrichment-tier interplay.** The line-keyed owner attribution in the enrichment tiers (the finding disclosed in the #677 round-6 thread) now has a new caller population to disagree with on shared lines. Nothing in this diff changes those tiers; it makes the case for that separate fix stronger.

