### PR TITLE
tstypes: adopt the extractor's caller attribution for call facts

### DIFF
--- a/internal/semantic/tstypes/csharp_accessor_attribution_test.go
+++ b/internal/semantic/tstypes/csharp_accessor_attribution_test.go
@@ -1,0 +1,146 @@
+package tstypes
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// A call inside a property accessor body reaches the apply phase as an
+// ordinary callFact (the binder walks accessor bodies and grounds field
+// receivers through the type scope), but enclosingCallable answers nil —
+// properties are field-kind nodes, outside idx.funcs — so applyCall
+// drops the site: never typed-resolved, never confirmed. The extractor
+// attributes these calls to the property node byte-precisely; the engine
+// must land its resolution on the same owner.
+func TestCSharp_AccessorBodyCallResolvesFromProperty(t *testing.T) {
+	g, dir := buildFixture(t, map[string]string{
+		"A/Svc.cs": csSvc,
+		"B/App.cs": `namespace B {
+    public class App {
+        private Svc worker;
+
+        public int Tick {
+            get { worker.Run(); return 1; }
+        }
+    }
+}
+`,
+	})
+	p := NewProvider(CSharpSpec(), zap.NewNop())
+	res, err := p.Enrich(g, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tick := nodeByNameKind(t, g, "Tick", graph.KindField)
+	run := nodeByNameKind(t, g, "Run", graph.KindMethod)
+	e := callEdgeTo(g, tick.ID, run.ID)
+	if e == nil {
+		t.Fatalf("accessor-body call not resolved from property; edges: %v", g.GetOutEdges(tick.ID))
+	}
+	assertASTProvenance(t, e, "csharp-types")
+	if res.EdgesConfirmed+res.EdgesAdded == 0 {
+		t.Errorf("result reported no edge work: %+v", res)
+	}
+}
+
+// A property sharing a physical line with a method must not have its
+// accessor call re-attributed to the method. The extractor's stub rides
+// the property (byte attribution); a line-keyed caller lookup answers
+// the method, misses the stub on the property's edge list, and mints a
+// second edge for the same authored site — a duplicate nothing dedupes,
+// because From is part of every edge identity.
+func TestCSharp_SharedLineAccessorCallStaysWithProperty(t *testing.T) {
+	g, dir := buildFixture(t, map[string]string{
+		"A/Svc.cs": csSvc,
+		"B/App.cs": `namespace B {
+    public class App {
+        private Svc worker;
+        public int Quick { get { worker.Run(); return 1; } } public void Onlooker() { }
+    }
+}
+`,
+	})
+	p := NewProvider(CSharpSpec(), zap.NewNop())
+	if _, err := p.Enrich(g, dir); err != nil {
+		t.Fatal(err)
+	}
+	quick := nodeByNameKind(t, g, "Quick", graph.KindField)
+	run := nodeByNameKind(t, g, "Run", graph.KindMethod)
+	e := callEdgeTo(g, quick.ID, run.ID)
+	if e == nil {
+		t.Fatalf("shared-line accessor call not resolved from property; edges: %v", g.GetOutEdges(quick.ID))
+	}
+	assertASTProvenance(t, e, "csharp-types")
+	onlooker := nodeByNameKind(t, g, "Onlooker", graph.KindMethod)
+	if dupes := callEdgesNamed(g, onlooker.ID, "Run"); len(dupes) != 0 {
+		t.Errorf("line-sharing method minted %d duplicate edge(s) for the property's call: %v", len(dupes), dupes)
+	}
+}
+
+// A property and a method on one line, each with its own call: the stub
+// name disambiguates the shared line, so each owner resolves exactly its
+// own call and neither steals the other's.
+func TestCSharp_SharedLineCallsSplitByOwner(t *testing.T) {
+	g, dir := buildFixture(t, map[string]string{
+		"A/Svc.cs": csSvc,
+		"B/App.cs": `namespace B {
+    public class App {
+        private Svc worker;
+        public int Quick { get { worker.Run(); return 1; } } public void Busy() { worker.Stop(); }
+    }
+}
+`,
+	})
+	p := NewProvider(CSharpSpec(), zap.NewNop())
+	if _, err := p.Enrich(g, dir); err != nil {
+		t.Fatal(err)
+	}
+	quick := nodeByNameKind(t, g, "Quick", graph.KindField)
+	busy := nodeByNameKind(t, g, "Busy", graph.KindMethod)
+	run := nodeByNameKind(t, g, "Run", graph.KindMethod)
+	stop := nodeByNameKind(t, g, "Stop", graph.KindMethod)
+	if e := callEdgeTo(g, quick.ID, run.ID); e == nil {
+		t.Errorf("property's own call not resolved; edges: %v", g.GetOutEdges(quick.ID))
+	} else {
+		assertASTProvenance(t, e, "csharp-types")
+	}
+	if e := callEdgeTo(g, busy.ID, stop.ID); e == nil {
+		t.Errorf("method's own call not resolved; edges: %v", g.GetOutEdges(busy.ID))
+	} else {
+		assertASTProvenance(t, e, "csharp-types")
+	}
+	if e := callEdgeTo(g, quick.ID, stop.ID); e != nil {
+		t.Errorf("property stole the method's call: %v", e)
+	}
+	if e := callEdgeTo(g, busy.ID, run.ID); e != nil {
+		t.Errorf("method stole the property's call: %v", e)
+	}
+}
+
+// Two properties on one line calling the SAME method: the stub lookup
+// cannot tell the owners apart by (line, name), and the engine never
+// guesses among candidates — both sites stay untouched rather than one
+// owner collecting both.
+func TestCSharp_SharedLineSameNameAmbiguityRefused(t *testing.T) {
+	g, dir := buildFixture(t, map[string]string{
+		"A/Svc.cs": csSvc,
+		"B/App.cs": `namespace B {
+    public class App {
+        private Svc worker;
+        public int A1 { get { worker.Run(); return 1; } } public int A2 { get { worker.Run(); return 2; } }
+    }
+}
+`,
+	})
+	p := NewProvider(CSharpSpec(), zap.NewNop())
+	if _, err := p.Enrich(g, dir); err != nil {
+		t.Fatal(err)
+	}
+	a1 := nodeByNameKind(t, g, "A1", graph.KindField)
+	a2 := nodeByNameKind(t, g, "A2", graph.KindField)
+	assertUntouched(t, g, a1.ID, "Run", "csharp-types")
+	assertUntouched(t, g, a2.ID, "Run", "csharp-types")
+}

--- a/internal/semantic/tstypes/csharp_adopt_shapes_test.go
+++ b/internal/semantic/tstypes/csharp_adopt_shapes_test.go
@@ -1,0 +1,376 @@
+package tstypes
+
+// Shape pins for stub adoption beyond the core four in
+// csharp_accessor_attribution_test.go: the initializer lanes, chained
+// heads, pre-resolved stubs, snapshot-hygiene guards, and the tie
+// semantics (line containment breaks a tie only WITHIN the tied owner
+// set — a callable that merely shares the line never collects a call it
+// did not author).
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+const csSvcInt = `namespace A {
+    public class Svc {
+        public int Run() { return 1; }
+        public int Stop() { return 2; }
+    }
+}
+`
+
+// A property INITIALIZER call (not an accessor body) sharing a line with
+// a method: the stub rides the property, the line-keyed lookup answers
+// the method.
+func TestCSharpAdopt_PropertyInitializerSharedLine(t *testing.T) {
+	g, dir := buildFixture(t, map[string]string{
+		"A/Svc.cs": csSvcInt,
+		"B/App.cs": `namespace B {
+    public class App {
+        private static Svc worker = new Svc();
+        public int Seed { get; } = worker.Run(); public void Idle() { }
+    }
+}
+`,
+	})
+	p := NewProvider(CSharpSpec(), zap.NewNop())
+	if _, err := p.Enrich(g, dir); err != nil {
+		t.Fatal(err)
+	}
+	seed := nodeByNameKind(t, g, "Seed", graph.KindField)
+	run := nodeByNameKind(t, g, "Run", graph.KindMethod)
+	idle := nodeByNameKind(t, g, "Idle", graph.KindMethod)
+	e := callEdgeTo(g, seed.ID, run.ID)
+	if e == nil {
+		t.Fatalf("property-initializer call not resolved from the property; edges: %v", g.GetOutEdges(seed.ID))
+	}
+	assertASTProvenance(t, e, "csharp-types")
+	if dupes := callEdgesNamed(g, idle.ID, "Run"); len(dupes) != 0 {
+		t.Errorf("line-sharing method minted %d edge(s) for the property's call: %v", len(dupes), dupes)
+	}
+}
+
+// A FIELD initializer declarator sharing a line with a method — the
+// field is the same node kind the property case rides on, but reached
+// through a different extractor path.
+func TestCSharpAdopt_FieldInitializerSharedLine(t *testing.T) {
+	g, dir := buildFixture(t, map[string]string{
+		"A/Svc.cs": csSvcInt,
+		"B/App.cs": `namespace B {
+    public class App {
+        private static Svc worker = new Svc();
+        private int seed = worker.Run(); public void Idle() { }
+    }
+}
+`,
+	})
+	p := NewProvider(CSharpSpec(), zap.NewNop())
+	if _, err := p.Enrich(g, dir); err != nil {
+		t.Fatal(err)
+	}
+	seed := nodeByNameKind(t, g, "seed", graph.KindField)
+	run := nodeByNameKind(t, g, "Run", graph.KindMethod)
+	idle := nodeByNameKind(t, g, "Idle", graph.KindMethod)
+	e := callEdgeTo(g, seed.ID, run.ID)
+	if e == nil {
+		t.Fatalf("field-initializer call not resolved from the field; edges: %v", g.GetOutEdges(seed.ID))
+	}
+	assertASTProvenance(t, e, "csharp-types")
+	if dupes := callEdgesNamed(g, idle.ID, "Run"); len(dupes) != 0 {
+		t.Errorf("line-sharing method minted %d edge(s) for the field's call: %v", len(dupes), dupes)
+	}
+}
+
+// The head of a chained call inside an accessor body. (The chain TAIL is
+// a pre-existing engine gap — it is dropped from an ordinary method too —
+// so only the head is pinned here.)
+func TestCSharpAdopt_ChainHeadInAccessor(t *testing.T) {
+	g, dir := buildFixture(t, map[string]string{
+		"A/Svc.cs": `namespace A {
+    public class Inner {
+        public void Deep() {}
+    }
+    public class Svc {
+        public Inner Get() { return null; }
+    }
+}
+`,
+		"B/App.cs": `namespace B {
+    public class App {
+        private Svc worker;
+
+        public int Tick {
+            get { worker.Get().Deep(); return 1; }
+        }
+    }
+}
+`,
+	})
+	p := NewProvider(CSharpSpec(), zap.NewNop())
+	if _, err := p.Enrich(g, dir); err != nil {
+		t.Fatal(err)
+	}
+	tick := nodeByNameKind(t, g, "Tick", graph.KindField)
+	get := nodeByNameKind(t, g, "Get", graph.KindMethod)
+	e := callEdgeTo(g, tick.ID, get.ID)
+	if e == nil {
+		t.Fatalf("chain head Get() not resolved from the property; edges: %v", g.GetOutEdges(tick.ID))
+	}
+	assertASTProvenance(t, e, "csharp-types")
+}
+
+// The accessor's stub is ALREADY resolver-resolved before Enrich.
+// Adoption must land on the same owner and CONFIRM the edge in place —
+// never mint a second one beside it.
+func TestCSharpAdopt_AlreadyResolvedAccessorStubIsConfirmed(t *testing.T) {
+	g, dir := buildFixture(t, map[string]string{
+		"A/Svc.cs": csSvc,
+		"B/App.cs": `namespace B {
+    public class App {
+        private Svc worker;
+
+        public int Tick {
+            get { worker.Run(); return 1; }
+        }
+    }
+}
+`,
+	})
+	tick := nodeByNameKind(t, g, "Tick", graph.KindField)
+	run := nodeByNameKind(t, g, "Run", graph.KindMethod)
+	var stub *graph.Edge
+	for _, e := range g.GetOutEdges(tick.ID) {
+		if e.Kind == graph.EdgeCalls {
+			stub = e
+		}
+	}
+	if stub == nil {
+		t.Fatal("no extracted calls stub on the property")
+	}
+	oldTo := stub.To
+	stub.To = run.ID
+	g.ReindexEdge(stub, oldTo)
+
+	p := NewProvider(CSharpSpec(), zap.NewNop())
+	res, err := p.Enrich(g, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if edges := callEdgesNamed(g, tick.ID, "Run"); len(edges) != 1 {
+		t.Errorf("pre-resolved stub produced %d Run edges, want 1 (no re-mint): %v", len(edges), edges)
+	}
+	if res.EdgesAdded != 0 {
+		t.Errorf("EdgesAdded = %d, want 0 (confirm, not mint): %+v", res.EdgesAdded, res)
+	}
+	if res.EdgesConfirmed == 0 {
+		t.Errorf("EdgesConfirmed = 0, want >= 1: %+v", res)
+	}
+}
+
+// Two authored calls of the SAME name on one line from the SAME owner —
+// two stubs, one owner. stubOwnerAt must not read the repeat as a tie.
+func TestCSharpAdopt_SameOwnerTwoSameNameCallsOnOneLine(t *testing.T) {
+	g, dir := buildFixture(t, map[string]string{
+		"A/Svc.cs": csSvc,
+		"B/App.cs": `namespace B {
+    public class App {
+        private Svc worker;
+
+        public int Tick {
+            get { worker.Run(); worker.Run(); return 1; }
+        }
+    }
+}
+`,
+	})
+	p := NewProvider(CSharpSpec(), zap.NewNop())
+	if _, err := p.Enrich(g, dir); err != nil {
+		t.Fatal(err)
+	}
+	tick := nodeByNameKind(t, g, "Tick", graph.KindField)
+	run := nodeByNameKind(t, g, "Run", graph.KindMethod)
+	e := callEdgeTo(g, tick.ID, run.ID)
+	if e == nil {
+		t.Fatalf("same-owner repeated-name line not resolved; edges: %v", g.GetOutEdges(tick.ID))
+	}
+	assertASTProvenance(t, e, "csharp-types")
+}
+
+// The FilePath guard in buildIndex: a stale calls-edge carrying ANOTHER
+// file's path, parked on a line-sharing node at the same line and name,
+// must not be admitted to the snapshot. Without the guard it makes the
+// (line, name) pair ambiguous and the property loses its call.
+func TestCSharpAdopt_ForeignFilePathStubNotAdopted(t *testing.T) {
+	g, dir := buildFixture(t, map[string]string{
+		"A/Svc.cs": csSvc,
+		"B/App.cs": `namespace B {
+    public class App {
+        private Svc worker;
+        public int Quick { get { worker.Run(); return 1; } } public void Onlooker() { }
+    }
+}
+`,
+	})
+	onlooker := nodeByNameKind(t, g, "Onlooker", graph.KindMethod)
+	g.AddEdge(&graph.Edge{
+		From:     onlooker.ID,
+		To:       "unresolved::*.Run",
+		Kind:     graph.EdgeCalls,
+		FilePath: "C/Other.cs",
+		Line:     4,
+	})
+	p := NewProvider(CSharpSpec(), zap.NewNop())
+	if _, err := p.Enrich(g, dir); err != nil {
+		t.Fatal(err)
+	}
+	quick := nodeByNameKind(t, g, "Quick", graph.KindField)
+	run := nodeByNameKind(t, g, "Run", graph.KindMethod)
+	if e := callEdgeTo(g, quick.ID, run.ID); e == nil {
+		t.Errorf("foreign-file stub broke adoption: property's call not resolved; edges: %v", g.GetOutEdges(quick.ID))
+	}
+	if e := callEdgeTo(g, onlooker.ID, run.ID); e != nil {
+		t.Errorf("foreign-file stub was adopted as this file's owner: %v", e)
+	}
+}
+
+// The extent guard: a synthesized calls-edge whose Line lies OUTSIDE its
+// owning node's span (the framework-dispatch shape — Rails callbacks and
+// Laravel middleware park an action's edge on a class-body line) must not
+// enter the snapshot as an owner at that line, or it would tie against
+// the real owner and cost the property its call.
+func TestCSharpAdopt_OutOfExtentSyntheticEdgeNotAdopted(t *testing.T) {
+	g, dir := buildFixture(t, map[string]string{
+		"A/Svc.cs": csSvc,
+		"B/App.cs": `namespace B {
+    public class App {
+        private Svc worker;
+        public void Macro() { }
+        public int Late { get { worker.Run(); return 1; } }
+    }
+}
+`,
+	})
+	macro := nodeByNameKind(t, g, "Macro", graph.KindMethod)
+	late := nodeByNameKind(t, g, "Late", graph.KindField)
+	g.AddEdge(&graph.Edge{
+		From:     macro.ID,
+		To:       "unresolved::*.Run",
+		Kind:     graph.EdgeCalls,
+		FilePath: "B/App.cs",
+		Line:     late.StartLine, // outside Macro's own span
+	})
+	p := NewProvider(CSharpSpec(), zap.NewNop())
+	if _, err := p.Enrich(g, dir); err != nil {
+		t.Fatal(err)
+	}
+	run := nodeByNameKind(t, g, "Run", graph.KindMethod)
+	if e := callEdgeTo(g, late.ID, run.ID); e == nil {
+		t.Errorf("out-of-extent synthetic edge broke adoption: property's call not resolved; edges: %v", g.GetOutEdges(late.ID))
+	}
+	if e := callEdgeTo(g, macro.ID, run.ID); e != nil {
+		t.Errorf("out-of-extent synthetic edge's owner collected the call: %v", e)
+	}
+}
+
+// The dangerous tie variant: TWO properties call the same name on a line
+// shared with a method that calls it NOT AT ALL. The tie must refuse the
+// site outright — falling back to line containment would name the
+// method, find no claimable stub, and MINT an ast_resolved edge for a
+// call the method never authored.
+func TestCSharp_TieWithNonCandidateCallableRefusesMint(t *testing.T) {
+	g, dir := buildFixture(t, map[string]string{
+		"A/Svc.cs": csSvc,
+		"B/App.cs": `namespace B {
+    public class App {
+        private Svc worker;
+        public int A1 { get { worker.Run(); return 1; } } public int A2 { get { worker.Run(); return 2; } } public void Idle() { }
+    }
+}
+`,
+	})
+	p := NewProvider(CSharpSpec(), zap.NewNop())
+	if _, err := p.Enrich(g, dir); err != nil {
+		t.Fatal(err)
+	}
+	idle := nodeByNameKind(t, g, "Idle", graph.KindMethod)
+	if got := callEdgesNamed(g, idle.ID, "Run"); len(got) != 0 {
+		t.Errorf("tie fallback fabricated %d Run edge(s) on a method that authored none: %v", len(got), got)
+	}
+	a1 := nodeByNameKind(t, g, "A1", graph.KindField)
+	a2 := nodeByNameKind(t, g, "A2", graph.KindField)
+	assertUntouched(t, g, a1.ID, "Run", "csharp-types")
+	assertUntouched(t, g, a2.ID, "Run", "csharp-types")
+}
+
+// A same-name tie where the line-containment answer IS one of the tied
+// owners: the method keeps its own call (claimed in place) and the
+// property's indistinguishable site stays untouched — never handed to a
+// third party, never doubled.
+func TestCSharp_SameNameTieMethodKeepsOwnCall(t *testing.T) {
+	g, dir := buildFixture(t, map[string]string{
+		"A/Svc.cs": csSvc,
+		"B/App.cs": `namespace B {
+    public class App {
+        private Svc worker;
+        public int Quick { get { worker.Run(); return 1; } } public void Busy() { worker.Run(); }
+    }
+}
+`,
+	})
+	p := NewProvider(CSharpSpec(), zap.NewNop())
+	if _, err := p.Enrich(g, dir); err != nil {
+		t.Fatal(err)
+	}
+	busy := nodeByNameKind(t, g, "Busy", graph.KindMethod)
+	run := nodeByNameKind(t, g, "Run", graph.KindMethod)
+	if e := callEdgeTo(g, busy.ID, run.ID); e == nil {
+		t.Errorf("method's own call lost on a same-name tie; edges: %v", g.GetOutEdges(busy.ID))
+	}
+	quick := nodeByNameKind(t, g, "Quick", graph.KindField)
+	if edges := callEdgesNamed(g, busy.ID, "Run"); len(edges) > 1 {
+		t.Errorf("same-name tie doubled the method's edges: %v", edges)
+	}
+	if e := callEdgeTo(g, quick.ID, run.ID); e != nil {
+		t.Logf("note: property side also resolved (%v) — acceptable, but not required by the tie contract", e)
+	}
+}
+
+// Enrich twice: the second pass sees its own confirmed stub in the
+// snapshot (confirmation stamps semantic_source on the EXTRACTION edge,
+// so any filter keyed on that stamp would evict the real owner and
+// re-open the shared-line theft). Idempotency is the pin.
+func TestCSharp_SecondEnrichIsIdempotentOnSharedLine(t *testing.T) {
+	g, dir := buildFixture(t, map[string]string{
+		"A/Svc.cs": csSvc,
+		"B/App.cs": `namespace B {
+    public class App {
+        private Svc worker;
+        public int Quick { get { worker.Run(); return 1; } } public void Onlooker() { }
+    }
+}
+`,
+	})
+	p := NewProvider(CSharpSpec(), zap.NewNop())
+	if _, err := p.Enrich(g, dir); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := p.Enrich(g, dir); err != nil {
+		t.Fatal(err)
+	}
+	quick := nodeByNameKind(t, g, "Quick", graph.KindField)
+	run := nodeByNameKind(t, g, "Run", graph.KindMethod)
+	if edges := callEdgesNamed(g, quick.ID, "Run"); len(edges) != 1 {
+		t.Errorf("second enrich changed the property's Run edges: %v", edges)
+	}
+	if callEdgeTo(g, quick.ID, run.ID) == nil {
+		t.Errorf("property's resolved call lost on second enrich")
+	}
+	onlooker := nodeByNameKind(t, g, "Onlooker", graph.KindMethod)
+	if dupes := callEdgesNamed(g, onlooker.ID, "Run"); len(dupes) != 0 {
+		t.Errorf("second enrich minted %d edge(s) on the line-sharing method: %v", len(dupes), dupes)
+	}
+}

--- a/internal/semantic/tstypes/engine.go
+++ b/internal/semantic/tstypes/engine.go
@@ -595,17 +595,22 @@ type fileIndex struct {
 	// spec doesn't widen.
 	superTypes map[string]*graph.Node
 	funcs      []*graph.Node // function/method nodes, for line containment
-	// stubsByLine indexes the file's extracted calls-edges by call line,
-	// snapshotted before any apply mutation. The extractor attributes a
+	// stubsByLine indexes the file's calls-edges by call line, snapshotted
+	// before this file's calls phase applies. The extractor attributes a
 	// call to its owner precisely (byte extents where the language has
 	// them), so the stub's From is the ground truth a line-keyed caller
 	// lookup can only approximate — and disagree with, when the owner
 	// is a node kind outside idx.funcs (a C# property owning its
 	// accessor-body calls) or shares its line with another member.
+	// The snapshot stays sound in the paged driver too, where indexes are
+	// rebuilt per phase after earlier pages mutated the graph: applyCall
+	// only touches edges whose From is a node of the applying file, and
+	// the fact spool keys one row per (class, file), so no other file's
+	// apply can have disturbed this file's calls-edges first.
 	stubsByLine map[int][]stubRef
 }
 
-// stubRef is one extracted calls-edge under stubsByLine: the owning
+// stubRef is one snapshotted calls-edge under stubsByLine: the owning
 // file node plus the edge's target id at snapshot time (the authored
 // callee name survives there across the unresolved / resolved shapes).
 type stubRef struct {
@@ -613,23 +618,27 @@ type stubRef struct {
 	to    string
 }
 
-// stubOwnerAt returns the single file node owning an extracted call of
-// the given trailing name at line — the caller the extractor already
-// attributed the site to. Returns nil when no stub matches, or when two
-// owners claim the same (line, name): the engine never guesses among
-// candidates.
-func (idx *fileIndex) stubOwnerAt(line int, method string) *graph.Node {
-	var owner *graph.Node
+// stubOwnersAt returns the distinct file nodes owning a snapshotted call
+// of the given trailing name at line — the callers the extractor already
+// attributed sites there to.
+func (idx *fileIndex) stubOwnersAt(line int, method string) []*graph.Node {
+	var owners []*graph.Node
 	for _, s := range idx.stubsByLine[line] {
 		if !trailingNameMatches(s.to, method) {
 			continue
 		}
-		if owner != nil && owner.ID != s.owner.ID {
-			return nil
+		seen := false
+		for _, o := range owners {
+			if o.ID == s.owner.ID {
+				seen = true
+				break
+			}
 		}
-		owner = s.owner
+		if !seen {
+			owners = append(owners, s.owner)
+		}
 	}
-	return owner
+	return owners
 }
 
 func (a *applier) buildIndex(facts *fileFacts) *fileIndex {
@@ -663,11 +672,23 @@ func (a *applier) buildIndex(facts *fileFacts) *fileIndex {
 		if n.Kind == graph.KindFunction || n.Kind == graph.KindMethod {
 			idx.funcs = append(idx.funcs, n)
 		}
+		if n.Kind == graph.KindFile {
+			// Some languages park top-level calls on the file node; it is
+			// never an adoptable caller (and the paged compatibility
+			// branch loads file nodes a kind-filtered store would not).
+			continue
+		}
 		for _, e := range a.outEdges(n.ID) {
-			if e.Kind != graph.EdgeCalls || e.Line == 0 {
+			if e == nil || e.Kind != graph.EdgeCalls || e.Line == 0 {
 				continue
 			}
 			if e.FilePath != "" && e.FilePath != facts.file {
+				continue
+			}
+			if e.Line < n.StartLine || e.Line > n.EndLine {
+				// Framework-dispatch synthesis (Rails callbacks, Laravel
+				// middleware) parks an owner's edge on a line outside the
+				// owner's own span — not site evidence at that line.
 				continue
 			}
 			idx.stubsByLine[e.Line] = append(idx.stubsByLine[e.Line], stubRef{owner: n, to: e.To})
@@ -1115,10 +1136,29 @@ func (a *applier) applyCall(idx *fileIndex, cf callFact, res *semantic.EnrichRes
 	// different node than extraction chose (a shared line would
 	// otherwise mint a duplicate edge nothing dedupes, From being part
 	// of every edge identity). The line-keyed containment lookup stays
-	// as the fallback for sites the extractor recorded no stub for.
-	caller := idx.stubOwnerAt(cf.line, cf.method)
-	if caller == nil {
+	// as the fallback for sites the extractor recorded no stub for
+	// (desugared operator calls carry no authored-name stub). On a
+	// multi-owner tie, containment may still break it — but only WITHIN
+	// the tied set: a callable that merely shares the line never
+	// collects a call it did not author (it has no stub to claim, so it
+	// would mint), and when no tied owner contains the line the site is
+	// refused outright.
+	var caller *graph.Node
+	owners := idx.stubOwnersAt(cf.line, cf.method)
+	switch len(owners) {
+	case 0:
 		caller = idx.enclosingCallable(cf.line)
+	case 1:
+		caller = owners[0]
+	default:
+		if enc := idx.enclosingCallable(cf.line); enc != nil {
+			for _, o := range owners {
+				if o.ID == enc.ID {
+					caller = enc
+					break
+				}
+			}
+		}
 	}
 	if caller == nil {
 		return

--- a/internal/semantic/tstypes/engine.go
+++ b/internal/semantic/tstypes/engine.go
@@ -595,13 +595,49 @@ type fileIndex struct {
 	// spec doesn't widen.
 	superTypes map[string]*graph.Node
 	funcs      []*graph.Node // function/method nodes, for line containment
+	// stubsByLine indexes the file's extracted calls-edges by call line,
+	// snapshotted before any apply mutation. The extractor attributes a
+	// call to its owner precisely (byte extents where the language has
+	// them), so the stub's From is the ground truth a line-keyed caller
+	// lookup can only approximate — and disagree with, when the owner
+	// is a node kind outside idx.funcs (a C# property owning its
+	// accessor-body calls) or shares its line with another member.
+	stubsByLine map[int][]stubRef
+}
+
+// stubRef is one extracted calls-edge under stubsByLine: the owning
+// file node plus the edge's target id at snapshot time (the authored
+// callee name survives there across the unresolved / resolved shapes).
+type stubRef struct {
+	owner *graph.Node
+	to    string
+}
+
+// stubOwnerAt returns the single file node owning an extracted call of
+// the given trailing name at line — the caller the extractor already
+// attributed the site to. Returns nil when no stub matches, or when two
+// owners claim the same (line, name): the engine never guesses among
+// candidates.
+func (idx *fileIndex) stubOwnerAt(line int, method string) *graph.Node {
+	var owner *graph.Node
+	for _, s := range idx.stubsByLine[line] {
+		if !trailingNameMatches(s.to, method) {
+			continue
+		}
+		if owner != nil && owner.ID != s.owner.ID {
+			return nil
+		}
+		owner = s.owner
+	}
+	return owner
 }
 
 func (a *applier) buildIndex(facts *fileFacts) *fileIndex {
 	idx := &fileIndex{
-		facts:   facts,
-		imports: make(map[string]string, len(facts.imports)),
-		types:   make(map[string]*graph.Node),
+		facts:       facts,
+		imports:     make(map[string]string, len(facts.imports)),
+		types:       make(map[string]*graph.Node),
+		stubsByLine: make(map[int][]stubRef),
 	}
 	idx.superTypes = idx.types
 	superKinds := a.supertypeKinds()
@@ -626,6 +662,15 @@ func (a *applier) buildIndex(facts *fileFacts) *fileIndex {
 		}
 		if n.Kind == graph.KindFunction || n.Kind == graph.KindMethod {
 			idx.funcs = append(idx.funcs, n)
+		}
+		for _, e := range a.outEdges(n.ID) {
+			if e.Kind != graph.EdgeCalls || e.Line == 0 {
+				continue
+			}
+			if e.FilePath != "" && e.FilePath != facts.file {
+				continue
+			}
+			idx.stubsByLine[e.Line] = append(idx.stubsByLine[e.Line], stubRef{owner: n, to: e.To})
 		}
 	}
 	return idx
@@ -1064,7 +1109,17 @@ func (a *applier) applyCall(idx *fileIndex, cf callFact, res *semantic.EnrichRes
 	if target == nil {
 		return
 	}
-	caller := idx.enclosingCallable(cf.line)
+	// The extractor already attributed this site to its owner — adopt
+	// that attribution when a stub of the authored name exists at the
+	// call line, so the engine can never land its resolution on a
+	// different node than extraction chose (a shared line would
+	// otherwise mint a duplicate edge nothing dedupes, From being part
+	// of every edge identity). The line-keyed containment lookup stays
+	// as the fallback for sites the extractor recorded no stub for.
+	caller := idx.stubOwnerAt(cf.line, cf.method)
+	if caller == nil {
+		caller = idx.enclosingCallable(cf.line)
+	}
 	if caller == nil {
 		return
 	}


### PR DESCRIPTION
## What this fixes

The tstypes apply phase derives a call fact's caller by line containment over function and method nodes only (buildIndex admits nothing else into idx.funcs; applyCall returns when enclosingCallable answers nil). That disagrees with extraction in two ways, and both showed up on my counted C# fixture repo:

- **Accessor-body calls are dropped.** The binder walks accessor bodies and grounds field-typed receivers through the type scope, so the call fact arrives intact - then dies at the nil-caller gate, because a C# property is a field-kind node. The site is never typed-resolved and never confirmed. This matters most where the semantic tier is the ONLY resolver that can land the call: a field-typed receiver whose method name also exists on another type is refused by the static resolver (cross-type same-name evidence), and used to stay a dead stub forever when the call sat in a getter.
- **Shared lines mint duplicates.** A property sharing a physical line with a method has its accessor call re-attributed to the method: the line-keyed lookup picks the method, misses the extracted stub on the property's edge list, and addASTEdge mints a second ast_resolved edge at 0.95 for the same authored site. Nothing dedupes the pair - From is part of every edge identity. In a settled lab store the one authored call sat as TWO resolved edges from two owners.

The accessor-owners change (#720) made this population real: extraction now attributes accessor-body calls to the property byte-precisely, so the enrichment tier's line-keyed re-derivation had a whole new caller class to disagree with. This implements the csharp-types half of #703 (the arc I offered there); the csharp-ls half is disclosed below.

NOTE ON THE BASE: rebased onto main after #720 merged - now just the two engine commits, and the diff vs main is exactly this change. The tstypes suite was re-run on top of the merged refusal guard: green, golden unchanged.

## What lands

- **buildIndex snapshots the file's calls-edges by line** (owner node + target id), taken before the file's calls phase applies. Three admission guards keep the snapshot honest site evidence: file-node owners are skipped (some languages park top-level calls there, and the paged compatibility branch loads file nodes a kind-filtered store would not), edges whose line lies outside the owning node's span are skipped (framework-dispatch synthesis - Rails callbacks, Laravel middleware - parks an action's edge on a class-body line), and edges carrying another file's path are skipped.
- **applyCall adopts the stub's From** when exactly one owner claims the (line, authored-name) pair. The engine can then never land a resolution on a different node than extraction chose. The line-keyed containment lookup stays as the fallback ONLY for sites with no stub at all (desugared operator calls carry no authored-name stub - the Kotlin operator and PHP static suites pin that path).
- **Ties are broken only within the tied owner set.** When two owners claim the same (line, name), containment may pick between THEM (a method keeps the claim on its own call when a same-named property site shares the line), but a callable that merely shares the line is never handed the site - it has no stub to claim, so it would mint an edge for a call it never authored. When no tied owner contains the line, the site is refused outright. Both tie shapes are pinned, including the fabrication one (two properties plus a bystander method: pre-change, the bystander gained an ast_resolved 0.95 edge for a call it never made).
- No new store queries: the apply phase already preloads adjacency for every projected node, and the snapshot rides the existing buildIndex pass over file nodes.

This is engine-level, so every language spec gets the same rule. Behavior changes only where extraction and line containment disagree - where they agree (the overwhelmingly common case), the adopted caller is the same node the old lookup answered.

## Evidence

- RED-first pins, committed: accessor-body recall (property resolves through the field type), shared-line theft (the line-sharing method must mint nothing), shared-line disambiguation by authored name (property and method each keep exactly their own call), and the tie-fabrication shape (the bystander method mints nothing).
- Ten more shape pins from an adversarial review round over the first commit: property/field INITIALIZER calls sharing a line, chained heads in accessors, an already-resolved stub confirmed in place (never re-minted), same-owner repeated names, the foreign-file and out-of-extent snapshot guards, the same-name tie keeping the method's own claim, and second-enrich idempotency. That last one pins a deliberate non-fix: confirmation stamps semantic_source on the EXTRACTION edge itself, so filtering the snapshot by that stamp (tempting, to exclude the engine's own past mints) would evict the real owner on re-enrich and re-open the shared-line theft.
- Full tstypes suite green, all language specs; the apply golden snapshot is byte-identical (adoption picks the same owners there).
- Whole-repo fail-name A/B against the base commit: identical sets (one control-side flake in an unrelated concurrency test).
- Cold-lab A/B on my counted C# fixture repo, same recipe and fixture tree both sides: the recall cell goes unresolved-stub to exactly one ast_resolved edge with a same-name decoy type in the repo (the stub is claimed in place - no unresolved companion left behind); the theft cell goes 1 to 0 with the property's own edge intact; a round-22 probe pair that pinned this exact misattribution (two methods split across a shared line) went 3 stolen edges to 0. Battery of 216 cells otherwise byte-identical to the base lab.

## Behavior notes, disclosed

- **The LSP enrichment lane has the same line-keyed shape** (the remaining half of #703) and is untouched here: matchCallableByFileLine (internal/semantic/lsp/graph_batch.go) filters to function/method/closure kinds with a +/-2-line nearest fallback, and is consumed by the call-hierarchy joins (provider.go) and the references lane (references_add.go). In lab stores it both misses property callers and can mint its own lsp_resolved edges beside extraction's. Same adopt-the-stub idea could apply to the references lane, and the hierarchy joins would want the callable filter widened instead (they match declaration lines, not call sites) - happy to take that as a follow-up, or leave it with you since it touches the LSP lane's contract.
- **Kotlin companion-object callers move to the alias node.** The one non-C# attribution change a nine-language sweep found: the extractor mints a companion alias method (Foo.Factory.thing) with the identical span as Foo.thing, and its ID sorts first, so the stub - and now the resolved edge - rides the alias. It also REMOVES a Kotlin duplicate (pre-change the engine minted from Foo.thing while the alias stub stayed unresolved beside it), but "extraction is the better attribution" is arguable when the owner is synthetic. Kept as-is here since it follows the adoption rule honestly; happy to exclude alias-minted owners if you prefer the real node.
- **Overload-suffixed target ids opt out of adoption.** trailingNameMatches does not recognize the _L<line> collision suffix, so a stub already resolved to a suffixed overload id falls back to the line lookup (old behavior, not a regression). Teaching the predicate the suffix is a small follow-up but it is shared with the claim path, so I left it out of this diff.
- **Stores enriched by the OLD engine can carry its line-keyed mints**, which enter the snapshot as competing owners and turn those sites into ties (degrading to today's behavior, never worse). They clear when the file re-extracts (for C#, the salt bump in this stack's base forces that on landing; other languages heal at their next reindex).
- **The snapshot is per-file, pre-calls state**: engine mints from the same run are invisible to it, so adoption never chains onto the engine's own output; the paged driver's per-phase index rebuild stays safe because a file's calls apply exactly once and applyCall only touches the applying file's own edges (now stated in the comments).
