### PR TITLE
csharp: unify the canonical identifier domain for verbatim spellings

### DIFF
--- a/internal/indexer/extractor_version.go
+++ b/internal/indexer/extractor_version.go
@@ -40,7 +40,7 @@ var extractorVersions = map[string]int{
 	//   "go": 2,
 	"c":      generatedParserProjectionPolicyVersion, // generated parser projection covers all strictly detected table sizes
 	"php":    2,                                      // class/interface inheritance now emits typed structural edges
-	"csharp": 18,                                     // accessor bodies, property/field initializers, and the typed value parameter own their calls (was: clause-specific binder extents, offset-aware typed locals + field uses, byte-interval caller attribution, canonical base-list spellings, partial-fragment base preservation)
+	"csharp": 19,                                     // verbatim-identifier canonicalization unified across type refs, the base-list prescan, and partial identity (was: accessor bodies, property/field initializers, and the typed value parameter own their calls)
 	"scala":  2,                                      // explicitly instantiated generic calls emit call edges
 	"go":     3,                                      // generic instantiations are marked so indexing a func value cannot bind (was: generic calls emit call edges)
 	"cpp":    2,                                      // templated and namespace-qualified calls emit call edges

--- a/internal/indexer/extractor_version_test.go
+++ b/internal/indexer/extractor_version_test.go
@@ -229,7 +229,7 @@ func TestStaleLangsDetection(t *testing.T) {
 		}
 
 		for _, path := range []string{"src/Handler.cs", "Views/Page.razor", "Views/Page.cshtml"} {
-			want := policySalt + "|csharp@18"
+			want := policySalt + "|csharp@19"
 			if got := merkleSaltFor(path); got != want {
 				t.Errorf("C# extractor salt for %s = %q, want %q", path, got, want)
 			}

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -2501,7 +2501,7 @@ func csharpBaseNameCounts(root *sitter.Node, src []byte, filePath string, fileAl
 		if nameNode == nil {
 			return
 		}
-		id := filePath + "::" + nameNode.Content(src)
+		id := filePath + "::" + csharpCanonBaseIdent(nameNode.Content(src))
 		m := counts[id]
 		if m == nil {
 			m = map[string]int{}
@@ -2584,10 +2584,23 @@ type csharpPartialIdentity struct {
 
 func csharpPartialIdentityOf(decl *sitter.Node, src []byte) csharpPartialIdentity {
 	return csharpPartialIdentity{
-		ns:         csharpEnclosingNamespace(decl, src),
+		ns:         csharpCanonDottedName(csharpEnclosingNamespace(decl, src)),
 		outerChain: csharpEnclosingTypeChain(decl, src),
 		arity:      csharpTypeParamArity(decl),
 	}
+}
+
+// csharpCanonDottedName canonicalizes each segment of a dotted name so
+// the identity key compares identifiers, not spellings.
+func csharpCanonDottedName(s string) string {
+	if s == "" || !strings.ContainsAny(s, "@\\") {
+		return s
+	}
+	parts := strings.Split(s, ".")
+	for i := range parts {
+		parts[i] = csharpCanonBaseIdent(strings.TrimSpace(parts[i]))
+	}
+	return strings.Join(parts, ".")
 }
 
 // sameType reports whether a later fragment's identity key matches -
@@ -2605,7 +2618,7 @@ func csharpEnclosingTypeChain(decl *sitter.Node, src []byte) string {
 		switch n.Type() {
 		case "class_declaration", "struct_declaration", "record_declaration", "interface_declaration":
 			if nm := n.ChildByFieldName("name"); nm != nil {
-				parts = append(parts, nm.Content(src))
+				parts = append(parts, csharpCanonBaseIdent(nm.Content(src)))
 			}
 		}
 	}

--- a/internal/parser/languages/csharp_function_shape.go
+++ b/internal/parser/languages/csharp_function_shape.go
@@ -220,7 +220,11 @@ func canonicalizeCSharpTypeRef(t string) string {
 	if idx := strings.LastIndex(t, "."); idx >= 0 {
 		t = t[idx+1:]
 	}
-	return strings.TrimSpace(t)
+	// Same canonical identifier domain the DECLARATION side mints its
+	// node IDs in: `@event` is the only legal spelling of a
+	// keyword-named type, so a reference must reduce to the identifier
+	// the declaration registered or it can never bind.
+	return csharpCanonBaseIdent(strings.TrimSpace(t))
 }
 
 func isCSharpPrimitive(t string) bool {

--- a/internal/parser/languages/csharp_verbatim_canon_test.go
+++ b/internal/parser/languages/csharp_verbatim_canon_test.go
@@ -1,0 +1,91 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The declaration side mints canonical node IDs for verbatim-declared
+// types (`interface @event` -> `<file>::event`), so every lookup keyed
+// by a type NAME must reduce to the same canonical identifier domain or
+// the two halves never meet (issue #723). These pins cover the
+// name-keyed lookups on the parser side; the reference-side
+// canonicalizeCSharpTypeRef split is pinned through the resolver in
+// internal/resolver/csharp_verbatim_type_ref_test.go.
+
+// csharpBaseNameCounts keyed the duplicate-base prescan by the RAW
+// spelling while emitCSharpBaseList looks the entry up by the canonical
+// typeID - the miss made the stamp guard fail closed, so a
+// verbatim-declared type silently lost target_type_args while a
+// plainly-spelled sibling with the IDENTICAL base list kept it.
+func TestCSharpBaseList_VerbatimDeclaredTypeKeepsTypeArgStamps(t *testing.T) {
+	src := []byte(`namespace App {
+    public class Widget { }
+    public interface IOther<T> { }
+    public class @event : IOther<Widget> { }
+    public class plain  : IOther<Widget> { }
+}
+`)
+	res, err := NewCSharpExtractor().Extract("T.cs", src)
+	require.NoError(t, err)
+
+	plainEdges := csharpBaseEdges(res, "T.cs::plain")
+	require.Len(t, plainEdges, 1)
+	require.NotNil(t, plainEdges[0].Meta)
+	require.NotNil(t, plainEdges[0].Meta["target_type_args"],
+		"the plainly-spelled control must stamp - if this fails the fixture is broken, not the canon")
+
+	verbEdges := csharpBaseEdges(res, "T.cs::event")
+	require.Len(t, verbEdges, 1,
+		"the verbatim-declared type's base edge rides its canonical node ID")
+	require.NotNil(t, verbEdges[0].Meta,
+		"identical base list, identical evidence - the spelling of the DECLARING type must not drop the stamp")
+	assert.Equal(t, plainEdges[0].Meta["target_type_args"], verbEdges[0].Meta["target_type_args"],
+		"@event and plain close the same base with the same argument - equal stamps")
+}
+
+// csharpPartialIdentityOf compared enclosing namespace and type-chain
+// spellings RAW, so two fragments of a genuinely partial type failed
+// sameType when only one fragment spelled an ENCLOSING scope verbatim,
+// and the merge was refused. One subtest per identity component, so
+// each canonicalization hunk is individually revert-red.
+func TestCSharpPartialMerge_VerbatimEnclosingSpellings(t *testing.T) {
+	collect := func(t *testing.T, path, src string) map[string]bool {
+		t.Helper()
+		res, err := NewCSharpExtractor().Extract(path, []byte(src))
+		require.NoError(t, err)
+		targets := map[string]bool{}
+		for _, e := range csharpBaseEdges(res, path+"::Box") {
+			targets[e.To] = true
+		}
+		return targets
+	}
+
+	t.Run("outer type spelled verbatim in one fragment", func(t *testing.T) {
+		targets := collect(t, "P.cs", `namespace App {
+    public interface IA { void A(); }
+    public interface IB { void B(); }
+    public partial class @Outer { public partial class Box : IA { public void A() { } } }
+    public partial class Outer  { public partial class Box : IB { public void B() { } } }
+}
+`)
+		assert.True(t, targets["unresolved::IA"] && targets["unresolved::IB"],
+			"@Outer and Outer are the same identifier - both fragments' bases must merge onto one Box, got %v", targets)
+	})
+
+	t.Run("namespace spelled verbatim in one fragment", func(t *testing.T) {
+		targets := collect(t, "N.cs", `namespace @App {
+    public interface IA { void A(); }
+    public partial class Outer { public partial class Box : IA { public void A() { } } }
+}
+namespace App {
+    public interface IB { void B(); }
+    public partial class Outer { public partial class Box : IB { public void B() { } } }
+}
+`)
+		assert.True(t, targets["unresolved::IA"] && targets["unresolved::IB"],
+			"@App and App are the same namespace - both fragments' bases must merge onto one Box, got %v", targets)
+	})
+}

--- a/internal/resolver/csharp_verbatim_type_ref_test.go
+++ b/internal/resolver/csharp_verbatim_type_ref_test.go
@@ -1,0 +1,53 @@
+package resolver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// `@event` is the ONLY legal spelling of a keyword-named C# type, and
+// the declaration side mints its node ID canonically (`<file>::event`).
+// canonicalizeCSharpTypeRef stripped `?`, `[]`, generics and qualifiers
+// but not the verbatim `@`, so every reference emitted
+// `unresolved::@event` and the two halves never met: field, parameter
+// and return types naming such a type lost their bindings entirely
+// (issue #723 shape 1 - a total regression, only visible THROUGH the
+// resolver because extraction always emits unresolved::).
+func TestResolveCSharp_VerbatimTypeReferencesBind(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{"V.cs": `namespace App {
+    public interface @event { void Put(int x); }
+    public class Flow {
+        private readonly @event _e;
+        public @event Make() { return _e; }
+        public void Take(@event e) { }
+    }
+}`})
+	New(g).ResolveAll()
+
+	wants := map[string]graph.EdgeKind{
+		"V.cs::Flow._e":            graph.EdgeTypedAs,
+		"V.cs::Flow.Make":          graph.EdgeReturns,
+		"V.cs::Flow.Take#param:e@0": graph.EdgeTypedAs,
+	}
+	for from, kind := range wants {
+		bound := false
+		var got []string
+		for _, e := range g.AllEdges() {
+			if e == nil || e.From != from || e.Kind != kind {
+				continue
+			}
+			got = append(got, e.To)
+			if e.To == "V.cs::event" {
+				bound = true
+			}
+			assert.False(t, strings.Contains(e.To, "@"),
+				"[%s] the verbatim marker is spelling, not identity - it may never appear in a target ID, got %s", from, e.To)
+		}
+		assert.True(t, bound,
+			"[%s] the %s edge must bind to the canonical declaration V.cs::event, got targets %v", from, kind, got)
+	}
+}


### PR DESCRIPTION
Fixes #723.

## What lands

Your four hunks, verbatim - canonicalizeCSharpTypeRef reduces through csharpCanonBaseIdent, csharpBaseNameCounts keys the prescan canonically, and csharpPartialIdentityOf canonicalizes both the enclosing namespace (via the new csharpCanonDottedName) and the type chain. The only additions are the pins the issue asked for and a salt bump:

- **One pin per hunk, each individually revert-red** (verified by reverting each hunk alone and watching exactly its pin fail):
  - `TestResolveCSharp_VerbatimTypeReferencesBind` - shape 1, measured through ResolveAll as the issue prescribes: field, return, and parameter types naming `@event` must bind to the canonical declaration, and no target ID may ever carry the verbatim marker. RED before the fix with `unresolved::@event` on all three edges.
  - `TestCSharpBaseList_VerbatimDeclaredTypeKeepsTypeArgStamps` - shape 2: `@event : IOther<Widget>` beside a plainly-spelled `plain` control with the identical base list; equal stamps required.
  - `TestCSharpPartialMerge_VerbatimEnclosingSpellings` - shape 3, one subtest per identity component (`@Outer`/`Outer` pins the type-chain hunk, `namespace @App`/`namespace App` pins the ns hunk), so the two partial-identity canonicalizations are separately load-bearing.
- **Extractor salt 18 to 19**: existing stores carry `unresolved::@`-spelled type refs from the split domain; the bump re-extracts C# files so those references re-emit canonically and bind. Say the word if you would rather batch the bump with something else - it is its own commit, easy to drop.

## Evidence

- Full parser/resolver/indexer/tstypes suites: fail-name sets byte-identical to clean-main Windows controls (the standing environment set; the tstypes apply golden is unchanged).
- On my counted C# fixture repo, a new round pins all three shapes as battery cells (a keyword-named `@event` interface used as field/return/param type, a `@struct`-named class in base-list position beside a plainly-spelled control, and partial fragments under `@`-spelled enclosing scopes). Cold-lab A/B, base (merged main) vs this branch, same recipe and fixture tree: the three type-ref cells each go one `unresolved::@event` row to one canonical binding; the stamp count goes 1 to 2 (the control alone, then both). One honest observation from the same A/B: shape 3 self-heals at the STORE level on the base too - the duplicate_decl dedup path collapses the extraction-refused fragments and the second fragment's implements edge survives line-suffixed - so the store-level battery cell guards the end state while the extraction-level discrimination is pinned by the unit test. The rest of the battery is byte-identical between the two labs.
- This was the third half-canonicalized-identifier recall bug, so the battery cells are deliberately shaped to catch the next split (references, prescan keys, and identity keys each probed through a different lane).
