### PR TITLE
csharp: scope label and when-guard pattern variables to their switch section

### DIFF
--- a/internal/indexer/extractor_version.go
+++ b/internal/indexer/extractor_version.go
@@ -40,7 +40,7 @@ var extractorVersions = map[string]int{
 	//   "go": 2,
 	"c":      generatedParserProjectionPolicyVersion, // generated parser projection covers all strictly detected table sizes
 	"php":    2,                                      // class/interface inheritance now emits typed structural edges
-	"csharp": 20,                                     // indexers and accessor-bearing events are emitted as members and own their body calls (was: verbatim-identifier canonicalization unified across type refs, the base-list prescan, and partial identity)
+	"csharp": 21,                                     // case-label and when-guard pattern variables scope to their switch section (was: indexers and accessor-bearing events are emitted as members and own their body calls)
 	"scala":  2,                                      // explicitly instantiated generic calls emit call edges
 	"go":     3,                                      // generic instantiations are marked so indexing a func value cannot bind (was: generic calls emit call edges)
 	"cpp":    2,                                      // templated and namespace-qualified calls emit call edges

--- a/internal/indexer/extractor_version_test.go
+++ b/internal/indexer/extractor_version_test.go
@@ -229,7 +229,7 @@ func TestStaleLangsDetection(t *testing.T) {
 		}
 
 		for _, path := range []string{"src/Handler.cs", "Views/Page.razor", "Views/Page.cshtml"} {
-			want := policySalt + "|csharp@20"
+			want := policySalt + "|csharp@21"
 			if got := merkleSaltFor(path); got != want {
 				t.Errorf("C# extractor salt for %s = %q, want %q", path, got, want)
 			}

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -287,12 +287,16 @@ func (s csharpLocalScopes) shadowsAnywhere(owner, name string) bool {
 // an `if` condition escapes to the ENCLOSING block (definite-assignment
 // scoping), so stopping at the `if` would under-refuse. Loop headers do
 // not leak their pattern variables past the statement. The switch BODY
-// is one declaration space shared by every section — that is exactly
-// why redeclaring a name in a sibling section is CS0128 — so the extent
-// stops at `switch_body`, never at a single section (round-6 finding
-// B1: stopping at the section read a sibling-section local as expired,
-// dropping its receiver evidence and re-minting its assignments as
-// field writes).
+// is one declaration space shared by every section for the locals its
+// STATEMENT LISTS declare — that is exactly why redeclaring a name in a
+// sibling section is CS0128 — so those extents stop at `switch_body`
+// (round-6 finding B1: stopping at the section read a sibling-section
+// local as expired, dropping its receiver evidence and re-minting its
+// assignments as field writes). A pattern variable bound in a case
+// LABEL or `when` guard is the one exception: it is section-scoped
+// (sibling sections may redeclare it), handled positionally in
+// csharpLocalScopeOf rather than by this table — the ancestor node type
+// alone cannot express both rules.
 var csharpScopeFormers = map[string]bool{
 	"block":                       true,
 	"switch_body":                 true,
@@ -325,11 +329,38 @@ var csharpScopeFormers = map[string]bool{
 // lose a refusal.
 func csharpLocalScopeOf(n *sitter.Node) csharpLocalScope {
 	for cur := n; cur != nil; cur = cur.Parent() {
+		// A switch SECTION is not a declaration space for the locals its
+		// statement list declares (those live in the switch BODY), but it
+		// IS one for a pattern variable bound in a case label or a `when`
+		// guard. Roslyn accepts `case int x:` beside `case string x:` in a
+		// sibling section AND accepts `case 1: int y = 1;` / `default: y =
+		// 2;`, so the two rules coexist and the answer depends on where in
+		// the section the binder sits: label territory is everything
+		// before the section's first statement.
+		if cur.Type() == "switch_section" && csharpInSwitchLabel(cur, n) {
+			return csharpLocalScope{start: int(cur.StartByte()), end: int(cur.EndByte())}
+		}
 		if csharpScopeFormers[cur.Type()] {
 			return csharpLocalScope{start: int(cur.StartByte()), end: int(cur.EndByte())}
 		}
 	}
 	return csharpLocalScope{start: 0, end: math.MaxInt}
+}
+
+// csharpInSwitchLabel reports whether binder sits in section's LABEL
+// region - before the first statement the section lists.
+func csharpInSwitchLabel(section, binder *sitter.Node) bool {
+	for i, _nc := 0, int(section.NamedChildCount()); i < _nc; i++ {
+		c := section.NamedChild(i)
+		if c == nil {
+			continue
+		}
+		t := c.Type()
+		if strings.HasSuffix(t, "_statement") || t == "block" {
+			return binder.StartByte() < c.StartByte()
+		}
+	}
+	return false
 }
 
 // csharpTypedBinding is one typed local declaration's evidence record:

--- a/internal/resolver/csharp_switch_label_scope_test.go
+++ b/internal/resolver/csharp_switch_label_scope_test.go
@@ -1,0 +1,110 @@
+package resolver
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// C# has TWO switch scoping rules that coexist (issue #724): an
+// ordinary local declared in a section is BODY-scoped (redeclaring it
+// in a sibling is CS0128 - pinned by
+// TestResolveCSharpTypedLocal_AliveAcrossSwitchSections), while a
+// pattern variable bound in a case label or `when` guard is
+// SECTION-scoped (sibling sections may redeclare it - Roslyn accepts
+// `case int x:` beside `case string x:`). Stopping every extent at
+// switch_body let a label's pattern variable shadow the whole body and
+// eat a same-named FIELD use in a sibling section: the field read
+// vanished entirely (0 reads; the merge base wrongly minted 2 - one
+// was the label's own local; the correct answer is exactly 1).
+func TestResolveCSharp_LabelPatternVarScopesToItsSection(t *testing.T) {
+	fieldReads := func(t *testing.T, src string) int {
+		t.Helper()
+		g := buildCSharpResolverGraph(t, map[string]string{"L.cs": src})
+		New(g).ResolveAll()
+		n := 0
+		for _, e := range g.AllEdges() {
+			if e == nil || e.Kind != graph.EdgeReads || e.From != "L.cs::LbFlow.Run" {
+				continue
+			}
+			if strings.HasSuffix(e.To, ".repo") || strings.HasSuffix(e.To, "::repo") {
+				n++
+			}
+		}
+		return n
+	}
+
+	t.Run("when guard pattern", func(t *testing.T) {
+		got := fieldReads(t, `namespace App {
+    public class LbRepo { public int Get(int id) { return id; } }
+    public class LbFlow {
+        private readonly LbRepo repo;
+        public int Run(object o, int k) {
+            switch (k) {
+                case 1 when o is LbRepo repo: return repo.Get(1);
+                default: return repo.Get(2);
+            }
+        }
+    }
+}`)
+		assert.Equal(t, 1, got,
+			"the guard's pattern variable dies with its section - the default section's `repo` is the FIELD, exactly one field read")
+	})
+
+	t.Run("case label pattern", func(t *testing.T) {
+		got := fieldReads(t, `namespace App {
+    public class LbRepo { public int Get(int id) { return id; } }
+    public class LbFlow {
+        private readonly LbRepo repo;
+        public int Run(object o, int k) {
+            switch (o) {
+                case LbRepo repo: return repo.Get(1);
+                default: return repo.Get(2);
+            }
+        }
+    }
+}`)
+		assert.Equal(t, 1, got,
+			"the label's pattern variable dies with its section - the default section's `repo` is the FIELD, exactly one field read")
+	})
+}
+
+// The boundary case that fixes the discriminator as POSITION IN THE
+// SECTION, not ancestor node type: a pattern variable introduced by an
+// `if` INSIDE a section's statement list escapes to the switch body
+// (Roslyn reports CS0165 - it resolves to the local and is merely not
+// definitely assigned, never falling back to a same-named field). The
+// fixture would be CS0165 under Roslyn for exactly that reason; what is
+// pinned here is resolution, not definite assignment: the sibling
+// section's `esc.Get(2)` must bind through the body-scoped LOCAL's
+// type, and the same-named DECOY field (which has no Get) must attract
+// nothing.
+func TestResolveCSharp_SectionStatementPatternVarEscapesToBody(t *testing.T) {
+	g := buildCSharpResolverGraph(t, map[string]string{"E.cs": `namespace App {
+    public class EbRepo { public int Get(int id) { return id; } }
+    public class EbDecoy { public int Peek() { return 9; } }
+    public class EbFlow {
+        private readonly EbDecoy esc;
+        public int Run(object o, int k) {
+            switch (k) {
+                case 1: if (o is EbRepo esc) { return esc.Get(1); } break;
+                default: return esc.Get(2);
+            }
+            return 0;
+        }
+    }
+}`})
+	New(g).ResolveAll()
+
+	bound := 0
+	for _, to := range callsFrom(g, "E.cs::EbFlow.Run") {
+		if to == "E.cs::EbRepo.Get" {
+			bound++
+		}
+	}
+	assert.Equal(t, 2, bound,
+		"a statement-territory pattern variable is BODY-scoped: both Get sites bind through the local's type, the sibling section included")
+}

--- a/internal/resolver/csharp_switch_label_scope_test.go
+++ b/internal/resolver/csharp_switch_label_scope_test.go
@@ -70,9 +70,31 @@ func TestResolveCSharp_LabelPatternVarScopesToItsSection(t *testing.T) {
 		assert.Equal(t, 1, got,
 			"the label's pattern variable dies with its section - the default section's `repo` is the FIELD, exactly one field read")
 	})
+
+	// A braced section body is the one shape whose first statement is a
+	// `block`, not a `*_statement`: it is what the discriminator's block
+	// arm exists for. Without that arm every braced section reads as
+	// all-label and #724 returns in full for the idiomatic
+	// `case X x: { ... }` form.
+	t.Run("case label pattern, braced section bodies", func(t *testing.T) {
+		got := fieldReads(t, `namespace App {
+    public class LbRepo { public int Get(int id) { return id; } }
+    public class LbFlow {
+        private readonly LbRepo repo;
+        public int Run(object o, int k) {
+            switch (o) {
+                case LbRepo repo: { return repo.Get(1); }
+                default: { return repo.Get(2); }
+            }
+        }
+    }
+}`)
+		assert.Equal(t, 1, got,
+			"a braced section body is the section's first statement - the label's pattern variable still dies with its section, exactly one field read")
+	})
 }
 
-// The boundary case that fixes the discriminator as POSITION IN THE
+// The boundary case that motivates the discriminator as POSITION IN THE
 // SECTION, not ancestor node type: a pattern variable introduced by an
 // `if` INSIDE a section's statement list escapes to the switch body
 // (Roslyn reports CS0165 - it resolves to the local and is merely not
@@ -82,6 +104,13 @@ func TestResolveCSharp_LabelPatternVarScopesToItsSection(t *testing.T) {
 // section's `esc.Get(2)` must bind through the body-scoped LOCAL's
 // type, and the same-named DECOY field (which has no Get) must attract
 // nothing.
+//
+// This is a companion assertion, not the discriminator's guard: an `if`
+// pattern binder sits inside a statement, so a discriminator that
+// section-scoped EVERY binder under switch_section would still leave it
+// green. The over-correction is caught by
+// TestResolveCSharpTypedLocal_AliveAcrossSwitchSections (a body-scoped
+// ordinary local), which is the test to keep when touching either.
 func TestResolveCSharp_SectionStatementPatternVarEscapesToBody(t *testing.T) {
 	g := buildCSharpResolverGraph(t, map[string]string{"E.cs": `namespace App {
     public class EbRepo { public int Get(int id) { return id; } }


### PR DESCRIPTION
Fixes #724.

## What lands

Your patch and helper, verbatim - the positional discriminator in csharpLocalScopeOf (label territory is everything before the section's first statement) plus csharpInSwitchLabel. Additions:

- **Pins.** The eaten-field shape in BOTH label variants (`case 1 when o is Repo repo:` and `case Repo repo:`) - RED at 0 field reads pre-fix, exactly 1 after, matching your three-revision table. Plus the boundary case as a standing guard on the discriminator itself: a pattern variable introduced by an `if` INSIDE a section's statement list stays BODY-scoped (the fixture is deliberately CS0165 - resolution is what is pinned, not definite assignment, per your Roslyn ground truth), with a same-named decoy field of a different type proving the sibling section binds through the local. The two round-6 B1 tests you named keep passing, and the scope-former table's doc comment now states both rules instead of overclaiming `switch_body`.
- **Extractor salt 18 to 19** (own commit): existing stores carry body-wide label-pattern shadows that ate sibling field reads. Note #732 bumps 18 to 19 for the verbatim canonicalization on an independent branch - whichever lands second resolves the one-line conflict by taking 20.

## Evidence

- Full parser/resolver/indexer/tstypes suites: fail-name sets byte-identical to clean-main Windows controls; the fix's pin set individually revert-red.
- On my counted C# fixture repo, a new round pins both rules as battery cells. Cold-lab A/B, base (merged main) vs this branch, same recipe and fixture tree: the eaten-field cell goes 0 reads (the regression) to exactly 1 (the field read, the guard variable's own use riding the local); the boundary-control cell reads identically on both labs (both sibling sites bind through the body-scoped local past the decoy field, no companions). The rest of the battery is byte-identical between the two labs.
