### PR TITLE
csharp: drop repeated partial bases, type chained/awaited receivers at the site offset

### DIFF
--- a/internal/indexer/extractor_version.go
+++ b/internal/indexer/extractor_version.go
@@ -40,7 +40,7 @@ var extractorVersions = map[string]int{
 	//   "go": 2,
 	"c":      generatedParserProjectionPolicyVersion, // generated parser projection covers all strictly detected table sizes
 	"php":    2,                                      // class/interface inheritance now emits typed structural edges
-	"csharp": 21,                                     // case-label and when-guard pattern variables scope to their switch section (was: indexers and accessor-bearing events are emitted as members and own their body calls)
+	"csharp": 22,                                     // repeated partial base classes dropped, chained/awaited receivers typed at the site offset (was: case-label and when-guard pattern variables scope to their switch section)
 	"scala":  2,                                      // explicitly instantiated generic calls emit call edges
 	"go":     3,                                      // generic instantiations are marked so indexing a func value cannot bind (was: generic calls emit call edges)
 	"cpp":    2,                                      // templated and namespace-qualified calls emit call edges

--- a/internal/indexer/extractor_version_test.go
+++ b/internal/indexer/extractor_version_test.go
@@ -229,7 +229,7 @@ func TestStaleLangsDetection(t *testing.T) {
 		}
 
 		for _, path := range []string{"src/Handler.cs", "Views/Page.razor", "Views/Page.cshtml"} {
-			want := policySalt + "|csharp@21"
+			want := policySalt + "|csharp@22"
 			if got := merkleSaltFor(path); got != want {
 				t.Errorf("C# extractor salt for %s = %q, want %q", path, got, want)
 			}

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -408,6 +408,48 @@ func csharpTypedLocalAt(m map[string]map[string][]*csharpTypedBinding, owner, na
 	return best, csharpTypedFound
 }
 
+// csharpChainHead returns the leading identifier of a chained receiver
+// expression (`h.Make().Ping` -> `h`), the only name the chain walker
+// looks up in the type environment.
+func csharpChainHead(expr string) string {
+	cleaned := strings.ReplaceAll(stripCallArgs(expr), "::", ".")
+	if i := strings.IndexByte(cleaned, '.'); i >= 0 {
+		cleaned = cleaned[:i]
+	}
+	return strings.TrimSpace(cleaned)
+}
+
+// csharpOffsetEnv hands the offset-blind chain/awaited walkers a type
+// environment whose HEAD entry is corrected by the offset-aware
+// typed-local records (issue #725 item 3: the function-wide tenv is
+// written last-wins by sibling redeclarations, so consulting it raw
+// types a chain through whichever sibling declared LAST). A Found
+// record overrides the head, an Expired or type-less record removes it
+// (the flat value belongs to a sibling), and an Absent name keeps the
+// function-wide fallback exactly as before.
+func csharpOffsetEnv(typedLocals map[string]map[string][]*csharpTypedBinding, tenv typeEnv, owner, head string, offset int) typeEnv {
+	if head == "" {
+		return tenv
+	}
+	b, state := csharpTypedLocalAt(typedLocals, owner, head, offset)
+	if state == csharpTypedAbsent {
+		return tenv
+	}
+	if state == csharpTypedFound && b.typ != "" && tenv[head] == b.typ {
+		return tenv
+	}
+	env := make(typeEnv, len(tenv))
+	for k, v := range tenv {
+		env[k] = v
+	}
+	if state == csharpTypedFound && b.typ != "" {
+		env[head] = b.typ
+	} else {
+		delete(env, head)
+	}
+	return env
+}
+
 // csharpTypeUse buffers a type referenced only in a local-variable
 // annotation (`HttpResponse resp = Get();`) so the post-pass can emit an
 // EdgeTypedAs from the enclosing function once funcRanges are built.
@@ -835,7 +877,12 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 			if inner == nil {
 				return
 			}
-			if t := csharpAwaitedCallType(inner.Content(src), csharpOwnerTypeName(owner), tenvByOwner[owner], result); t != "" {
+			// The awaited call's receiver is typed at the DECLARATION's
+			// offset, not from the function-wide last-wins map — a sibling
+			// block's same-named local must not type this block's await.
+			innerText := inner.Content(src)
+			env := csharpOffsetEnv(typedLocalsByOwner, tenvByOwner[owner], owner, csharpChainHead(innerText), int(n.StartByte()))
+			if t := csharpAwaitedCallType(innerText, csharpOwnerTypeName(owner), env, result); t != "" {
 				setLocalType(owner, l, t)
 			}
 		})
@@ -1068,11 +1115,13 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 				// `(await LoadAsync()).X()` — the chain walker collapses a
 				// fully-parenthesized receiver to nothing; the receiver is
 				// the T inside the awaited call's Task<T>.
-				if t := csharpAwaitedCallType(inner, csharpOwnerTypeName(callerID), tenvByOwner[callerID], result); t != "" {
+				env := csharpOffsetEnv(typedLocalsByOwner, tenvByOwner[callerID], callerID, csharpChainHead(inner), c.offset)
+				if t := csharpAwaitedCallType(inner, csharpOwnerTypeName(callerID), env, result); t != "" {
 					edge.Meta = map[string]any{"receiver_type": t}
 				}
 			} else if strings.Contains(c.receiver, ".") || strings.Contains(c.receiver, "(") {
-				stampFactoryChainReceiver(edge, c.receiver, resolveChainType(c.receiver, tenvByOwner[callerID], result))
+				env := csharpOffsetEnv(typedLocalsByOwner, tenvByOwner[callerID], callerID, csharpChainHead(c.receiver), c.offset)
+				stampFactoryChainReceiver(edge, c.receiver, resolveChainType(c.receiver, env, result))
 				if edge.Meta == nil && !strings.Contains(c.receiver, "(") {
 					// A namespace-qualified receiver the chain walker could
 					// not type (`Lib.BagExt.Add(bag)`). That is the same

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -1273,7 +1273,7 @@ func (e *CSharpExtractor) emitContainer(m parser.QueryResult, kind string, nodeK
 		case "class", "struct", "record", "iface":
 			if pi := partialSeen[id]; pi != nil && csharpHasModifier(def.Node, src, "partial") &&
 				pi.sameType(csharpPartialIdentityOf(def.Node, src)) {
-				pi.extendsTaken = emitCSharpBaseList(id, def.Node, src, filePath, localInterfaces, fileAliases, baseNameCounts, result, pi.extendsTaken)
+				pi.extendsBase = emitCSharpBaseList(id, def.Node, src, filePath, localInterfaces, fileAliases, baseNameCounts, result, pi.extendsBase)
 			}
 		}
 		return
@@ -1342,9 +1342,9 @@ func (e *CSharpExtractor) emitContainer(m parser.QueryResult, kind string, nodeK
 	// for structs and records, inheritance for interfaces).
 	switch kind {
 	case "class", "struct", "record", "iface":
-		took := emitCSharpBaseList(id, def.Node, src, filePath, localInterfaces, fileAliases, baseNameCounts, result, false)
+		took := emitCSharpBaseList(id, def.Node, src, filePath, localInterfaces, fileAliases, baseNameCounts, result, "")
 		if pi := partialSeen[id]; pi != nil {
-			pi.extendsTaken = took
+			pi.extendsBase = took
 		}
 	case "enum":
 		e.emitCSharpEnumMembers(def.Node, src, filePath, id, name, result, seen)
@@ -2749,10 +2749,16 @@ func collectCSharpInterfaceNames(root *sitter.Node, src []byte) map[string]bool 
 // arity twins, namespace twins, and nested twins all share an ID with
 // a genuinely-partial type's fragments).
 type csharpPartialIdentity struct {
-	ns           string
-	outerChain   string
-	arity        int
-	extendsTaken bool
+	ns         string
+	outerChain string
+	arity      int
+	// extendsBase is the canonical name of the base CLASS an earlier
+	// fragment's extends budget was spent on ("" = unspent). It must be
+	// the target, not a boolean: C# permits every partial part to
+	// repeat the base class, and a repeat of the SAME base is dropped
+	// while only a genuinely different class entry degrades to
+	// implements.
+	extendsBase string
 }
 
 func csharpPartialIdentityOf(decl *sitter.Node, src []byte) csharpPartialIdentity {
@@ -2777,7 +2783,7 @@ func csharpCanonDottedName(s string) string {
 }
 
 // sameType reports whether a later fragment's identity key matches -
-// extendsTaken is bookkeeping, not identity, so it stays out.
+// extendsBase is bookkeeping, not identity, so it stays out.
 func (p csharpPartialIdentity) sameType(o csharpPartialIdentity) bool {
 	return p.ns == o.ns && p.outerChain == o.outerChain && p.arity == o.arity
 }
@@ -2818,12 +2824,14 @@ func csharpTypeParamArity(decl *sitter.Node) int {
 }
 
 // emitCSharpBaseList emits the declaration's base-list edges. It
-// receives whether an earlier fragment of the same type already minted
-// the base class and reports the state back, so partial fragments share
-// ONE extends budget the way entries within one base list always have.
-func emitCSharpBaseList(typeID string, decl *sitter.Node, src []byte, filePath string, localInterfaces, fileAliases map[string]bool, baseNameCounts map[string]map[string]int, result *parser.ExtractionResult, extendsAlready bool) bool {
+// receives which base class an earlier fragment of the same type
+// already minted ("" = none) and reports the state back, so partial
+// fragments share ONE extends budget the way entries within one base
+// list always have - and a later fragment legally REPEATING that same
+// base class emits nothing for it, instead of a demoted implements.
+func emitCSharpBaseList(typeID string, decl *sitter.Node, src []byte, filePath string, localInterfaces, fileAliases map[string]bool, baseNameCounts map[string]map[string]int, result *parser.ExtractionResult, extendsBaseAlready string) string {
 	if decl == nil {
-		return extendsAlready
+		return extendsBaseAlready
 	}
 	baseList := decl.ChildByFieldName("bases")
 	if baseList == nil {
@@ -2838,7 +2846,7 @@ func emitCSharpBaseList(typeID string, decl *sitter.Node, src []byte, filePath s
 		}
 	}
 	if baseList == nil {
-		return extendsAlready
+		return extendsBaseAlready
 	}
 	// Structs and `record struct` cannot derive from a base class — the
 	// CLR forbids it — so every entry in their base list is an interface
@@ -2866,7 +2874,7 @@ func emitCSharpBaseList(typeID string, decl *sitter.Node, src []byte, filePath s
 	// the winner's stamp. An absent entry counts as 0 and stamps nothing,
 	// so a shape the prescan cannot attribute keeps the full fan-out.
 	baseNameCount := baseNameCounts[typeID]
-	extendsTaken := extendsAlready
+	extendsBase := extendsBaseAlready
 	for i, _nc := 0, int(baseList.NamedChildCount()); i < _nc; i++ {
 		entry := baseList.NamedChild(i)
 		if entry == nil {
@@ -2882,13 +2890,19 @@ func emitCSharpBaseList(typeID string, decl *sitter.Node, src []byte, filePath s
 		// an interface.
 		isInterface := !isCtorBase &&
 			(localInterfaces[name] || csharpInterfaceNamePattern.MatchString(name))
+		// C# permits every partial part to repeat the base class the
+		// budget already spent — the repeat names the same base, so it
+		// emits nothing rather than a demoted implements.
+		if !ifaceDecl && !isInterface && name == extendsBase {
+			continue
+		}
 		kind := graph.EdgeImplements
 		switch {
 		case ifaceDecl:
 			kind = graph.EdgeExtends
-		case !isInterface && allowsBaseClass && !extendsTaken:
+		case !isInterface && allowsBaseClass && extendsBase == "":
 			kind = graph.EdgeExtends
-			extendsTaken = true
+			extendsBase = name
 		}
 		edge := &graph.Edge{
 			From: typeID, To: "unresolved::" + name,
@@ -2923,7 +2937,7 @@ func emitCSharpBaseList(typeID string, decl *sitter.Node, src []byte, filePath s
 		}
 		result.Edges = append(result.Edges, edge)
 	}
-	return extendsTaken
+	return extendsBase
 }
 
 // csharpQualifiedReceiverType resolves the type a `this.` or `base.`

--- a/internal/parser/languages/csharp_partial_base_repeat_test.go
+++ b/internal/parser/languages/csharp_partial_base_repeat_test.go
@@ -1,0 +1,80 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// C# permits every partial part to repeat the base class as long as the
+// parts agree. The shared extends budget was a bare boolean that never
+// inspected the base TARGET, so the second and later fragments demoted
+// the repeat to EdgeImplements - a class posing as an interface in
+// implementor fan-out and hierarchy walks (issue #725 item 2). The
+// repeat names the same base class the budget already spent: it is
+// DROPPED, not demoted.
+func TestCSharpPartialBase_RepeatedBaseClassDroppedNotDemoted(t *testing.T) {
+	count := func(t *testing.T, src string) (extends, implements int, implTargets map[string]int) {
+		t.Helper()
+		res, err := NewCSharpExtractor().Extract("P.cs", []byte(src))
+		require.NoError(t, err)
+		implTargets = map[string]int{}
+		for _, e := range csharpBaseEdges(res, "P.cs::Box") {
+			switch e.Kind {
+			case graph.EdgeExtends:
+				extends++
+			case graph.EdgeImplements:
+				implements++
+				implTargets[e.To]++
+			}
+		}
+		return
+	}
+
+	t.Run("two parts", func(t *testing.T) {
+		extends, implements, implTargets := count(t, `namespace App {
+    public class BaseA {}
+    public interface IA {}
+    public interface IB {}
+    public partial class Box : BaseA, IA {}
+    public partial class Box : BaseA, IB {}
+}`)
+		assert.Equal(t, 1, extends, "one base class, one extends edge - the repeat is the SAME base")
+		assert.Equal(t, 2, implements, "IA and IB, nothing else")
+		assert.Zero(t, implTargets["unresolved::BaseA"],
+			"a repeated base CLASS must never surface as implements")
+	})
+
+	t.Run("three parts", func(t *testing.T) {
+		extends, implements, implTargets := count(t, `namespace App {
+    public class BaseA {}
+    public interface IA {}
+    public interface IB {}
+    public interface IC {}
+    public partial class Box : BaseA, IA {}
+    public partial class Box : BaseA, IB {}
+    public partial class Box : BaseA, IC {}
+}`)
+		assert.Equal(t, 1, extends)
+		assert.Equal(t, 3, implements)
+		assert.Zero(t, implTargets["unresolved::BaseA"])
+	})
+
+	// A DIFFERENT class name in a later fragment's base position is not
+	// a repeat (it is invalid C#, but the extractor must not guess): the
+	// existing demote-to-implements degrade stays for that shape.
+	t.Run("different class keeps the demote", func(t *testing.T) {
+		extends, implements, implTargets := count(t, `namespace App {
+    public class BaseA {}
+    public class BaseB {}
+    public partial class Box : BaseA {}
+    public partial class Box : BaseB {}
+}`)
+		assert.Equal(t, 1, extends)
+		assert.Equal(t, 1, implements)
+		assert.NotZero(t, implTargets["unresolved::BaseB"])
+	})
+}

--- a/internal/parser/languages/csharp_sibling_var_chain_test.go
+++ b/internal/parser/languages/csharp_sibling_var_chain_test.go
@@ -1,0 +1,86 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Sibling `var` redeclarations mint per-scope offset records, but
+// setLocalType also writes the function-wide tenv last-wins - and the
+// chained-receiver and awaited paths consulted THAT map, offset-blind
+// (issue #725 item 3: first-wins flipped to last-wins; every revision
+// was wrong on one of the two sites). The chain/awaited walkers now
+// receive an env whose HEAD entry is corrected by the offset-aware
+// records, so each site types through its own block's local.
+func csharpPingReceivers(t *testing.T, src string) map[int]string {
+	t.Helper()
+	res, err := NewCSharpExtractor().Extract("C.cs", []byte(src))
+	require.NoError(t, err)
+	got := map[int]string{}
+	for _, e := range res.Edges {
+		if e.Kind != graph.EdgeCalls || e.Meta == nil {
+			continue
+		}
+		if e.To == "unresolved::*.Ping" {
+			if rt, _ := e.Meta["receiver_type"].(string); rt != "" {
+				got[e.Line] = rt
+			}
+		}
+	}
+	return got
+}
+
+func TestCSharpSiblingVar_ChainedReceiverTypesPerSite(t *testing.T) {
+	got := csharpPingReceivers(t, `namespace App {
+    public class Widget { public void Ping() { } }
+    public class Gadget { public void Ping() { } }
+    public class MakerA { public Widget Make() { return null; } }
+    public class MakerB { public Gadget Make() { return null; } }
+    public sealed class ChainFlow {
+        public void Run() {
+            { var h = new MakerA(); h.Make().Ping(); }
+            { var h = new MakerB(); h.Make().Ping(); }
+        }
+    }
+}`)
+	assert.Equal(t, "Widget", got[8], "first block's h is a MakerA - its chain types Widget, got %v", got)
+	assert.Equal(t, "Gadget", got[9], "second block's h is a MakerB - its chain types Gadget, got %v", got)
+}
+
+func TestCSharpSiblingVar_AwaitedReceiverTypesPerSite(t *testing.T) {
+	got := csharpPingReceivers(t, `namespace App {
+    public class Widget { public void Ping() { } }
+    public class Gadget { public void Ping() { } }
+    public class LoaderA { public System.Threading.Tasks.Task<Widget> Load() { return null; } }
+    public class LoaderB { public System.Threading.Tasks.Task<Gadget> Load() { return null; } }
+    public sealed class AwaitFlow {
+        public async System.Threading.Tasks.Task Run() {
+            { var h = new LoaderA(); (await h.Load()).Ping(); }
+            { var h = new LoaderB(); (await h.Load()).Ping(); }
+        }
+    }
+}`)
+	assert.Equal(t, "Widget", got[8], "first block awaits LoaderA.Load - Task<Widget> unwraps per site, got %v", got)
+	assert.Equal(t, "Gadget", got[9], "second block awaits LoaderB.Load - Task<Gadget> unwraps per site, got %v", got)
+}
+
+func TestCSharpSiblingVar_AwaitAssignedLocalTypesPerSite(t *testing.T) {
+	got := csharpPingReceivers(t, `namespace App {
+    public class Widget { public void Ping() { } }
+    public class Gadget { public void Ping() { } }
+    public class LoaderA { public System.Threading.Tasks.Task<Widget> Load() { return null; } }
+    public class LoaderB { public System.Threading.Tasks.Task<Gadget> Load() { return null; } }
+    public sealed class VarFlow {
+        public async System.Threading.Tasks.Task Run() {
+            { var h = new LoaderA(); var w = await h.Load(); w.Ping(); }
+            { var h = new LoaderB(); var w = await h.Load(); w.Ping(); }
+        }
+    }
+}`)
+	assert.Equal(t, "Widget", got[8], "tier-2 types the first w through ITS block's h, got %v", got)
+	assert.Equal(t, "Gadget", got[9], "tier-2 types the second w through ITS block's h, got %v", got)
+}


### PR DESCRIPTION
Fixes the two items of #725 that #720 left open (item 1 is re-verified closed below).

## Item 2: a repeated partial base class is dropped, not demoted

The shared extends budget now records WHICH base class it was spent on instead of a bare boolean. A later fragment legally repeating that same base emits nothing; a genuinely different class entry (invalid C#, but not the extractor's to guess about) keeps the existing demote degrade. Pins: two-part and three-part repeats (exactly one extends, zero implements-of-the-base) plus the different-class degrade as a control.

## Item 3: chained and awaited receivers are typed at the site offset

Your prescription taken literally - the offset-blind consumers are made offset-aware rather than picking a different wrong winner. The chain walker only ever looks up the HEAD of the receiver expression, so the three consumers (the chained-receiver walk, the parenthesized-await unwrap, and the tier-2 await-assigned-local walk) now hand it an env whose head entry is corrected by the offset-aware typed-local records: Found overrides, Expired or type-less removes (the flat value belongs to a sibling), Absent keeps the function-wide fallback unchanged. Pins: one per consumer, each individually revert-red, each asserting BOTH sites type through their own block (your fixture's first site goes Gadget back to Widget, and the second stays Gadget).

## Item 1, re-verified closed

Measured on merged main (b4bd4d58) with both your fixtures, extractor only: `Box.Count -> *.Tally` / `Box.Reset -> *.Clear`, and `A.M -> *.Stop` / `B.P -> *.Go` - both false edges gone, as your #720-head measurement predicted. The residual you noted ("the fallback still cannot return a member kind that owns no calls") is also closed since your comment: the refusal guard from the #720 review round means an extent-less member's call refuses rather than landing on a same-line neighbour.

## Salt and evidence

- Extractor salt 18 to 19 (own commit); same note as #732/#734 - the three open branches each bump 18 to 19 independently, and each later-landing one resolves the one-line conflict by taking the next number.
- Full parser/resolver/indexer/tstypes suites: fail-name sets byte-identical to clean-main Windows controls.
- On my counted C# fixture repo, a new round pins both items. Cold-lab A/B, base (merged main) vs this branch: the repeated-base cell goes one demoted implements edge to zero with the extends control identical on both labs. One honest observation on item 3: the sibling-chain cells read correctly on BOTH labs, because csharp-ls (auto-spawned in the lab) types each site per-block at lsp_resolved 1.0 regardless of extraction's stamps - so heavy-lane stores self-heal this shape, and what the fix corrects is the extraction evidence itself (which surfaces on stores without csharp-ls, and in the evidence trail the resolver binds on). The extraction-level discrimination is pinned by the unit tests; the battery cells guard the end state. The rest of the battery is byte-identical between the two labs.
