### PR TITLE
test: pin the unpinned csharp scoping and attribution surfaces

### DIFF
--- a/internal/parser/languages/csharp_base_type_args_test.go
+++ b/internal/parser/languages/csharp_base_type_args_test.go
@@ -456,12 +456,18 @@ func TestCSharpExtractor_SameLineSameNameCallsMarkReceiverAmbiguous(t *testing.T
 // stamp is the refusal; this pin is the assertion the round-5 test of
 // the same name carried before its rewrite lost it (round-6
 // non-blocking finding 7).
+//
+// The tied members call DIFFERENT names on DISTINCT receivers: a
+// same-name site is already marked by the (name,line) receiver-conflict
+// map, and the original same-name fixture pinned only that map - the
+// range-tie question itself could be reverted with the suite green
+// (issue #726). Here only ambiguousAt can produce the stamp.
 func TestCSharpExtractor_TwoMembersOnOneLineMarkReceiverAmbiguous(t *testing.T) {
 	src := []byte(`namespace App {
-    public class Store { public int Fetch(int id) { return id; } }
+    public class Store { public int Fetch(int id) { return id; } public int Grab(int id) { return id; } }
     public class Flow {
         private readonly Store _crates;
-        public int B(Store s) { return s.Fetch(1); } public int A(Store t) { return t.Fetch(2); }
+        public int B(Store s) { return s.Fetch(1); } public int A(Store t) { return t.Grab(2); }
         public int Lone(Store s) { return s.Fetch(3); }
     }
 }
@@ -471,16 +477,17 @@ func TestCSharpExtractor_TwoMembersOnOneLineMarkReceiverAmbiguous(t *testing.T) 
 
 	tied, lone := 0, 0
 	for _, ed := range result.Edges {
-		if ed == nil || ed.Kind != graph.EdgeCalls || ed.To != "unresolved::*.Fetch" {
+		if ed == nil || ed.Kind != graph.EdgeCalls {
 			continue
 		}
-		switch ed.From {
-		case "Tie.cs::Flow.B", "Tie.cs::Flow.A":
+		switch {
+		case ed.From == "Tie.cs::Flow.B" && ed.To == "unresolved::*.Fetch",
+			ed.From == "Tie.cs::Flow.A" && ed.To == "unresolved::*.Grab":
 			tied++
 			require.NotNil(t, ed.Meta)
 			assert.Equal(t, true, ed.Meta["receiver_ambiguous"],
 				"equal-span members tie on the line - the attribution is arbitrary and the evidence must say so")
-		case "Tie.cs::Flow.Lone":
+		case ed.From == "Tie.cs::Flow.Lone" && ed.To == "unresolved::*.Fetch":
 			lone++
 			if ed.Meta != nil {
 				assert.NotContains(t, ed.Meta, "receiver_ambiguous",
@@ -488,7 +495,7 @@ func TestCSharpExtractor_TwoMembersOnOneLineMarkReceiverAmbiguous(t *testing.T) 
 			}
 		}
 	}
-	require.NotZero(t, tied, "fixture: the tied line must emit member calls")
+	require.Equal(t, 2, tied, "fixture: both tied-line member calls must emit")
 	require.NotZero(t, lone, "fixture: the control line must emit a member call")
 }
 

--- a/internal/parser/languages/csharp_binding_scopes_shadow_test.go
+++ b/internal/parser/languages/csharp_binding_scopes_shadow_test.go
@@ -1,0 +1,169 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// The POSITIVE direction of csharpCollectExtraBindingScopes: every
+// binding form the file indexes must SHADOW a same-named field inside
+// its extent - the miss mints a spurious field read on an
+// injected-repository-style name. The committed tests all asserted the
+// negative direction (a use outside the extent keeps its edge), so
+// no-op'ing the whole collector left both packages green (issue #726).
+//
+// One case per switch arm. Cases whose binder scopes to its own
+// statement (foreach, for, using, catch, lambda, local-function
+// parameters, query clauses) also place a call AFTER the extent and
+// expect exactly that one field read - the count pins suppression and
+// extent-end in a single assertion. Cases whose binder escapes to the
+// enclosing block (patterns, out vars, deconstructions) expect zero.
+func TestCSharpBindingScopes_BindersShadowSameNamedField(t *testing.T) {
+	// Every fixture reuses this helper type as the field's type.
+	const bag = `    public sealed class ShBag : System.IDisposable {
+        public void Touch() { }
+        public int Weigh() { return 1; }
+        public bool Alive() { return true; }
+        public int Key() { return 2; }
+        public void Dispose() { }
+    }
+`
+	cases := map[string]struct {
+		body  string // members of the ShFlow class (field + method)
+		owner string // method under test
+		name  string // colliding identifier
+		reads int    // expected field reads from owner
+	}{
+		"foreach_identifier": {body: `        private ShBag _box = new ShBag();
+        public void Go(ShBag[] bags) {
+            foreach (var _box in bags) { _box.Touch(); }
+            _box.Touch();
+        }`, owner: "ShFlow.Go", name: "_box", reads: 1},
+		"foreach_tuple": {body: `        private ShBag _box = new ShBag();
+        public void Go((int, ShBag)[] pairs) {
+            foreach (var (_n, _box) in pairs) { _box.Touch(); _ = _n; }
+            _box.Touch();
+        }`, owner: "ShFlow.Go", name: "_box", reads: 1},
+		"lambda_implicit_param": {body: `        private ShBag _box = new ShBag();
+        public void Go() {
+            System.Func<ShBag, int> f = _box => _box.Weigh();
+            _ = f;
+            _box.Touch();
+        }`, owner: "ShFlow.Go", name: "_box", reads: 1},
+		"lambda_typed_param_list": {body: `        private ShBag _box = new ShBag();
+        public void Go() {
+            System.Func<ShBag, int> f = (ShBag _box) => _box.Weigh();
+            _ = f;
+            _box.Touch();
+        }`, owner: "ShFlow.Go", name: "_box", reads: 1},
+		"anonymous_method_param": {body: `        private ShBag _box = new ShBag();
+        public void Go() {
+            System.Func<ShBag, int> f = delegate(ShBag _box) { return _box.Weigh(); };
+            _ = f;
+            _box.Touch();
+        }`, owner: "ShFlow.Go", name: "_box", reads: 1},
+		"local_function_param": {body: `        private ShBag _box = new ShBag();
+        public void Go() {
+            _box.Touch();
+            int Helper(ShBag _box) { return _box.Weigh(); }
+            _ = Helper(new ShBag());
+        }`, owner: "ShFlow.Go", name: "_box", reads: 1},
+		"catch_variable": {body: `        private ShBag _box = new ShBag();
+        public void Go() {
+            try { } catch (System.Exception _box) { _ = _box.ToString(); }
+            _box.Touch();
+        }`, owner: "ShFlow.Go", name: "_box", reads: 1},
+		"for_initializer": {body: `        private ShBag _box = new ShBag();
+        public void Go() {
+            for (var _box = new ShBag(); _box.Alive(); ) { _box.Touch(); break; }
+            _box.Touch();
+        }`, owner: "ShFlow.Go", name: "_box", reads: 1},
+		"using_resource": {body: `        private ShBag _box = new ShBag();
+        public void Go() {
+            using (var _box = new ShBag()) { _box.Touch(); }
+            _box.Touch();
+        }`, owner: "ShFlow.Go", name: "_box", reads: 1},
+		"declaration_pattern_escapes_to_block": {body: `        private ShBag _box = new ShBag();
+        public void Go(object o) {
+            if (!(o is ShBag _box)) { return; }
+            _box.Touch();
+        }`, owner: "ShFlow.Go", name: "_box", reads: 0},
+		"var_pattern": {body: `        private ShBag _box = new ShBag();
+        public void Go(object o) {
+            if (o is var _box) { _ = _box.ToString(); }
+        }`, owner: "ShFlow.Go", name: "_box", reads: 0},
+		"out_var_declaration": {body: `        private ShBag _box = new ShBag();
+        public void Go(System.Collections.Generic.Dictionary<int, ShBag> map) {
+            if (map.TryGetValue(1, out var _box)) { _box.Touch(); }
+        }`, owner: "ShFlow.Go", name: "_box", reads: 0},
+		"recursive_pattern_designation": {body: `        private ShBag _box = new ShBag();
+        public void Go(object o) {
+            if (o is ShBag { } _box) { _box.Touch(); }
+        }`, owner: "ShFlow.Go", name: "_box", reads: 0},
+		"list_pattern_designation": {body: `        private ShBag[] _row = new ShBag[0];
+        public void Go(ShBag[] xs) {
+            if (xs is [_] _row) { _ = _row.Length; }
+        }`, owner: "ShFlow.Go", name: "_row", reads: 0},
+		"switch_case_var_designation": {body: `        private ShBag _box = new ShBag();
+        public void Go((int, ShBag) pair) {
+            switch (pair) {
+                case var (_n, _box): _box.Touch(); _ = _n; break;
+            }
+        }`, owner: "ShFlow.Go", name: "_box", reads: 0},
+		"deconstruction_declaration": {body: `        private ShBag _box = new ShBag();
+        public void Go((int, ShBag) pair) {
+            var (_n, _box) = pair;
+            _box.Touch();
+            _ = _n;
+        }`, owner: "ShFlow.Go", name: "_box", reads: 0},
+		"is_var_deconstruction_misparse": {body: `        private ShBag _box = new ShBag();
+        public void Go((int, ShBag) pair) {
+            if (pair is var (_n, _box)) { _box.Touch(); _ = _n; }
+        }`, owner: "ShFlow.Go", name: "_box", reads: 0},
+		"query_from_range_variable": {body: `        private ShBag _box = new ShBag();
+        public void Go(ShBag[] bags) {
+            var q = from _box in bags select _box.Weigh();
+            _ = q;
+            _box.Touch();
+        }`, owner: "ShFlow.Go", name: "_box", reads: 1},
+		"query_let_variable": {body: `        private ShBag _box = new ShBag();
+        public ShBag Make(int x) { return new ShBag(); }
+        public void Go(int[] xs) {
+            var q = from x in xs let _box = Make(x) select _box.Weigh();
+            _ = q;
+            _box.Touch();
+        }`, owner: "ShFlow.Go", name: "_box", reads: 1},
+		"query_join_variable": {body: `        private ShBag _box = new ShBag();
+        public void Go(int[] xs, ShBag[] bags) {
+            var q = from x in xs join _box in bags on x equals _box.Key() select _box.Weigh();
+            _ = q;
+            _box.Touch();
+        }`, owner: "ShFlow.Go", name: "_box", reads: 1},
+		"query_join_into_group": {body: `        private ShBag[] grp = new ShBag[0];
+        public void Go(int[] xs, ShBag[] bags) {
+            var q = from x in xs join b in bags on x equals b.Key() into grp select grp.Count();
+            _ = q;
+            _ = grp.Length;
+        }`, owner: "ShFlow.Go", name: "grp", reads: 1},
+		"query_continuation_variable": {body: `        private ShBag _box = new ShBag();
+        public void Go(int[] xs) {
+            var q = from x in xs select x into _box select _box.CompareTo(1);
+            _ = q;
+            _box.Touch();
+        }`, owner: "ShFlow.Go", name: "_box", reads: 1},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			src := "using System.Linq;\nnamespace App {\n" + bag +
+				"    public sealed class ShFlow {\n" + tc.body + "\n    }\n}\n"
+			res, err := NewCSharpExtractor().Extract("Sh.cs", []byte(src))
+			require.NoError(t, err)
+			assert.Equal(t, tc.reads, csharpFieldEdgeCount(res, "Sh.cs::"+tc.owner, tc.name, graph.EdgeReads),
+				"the binder shadows the field inside its extent; a use outside it (when the case has one) is the field again")
+		})
+	}
+}

--- a/internal/parser/languages/csharp_sibling_shape_test.go
+++ b/internal/parser/languages/csharp_sibling_shape_test.go
@@ -1,0 +1,57 @@
+package languages
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// The shape pass's per-record guard, distinguished from the function-wide
+// map it replaced (issue #726: the guard's revert left the suite green).
+// Two same-named explicitly-typed locals in SIBLING scopes carry
+// DIFFERENT generic shapes; each call site must stamp ITS declaration's
+// shape. A function-wide guard skips the second declaration, its record
+// never learns a shape, and the second site loses the receiver_shape
+// stamp the generic-extension applicability veto reads.
+func TestCSharpSiblingShape_RedeclarationStampsPerSite(t *testing.T) {
+	src := []byte(`using System.Collections.Generic;
+namespace App {
+    public static class ShpExt {
+        public static void Drain(this List<int> rack) { }
+        public static void Drain(this List<string> rack) { }
+    }
+    public sealed class ShpRunner {
+        public void Run(List<int> a, List<string> b, bool flag) {
+            if (flag) { List<int> conv = a; conv.Drain(); }
+            else      { List<string> conv = b; conv.Drain(); }
+        }
+    }
+}
+`)
+	res, err := NewCSharpExtractor().Extract("Shp.cs", src)
+	require.NoError(t, err)
+
+	type site struct {
+		line  int
+		shape string
+	}
+	var sites []site
+	for _, e := range res.Edges {
+		if e == nil || e.Kind != graph.EdgeCalls || e.From != "Shp.cs::ShpRunner.Run" || e.To != "unresolved::*.Drain" {
+			continue
+		}
+		require.NotNil(t, e.Meta, "line %d: the receiver is a typed local - evidence must ride", e.Line)
+		shape, _ := e.Meta["receiver_shape"].(string)
+		sites = append(sites, site{line: e.Line, shape: shape})
+	}
+	sort.Slice(sites, func(i, j int) bool { return sites[i].line < sites[j].line })
+	require.Len(t, sites, 2, "fixture: both sibling Drain sites must emit")
+	assert.Equal(t, "List<int>", sites[0].shape,
+		"the first declaration's generic arguments survive at ITS site")
+	assert.Equal(t, "List<string>", sites[1].shape,
+		"the sibling redeclaration mints its OWN record - a function-wide guard starves it and the stamp vanishes")
+}

--- a/internal/resolver/csharp_respelled_bases_test.go
+++ b/internal/resolver/csharp_respelled_bases_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/zzet/gortex/internal/graph"
 )
@@ -62,6 +63,16 @@ func TestResolveCSharp_VerbatimDeclaredTypeKeepsItsHierarchy(t *testing.T) {
 	assert.Contains(t, targets, "Ev.cs::EvB.Put")
 }
 
+// The fan-out assertion this test once carried went vacuous when the
+// dispatch gate was deferred - with no type-argument gate every
+// implementor survives however the bases are spelled (issue #726). The
+// pins now sit where the canonicalization actually acts, on the
+// hierarchy edges and their closure stamps: a respelled entry must pass
+// the interface test (no extends misclassification), enter the
+// duplicate count (a dual type's surviving stamp must NOT read as the
+// unique closure), enter the alias-sentinel lookup (an @-spelled alias
+// suppresses the stamp exactly like its plain spelling), and decode
+// before minting an unresolved target (no `@` survives into any edge).
 func TestResolveCSharpInterfaceDispatch_RespelledBasesKeepTheFamily(t *testing.T) {
 	g := buildCSharpResolverGraph(t, map[string]string{
 		"Rack.cs": `namespace App {
@@ -69,11 +80,6 @@ func TestResolveCSharpInterfaceDispatch_RespelledBasesKeepTheFamily(t *testing.T
     public class Widget { }
     public interface IBox<T> { void Put(T item); }
     public class PlainCrateBox : IBox<Crate> { public void Put(Crate item) { } }
-    public class Flow {
-        private readonly IBox<Crate> _box;
-        public Flow(IBox<Crate> box) { _box = box; }
-        public void Pull(Crate item) { _box.Put(item); }
-    }
 }`,
 		"Dual.cs": `using @BX = App.IBox<App.Crate>;
 namespace App {
@@ -89,20 +95,39 @@ namespace App {
 	})
 	New(g).ResolveAll()
 
-	const callerID = "Rack.cs::Flow.Pull"
-	bindMemberCallAtLine(t, g, callerID, "Put", "Rack.cs::IBox.Put")
-	ResolveCSharpInterfaceDispatch(g)
+	type hier struct {
+		kind graph.EdgeKind
+		to   string
+		args any
+	}
+	byFrom := map[string][]hier{}
+	for _, e := range g.AllEdges() {
+		if e == nil || (e.Kind != graph.EdgeImplements && e.Kind != graph.EdgeExtends) {
+			continue
+		}
+		var args any
+		if e.Meta != nil {
+			args = e.Meta["target_type_args"]
+		}
+		byFrom[e.From] = append(byFrom[e.From], hier{kind: e.Kind, to: e.To, args: args})
+		assert.NotContains(t, e.To, "@",
+			"a respelled base entry decodes before minting its target - %s -> %s", e.From, e.To)
+	}
 
-	targets := dispatchTargets(g, callerID)
-	hasA, hasB := false, false
-	for _, to := range targets {
-		switch to {
-		case "Dual.cs::DualA.Put":
-			hasA = true
-		case "Dual.cs::DualB.Put":
-			hasB = true
+	assert.Equal(t, []hier{{kind: graph.EdgeImplements, to: "Rack.cs::IBox", args: "Crate"}},
+		byFrom["Rack.cs::PlainCrateBox"],
+		"control: a lone plain base keeps its unique-closure stamp")
+
+	assert.Equal(t, []hier{{kind: graph.EdgeImplements, to: "Rack.cs::IBox", args: nil}},
+		byFrom["Dual.cs::DualB"],
+		"the verbatim entry passes the interface test (no extends misclassification) and the duplicate count - a dual type's surviving stamp must not claim the unique closure")
+
+	require.Len(t, byFrom["Dual.cs::DualA"], 2, "alias entry plus plain entry, got %v", byFrom["Dual.cs::DualA"])
+	for _, h := range byFrom["Dual.cs::DualA"] {
+		if h.kind == graph.EdgeImplements {
+			assert.Equal(t, "Rack.cs::IBox", h.to)
+			assert.Nil(t, h.args,
+				"the @-spelled alias enters the alias-sentinel lookup - the plain entry's stamp is suppressed exactly as it would be beside `BX`")
 		}
 	}
-	assert.True(t, hasA, "the alias-based dual implementor must stay in the fan-out, got %v", targets)
-	assert.True(t, hasB, "the verbatim-direct dual implementor must stay in the fan-out, got %v", targets)
 }

--- a/internal/resolver/csharp_same_line_attribution_test.go
+++ b/internal/resolver/csharp_same_line_attribution_test.go
@@ -133,17 +133,21 @@ func TestResolveCSharp_UnequalSpanMethodsSharingALine(t *testing.T) {
 	assert.Empty(t, callsFrom(g, "UnequalSpanSameLine.cs::SMFlow.B"),
 		"B's body is `return 0;` - it owns no call, whatever shares its line")
 
+	// The fan-out assertion this test once ended on went vacuous when
+	// the dispatch gate was deferred - with no type-argument gate every
+	// implementor survives whoever owns the call (issue #726). The
+	// round-5 failure chain is pinned at its first two links instead:
+	// the companion must hang off A, and the shadow refusal must
+	// consult A's OWN parameter set - `_store` is A's parameter, so no
+	// field read may be minted anywhere. Under line-keyed attribution B
+	// carried the call, B has no `_store` parameter, and the field read
+	// appeared with full receiver evidence.
 	const callerID = "UnequalSpanSameLine.cs::SMFlow.A"
-	bindMemberCallAtLine(t, g, callerID, "Get", "UnequalSpanSameLine.cs::SMBox.Get")
-	ResolveCSharpInterfaceDispatch(g)
-
-	targets := dispatchTargets(g, callerID)
-	widgetSurvives := false
-	for _, to := range targets {
-		if to == "UnequalSpanSameLine.cs::SMWidgetBox.Get" {
-			widgetSurvives = true
+	assert.Contains(t, callsFrom(g, callerID), "unresolved::*.Get",
+		"the split-line call's companion rides on A, whose byte extent contains it")
+	for _, e := range g.AllEdges() {
+		if e != nil && e.Kind == graph.EdgeReads && strings.Contains(e.To, "_store") {
+			t.Fatalf("the receiver is A's parameter - no member may read the `_store` FIELD, got %s -> %s", e.From, e.To)
 		}
 	}
-	assert.True(t, widgetSurvives,
-		"the call belongs to A and its receiver is A's SMBox<SMWidget> parameter - at minimum SMWidgetBox.Get must survive in A's fan-out, got %v", targets)
 }

--- a/internal/resolver/csharp_typed_local_scope_test.go
+++ b/internal/resolver/csharp_typed_local_scope_test.go
@@ -21,12 +21,18 @@ import (
 // siblings, so a sibling-section use must keep the receiver's type and
 // an assignment there must stay a local write, not a field write
 // (round-6 finding B1).
+//
+// SwRunner declares a SAME-NAMED field: without it the no-field-write
+// branch was unreachable - writes are only minted for names that ARE
+// fields of the enclosing type, so the assertion held vacuously however
+// the extent was drawn (issue #726).
 func TestResolveCSharpTypedLocal_AliveAcrossSwitchSections(t *testing.T) {
 	g := buildCSharpResolverGraph(t, map[string]string{
 		"Switch.cs": `namespace App {
     public interface ISwConverter { string Convert(int n); }
     public class SwEnglish : ISwConverter { public string Convert(int n) { return "en"; } }
     public class SwRunner {
+        private ISwConverter conv;
         public void Run(ISwConverter c, int k) {
             switch (k) {
                 case 1: ISwConverter conv = c; conv.Convert(1); break;


### PR DESCRIPTION
Closes #726, item by item. Test-only - no behavior change, no salt bump, so it stacks cleanly beside the three open fix PRs. Every new or repaired pin was verified RED under the exact mutation your sweep used, and green on the intact tree.

## The binding-scope collector's positive direction

A 22-case table, one case per collector arm (foreach including the tuple form, the pattern family, out vars, all three lambda spellings, local-function parameters, catch, the for initializer, the using resource, all four query clauses plus the continuation, deconstruction, the is-var misparse, and the switch-case var designation). Each case collides the binder with a same-named field, calls through the name inside the extent, and counts field reads; the statement-scoped forms also place a use after the extent so a single count pins suppression and extent-end together. Under your `if true { return }` mutation all 22 go red. The collector's statement coverage under this one test is 94.6%; the uncovered remainder is nil/empty-tree guards and by-construction fallbacks reachable only from malformed input. All fixtures compile under Roslyn with zero errors and zero warnings, including the nested-block escape lanes.

## The two inert guards

Fixture, not revert, for both - and one of the two fixtures already sits on your desk:

- The shape guard gets its distinguishing fixture here: two same-named explicitly-typed locals in sibling scopes with different generic shapes, `receiver_shape` asserted per site. Reverting the guard to the function-wide map starves the second record and its stamp vanishes - red.
- The tier-2 guard is deliberately not re-pinned in this PR: #735's `TestCSharpSiblingVar_AwaitAssignedLocalTypesPerSite` already distinguishes it. Verified by mutation on that branch's head: reverting the guard to the function-wide tenv makes the second site lose its type and the test goes red. Your instrumentation found no divergence because no fixture on main has two same-named await-assigned vars in sibling scopes; that fixture arrives with #735. If #735 changes shape in review, this item comes back here.

## ambiguousAt

Confirmed your diagnosis: the tie fixture called the SAME name from both tied members, so the (name,line) receiver-conflict map produced the stamp and the range-tie question could revert green. The tied members now call different names on distinct receivers - only `ambiguousAt` can stamp there, and forcing it to false goes red.

## The three tests that could not fail

- `RespelledBasesKeepTheFamily`: the fan-out it ended on has no type-argument gate while the gate is deferred. The pins moved to where the canonicalization acts - the hierarchy edges: a verbatim interface entry must not misclassify as extends, a dual type's surviving stamp must not claim the unique closure, the @-spelled alias must suppress the stamp through the alias-sentinel lookup, and no `@` may survive into any minted target. All red when `csharpCanonBaseIdent` becomes identity. One observation from the probe run: an alias base entry currently sits as `extends -> unresolved::BX` (decoded but unbound - base-list alias binding does not exist). Not pinned, just noting the wart in case you want an issue for it.
- `AliveAcrossSwitchSections`: writes are only minted for names that ARE fields, and the fixture declared no field, so the no-field-write branch held vacuously. The runner now declares a same-named field; scoping the extent to the switch section mints the field write and the test catches it.
- `UnequalSpanMethodsSharingALine`: same gate-deferral vacuity. Replaced with the first two links of the round-5 chain - the companion must ride on A, and no member may read the `_store` field (it is A's parameter). Under line-keyed attribution B carries the call and mints the read, both red.

## Evidence

- Full parser/resolver/indexer/semantic suites: fail-name sets byte-identical to clean-main Windows controls.
- On my counted C# fixture repo, a new round adds six shadow-lane cells (one per major binding form, count-positive by construction). No A/B delta exists to show - this PR changes no extraction output - so the cells guard the end state against future drift: a collector regression mints a second read in every lane and the counts fail. First observation on a cold lab with this branch's build: all six pass, reads bound at confidence 1.0, the rest of the battery in its documented state.
- Your habit suggestion is adopted: revert-the-line mutation checks are now part of the standing acceptance drill for this extractor, alongside the RED-first rule for new pins.
