### PR TITLE
csharp: indexers and accessor-bearing events own their body calls

### DIFF
--- a/internal/indexer/extractor_version.go
+++ b/internal/indexer/extractor_version.go
@@ -40,7 +40,7 @@ var extractorVersions = map[string]int{
 	//   "go": 2,
 	"c":      generatedParserProjectionPolicyVersion, // generated parser projection covers all strictly detected table sizes
 	"php":    2,                                      // class/interface inheritance now emits typed structural edges
-	"csharp": 19,                                     // verbatim-identifier canonicalization unified across type refs, the base-list prescan, and partial identity (was: accessor bodies, property/field initializers, and the typed value parameter own their calls)
+	"csharp": 20,                                     // indexers and accessor-bearing events are emitted as members and own their body calls (was: verbatim-identifier canonicalization unified across type refs, the base-list prescan, and partial identity)
 	"scala":  2,                                      // explicitly instantiated generic calls emit call edges
 	"go":     3,                                      // generic instantiations are marked so indexing a func value cannot bind (was: generic calls emit call edges)
 	"cpp":    2,                                      // templated and namespace-qualified calls emit call edges

--- a/internal/indexer/extractor_version_test.go
+++ b/internal/indexer/extractor_version_test.go
@@ -229,7 +229,7 @@ func TestStaleLangsDetection(t *testing.T) {
 		}
 
 		for _, path := range []string{"src/Handler.cs", "Views/Page.razor", "Views/Page.cshtml"} {
-			want := policySalt + "|csharp@19"
+			want := policySalt + "|csharp@20"
 			if got := merkleSaltFor(path); got != want {
 				t.Errorf("C# extractor salt for %s = %q, want %q", path, got, want)
 			}

--- a/internal/mcp/tools_analyze_missing_fields.go
+++ b/internal/mcp/tools_analyze_missing_fields.go
@@ -63,6 +63,9 @@ func (s *Server) handleAnalyzeConstructorsMissingFields(ctx context.Context, req
 		if n.Kind != graph.KindField {
 			continue
 		}
+		if isUnsettableMember(n) {
+			continue
+		}
 		for _, e := range s.graph.GetOutEdges(n.ID) {
 			if e.Kind != graph.EdgeMemberOf {
 				continue
@@ -189,6 +192,25 @@ func (s *Server) handleAnalyzeConstructorsMissingFields(ctx context.Context, req
 //   - meta["nullable"]   bool — explicit opt-out
 //   - meta["optional"]   bool — same intent, different convention
 //   - meta["json_tag"]   string containing "omitempty" — Go convention
+// isUnsettableMember reports whether a field-kind member cannot be
+// assigned at construction, which makes it a guaranteed false positive
+// here: this heuristic asks which of a type's members an instantiation
+// site left unset, and a member that no instantiation CAN set is
+// missing at every site forever. C# indexers and events are both
+// field-kind member nodes and both qualify - an indexer needs an index
+// argument, so it can never appear in an object initializer, and an
+// event is reachable only through += and -=.
+func isUnsettableMember(n *graph.Node) bool {
+	if n == nil || n.Meta == nil {
+		return false
+	}
+	switch k, _ := n.Meta["kind"].(string); k {
+	case "indexer", "event_accessor":
+		return true
+	}
+	return false
+}
+
 func isNullableField(n *graph.Node) bool {
 	if n.Meta == nil {
 		return false

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -69,6 +69,17 @@ const qCSharpAll = `
   (property_declaration
     name: (identifier) @prop.name) @prop.def
 
+  ; An indexer has no name node - "this" is a keyword, not an
+  ; identifier - so the whole declaration is captured and the member is
+  ; named at emission.
+  (indexer_declaration) @indexer.def
+
+  ; An event declared with add/remove accessor bodies. The bodyless
+  ; field form (event T E;) is a separate grammar node
+  ; (event_field_declaration) with nothing executable in it.
+  (event_declaration
+    name: (identifier) @event.name) @event.def
+
   (using_directive (_) @using.path) @using.def
 
   ; An invocation that spells explicit type arguments parses its callee
@@ -531,6 +542,12 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 
 		case m.Captures["prop.def"] != nil:
 			e.emitProperty(m, filePath, fileID, src, result, seen, fileAliases, funcBytes, funcLines, valueProps)
+
+		case m.Captures["indexer.def"] != nil:
+			e.emitAccessorMember(m.Captures["indexer.def"], csharpIndexerName, "indexer", filePath, fileID, src, result, seen, fileAliases, funcBytes, funcLines, valueProps)
+
+		case m.Captures["event.def"] != nil:
+			e.emitAccessorMember(m.Captures["event.def"], m.Captures["event.name"].Text, "event", filePath, fileID, src, result, seen, fileAliases, funcBytes, funcLines, valueProps)
 
 		case m.Captures["using.def"] != nil:
 			e.emitUsing(m, filePath, fileID, result)
@@ -2125,6 +2142,102 @@ func (e *CSharpExtractor) emitProperty(m parser.QueryResult, filePath, fileID st
 	emitCSharpTypeUseEdges(id, propTypeRaw, filePath, def.StartLine+1, result)
 }
 
+// csharpIndexerName is the node name an indexer carries. The grammar
+// gives it none (`this` is a keyword), and the CLR metadata name `Item`
+// is unsafe here: [IndexerName] lets a type spell the indexer one way
+// and still declare an unrelated member called Item, so borrowing it
+// would fuse two distinct members onto one node. `this[]` cannot collide
+// with any legal C# identifier.
+const csharpIndexerName = "this[]"
+
+// emitAccessorMember mints the member node for the accessor-bearing
+// kinds that carry executable code but had no node at all: indexers and
+// events declared with add/remove bodies. Without a node the owner
+// lookup could not name the member holding an accessor body, so the
+// funcRanges gate dropped every call inside it - the exact loss
+// properties took before #720 recorded their extents (probe cells
+// AC19-AC21).
+//
+// They ride KindField with a `kind` stamp, the same shape properties
+// use, because csharpOwnerRanges already widens the call-owner set with
+// extent-carrying field-kind members. That keeps a real recall fix from
+// introducing a new node kind into federation, the wire formats, both
+// store backends and every consumer filter at the same time.
+//
+// Attribution, not just existence, is the point: an indexer sharing a
+// physical line with a property used to have its body call parked on
+// the property by the extractor's line fallback, and the semantic
+// tier's caller adoption then promoted that stub to a confident
+// resolved edge on a member that cannot call anything (issue #728).
+func (e *CSharpExtractor) emitAccessorMember(def *parser.CapturedNode, name, memberKind, filePath, fileID string, src []byte, result *parser.ExtractionResult, seen map[string]bool, fileAliases map[string]bool, funcBytes, funcLines map[string][2]int, valueProps map[string]csharpValueProp) {
+	if def == nil || def.Node == nil || name == "" {
+		return
+	}
+	owner := csharpDirectMemberOwner(def.Node, src, "class_declaration", "struct_declaration", "interface_declaration", "record_declaration")
+	if owner.kind == "" {
+		return
+	}
+	id := filePath + "::" + owner.name + "." + name
+	// Overloads collide on the name-keyed ID - two indexers differ only
+	// by parameter list, and a type may declare both. Overloaded METHODS
+	// already resolve this by suffixing the second declaration with its
+	// line; taking the same route keeps one convention instead of two.
+	if seen[id] {
+		id = id + "_L" + fmt.Sprint(def.StartLine+1)
+	}
+	if seen[id] {
+		return
+	}
+	seen[id] = true
+	// Accessor bodies and an expression body both live inside the
+	// declaration span, so recording it makes the member a call owner.
+	// An indexer's set accessor carries the implicit `value` parameter
+	// exactly as a property's does, and rides the same seed.
+	csharpRecordPropertyOwnership(id, def.Node, def.StartLine, def.EndLine, src, funcBytes, funcLines, valueProps)
+	isIface := owner.kind == "interface_declaration"
+	defaultVis := VisibilityPrivate
+	if isIface {
+		defaultVis = VisibilityPublic
+	}
+	meta := map[string]any{
+		"receiver":   owner.name,
+		"visibility": csharpVisibility(def.Node, src, defaultVis),
+		"kind":       memberKind,
+	}
+	// Call owners carry scope_ns: the resolver's scoped-usings narrowing
+	// reads it off the caller.
+	if ns := csharpEnclosingNamespace(def.Node, src); ns != "" {
+		meta["scope_ns"] = ns
+	}
+	if isIface {
+		meta["iface_member"] = true
+	}
+	var typeRaw string
+	if t := def.Node.ChildByFieldName("type"); t != nil {
+		typeRaw = strings.TrimSpace(t.Content(src))
+		meta["field_type"] = typeRaw
+		if args := csharpTypeArgsFromTypeNode(t, src, csharpUnstampableArgNames(def.Node, src, fileAliases)); args != "" {
+			meta["field_type_args"] = args
+		}
+	}
+	if doc := extractCSharpDoc(src, def.StartLine); doc != "" {
+		meta["doc"] = doc
+	}
+	result.Nodes = append(result.Nodes, &graph.Node{
+		ID: id, Kind: graph.KindField, Name: name,
+		FilePath: filePath, StartLine: def.StartLine + 1, EndLine: def.EndLine + 1,
+		Language: "csharp",
+		Meta:     meta,
+	})
+	result.Edges = append(result.Edges, &graph.Edge{
+		From: fileID, To: id, Kind: graph.EdgeDefines, FilePath: filePath, Line: def.StartLine + 1,
+	})
+	result.Edges = append(result.Edges, &graph.Edge{
+		From: id, To: filePath + "::" + owner.name, Kind: graph.EdgeMemberOf, FilePath: filePath, Line: def.StartLine + 1,
+	})
+	emitCSharpTypeUseEdges(id, typeRaw, filePath, def.StartLine+1, result)
+}
+
 // stampCSharpUsings records the file's plain namespace usings (global
 // ones included) on the file node as Meta["usings"]. Aliases grant no
 // bare-name namespace visibility and are skipped. Two side stamps carry
@@ -2263,7 +2376,8 @@ type csharpFuncLookup struct {
 
 // csharpOwnerRanges widens the method/constructor owner set with every
 // member that recorded byte extents but is not a KindFunction/KindMethod
-// node — properties today, any extent-carrying member kind tomorrow. A
+// node — properties, indexers and accessor-bearing events today, any
+// extent-carrying member kind tomorrow. A
 // member that can hold executable code must be able to OWN the calls in
 // it: the funcRanges gate drops a call whose enclosing member it cannot
 // name, which is how every accessor-body call vanished (round-23 catch
@@ -2320,12 +2434,13 @@ func newCSharpFuncLookup(ranges []funcRange, bytes map[string][2]int) *csharpFun
 // carried A's call and every consumer of the attribution read the wrong
 // member's evidence (round-5 finding 4). Falls back to the line answer
 // whenever no recorded byte extent contains the offset: extents are
-// recorded for methods, constructors, properties, and initialized field
-// declarators, so a member kind still without them (indexer, event
-// accessor) sharing a line with one that has them would otherwise lose
-// its call outright rather than degrade to line attribution (round-6
-// finding B3) - unless the line answer's own recorded bytes exclude the
-// offset, in which case the fallback is refused (see below).
+// recorded for methods, constructors, properties, indexers, events and
+// initialized field declarators, so a member kind still without them
+// (operator, conversion operator, destructor) sharing a line with one
+// that has them would otherwise lose its call outright rather than
+// degrade to line attribution (round-6 finding B3) - unless the line
+// answer's own recorded bytes exclude the offset, in which case the
+// fallback is refused (see below).
 func (l *csharpFuncLookup) enclosingAt(line, offset int) string {
 	if offset < 0 || len(l.bytes) == 0 {
 		return l.enclosing(line)
@@ -2357,7 +2472,8 @@ func (l *csharpFuncLookup) enclosingAt(line, offset int) string {
 		return best
 	}
 	// The line fallback exists for member kinds that record NO extents
-	// at all (indexer, event accessor). If the line answer does have
+	// at all (operator, conversion operator, destructor). If the line
+	// answer does have
 	// recorded bytes and the offset sits outside them, the offset is
 	// provably not inside that member, so handing it the call invents a
 	// false edge on a same-line neighbour - strictly worse than the drop

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -547,7 +547,12 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 			e.emitAccessorMember(m.Captures["indexer.def"], csharpIndexerName, "indexer", filePath, fileID, src, result, seen, fileAliases, funcBytes, funcLines, valueProps)
 
 		case m.Captures["event.def"] != nil:
-			e.emitAccessorMember(m.Captures["event.def"], m.Captures["event.name"].Text, "event", filePath, fileID, src, result, seen, fileAliases, funcBytes, funcLines, valueProps)
+			// "event_accessor", not "event": this arm sees only the
+			// accessor-bearing form. The far commoner field form
+			// (event T E;) is a different grammar node and stays
+			// unemitted, so a stamp spelled "event" would promise a
+			// type's events and deliver a biased minority of them.
+			e.emitAccessorMember(m.Captures["event.def"], m.Captures["event.name"].Text, "event_accessor", filePath, fileID, src, result, seen, fileAliases, funcBytes, funcLines, valueProps)
 
 		case m.Captures["using.def"] != nil:
 			e.emitUsing(m, filePath, fileID, result)
@@ -2178,11 +2183,30 @@ func (e *CSharpExtractor) emitAccessorMember(def *parser.CapturedNode, name, mem
 		return
 	}
 	id := filePath + "::" + owner.name + "." + name
-	// Overloads collide on the name-keyed ID - two indexers differ only
-	// by parameter list, and a type may declare both. Overloaded METHODS
-	// already resolve this by suffixing the second declaration with its
-	// line; taking the same route keeps one convention instead of two.
 	if seen[id] {
+		// A C# 13 partial indexer (C# 14: partial event) splits a single
+		// member across a declaring fragment and an implementing one, and
+		// either may extract first. That is NOT an overload, and minting a
+		// second node would leave the name-keyed ID - the one anything
+		// queries - pointing at the bodyless fragment while the code sat
+		// under a line-suffixed twin. Properties merge these onto the one
+		// node by moving the ownership record to the body-bearing
+		// fragment; the same rule applies here. The `partial` modifier is
+		// the discriminator rather than a body test: C# requires BOTH
+		// fragments to spell it, and no overload may, so it separates the
+		// two cases exactly.
+		if csharpHasModifier(def.Node, src, "partial") {
+			if csharpPropertyHasExecutableBody(def.Node) {
+				csharpRecordPropertyOwnership(id, def.Node, def.StartLine, def.EndLine, src, funcBytes, funcLines, valueProps)
+			}
+			return
+		}
+		// A genuine overload: two indexers differing only by parameter
+		// list, both body-bearing. Overloaded METHODS already resolve the
+		// ID collision by suffixing the second declaration with its line;
+		// taking the same route keeps one convention instead of two. A
+		// THIRD declaration on the same line collides again and is
+		// dropped, exactly as a third same-line method overload is.
 		id = id + "_L" + fmt.Sprint(def.StartLine+1)
 	}
 	if seen[id] {
@@ -2192,7 +2216,9 @@ func (e *CSharpExtractor) emitAccessorMember(def *parser.CapturedNode, name, mem
 	// Accessor bodies and an expression body both live inside the
 	// declaration span, so recording it makes the member a call owner.
 	// An indexer's set accessor carries the implicit `value` parameter
-	// exactly as a property's does, and rides the same seed.
+	// exactly as a property's does and rides the same seed; an event's
+	// add/remove bind `value` too, but csharpSetInitAccessorSpans scans
+	// for set/init only, so events deliberately get no seed here.
 	csharpRecordPropertyOwnership(id, def.Node, def.StartLine, def.EndLine, src, funcBytes, funcLines, valueProps)
 	isIface := owner.kind == "interface_declaration"
 	defaultVis := VisibilityPrivate

--- a/internal/parser/languages/csharp_indexer_event_owners_test.go
+++ b/internal/parser/languages/csharp_indexer_event_owners_test.go
@@ -1,6 +1,7 @@
 package languages
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -84,7 +85,7 @@ func TestCSharpExtractor_IndexerAndEventBodiesOwnTheirCalls(t *testing.T) {
 		}
 		for id, kind := range map[string]string{
 			"App.cs::Derrick.this[]": "indexer",
-			"App.cs::Derrick.Swing":  "event",
+			"App.cs::Derrick.Swing":  "event_accessor",
 			"App.cs::Gantry.this[]":  "indexer",
 		} {
 			n := byID[id]
@@ -133,6 +134,41 @@ func TestCSharpExtractor_OverloadedIndexersEachOwnTheirBody(t *testing.T) {
 		"the second indexer takes the line-suffixed node, as overloaded methods do")
 }
 
+// A partial indexer is NOT an overload: C# 13 splits one member across a
+// declaring fragment and an implementing one, and either may extract
+// first. Suffixing the second would leave the name-keyed ID - the one
+// anything queries - pointing at the bodyless fragment while the code
+// sat under a line-suffixed twin. The `partial` modifier separates the
+// two cases exactly, because C# requires both fragments to spell it and
+// forbids it on an overload.
+func TestCSharpExtractor_PartialIndexerMergesOntoOneMember(t *testing.T) {
+	src := []byte(`namespace App {
+    public class Hoist { public int Lift() { return 1; } }
+    public partial class Winder {
+        private Hoist _h = new Hoist();
+        public partial int this[int i] { get; }
+    }
+    public partial class Winder {
+        public partial int this[int i] { get { return _h.Lift(); } }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("App.cs", src)
+	require.NoError(t, err)
+
+	var ids []string
+	for _, n := range result.Nodes {
+		if strings.Contains(n.ID, "this[]") {
+			ids = append(ids, n.ID)
+		}
+	}
+	assert.Equal(t, []string{"App.cs::Winder.this[]"}, ids,
+		"the two fragments are one member, not a member and a line-suffixed twin")
+	assert.Len(t, callEdgesFrom(result.Edges, "App.cs::Winder.this[]", "Lift"), 1,
+		"the implementing fragment's call rides the canonical node")
+}
+
 // The extraction half of issue #728. An indexer sharing a physical line
 // with a property put the semantic tier in a bind: the indexer owned no
 // node, so the extractor's line fallback parked its body call on the
@@ -155,6 +191,10 @@ func TestCSharpExtractor_SharedLineIndexerDoesNotStealThePropertysOwnership(t *t
 	result, err := e.Extract("App.cs", src)
 	require.NoError(t, err)
 
+	// This half pins #720's byte-extent refusal, not the emission: it
+	// holds with emission disabled too, because the refusal already
+	// stopped the property collecting the call. It is the second
+	// assertion that this change makes true.
 	assert.Empty(t, callEdgesFrom(result.Edges, "App.cs::Ledge.Slot", "Lift"),
 		"a property whose body is `=> 1` can call nothing")
 	assert.Len(t, callEdgesFrom(result.Edges, "App.cs::Ledge.this[]", "Lift"), 1,

--- a/internal/parser/languages/csharp_indexer_event_owners_test.go
+++ b/internal/parser/languages/csharp_indexer_event_owners_test.go
@@ -1,0 +1,162 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Indexers and events with accessors were not emitted as nodes at all,
+// so the owner lookup could not name the member holding their accessor
+// bodies and every call in them was dropped at the funcRanges gate -
+// the same loss properties took before they recorded byte extents. Both
+// kinds now mint a member node and record their declaration span, so an
+// accessor body owns its calls the way a property accessor does.
+//
+// The indexer has no name in the grammar, so it is spelled `this[]`:
+// no legal C# identifier can collide with it, unlike the CLR metadata
+// name `Item`, which a class may genuinely declare alongside an indexer
+// under [IndexerName].
+func TestCSharpExtractor_IndexerAndEventBodiesOwnTheirCalls(t *testing.T) {
+	src := []byte(`namespace App {
+    public class Hoist {
+        public int Lift() { return 1; }
+        public void Drop(int v) { }
+        public void Bind(System.EventHandler h) { }
+        public void Free(System.EventHandler h) { }
+    }
+
+    public class Derrick {
+        private readonly Hoist _hoist = new Hoist();
+
+        public int this[int i] {
+            get { return _hoist.Lift(); }
+            set { _hoist.Drop(i); }
+        }
+
+        public event System.EventHandler Swing {
+            add { _hoist.Bind(value); }
+            remove { _hoist.Free(value); }
+        }
+
+        public int Plain() { return _hoist.Lift(); }
+    }
+
+    public class Gantry {
+        private readonly Hoist _hoist = new Hoist();
+
+        public int this[int i] => _hoist.Lift();
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("App.cs", src)
+	require.NoError(t, err)
+
+	for _, row := range []struct {
+		shape, owner, method string
+		count                int
+	}{
+		{"indexer get accessor", "App.cs::Derrick.this[]", "Lift", 1},
+		{"indexer set accessor", "App.cs::Derrick.this[]", "Drop", 1},
+		{"event add accessor", "App.cs::Derrick.Swing", "Bind", 1},
+		{"event remove accessor", "App.cs::Derrick.Swing", "Free", 1},
+		{"expression-bodied indexer", "App.cs::Gantry.this[]", "Lift", 1},
+	} {
+		t.Run(row.shape, func(t *testing.T) {
+			assert.Len(t, callEdgesFrom(result.Edges, row.owner, row.method), row.count,
+				"accessor-body call must attribute to the member that holds it")
+		})
+	}
+
+	t.Run("ordinary method control", func(t *testing.T) {
+		require.Len(t, callEdgesFrom(result.Edges, "App.cs::Derrick.Plain", "Lift"), 1,
+			"the shape that always worked must stay alive")
+	})
+
+	t.Run("members are nodes with their owner and kind", func(t *testing.T) {
+		byID := map[string]*graph.Node{}
+		for _, n := range result.Nodes {
+			byID[n.ID] = n
+		}
+		for id, kind := range map[string]string{
+			"App.cs::Derrick.this[]": "indexer",
+			"App.cs::Derrick.Swing":  "event",
+			"App.cs::Gantry.this[]":  "indexer",
+		} {
+			n := byID[id]
+			if !assert.NotNil(t, n, "member node %s must exist", id) {
+				continue
+			}
+			assert.Equal(t, graph.KindField, n.Kind, "%s rides the property-shaped member kind", id)
+			assert.Equal(t, kind, n.Meta["kind"], "%s carries its member kind", id)
+		}
+		var memberOf int
+		for _, ed := range result.Edges {
+			if ed.Kind == graph.EdgeMemberOf && ed.To == "App.cs::Derrick" &&
+				(ed.From == "App.cs::Derrick.this[]" || ed.From == "App.cs::Derrick.Swing") {
+				memberOf++
+			}
+		}
+		assert.Equal(t, 2, memberOf, "both members belong to their declaring type")
+	})
+}
+
+// Two indexers on one type differ only by parameter list, so they
+// collide on the name-keyed node ID. Overloaded METHODS already resolve
+// this by suffixing the second declaration with its line; indexers take
+// the same route rather than inventing a second convention, so each
+// overload keeps its own node and owns its own body.
+func TestCSharpExtractor_OverloadedIndexersEachOwnTheirBody(t *testing.T) {
+	src := []byte(`namespace App {
+    public class Hoist {
+        public int Lift() { return 1; }
+        public int Haul() { return 2; }
+    }
+    public class Winder {
+        private readonly Hoist _hoist = new Hoist();
+        public int this[int i] { get { return _hoist.Lift(); } }
+        public int this[string k] { get { return _hoist.Haul(); } }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("App.cs", src)
+	require.NoError(t, err)
+
+	assert.Len(t, callEdgesFrom(result.Edges, "App.cs::Winder.this[]", "Lift"), 1,
+		"the first indexer keeps the unsuffixed node")
+	assert.Len(t, callEdgesFrom(result.Edges, "App.cs::Winder.this[]_L9", "Haul"), 1,
+		"the second indexer takes the line-suffixed node, as overloaded methods do")
+}
+
+// The extraction half of issue #728. An indexer sharing a physical line
+// with a property put the semantic tier in a bind: the indexer owned no
+// node, so the extractor's line fallback parked its body call on the
+// property, and #722's caller adoption promoted that stub to a confident
+// resolved edge on a member whose entire body is `=> 1`. The byte-extent
+// refusal added in #720's revision stopped the false attribution; the
+// member node here is what turns the refusal back into a real edge.
+func TestCSharpExtractor_SharedLineIndexerDoesNotStealThePropertysOwnership(t *testing.T) {
+	src := []byte(`namespace App {
+    public class Hoist {
+        public int Lift() { return 1; }
+    }
+    public class Ledge {
+        private readonly Hoist _hoist = new Hoist();
+        public int Slot => 1; public int this[int i] { get { return _hoist.Lift(); } }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("App.cs", src)
+	require.NoError(t, err)
+
+	assert.Empty(t, callEdgesFrom(result.Edges, "App.cs::Ledge.Slot", "Lift"),
+		"a property whose body is `=> 1` can call nothing")
+	assert.Len(t, callEdgesFrom(result.Edges, "App.cs::Ledge.this[]", "Lift"), 1,
+		"the indexer sharing the line owns its own accessor call")
+}

--- a/internal/resolver/csharp_same_line_attribution_test.go
+++ b/internal/resolver/csharp_same_line_attribution_test.go
@@ -59,6 +59,11 @@ func TestResolveCSharp_SameLineMemberCallAttribution(t *testing.T) {
  public class DtorRig { private DBag _b = new DBag();
   ~DtorRig() { _b.Take(); } public int Q => 1;
  } }`, refused: true},
+		"conversion_operator_beside_property_refused": {src: `namespace App {
+ public class CBag { public int Take() { return 1; } }
+ public class ConvRig { private static CBag _b = new CBag();
+  public static implicit operator int(ConvRig r) { _b.Take(); return 1; } public int Q => 1;
+ } }`, refused: true},
 		"field_init_shares_line": {src: `namespace App {
  public class BLBag { public int Take() { return 1; } }
  public class BLInit { private BLBag _b = new BLBag();

--- a/internal/resolver/csharp_same_line_attribution_test.go
+++ b/internal/resolver/csharp_same_line_attribution_test.go
@@ -14,19 +14,21 @@ import (
 // its call BYTE-precisely, not hand it to whoever shares the line (the
 // pre-owner-widening behavior this test silently tolerated).
 //
-// A member kind still WITHOUT extents (indexer, event accessor) is the
-// hard case: its call matches no recorded extent, and the line fallback
-// answers a same-line neighbour that provably does NOT contain the call
-// - the neighbour's recorded bytes exclude the offset. Handing it the
-// call invents a false edge carrying full receiver evidence and no
-// ambiguity stamp (ambiguousAt counts ranges, and an extent-less member
-// contributes none), indistinguishable downstream from a correct edge.
-// Such calls are REFUSED instead. This deliberately trades the
-// extent-less member's recall for precision; the recall returns when
-// indexers and event accessors are emitted with extents of their own
-// (tracked follow-up). Distinct from the round-6 B3 erasure: there the
-// "" answer dropped calls whose line owner was plausible - here the
-// line owner is provably wrong.
+// A member kind WITHOUT extents is the hard case: its call matches no
+// recorded extent, and the line fallback answers a same-line neighbour
+// that provably does NOT contain the call - the neighbour's recorded
+// bytes exclude the offset. Handing it the call invents a false edge
+// carrying full receiver evidence and no ambiguity stamp (ambiguousAt
+// counts ranges, and an extent-less member contributes none),
+// indistinguishable downstream from a correct edge. Such calls are
+// REFUSED instead, trading that member's recall for precision. Distinct
+// from the round-6 B3 erasure: there the "" answer dropped calls whose
+// line owner was plausible - here the line owner is provably wrong.
+//
+// Indexers and event accessors were the original refused kinds; they now
+// carry extents of their own, so the trade is off for them and they own
+// their calls outright. Operators, conversion operators and destructors
+// are still unemitted, and hold the refusal arm under test.
 func TestResolveCSharp_SameLineMemberCallAttribution(t *testing.T) {
 	cases := map[string]struct {
 		src     string
@@ -39,10 +41,23 @@ func TestResolveCSharp_SameLineMemberCallAttribution(t *testing.T) {
  public class BLProp { private BLBag _b = new BLBag();
   public int Q => _b.Take(); public void M() { }
  } }`, owner: "X.cs::BLProp.Q"},
-		"indexer_beside_method_refused": {src: `namespace App {
+		"indexer_beside_method_owns_its_call": {src: `namespace App {
  public class BLBag { public int Take() { return 1; } }
  public class BLIdx { private BLBag _b = new BLBag();
   public int this[int i] => _b.Take(); public void M() { }
+ } }`, owner: "X.cs::BLIdx.this[]"},
+		// Operators and destructors record no extents, so the refusal arm
+		// still governs them: the line answer is a member whose own bytes
+		// exclude the call, and a false edge there is worse than the drop.
+		"operator_beside_property_refused": {src: `namespace App {
+ public class OBag { public int Take() { return 1; } }
+ public class OpRig { private static OBag _b = new OBag();
+  public static OpRig operator +(OpRig a, OpRig b) { _b.Take(); return a; } public int Q => 1;
+ } }`, refused: true},
+		"destructor_beside_property_refused": {src: `namespace App {
+ public class DBag { public int Take() { return 1; } }
+ public class DtorRig { private DBag _b = new DBag();
+  ~DtorRig() { _b.Take(); } public int Q => 1;
  } }`, refused: true},
 		"field_init_shares_line": {src: `namespace App {
  public class BLBag { public int Take() { return 1; } }
@@ -54,24 +69,26 @@ func TestResolveCSharp_SameLineMemberCallAttribution(t *testing.T) {
  public class BLCtor { private BLBag _b = new BLBag();
   public BLCtor() { } public int Q => _b.Take();
  } }`, owner: "X.cs::BLCtor.Q"},
-		// The two shapes below are NEW false-edge populations opened by
-		// the owner widening itself: the base emitted nothing for them,
-		// while widened properties made a wrong owner available.
-		"indexer_beside_property_refused": {src: `namespace App {
+		// The two shapes below were the false-edge populations opened by
+		// the owner widening itself - the base emitted nothing for them,
+		// while widened properties made a wrong owner available. Issue
+		// #728 is exactly this pair reaching the semantic tier, where
+		// caller adoption turned the stub into a confident resolved edge.
+		"indexer_beside_property_owns_its_call": {src: `namespace App {
  public class QBag { public int Idx() { return 1; } public int Pro() { return 2; } }
  public class Q01 { private QBag _b = new QBag();
   public int this[int i] => _b.Idx(); public int Q => _b.Pro();
- } }`, call: "Idx", refused: true},
+ } }`, call: "Idx", owner: "X.cs::Q01.this[]"},
 		"indexer_beside_property_neighbour_keeps_own": {src: `namespace App {
  public class QBag { public int Idx() { return 1; } public int Pro() { return 2; } }
  public class Q01 { private QBag _b = new QBag();
   public int this[int i] => _b.Idx(); public int Q => _b.Pro();
  } }`, call: "Pro", owner: "X.cs::Q01.Q"},
-		"event_accessor_beside_property_refused": {src: `namespace App {
+		"event_accessor_beside_property_owns_its_call": {src: `namespace App {
  public class QBag { public int Ev() { return 1; } public int Pro() { return 2; } }
  public class Q03 { private QBag _b = new QBag();
   public event System.EventHandler E { add { _b.Ev(); } remove { } } public int Q => _b.Pro();
- } }`, call: "Ev", refused: true},
+ } }`, call: "Ev", owner: "X.cs::Q03.E"},
 		"event_accessor_beside_property_neighbour_keeps_own": {src: `namespace App {
  public class QBag { public int Ev() { return 1; } public int Pro() { return 2; } }
  public class Q03 { private QBag _b = new QBag();

--- a/internal/semantic/tstypes/csharp_indexer_event_attribution_test.go
+++ b/internal/semantic/tstypes/csharp_indexer_event_attribution_test.go
@@ -1,0 +1,78 @@
+package tstypes
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Issue #728. An indexer or an accessor-bearing event holds executable
+// code but used to own no node, so the extractor's line fallback parked
+// its body call on whatever member covered the physical line - a
+// same-line property - and caller adoption promoted that stub to a
+// confident resolved edge. The property in these fixtures is
+// `public int Slot => 1`: its entire body is a literal, so any call edge
+// leaving it is false by construction.
+//
+// The trigger is specifically a FIELD-KIND neighbour. Pair the indexer
+// with a method instead and line containment finds the method either
+// way, which is why a method-neighbour fixture shows nothing.
+//
+// Both halves are asserted per shape: the call lands on the member that
+// authored it, and the neighbour carries nothing.
+func TestCSharp_IndexerAndEventBodyCallsResolveFromTheirOwnMember(t *testing.T) {
+	for _, tc := range []struct {
+		name, member, body string
+	}{
+		{
+			name:   "indexer beside property",
+			member: "this[]",
+			body:   "public int Slot => 1; public int this[int i] { get { worker.Run(); return 1; } }",
+		},
+		{
+			name:   "event accessor beside property",
+			member: "Ev",
+			body:   "public int Slot => 1; public event System.EventHandler Ev { add { worker.Run(); } remove { } }",
+		},
+		{
+			name:   "indexer alone on its line",
+			member: "this[]",
+			body:   "public int this[int i] { get { worker.Run(); return 1; } }",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g, dir := buildFixture(t, map[string]string{
+				"A/Svc.cs": csSvc,
+				"B/App.cs": `namespace B {
+    public class App {
+        private Svc worker;
+        ` + tc.body + `
+    }
+}
+`,
+			})
+			p := NewProvider(CSharpSpec(), zap.NewNop())
+			if _, err := p.Enrich(g, dir); err != nil {
+				t.Fatal(err)
+			}
+			run := nodeByNameKind(t, g, "Run", graph.KindMethod)
+			member := nodeByNameKind(t, g, tc.member, graph.KindField)
+			if e := callEdgeTo(g, member.ID, run.ID); e == nil {
+				t.Fatalf("body call not resolved from %s; edges: %v", tc.member, g.GetOutEdges(member.ID))
+			} else {
+				assertASTProvenance(t, e, "csharp-types")
+			}
+			for _, e := range g.AllEdges() {
+				if e == nil || e.Kind != graph.EdgeCalls {
+					continue
+				}
+				if e.From != member.ID {
+					t.Errorf("call edge from %s: a member that authored no call must carry none (to %s, conf %.2f)",
+						e.From, e.To, e.Confidence)
+				}
+			}
+		})
+	}
+}

--- a/internal/semantic/tstypes/csharp_indexer_event_attribution_test.go
+++ b/internal/semantic/tstypes/csharp_indexer_event_attribution_test.go
@@ -64,13 +64,18 @@ func TestCSharp_IndexerAndEventBodyCallsResolveFromTheirOwnMember(t *testing.T) 
 			} else {
 				assertASTProvenance(t, e, "csharp-types")
 			}
+			// Scoped to edges reaching Run: the false edge #728 minted was
+			// a SECOND caller for this one authored site. Asserting over
+			// every call edge in the graph would pin that too, but would
+			// also break on any unrelated future extractor gain in the
+			// fixture, which is not what this test is for.
 			for _, e := range g.AllEdges() {
-				if e == nil || e.Kind != graph.EdgeCalls {
+				if e == nil || e.Kind != graph.EdgeCalls || e.To != run.ID {
 					continue
 				}
 				if e.From != member.ID {
-					t.Errorf("call edge from %s: a member that authored no call must carry none (to %s, conf %.2f)",
-						e.From, e.To, e.Confidence)
+					t.Errorf("call to Run attributed to %s: only the member that authored it may carry it (conf %.2f)",
+						e.From, e.Confidence)
 				}
 			}
 		})

--- a/internal/semantic/tstypes/engine.go
+++ b/internal/semantic/tstypes/engine.go
@@ -1150,11 +1150,18 @@ func (a *applier) applyCall(idx *fileIndex, cf callFact, res *semantic.EnrichRes
 	// that used to surface as a harmless unresolved stub surfaces here as
 	// a confident resolved edge instead: issue #728 caught an indexer's
 	// body call parked on a same-line property, promoted to
-	// ast_resolved/0.95 on a member whose whole body was `=> 1`. The
-	// extractor holds up its end two ways - it refuses a call whose line
-	// owner's recorded bytes provably exclude the offset, and every member
-	// kind that can hold executable code records extents of its own -
-	// so anyone widening the extractor's owner set must keep both.
+	// ast_resolved/0.95 on a member whose whole body was `=> 1`.
+	//
+	// Two different things hold that end up, and they cover different
+	// kinds. The accessor-bearing members (property, indexer, event with
+	// add/remove) record byte extents, so they own their calls outright.
+	// The kinds that still record NONE - operator, conversion operator,
+	// destructor - are held only by the extractor REFUSING a call whose
+	// line owner's recorded bytes provably exclude the offset. That
+	// refusal is what turns their attribution defect into a dropped edge
+	// rather than a confident wrong one. So: giving one of those kinds a
+	// node without giving it extents in the same change re-opens #728,
+	// because adoption would start trusting a line fallback again.
 	var caller *graph.Node
 	owners := idx.stubOwnersAt(cf.line, cf.method)
 	switch len(owners) {

--- a/internal/semantic/tstypes/engine.go
+++ b/internal/semantic/tstypes/engine.go
@@ -1143,6 +1143,18 @@ func (a *applier) applyCall(idx *fileIndex, cf callFact, res *semantic.EnrichRes
 	// collects a call it did not author (it has no stub to claim, so it
 	// would mint), and when no tied owner contains the line the site is
 	// refused outright.
+	//
+	// Adoption couples this tier's precision to extraction's attribution
+	// accuracy, and that trade is only sound where extraction is
+	// byte-precise for the owner kind in question. An attribution defect
+	// that used to surface as a harmless unresolved stub surfaces here as
+	// a confident resolved edge instead: issue #728 caught an indexer's
+	// body call parked on a same-line property, promoted to
+	// ast_resolved/0.95 on a member whose whole body was `=> 1`. The
+	// extractor holds up its end two ways - it refuses a call whose line
+	// owner's recorded bytes provably exclude the offset, and every member
+	// kind that can hold executable code records extents of its own -
+	// so anyone widening the extractor's owner set must keep both.
 	var caller *graph.Node
 	owners := idx.stubOwnersAt(cf.line, cf.method)
 	switch len(owners) {


### PR DESCRIPTION
Closes #728. Your mechanism description is exactly right - adoption does promote an extraction-attribution defect into a confident edge - so one thing worth saying up front, because it changes what this PR is.

## On main the symptom is already a silent drop, not a false edge

Both revisions in your table predate the byte-extent refusal that landed as the last commit of #720's round-2 revision (`cb0d09fa`), and neither is an ancestor of main. Reproduced your fixture at `6be528ef` verbatim: `B/App.cs::App.Slot -> A/Svc.cs::Svc.Run`, conf 0.95, `EdgesConfirmed 1`. Same fixture at `d0433b26`: no call edge at all, from any member, at any confidence.

So the guard you asked for as option (a) on #720 already downgraded this from a false edge to a recall loss. `enclosingAt` falls back to the line answer for kinds that record no extents, and refuses when the line answer's own bytes exclude the offset - exactly the property-beside-indexer shape. The false 0.95 edge stopped, and the indexer's real call went in the bin with it. Your root fix is the half that was still missing, and that is what this is.

## The root fix

Indexers and accessor-bearing events now mint a member node and record their declaration span, so the owner lookup names them and their accessor bodies own their calls.

They ride `KindField` with a `kind` stamp, the shape properties already use. `csharpOwnerRanges` was written to widen the call-owner set with extent-carrying field-kind members, so no new node kind is introduced.

That was a deliberate call against `KindMethod`, and I think the argument is stronger than "smaller blast radius". `csharp_iface_dispatch.go:210` seeds dispatch families from `KindMethod` + `iface_member`, so an interface `this[]` as a method would fan out to every implementation's `this[]`. And nothing can ever call an indexer: `element_access` appears nowhere in the extractor, so no call or reference edge can target one. As a method it would sit in betweenness and the process rollups as a permanently orphan callable. The real cost of `KindField` - invisibility to rollups that filter to function/method - is pre-existing for properties since #720 and is better fixed there, for both, than pre-empted with a kind here.

Two naming calls worth your eye:

- The indexer is spelled `this[]`. The grammar gives it no name, and the CLR metadata name `Item` is unsafe: `[IndexerName]` lets a type spell the indexer one way and still declare an unrelated member called `Item`, so borrowing it would fuse two distinct members onto one node. `this[]` cannot collide with any legal C# identifier.
- The event stamp is `event_accessor`, not `event`. This arm sees only the accessor-bearing form; the field form (`event T E;`) is a different grammar node and stays unemitted, so a stamp spelled `event` would promise a type's events and deliver a biased minority of them. It would also collide in string value with `graph.KindEvent`, which already means an observability topic.

Partial members are merged, not suffixed. A C# 13 partial indexer splits across a declaring and an implementing fragment; properties already merge these, and indexers now do too, discriminated on the `partial` modifier (C# requires both fragments to spell it and forbids it on an overload). A genuine overload still takes the `_L<line>` suffix, as overloaded methods do - and a THIRD same-line overload is still dropped, exactly as a third same-line method overload is.

## What this PR does not fix, stated plainly

Five member kinds emit no node and lose every body call. This fixes the two you named. Operators, conversion operators and destructors are left, because they are method-shaped rather than accessor-shaped and whether they become callables - and what `operator +` is even named - is a design question that is yours, not mine to settle unilaterally.

They are not silently left. The refusal guard means they lose recall rather than mint false edges, all three now hold the refusal arm under test in the same-line attribution test, and reverting that guard shows the #728 mechanism still live for them: the operator's body call lands on `OpRig.Q`, a property whose body is `=> 1`. Say the word and they follow in the same shape.

Also unemitted: `event T E;`. It holds no accessor body, but it CAN carry an initializer with real code (`= (s,e) => { _h.Lift(); };`), and that call is dropped today - I checked. Recall gap, no false-edge risk, disclosed rather than fixed here.

## Consumer sweep

Two consumers key on the `kind` stamp and both filter positively, so neither picks the new members up: DbSet detection (`kind != "property"`) and `isTraitNode` (`kind == "trait"`).

Two things the "no new kind" reasoning does not cover on its own, so naming them:

- `analyze constructors-missing-fields` asked which of a type's members an instantiation site left unset, over every field-kind member. An indexer needs an index argument and an event is reachable only through `+=`/`-=`, so neither can ever be set at construction and both would have been reported missing at every site forever. Excluded in this PR.
- An accessor-form event name now joins its type's field-name set in `csharpFieldNamesByType`, so a bare `Manual += h;` mints a Writes edge that did not exist before, which then binds through the name-keyed passes in `resolveFieldRef`. The behaviour is correct - an `+=` on an event genuinely is a write - and the population is small because the common field form still emits nothing, but it is a new edge population and you should see it flagged rather than discover it.

Interface indexers and events are NOT added to `ifaceMethods`, so structural implements-inference still verifies only method names and dead-code exemption still skips them. That asymmetry is pre-existing (they had no nodes at all before), and wiring them into a list named "methods" changes interface-contract semantics for dispatch and dead code, which felt like the wrong thing to do quietly inside a recall fix. Flagging it rather than acting on it.

Smaller, disclosed: `this[]` is a guaranteed dead-code candidate under the opt-in `IncludeFields` path, being unreferenceable by construction; and it contributes no FTS token, since the tokenizer flushes on brackets and `this` is a stop word, so indexers are findable by qualname and path but not by name.

## Evidence

- Full parser / resolver / indexer / semantic / mcp suites: fail-name sets byte-identical to clean-`d0433b26` Windows controls, whole-tree as well as per-package (264 names either way).
- Every new pin verified red under the exact revert. Disabling the two emission arms takes all four extraction tests, the resolver attribution test and the three-shape semantic test red together. Disabling the refusal guard takes the operator, conversion-operator and destructor cases red on their own, so the guard stays pinned by the kinds that still need it. One half of one assertion is a guard pin rather than a pin on this change, and says so in place.
- On my counted C# fixture repo, a new round disarms AC19 / AC20 / AC21 (armed at `gap_expect_count 0` since round 25) and adds eight cells: the issue-728 layout itself, count-positive on both sides so a re-parked call shows up twice; the overload pair; the event's add and remove halves split by target; the partial-fragment merge; and the operator remainder, armed. A/B on two cold labs, base vintage against this branch: 8 cells flip FAIL to PASS, the standing 11 unchanged either way. Fixtures compile-checked under Roslyn, 0 errors 0 warnings.

Salt csharp@20. Note the three-way: #734 and #735 still carry @19, which #732 took on merge, so whichever of us lands next renumbers.
