### PR TITLE
perf(tstypes): memoize stubOwnersAt and snapshot call stubs only where they are read

### DIFF
--- a/internal/semantic/tstypes/csharp_adopt_shapes_test.go
+++ b/internal/semantic/tstypes/csharp_adopt_shapes_test.go
@@ -171,8 +171,18 @@ func TestCSharpAdopt_AlreadyResolvedAccessorStubIsConfirmed(t *testing.T) {
 	}
 }
 
-// Two authored calls of the SAME name on one line from the SAME owner —
-// two stubs, one owner. stubOwnerAt must not read the repeat as a tie.
+// Two authored calls of the SAME trailing name on one line from the SAME
+// owner — two stubs, one owner. stubOwnersAt must not read the repeat as
+// a tie: without the owner dedupe the duplicate looks like a multi-owner
+// tie, and a property owner cannot win the containment tie-break (it is
+// not in idx.funcs), so the call would be dropped outright.
+//
+// Two same-name MEMBER calls cannot produce the shape — they stub to the
+// same target (unresolved::*.Run) and collapse into one edge under the
+// graph's (From, To, Kind, FilePath, Line) edge key. The receiverless
+// form stubs to a DIFFERENT id (unresolved::Run) with the same trailing
+// name, so member + receiverless is the minimal two-stub fixture; the
+// precondition below keeps it honest.
 func TestCSharpAdopt_SameOwnerTwoSameNameCallsOnOneLine(t *testing.T) {
 	g, dir := buildFixture(t, map[string]string{
 		"A/Svc.cs": csSvc,
@@ -181,17 +191,20 @@ func TestCSharpAdopt_SameOwnerTwoSameNameCallsOnOneLine(t *testing.T) {
         private Svc worker;
 
         public int Tick {
-            get { worker.Run(); worker.Run(); return 1; }
+            get { worker.Run(); Run(); return 1; }
         }
     }
 }
 `,
 	})
+	tick := nodeByNameKind(t, g, "Tick", graph.KindField)
+	if stubs := callEdgesNamed(g, tick.ID, "Run"); len(stubs) != 2 {
+		t.Fatalf("fixture precondition: want 2 extracted Run stubs on the property, got %d: %v", len(stubs), stubs)
+	}
 	p := NewProvider(CSharpSpec(), zap.NewNop())
 	if _, err := p.Enrich(g, dir); err != nil {
 		t.Fatal(err)
 	}
-	tick := nodeByNameKind(t, g, "Tick", graph.KindField)
 	run := nodeByNameKind(t, g, "Run", graph.KindMethod)
 	e := callEdgeTo(g, tick.ID, run.ID)
 	if e == nil {

--- a/internal/semantic/tstypes/engine.go
+++ b/internal/semantic/tstypes/engine.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -608,6 +609,11 @@ type fileIndex struct {
 	// the fact spool keys one row per (class, file), so no other file's
 	// apply can have disturbed this file's calls-edges first.
 	stubsByLine map[int][]stubRef
+	// stubOwners memoizes stubOwnersAt by (line, authored name). Every
+	// call fact on a line asks the same question, so without this the
+	// per-fact scan is quadratic in the sites sharing one physical line
+	// (a generated single-line class body made Enrich 49x slower).
+	stubOwners map[string][]*graph.Node
 }
 
 // stubRef is one snapshotted calls-edge under stubsByLine: the owning
@@ -622,22 +628,26 @@ type stubRef struct {
 // of the given trailing name at line — the callers the extractor already
 // attributed sites there to.
 func (idx *fileIndex) stubOwnersAt(line int, method string) []*graph.Node {
+	key := strconv.Itoa(line) + "\x00" + method
+	if owners, ok := idx.stubOwners[key]; ok {
+		return owners
+	}
 	var owners []*graph.Node
+	seen := make(map[string]struct{})
 	for _, s := range idx.stubsByLine[line] {
 		if !trailingNameMatches(s.to, method) {
 			continue
 		}
-		seen := false
-		for _, o := range owners {
-			if o.ID == s.owner.ID {
-				seen = true
-				break
-			}
+		if _, dup := seen[s.owner.ID]; dup {
+			continue
 		}
-		if !seen {
-			owners = append(owners, s.owner)
-		}
+		seen[s.owner.ID] = struct{}{}
+		owners = append(owners, s.owner)
 	}
+	if idx.stubOwners == nil {
+		idx.stubOwners = make(map[string][]*graph.Node)
+	}
+	idx.stubOwners[key] = owners
 	return owners
 }
 
@@ -647,6 +657,7 @@ func (a *applier) buildIndex(facts *fileFacts) *fileIndex {
 		imports:     make(map[string]string, len(facts.imports)),
 		types:       make(map[string]*graph.Node),
 		stubsByLine: make(map[int][]stubRef),
+		stubOwners:  make(map[string][]*graph.Node),
 	}
 	idx.superTypes = idx.types
 	superKinds := a.supertypeKinds()

--- a/internal/semantic/tstypes/engine.go
+++ b/internal/semantic/tstypes/engine.go
@@ -669,6 +669,13 @@ func (a *applier) buildIndex(facts *fileFacts) *fileIndex {
 			idx.imports[imp.Local] = imp.Path
 		}
 	}
+	// stubsByLine is read by applyCall alone, but buildIndex runs in
+	// EVERY apply phase — supers, metas, aliases and calls all reach it
+	// through preparePage, and applyAll builds it once per file whether
+	// or not the file has call facts. Snapshot only when this file's
+	// facts can ever ask: on a mixed corpus half the admitted stubs were
+	// built for phases that never read them (issue #729 item 2).
+	snapshotStubs := len(facts.calls) > 0
 	for _, n := range a.fileNodes(facts.file) {
 		if receiverTypeKinds[n.Kind] {
 			if _, dup := idx.types[n.Name]; !dup {
@@ -683,7 +690,7 @@ func (a *applier) buildIndex(facts *fileFacts) *fileIndex {
 		if n.Kind == graph.KindFunction || n.Kind == graph.KindMethod {
 			idx.funcs = append(idx.funcs, n)
 		}
-		if n.Kind == graph.KindFile {
+		if !snapshotStubs || n.Kind == graph.KindFile {
 			// Some languages park top-level calls on the file node; it is
 			// never an adoptable caller (and the paged compatibility
 			// branch loads file nodes a kind-filtered store would not).

--- a/internal/semantic/tstypes/engine_stub_owners_bench_test.go
+++ b/internal/semantic/tstypes/engine_stub_owners_bench_test.go
@@ -1,0 +1,49 @@
+package tstypes
+
+// Cost-shape benchmark for issue #729: stubOwnersAt runs once per
+// surviving call fact, and every fact on a physical line asks the same
+// (line, name) question. A class whose whole body sits on ONE line —
+// generated and minified C# does this — therefore concentrates N call
+// sites on a single stubsByLine bucket, and without the memo the
+// per-fact owner scan grows super-quadratically with N (49x over the
+// pre-adoption base at N=1600). Run with -benchtime=1x across the
+// member counts to see the growth shape; the fix restores clean
+// doubling.
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func BenchmarkEnrichSingleLineClassBody(b *testing.B) {
+	for _, members := range []int{200, 400, 800} {
+		b.Run(fmt.Sprintf("members=%d", members), func(b *testing.B) {
+			var body strings.Builder
+			body.WriteString("namespace B {\n    public class App {\n        private Svc worker;\n        ")
+			for i := 0; i < members; i++ {
+				fmt.Fprintf(&body, "public int M%d() { worker.Run(); return 1; } ", i)
+			}
+			body.WriteString("\n    }\n}\n")
+			files := map[string]string{
+				"A/Svc.cs": csSvc,
+				"B/App.cs": body.String(),
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				// Enrich mutates the graph, so each iteration pays for a
+				// fresh extraction — outside the timer.
+				b.StopTimer()
+				g, dir := buildFixture(b, files)
+				p := NewProvider(CSharpSpec(), zap.NewNop())
+				b.StartTimer()
+				if _, err := p.Enrich(g, dir); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/internal/semantic/tstypes/engine_stub_snapshot_test.go
+++ b/internal/semantic/tstypes/engine_stub_snapshot_test.go
@@ -1,0 +1,62 @@
+package tstypes
+
+// Unit pins for buildIndex's stub-snapshot admission (issue #729 items
+// 2 and 3): the calls-facts gate that keeps the snapshot out of the
+// phases that never read it, and the Line == 0 skip that keeps lineless
+// edges out of a line-keyed map.
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// stubSnapshotApplier builds a one-node, one-edge graph and an applier
+// with its adjacency preloaded, returning the applier and the owner
+// node's span so each pin can shape it.
+func stubSnapshotApplier(t *testing.T, startLine, endLine, edgeLine int) *applier {
+	t.Helper()
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID: "X.cs::App.Tick", Name: "Tick", Kind: graph.KindField,
+		FilePath: "X.cs", StartLine: startLine, EndLine: endLine,
+	})
+	g.AddEdge(&graph.Edge{
+		From: "X.cs::App.Tick", To: "unresolved::*.Run",
+		Kind: graph.EdgeCalls, FilePath: "X.cs", Line: edgeLine,
+	})
+	return newApplier(g, CSharpSpec(), "csharp-types")
+}
+
+// stubsByLine is read by applyCall alone, so buildIndex snapshots it
+// only for files whose facts carry calls — every other phase/file
+// combination built a map nothing could ever read.
+func TestBuildIndex_SnapshotsStubsOnlyForFilesWithCallFacts(t *testing.T) {
+	withCalls := &fileFacts{file: "X.cs", calls: []callFact{{line: 4, method: "Run"}}}
+	a := stubSnapshotApplier(t, 3, 5, 4)
+	a.preload([]*fileFacts{withCalls})
+	if idx := a.buildIndex(withCalls); len(idx.stubsByLine[4]) != 1 {
+		t.Errorf("calls-carrying file lost its stub snapshot: %v", idx.stubsByLine)
+	}
+
+	withoutCalls := &fileFacts{file: "X.cs"}
+	a = stubSnapshotApplier(t, 3, 5, 4)
+	a.preload([]*fileFacts{withoutCalls})
+	if idx := a.buildIndex(withoutCalls); len(idx.stubsByLine) != 0 {
+		t.Errorf("file with no call facts built a stub snapshot nothing reads: %v", idx.stubsByLine)
+	}
+}
+
+// The Line == 0 skip: an edge with no line evidence must not enter the
+// line-keyed snapshot. For any owner with a real span the extent guard
+// below it also rejects Line 0, but an owner whose span was never set
+// (StartLine == EndLine == 0) admits it — the skip is what keeps a
+// lineless edge from becoming an owner claim at "line 0".
+func TestBuildIndex_LinelessStubNotAdmitted(t *testing.T) {
+	facts := &fileFacts{file: "X.cs", calls: []callFact{{line: 0, method: "Run"}}}
+	a := stubSnapshotApplier(t, 0, 0, 0)
+	a.preload([]*fileFacts{facts})
+	if idx := a.buildIndex(facts); len(idx.stubsByLine) != 0 {
+		t.Errorf("lineless calls-edge admitted to the stub snapshot: %v", idx.stubsByLine)
+	}
+}

--- a/internal/semantic/tstypes/harness_test.go
+++ b/internal/semantic/tstypes/harness_test.go
@@ -14,8 +14,9 @@ import (
 // buildFixture writes the fixture files under a temp dir, indexes them
 // with the real per-language extractors (so the graph carries the
 // exact node-ID and unresolved-edge conventions the daemon's index
-// produces), and returns the graph plus the repo root.
-func buildFixture(t *testing.T, files map[string]string) (*graph.Graph, string) {
+// produces), and returns the graph plus the repo root. testing.TB so
+// benchmarks can build the same fixtures.
+func buildFixture(t testing.TB, files map[string]string) (*graph.Graph, string) {
 	t.Helper()
 	dir := t.TempDir()
 	g := graph.New()


### PR DESCRIPTION
Closes #729. All three items, in three commits; item 1 is your patch applied as prescribed.

## 1. `stubOwnersAt` memo + map dedupe (your patch, verbatim)

The diff from the issue applied cleanly: per-`(line, "\x00", name)` memo on `fileIndex`, owner dedupe through a `seen` map, `stubOwners` initialised in the `buildIndex` literal (the lazy-init guard kept for unit-constructed indexes), `strconv` imported.

Reproduced the cliff at current main before patching, with the committed `BenchmarkEnrichSingleLineClassBody` (your fixture shape: one class body on one physical line, N members calling one method on one typed field):

| members | main (`d0433b26`) | patched | 
|---|---|---|
| 200 | 16.4 ms | 10.5 ms |
| 400 | 60.8 ms | 15.9 ms |
| 800 | 445 ms | 30.4 ms |

Clean doubling restored, matching your restored-base numbers. One measurement note, same shape as #728: `903b520b` and `6be528ef` are not ancestors of main, but unlike #728 the symptom is fully live at HEAD - the quadratic loop merged with #722 and the cliff reproduces on main exactly as the issue describes.

## 2. Snapshot gated to files carrying call facts

`buildIndex` now skips the stub-snapshot loop when `len(facts.calls) == 0`. Since `pageClass` decodes exactly one fact class per phase, the supers/metas/aliases phases always see empty `facts.calls`, so in the paged driver this removes every dead snapshot, not just half; `applyAll` skips files with no call facts. On a 41-file mixed corpus here (every file carrying supers + metas + calls) it recovered ~433 allocs/op and ~55 KB/op through `Provider.Enrich`; your denser corpus's 8,478 allocs/op is the better headline number.

`TestBuildIndex_SnapshotsStubsOnlyForFilesWithCallFacts` pins the gate in both directions (verified red under exact revert).

## 3. The dedupe is now really pinned, and the `Line == 0` skip too

You were right that `TestCSharpAdopt_SameOwnerTwoSameNameCallsOnOneLine` never reached the loop - and the reason is structural: two same-name MEMBER calls both stub to `unresolved::*.Run` and collapse into one edge under the graph's `(From, To, Kind, FilePath, Line)` key, so no member-only fixture can produce the two-stub shape. The repaired fixture pairs the member form with the receiverless form (`unresolved::Run`): distinct target ids, same trailing name, same owner, same line. The test now asserts the two-stub precondition on the extracted graph so it cannot rot silently again, and it goes red under exact removal of the dedupe - the duplicate owner reads as a multi-owner tie, which a property owner cannot win (not in `idx.funcs`), and the call is dropped.

For the `e.Line == 0` skip I took the pin option rather than the drop: for any owner with a real span the extent guard indeed dominates, but an owner whose span was never set (`StartLine == EndLine == 0`) admits line 0 through both extent comparisons, and the skip is the only thing keeping a lineless edge from becoming an owner claim at "line 0". `TestBuildIndex_LinelessStubNotAdmitted` pins exactly that shape (also verified red under removal of the skip).

## Verification

- `./internal/semantic/tstypes` green (179 tests); full `./internal/semantic/...` green apart from the pre-existing Windows LSP path/URI names.
- Whole-tree Windows fail-name set diffed against a clean-main control at `d0433b26`: 199 names on branch vs 198 on control, the one differing name (`internal/eval` `TestHealthEndpoint`) fails identically on clean main when run in isolation - a pre-existing nondeterministic test, not this change.
- All three pins verified red under exact revert of the code they pin, green at HEAD.
- My counted C# fixture repo's acceptance battery, cold-lab indexed twice over the same fixture state - once with a clean-main build, once with this branch: the full probe outputs are byte-identical apart from the store-path header (same cells, same resolved targets, same confidences). Behavior-neutral end to end.
- No extraction change, so no salt or extractor-version bump; no store-format or wire-surface change.
