### PR TITLE
fix(tstypes): break a same-line stub-owner tie by the fact's own author

### DIFF
--- a/internal/semantic/tstypes/csharp.go
+++ b/internal/semantic/tstypes/csharp.go
@@ -45,8 +45,9 @@ func CSharpSpec() *LangSpec {
 			}
 			return ""
 		},
-		LocalBinding: csharpLocalBinding,
-		Call:         csharpCall,
+		LocalBinding:   csharpLocalBinding,
+		MemberDeclName: csharpMemberDeclName,
+		Call:           csharpCall,
 		NewExprType: func(n *sitter.Node, src []byte) string {
 			if n.Type() != "object_creation_expression" {
 				return ""
@@ -224,4 +225,46 @@ func csharpCall(n *sitter.Node, src []byte) (*sitter.Node, string, bool) {
 	// A `this` receiver needs no special case: its content matches
 	// SelfName, so it resolves against the enclosing type.
 	return obj, fieldText(fn, "name", src), true
+}
+
+// csharpMemberDeclName spells the authoring member the way the extractor
+// names its node: methods, properties and accessor events by identifier,
+// field declarators by their own name, constructors as `<Type>.<init>`,
+// indexers as `this[]`. Local functions and lambdas are deliberately
+// absent — the extractor mints no node for them, so their calls belong to
+// the enclosing member, exactly where its stubs already sit.
+func csharpMemberDeclName(n *sitter.Node, src []byte) (string, bool) {
+	switch n.Type() {
+	case "method_declaration", "property_declaration", "event_declaration":
+		name := fieldText(n, "name", src)
+		return name, name != ""
+	case "constructor_declaration":
+		if owner := csharpEnclosingTypeName(n, src); owner != "" {
+			return owner + ".<init>", true
+		}
+	case "indexer_declaration":
+		return "this[]", true
+	case "variable_declarator":
+		// Only a FIELD's declarator owns code (its initializer); a local's
+		// declarator sits inside a member named above already.
+		if p := n.Parent(); p != nil && p.Type() == "variable_declaration" {
+			if gp := p.Parent(); gp != nil && gp.Type() == "field_declaration" {
+				name := csharpDeclaratorName(n, src)
+				return name, name != ""
+			}
+		}
+	}
+	return "", false
+}
+
+// csharpEnclosingTypeName returns the name of the nearest type
+// declaration enclosing n ("" at file scope).
+func csharpEnclosingTypeName(n *sitter.Node, src []byte) string {
+	for p := n.Parent(); p != nil; p = p.Parent() {
+		switch p.Type() {
+		case "class_declaration", "struct_declaration", "record_declaration", "interface_declaration":
+			return fieldText(p, "name", src)
+		}
+	}
+	return ""
 }

--- a/internal/semantic/tstypes/csharp_accessor_attribution_test.go
+++ b/internal/semantic/tstypes/csharp_accessor_attribution_test.go
@@ -121,10 +121,11 @@ func TestCSharp_SharedLineCallsSplitByOwner(t *testing.T) {
 }
 
 // Two properties on one line calling the SAME method: the stub lookup
-// cannot tell the owners apart by (line, name), and the engine never
-// guesses among candidates — both sites stay untouched rather than one
-// owner collecting both.
-func TestCSharp_SharedLineSameNameAmbiguityRefused(t *testing.T) {
+// cannot tell the owners apart by (line, name), but each call fact
+// names the member that authored it, so each property resolves its own
+// site onto its own stub — the engine never guesses among candidates,
+// and neither owner collects both.
+func TestCSharp_SharedLineSameNameEachOwnerResolvesItsOwn(t *testing.T) {
 	g, dir := buildFixture(t, map[string]string{
 		"A/Svc.cs": csSvc,
 		"B/App.cs": `namespace B {
@@ -139,8 +140,16 @@ func TestCSharp_SharedLineSameNameAmbiguityRefused(t *testing.T) {
 	if _, err := p.Enrich(g, dir); err != nil {
 		t.Fatal(err)
 	}
-	a1 := nodeByNameKind(t, g, "A1", graph.KindField)
-	a2 := nodeByNameKind(t, g, "A2", graph.KindField)
-	assertUntouched(t, g, a1.ID, "Run", "csharp-types")
-	assertUntouched(t, g, a2.ID, "Run", "csharp-types")
+	run := nodeByNameKind(t, g, "Run", graph.KindMethod)
+	for _, name := range []string{"A1", "A2"} {
+		prop := nodeByNameKind(t, g, name, graph.KindField)
+		if e := callEdgeTo(g, prop.ID, run.ID); e == nil {
+			t.Errorf("%s: own call not resolved; edges: %v", name, g.GetOutEdges(prop.ID))
+		} else {
+			assertASTProvenance(t, e, "csharp-types")
+		}
+		if edges := callEdgesNamed(g, prop.ID, "Run"); len(edges) != 1 {
+			t.Errorf("%s: %d Run edge(s), want exactly its own: %v", name, len(edges), edges)
+		}
+	}
 }

--- a/internal/semantic/tstypes/csharp_adopt_shapes_test.go
+++ b/internal/semantic/tstypes/csharp_adopt_shapes_test.go
@@ -3,9 +3,10 @@ package tstypes
 // Shape pins for stub adoption beyond the core four in
 // csharp_accessor_attribution_test.go: the initializer lanes, chained
 // heads, pre-resolved stubs, snapshot-hygiene guards, and the tie
-// semantics (line containment breaks a tie only WITHIN the tied owner
-// set — a callable that merely shares the line never collects a call it
-// did not author).
+// semantics (the fact's own author breaks a same-line same-name tie;
+// line containment is the fallback and breaks it only WITHIN the tied
+// owner set — a callable that merely shares the line never collects a
+// call it did not author).
 
 import (
 	"testing"
@@ -290,10 +291,11 @@ func TestCSharpAdopt_OutOfExtentSyntheticEdgeNotAdopted(t *testing.T) {
 }
 
 // The dangerous tie variant: TWO properties call the same name on a line
-// shared with a method that calls it NOT AT ALL. The tie must refuse the
-// site outright — falling back to line containment would name the
-// method, find no claimable stub, and MINT an ast_resolved edge for a
-// call the method never authored.
+// shared with a method that calls it NOT AT ALL. Each property's fact
+// names its own author, so both sites resolve onto their own stubs; the
+// method never enters — falling back to line containment would name it,
+// find no claimable stub, and MINT an ast_resolved edge for a call it
+// never authored.
 func TestCSharp_TieWithNonCandidateCallableRefusesMint(t *testing.T) {
 	g, dir := buildFixture(t, map[string]string{
 		"A/Svc.cs": csSvc,
@@ -313,15 +315,24 @@ func TestCSharp_TieWithNonCandidateCallableRefusesMint(t *testing.T) {
 	if got := callEdgesNamed(g, idle.ID, "Run"); len(got) != 0 {
 		t.Errorf("tie fallback fabricated %d Run edge(s) on a method that authored none: %v", len(got), got)
 	}
-	a1 := nodeByNameKind(t, g, "A1", graph.KindField)
-	a2 := nodeByNameKind(t, g, "A2", graph.KindField)
-	assertUntouched(t, g, a1.ID, "Run", "csharp-types")
-	assertUntouched(t, g, a2.ID, "Run", "csharp-types")
+	run := nodeByNameKind(t, g, "Run", graph.KindMethod)
+	for _, name := range []string{"A1", "A2"} {
+		prop := nodeByNameKind(t, g, name, graph.KindField)
+		if e := callEdgeTo(g, prop.ID, run.ID); e == nil {
+			t.Errorf("%s: own call not resolved on a same-name tie; edges: %v", name, g.GetOutEdges(prop.ID))
+		} else {
+			assertASTProvenance(t, e, "csharp-types")
+		}
+		if edges := callEdgesNamed(g, prop.ID, "Run"); len(edges) != 1 {
+			t.Errorf("%s: %d Run edge(s), want exactly its own: %v", name, len(edges), edges)
+		}
+	}
 }
 
-// A same-name tie where the line-containment answer IS one of the tied
-// owners: the method keeps its own call (claimed in place) and the
-// property's indistinguishable site stays untouched — never handed to a
+// A same-name tie where a property and a method call the SAME target on
+// one shared line: a tie is broken per authored fact, not once per line,
+// so each owner resolves its own site onto its own stub — the method's
+// claimed in place, the property's independently — never handed to a
 // third party, never doubled.
 func TestCSharp_SameNameTieMethodKeepsOwnCall(t *testing.T) {
 	g, dir := buildFixture(t, map[string]string{
@@ -338,17 +349,74 @@ func TestCSharp_SameNameTieMethodKeepsOwnCall(t *testing.T) {
 	if _, err := p.Enrich(g, dir); err != nil {
 		t.Fatal(err)
 	}
-	busy := nodeByNameKind(t, g, "Busy", graph.KindMethod)
 	run := nodeByNameKind(t, g, "Run", graph.KindMethod)
-	if e := callEdgeTo(g, busy.ID, run.ID); e == nil {
-		t.Errorf("method's own call lost on a same-name tie; edges: %v", g.GetOutEdges(busy.ID))
-	}
+	busy := nodeByNameKind(t, g, "Busy", graph.KindMethod)
 	quick := nodeByNameKind(t, g, "Quick", graph.KindField)
-	if edges := callEdgesNamed(g, busy.ID, "Run"); len(edges) > 1 {
-		t.Errorf("same-name tie doubled the method's edges: %v", edges)
+	for _, owner := range []*graph.Node{busy, quick} {
+		if e := callEdgeTo(g, owner.ID, run.ID); e == nil {
+			t.Errorf("%s: own call lost on a same-name tie; edges: %v", owner.Name, g.GetOutEdges(owner.ID))
+		} else {
+			assertASTProvenance(t, e, "csharp-types")
+		}
+		if edges := callEdgesNamed(g, owner.ID, "Run"); len(edges) != 1 {
+			t.Errorf("%s: %d Run edge(s), want exactly its own: %v", owner.Name, len(edges), edges)
+		}
 	}
-	if e := callEdgeTo(g, quick.ID, run.ID); e != nil {
-		t.Logf("note: property side also resolved (%v) — acceptable, but not required by the tie contract", e)
+}
+
+// The issue-730 shape: two tied owners call the same NAME on different
+// TYPES. Each fact must land on its own author's stub. Before the authored
+// owner rode on the fact, the first fact applied (the property's)
+// retargeted the METHOD's stub to the property's target — the method then
+// carried a confident edge to a type it never calls, and its real call
+// was unreachable because the edge was no longer claimable.
+func TestCSharp_SameNameTieDifferentTargets(t *testing.T) {
+	g, dir := buildFixture(t, map[string]string{
+		"Core/Engine.cs": `namespace Core {
+    public class Engine {
+        public void Fire() {}
+        public void Halt() {}
+    }
+}
+`,
+		"Core/Other.cs": `namespace Core {
+    public class Other {
+        public void Fire() {}
+    }
+}
+`,
+		"Use/Rig.cs": `namespace Use {
+    public class Rig {
+        private Engine motor; private Other pal;
+        public int Level { get { motor.Fire(); return 7; } } public void Busy() { pal.Fire(); }
+    }
+}
+`,
+	})
+	p := NewProvider(CSharpSpec(), zap.NewNop())
+	if _, err := p.Enrich(g, dir); err != nil {
+		t.Fatal(err)
+	}
+	const engineFire, otherFire = "Core/Engine.cs::Engine.Fire", "Core/Other.cs::Other.Fire"
+	busy := nodeByNameKind(t, g, "Busy", graph.KindMethod)
+	level := nodeByNameKind(t, g, "Level", graph.KindField)
+	if e := callEdgeTo(g, busy.ID, otherFire); e == nil {
+		t.Errorf("method's own call (Other.Fire) lost; edges: %v", g.GetOutEdges(busy.ID))
+	} else {
+		assertASTProvenance(t, e, "csharp-types")
+	}
+	if e := callEdgeTo(g, busy.ID, engineFire); e != nil {
+		t.Errorf("method carries the property's resolution (Engine.Fire): %v", e)
+	}
+	if e := callEdgeTo(g, level.ID, engineFire); e == nil {
+		t.Errorf("property's own call (Engine.Fire) not resolved; edges: %v", g.GetOutEdges(level.ID))
+	} else {
+		assertASTProvenance(t, e, "csharp-types")
+	}
+	for _, owner := range []*graph.Node{busy, level} {
+		if edges := callEdgesNamed(g, owner.ID, "Fire"); len(edges) != 1 {
+			t.Errorf("%s: %d Fire edge(s), want exactly its own: %v", owner.Name, len(edges), edges)
+		}
 	}
 }
 

--- a/internal/semantic/tstypes/csharp_call_owner_test.go
+++ b/internal/semantic/tstypes/csharp_call_owner_test.go
@@ -1,0 +1,96 @@
+package tstypes
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// callOwnersFor parses one C# source through the binder and returns each
+// call fact's authored owner keyed by the called method name (every site
+// in the fixture calls a distinct name).
+func callOwnersFor(t *testing.T, spec *LangSpec, src string) map[string]string {
+	t.Helper()
+	abs := filepath.Join(t.TempDir(), "App.cs")
+	if err := os.WriteFile(abs, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	facts, err := analyzeFile(spec, fileRef{node: &graph.Node{FilePath: "B/App.cs"}, absPath: abs})
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := make(map[string]string, len(facts.calls))
+	for _, cf := range facts.calls {
+		if _, dup := out[cf.method]; dup {
+			t.Fatalf("fixture calls %s twice; keep one site per name", cf.method)
+		}
+		out[cf.method] = cf.owner
+	}
+	return out
+}
+
+// One site per member shape; the callee name doubles as the case key.
+const csCallOwnerFixture = `namespace B {
+    public class App {
+        private Svc worker;
+        private Svc seed = worker.FromFieldInit();
+        public App() { worker.FromCtor(); }
+        public int Quick { get { worker.FromGetter(); return 1; } set { worker.FromSetter(); } }
+        public int Arrow => worker.FromExprProp();
+        public int this[int i] { get { worker.FromIndexer(); return i; } }
+        public event System.Action Rang { add { worker.FromEventAdd(); } remove { } }
+        public void Busy() {
+            worker.FromMethod();
+            void Inner() { worker.FromLocalFunc(); }
+            Inner();
+            System.Action a = () => worker.FromLambda();
+        }
+    }
+}
+`
+
+// The binder names, on every call fact, the member declaration that
+// authored the site — spelled exactly as the extractor names that member's
+// node, so the apply phase can pick the author out of a same-line tie.
+// Local functions and lambdas mint no node of their own, so their calls
+// stay with the enclosing member, as the extractor's stubs do.
+func TestCSharpBinder_CallFactsCarryAuthoredMember(t *testing.T) {
+	got := callOwnersFor(t, CSharpSpec(), csCallOwnerFixture)
+	want := map[string]string{
+		"FromFieldInit": "seed",
+		"FromCtor":      "App.<init>",
+		"FromGetter":    "Quick",
+		"FromSetter":    "Quick",
+		"FromExprProp":  "Arrow",
+		"FromIndexer":   "this[]",
+		"FromEventAdd":  "Rang",
+		"FromMethod":    "Busy",
+		"FromLocalFunc": "Busy",
+		"FromLambda":    "Busy",
+	}
+	for method, owner := range want {
+		if have, ok := got[method]; !ok {
+			t.Errorf("%s: no call fact recorded", method)
+		} else if have != owner {
+			t.Errorf("%s: owner = %q, want %q", method, have, owner)
+		}
+	}
+}
+
+// A spec without MemberDeclName records no owner at all — the apply
+// phase then breaks a tie exactly as before (line containment).
+func TestBinder_NoMemberDeclNameLeavesOwnerEmpty(t *testing.T) {
+	spec := CSharpSpec()
+	spec.MemberDeclName = nil
+	got := callOwnersFor(t, spec, csCallOwnerFixture)
+	if len(got) == 0 {
+		t.Fatal("fixture produced no call facts")
+	}
+	for method, owner := range got {
+		if owner != "" {
+			t.Errorf("%s: owner = %q, want empty without MemberDeclName", method, owner)
+		}
+	}
+}

--- a/internal/semantic/tstypes/engine.go
+++ b/internal/semantic/tstypes/engine.go
@@ -1125,6 +1125,29 @@ func (idx *fileIndex) enclosingCallable(line int) *graph.Node {
 	return best
 }
 
+// authoredOwner picks, out of a same-line same-name stub tie, the owner
+// the binder named as the call fact's author (LangSpec.MemberDeclName
+// spells it exactly as the extractor names the node). nil when the author
+// is unnamed, names none of the tied owners (a member the extractor mints
+// no node for), or names more than one (same-named overloads sharing a
+// line) — every one of those falls back to line containment.
+func authoredOwner(owners []*graph.Node, author string) *graph.Node {
+	if author == "" {
+		return nil
+	}
+	var match *graph.Node
+	for _, o := range owners {
+		if o.Name != author {
+			continue
+		}
+		if match != nil {
+			return nil
+		}
+		match = o
+	}
+	return match
+}
+
 // --- Call application -------------------------------------------------
 
 func (a *applier) applyCall(idx *fileIndex, cf callFact, res *semantic.EnrichResult) {
@@ -1156,11 +1179,17 @@ func (a *applier) applyCall(idx *fileIndex, cf callFact, res *semantic.EnrichRes
 	// of every edge identity). The line-keyed containment lookup stays
 	// as the fallback for sites the extractor recorded no stub for
 	// (desugared operator calls carry no authored-name stub). On a
-	// multi-owner tie, containment may still break it — but only WITHIN
-	// the tied set: a callable that merely shares the line never
-	// collects a call it did not author (it has no stub to claim, so it
-	// would mint), and when no tied owner contains the line the site is
-	// refused outright.
+	// multi-owner tie the fact's own author breaks it: the binder names
+	// the member each call sits in, spelled as the extractor names its
+	// node, so a same-line same-name tie resolves each fact onto its own
+	// owner's stub — never onto a neighbour's, whatever target that
+	// neighbour's own site resolves to. Containment breaks a tie only
+	// when the author is unnamed (a spec without MemberDeclName) or names
+	// none — or several — of the tied owners, and then only WITHIN the
+	// tied set: a callable that merely shares the line never collects a
+	// call it did not author (it has no stub to claim, so it would mint),
+	// and when no tied owner contains the line the site is refused
+	// outright.
 	//
 	// Adoption couples this tier's precision to extraction's attribution
 	// accuracy, and that trade is only sound where extraction is
@@ -1188,11 +1217,14 @@ func (a *applier) applyCall(idx *fileIndex, cf callFact, res *semantic.EnrichRes
 	case 1:
 		caller = owners[0]
 	default:
-		if enc := idx.enclosingCallable(cf.line); enc != nil {
-			for _, o := range owners {
-				if o.ID == enc.ID {
-					caller = enc
-					break
+		caller = authoredOwner(owners, cf.owner)
+		if caller == nil {
+			if enc := idx.enclosingCallable(cf.line); enc != nil {
+				for _, o := range owners {
+					if o.ID == enc.ID {
+						caller = enc
+						break
+					}
 				}
 			}
 		}

--- a/internal/semantic/tstypes/fact_spool.go
+++ b/internal/semantic/tstypes/fact_spool.go
@@ -116,6 +116,7 @@ type encodedCall struct {
 	Inferred          bool         `json:"inferred,omitempty"`
 	ArgCount          int          `json:"arg_count,omitempty"`
 	ArgKnown          bool         `json:"arg_known,omitempty"`
+	Owner             string       `json:"owner,omitempty"`
 }
 
 type encodedSuper struct {
@@ -150,6 +151,7 @@ func encodeCallFact(in *callFact) *encodedCall {
 		RecvPendingCallee: in.recvPendingCallee, RecvCallTypeArg: in.recvCallTypeArg,
 		RecvIdent: in.recvIdent, RecvChain: encodeCallFact(in.recvChain),
 		Inferred: in.inferred, ArgCount: in.argCount, ArgKnown: in.argKnown,
+		Owner: in.owner,
 	}
 }
 
@@ -162,6 +164,7 @@ func decodeCallFact(in *encodedCall) *callFact {
 		recvPendingCallee: in.RecvPendingCallee, recvCallTypeArg: in.RecvCallTypeArg,
 		recvIdent: in.RecvIdent, recvChain: decodeCallFact(in.RecvChain),
 		inferred: in.Inferred, argCount: in.ArgCount, argKnown: in.ArgKnown,
+		owner: in.Owner,
 	}
 }
 

--- a/internal/semantic/tstypes/fact_spool_partition_test.go
+++ b/internal/semantic/tstypes/fact_spool_partition_test.go
@@ -14,7 +14,7 @@ func sampleFacts() *fileFacts {
 		imports: []Import{{Local: "Sys"}},
 		supers:  []superFact{{typeName: "A", superName: "B", kind: graph.EdgeExtends, line: 1}},
 		metas:   []metaFact{{key: "return_type", value: "C", owner: "A", name: "M", line: 2}},
-		calls: []callFact{{line: 3, method: "M", recvType: "C",
+		calls: []callFact{{line: 3, method: "M", recvType: "C", owner: "Q",
 			recvChain: &callFact{line: 3, method: "N"}, argCount: 2, argKnown: true}},
 		// aliases deliberately empty — must be absent from the payload map
 	}
@@ -51,6 +51,9 @@ func TestMarshalClassPayloadsRoundTrip(t *testing.T) {
 	}
 	if len(dst.calls) != 1 || dst.calls[0].recvChain == nil || dst.calls[0].recvChain.method != "N" {
 		t.Fatalf("calls (incl. chain) lost: %+v", dst.calls)
+	}
+	if dst.calls[0].owner != "Q" {
+		t.Fatalf("authored owner lost across the spool: %+v", dst.calls[0])
 	}
 	if len(dst.aliases) != 0 {
 		t.Fatalf("aliases should stay empty: %+v", dst.aliases)

--- a/internal/semantic/tstypes/scope.go
+++ b/internal/semantic/tstypes/scope.go
@@ -65,6 +65,12 @@ type callFact struct {
 	// call's arity as unknown and never narrows an overload set by it.
 	argCount int
 	argKnown bool
+	// owner is the member declaration that authored this call site, spelled
+	// as the extractor names that member's node (LangSpec.MemberDeclName);
+	// "" when the spec names no members. The apply phase reads it for one
+	// purpose: breaking a same-line same-name stub tie in favour of the
+	// fact's own author.
+	owner string
 }
 
 // arity returns the call site's argument count, or -1 when it was not
@@ -228,6 +234,11 @@ type binder struct {
 	// declared after it — and, for Rust, fields declared on the struct
 	// while the method lives in a separate impl block.
 	fieldsByType map[string]map[string]fieldType
+	// member is the innermost member declaration the walk is inside, as
+	// LangSpec.MemberDeclName spells it; "" at type / file scope or when
+	// the spec names no members. Every call fact recorded under it carries
+	// it as its authored owner.
+	member string
 }
 
 func newBinder(spec *LangSpec, src []byte, facts *fileFacts) *binder {
@@ -286,6 +297,17 @@ func (b *binder) walk(n *sitter.Node, env *scopeEnv) {
 		return
 	}
 	t := n.Type()
+
+	// Entering a member declaration names the author of every call fact
+	// recorded beneath it; the previous author is restored on the way out,
+	// whichever branch below returns.
+	if b.spec.MemberDeclName != nil {
+		if name, ok := b.spec.MemberDeclName(n, b.src); ok {
+			prev := b.member
+			b.member = name
+			defer func() { b.member = prev }()
+		}
+	}
 
 	if b.spec.TypeDeclTypes[t] && b.spec.TypeDeclName != nil {
 		name := b.spec.TypeDeclName(n, b.src)
@@ -407,6 +429,7 @@ func (b *binder) walk(n *sitter.Node, env *scopeEnv) {
 			if cf, grounded := b.receiverFact(recv, env); grounded {
 				cf.line = nodeLine(n)
 				cf.method = method
+				cf.owner = b.member
 				if b.spec.CallArgCount != nil {
 					if c, ok := b.spec.CallArgCount(n, b.src); ok {
 						cf.argCount = c
@@ -434,6 +457,7 @@ func (b *binder) walk(n *sitter.Node, env *scopeEnv) {
 			if cf, grounded := b.receiverFact(sc.Receiver, env); grounded {
 				cf.line = nodeLine(n)
 				cf.method = sc.Method
+				cf.owner = b.member
 				b.facts.calls = append(b.facts.calls, cf)
 			}
 		}

--- a/internal/semantic/tstypes/spec.go
+++ b/internal/semantic/tstypes/spec.go
@@ -258,6 +258,18 @@ type LangSpec struct {
 	TypeDeclTypes map[string]bool
 	FuncDeclTypes map[string]bool
 
+	// MemberDeclName names the member declaration that authors every call
+	// site in n's subtree — a method, constructor, property, field
+	// declarator, indexer or event — spelled exactly as the extractor names
+	// that member's graph node, so the apply phase can pick a call fact's
+	// own author out of a same-line same-name stub tie. ok=false for any
+	// other node; a nested callable that mints no node of its own (a local
+	// function, a lambda) must answer false so its calls stay with the
+	// enclosing member, as the extractor's stubs do. nil (the default)
+	// records no author, and a tie is then broken by line containment
+	// alone, byte-for-byte as before.
+	MemberDeclName func(n *sitter.Node, src []byte) (string, bool)
+
 	// SelfName is the receiver keyword ("this", "self"); "" when the
 	// language has none.
 	SelfName string


### PR DESCRIPTION
Closes #730. Both shapes from the issue, in two commits: the arm now carries the authored fact's owner through to the claim, which is the first of the two options you named.

## What the arm was missing

The binder always knew which declaration it was walking when it recorded a call fact, but the fact carried only the line. So on a `len(owners) > 1` tie the apply phase had nothing but `enclosingCallable` to pick with, and `upgradeExistingCall` then claimed that owner's stub whichever owner had authored the fact - the retarget you observed (`Busy -> Engine.Fire 0.95`, `Level -> unresolved::*.Fire`), and the same-target variant where both facts land on the method and the property's site is never resolved on its own.

## Commit 1: the call fact names its author

`LangSpec.MemberDeclName` names the member declaration that owns every call site in its subtree, spelled exactly as the extractor names that member's graph node. The binder tracks the innermost named member across the walk and stamps it on each call fact as `owner`; the fact spool carries it (`omitempty`). A nil hook records no author, so every other language is byte-for-byte as before.

C# names methods, properties and accessor events by identifier, field declarators by their own name, constructors as `<Type>.<init>`, indexers as `this[]`. Local functions and lambdas are deliberately unnamed: the extractor mints no node for them, so their calls belong to the enclosing member, exactly where its stubs already sit. The indexer / event spellings match the nodes #738 adds; on current main they simply match nothing and fall through.

## Commit 2: the tie arm picks the author first

On a multi-owner tie, `authoredOwner` picks the tied owner whose `Name` is the fact's author. Containment stays the fallback in exactly three cases - the author is unnamed (spec without the hook), names none of the tied owners, or names several (same-named overloads sharing a line) - and it still breaks a tie only within the tied set, so the refuse-outright guarantee for a line-sharing non-candidate is unchanged. The single-owner and no-stub arms are untouched.

I did not extend the author check into the single-owner arm. A mismatch there would mean the extractor recorded no stub for the fact's own member at all, and turning that adoption into a drop trades a possible misattribution for a certain recall loss on any binder / extractor spelling disagreement; in the tie arm the same disagreement only falls back to today's behavior.

## Pins

- `TestCSharp_SameNameTieDifferentTargets` is your repro verbatim (Engine / Other / Rig, the one-line property + method): the method owns exactly one `Other.Fire`, never `Engine.Fire`; the property owns exactly one `Engine.Fire`; both ast-provenance stamped. Red on main with precisely the observed edge (`Busy -> Engine.Fire 0.95 ast_resolved`, meta still carrying `receiver_name: pal`).
- `TestCSharp_SameNameTieMethodKeepsOwnCall` now requires the property side too, exactly one edge each - the fixture you noted could not discriminate now does.
- `TestCSharp_TieWithNonCandidateCallableRefusesMint` (two properties + a non-calling method on one line) and the accessor-attribution pin formerly named `..._SharedLineSameNameAmbiguityRefused` both change contract: the two properties are no longer indistinguishable, so each resolves its own site (still exactly one edge each, still nothing on the method). The second is renamed `..._SharedLineSameNameEachOwnerResolvesItsOwn` to say what it pins.
- Binder side: every C# member shape's author (field initializer, ctor, getter, setter, expression-bodied property, indexer, event accessor, method, nested local function and lambda staying with the method), the nil-hook path recording nothing, and the spool round-trip.
- All four tie pins go red under exact revert of the arm; the binder pin and all four go red when the binder stops stamping the owner.

## Verification

- `./internal/semantic/tstypes` green (incl. the apply golden - no drift, the fixture has no tie shape); whole-tree Windows fail-name set diffed against a clean-main control at `d0433b26`: identical apart from the pre-existing nondeterministic `internal/eval` `TestHealthEndpoint` noted in #739.
- My counted C# fixture repo, two cold labs over the same fixture commit (LSP on), clean-main build vs this branch, five new cells shaped like the issue (every callee with a same-name decoy on the other type, so only receiver-type evidence can land anything): base fails the three that encode the bug - the method carries BOTH its real `lsp_resolved` target and the property's `ast_resolved` one (one authored call, two resolved edges to two types), and the two properties sit on unresolved stubs; branch passes all five, the properties' stubs claimed in place with no companion, nothing doubled. The two probe outputs differ only in those three cells.
- No extraction change, so no salt bump; the owner lives on the semantic tier's per-pass facts and is never stored.
