### PR TITLE
fix(tstypes): admit a stub inside the owner's recorded ownership span

### DIFF
--- a/internal/graph/node.go
+++ b/internal/graph/node.go
@@ -5,6 +5,22 @@ import (
 	"time"
 )
 
+// Node Meta keys shared between the extractor that writes them and the
+// tier that reads them, so both sides compile against one spelling.
+const (
+	// MetaOwnershipStartLine / MetaOwnershipEndLine carry the 1-based line
+	// span an extractor attributed a member's calls by, stamped only when
+	// that span is not contained by the node's own lines: a C# 13 partial
+	// property extracted declaring fragment first (or a property declared
+	// in both arms of an #if / #else) keeps its first declaration's lines
+	// while its calls live in the body-bearing fragment. Absent on every
+	// node whose own lines already answer. Any pass that rebases a node's
+	// lines (the Razor code-block delegation) must rebase these with them.
+	// Read by the semantic tier's stub admission guard (issue #731).
+	MetaOwnershipStartLine = "ownership_start_line"
+	MetaOwnershipEndLine   = "ownership_end_line"
+)
+
 type NodeKind string
 
 const (

--- a/internal/indexer/extractor_version.go
+++ b/internal/indexer/extractor_version.go
@@ -40,7 +40,7 @@ var extractorVersions = map[string]int{
 	//   "go": 2,
 	"c":      generatedParserProjectionPolicyVersion, // generated parser projection covers all strictly detected table sizes
 	"php":    2,                                      // class/interface inheritance now emits typed structural edges
-	"csharp": 22,                                     // repeated partial base classes dropped, chained/awaited receivers typed at the site offset (was: case-label and when-guard pattern variables scope to their switch section)
+	"csharp": 23,                                     // partial / conditionally-compiled properties carry their recorded ownership span (was: repeated partial base classes dropped, chained/awaited receivers typed at the site offset)
 	"scala":  2,                                      // explicitly instantiated generic calls emit call edges
 	"go":     3,                                      // generic instantiations are marked so indexing a func value cannot bind (was: generic calls emit call edges)
 	"cpp":    2,                                      // templated and namespace-qualified calls emit call edges

--- a/internal/indexer/extractor_version_test.go
+++ b/internal/indexer/extractor_version_test.go
@@ -229,7 +229,7 @@ func TestStaleLangsDetection(t *testing.T) {
 		}
 
 		for _, path := range []string{"src/Handler.cs", "Views/Page.razor", "Views/Page.cshtml"} {
-			want := policySalt + "|csharp@22"
+			want := policySalt + "|csharp@23"
 			if got := merkleSaltFor(path); got != want {
 				t.Errorf("C# extractor salt for %s = %q, want %q", path, got, want)
 			}

--- a/internal/parser/languages/csharp.go
+++ b/internal/parser/languages/csharp.go
@@ -735,6 +735,7 @@ func (e *CSharpExtractor) extractCSharp(filePath string, src []byte) (*parser.Ex
 	// type environments. Owner attribution runs once per local, call and
 	// type use — the sorted lookup keeps that from multiplying into an
 	// O(locals×functions) linear-scan product on member-heavy files.
+	csharpStampOwnershipSpans(result, funcLines)
 	funcRanges := newCSharpFuncLookup(csharpOwnerRanges(result, funcBytes, funcLines), funcBytes)
 
 	// Build type environments in legacy precedence, scoped per enclosing
@@ -2509,6 +2510,41 @@ func csharpOwnerRanges(result *parser.ExtractionResult, funcBytes, funcLines map
 		ranges = append(ranges, funcRange{id: n.ID, startLine: start, endLine: end})
 	}
 	return ranges
+}
+
+// csharpStampOwnershipSpans carries the recorded ownership span onto the
+// member node whenever the node's own lines do not contain it. A node is
+// minted once per id, so a C# 13 partial property extracted declaring
+// fragment first (or a property declared in both arms of an #if / #else)
+// keeps the first fragment's lines while csharpOwnerRanges owns its
+// calls by the body-bearing fragment's span - and every stub the
+// extractor parks there sits outside the node. A consumer that tests a
+// call's line against the owner's extent (the semantic tier's adoption
+// guard, issue #731) needs the span the extractor actually attributed
+// by; the stamp is that span, the same 1-based lines csharpOwnerRanges
+// reads. Two cases leave a node unstamped, deliberately alike in effect:
+// no span was recorded at all (a field without an initializer, a member
+// kind that records none), and a recorded span the node's own lines
+// already contain (the ordinary property, the implementing-first order,
+// a field's declarator inside its declaration). Either way the node's
+// lines answer and its meta stays as before. Kept as its own walk rather
+// than folded into csharpOwnerRanges so the owner lookup stays a pure
+// read of the result.
+func csharpStampOwnershipSpans(result *parser.ExtractionResult, funcLines map[string][2]int) {
+	for _, n := range result.Nodes {
+		if n.Kind != graph.KindField {
+			continue
+		}
+		ln, ok := funcLines[n.ID]
+		if !ok || (ln[0] >= n.StartLine && ln[1] <= n.EndLine) {
+			continue
+		}
+		if n.Meta == nil {
+			n.Meta = make(map[string]any)
+		}
+		n.Meta[graph.MetaOwnershipStartLine] = ln[0]
+		n.Meta[graph.MetaOwnershipEndLine] = ln[1]
+	}
 }
 
 func newCSharpFuncLookup(ranges []funcRange, bytes map[string][2]int) *csharpFuncLookup {

--- a/internal/parser/languages/csharp_owner_span_test.go
+++ b/internal/parser/languages/csharp_owner_span_test.go
@@ -1,0 +1,91 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+)
+
+func csharpNodeByID(t *testing.T, result *parser.ExtractionResult, id string) *graph.Node {
+	t.Helper()
+	for _, n := range result.Nodes {
+		if n.ID == id {
+			return n
+		}
+	}
+	t.Fatalf("node %s not extracted", id)
+	return nil
+}
+
+// A partial property whose declaring fragment extracts first keeps the
+// declaring fragment's lines on its node, while its calls are owned by
+// the implementing fragment's span. That span has to travel with the
+// node (issue #731): downstream consumers that test a call's line
+// against the owner's extent would otherwise refuse every site the
+// extractor deliberately attributed to it.
+func TestCSharpExtractor_PartialPropertyStampsOwnershipSpan(t *testing.T) {
+	src := []byte(`namespace App {
+    public class Crank {
+        public int Turn() { return 1; }
+    }
+    public partial class KPart {
+        private readonly Crank _crank = new Crank();
+        public partial int P { get; set; }
+    }
+    public partial class KPart {
+        public partial int P {
+            get { return _crank.Turn(); }
+        }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("App.cs", src)
+	require.NoError(t, err)
+
+	p := csharpNodeByID(t, result, "App.cs::KPart.P")
+	assert.Equal(t, 7, p.StartLine, "node keeps the declaring fragment's line")
+	assert.Equal(t, 7, p.EndLine)
+	assert.Equal(t, 10, p.Meta["ownership_start_line"], "recorded ownership span starts at the implementing fragment")
+	assert.Equal(t, 12, p.Meta["ownership_end_line"])
+
+	calls := callEdgesFrom(result.Edges, "App.cs::KPart.P", "Turn")
+	require.Len(t, calls, 1)
+	assert.Equal(t, 11, calls[0].Line, "the owned call sits inside the stamped span, outside the node's")
+}
+
+// When the node's lines already contain the recorded span (the ordinary
+// property, and the implementing-fragment-first order) nothing is
+// stamped: the node's own lines answer, and the meta stays as before.
+func TestCSharpExtractor_OwnershipSpanStampedOnlyWhenItDiffers(t *testing.T) {
+	src := []byte(`namespace App {
+    public class Crank {
+        public int Turn() { return 1; }
+    }
+    public partial class KPart {
+        private readonly Crank _crank = new Crank();
+        public partial int P {
+            get { return _crank.Turn(); }
+        }
+        public int Q { get { return _crank.Turn(); } }
+    }
+    public partial class KPart {
+        public partial int P { get; set; }
+    }
+}
+`)
+	e := NewCSharpExtractor()
+	result, err := e.Extract("App.cs", src)
+	require.NoError(t, err)
+
+	for _, id := range []string{"App.cs::KPart.P", "App.cs::KPart.Q"} {
+		n := csharpNodeByID(t, result, id)
+		_, hasStart := n.Meta["ownership_start_line"]
+		_, hasEnd := n.Meta["ownership_end_line"]
+		assert.False(t, hasStart || hasEnd, "%s: span equals the node's, no stamp expected; meta=%v", id, n.Meta)
+	}
+}

--- a/internal/parser/languages/razor.go
+++ b/internal/parser/languages/razor.go
@@ -204,6 +204,14 @@ func (e *RazorExtractor) delegateRazorCode(content []byte, lineOffset int, wrapP
 			n.Meta = map[string]any{}
 		}
 		n.Meta["inline_script"] = true
+		// The recorded ownership span is spelled in the same coordinates
+		// as the node's lines, so it moves with them; left in wrapper
+		// coordinates it would name unrelated host lines.
+		for _, k := range []string{graph.MetaOwnershipStartLine, graph.MetaOwnershipEndLine} {
+			if v, ok := n.Meta[k].(int); ok && v > 0 {
+				n.Meta[k] = v + shift
+			}
+		}
 		result.Nodes = append(result.Nodes, n)
 	}
 	for _, ed := range sub.Edges {

--- a/internal/parser/languages/razor_test.go
+++ b/internal/parser/languages/razor_test.go
@@ -63,6 +63,54 @@ func TestRazorExtractor(t *testing.T) {
 	}
 }
 
+// A @code block's members are rebased into host coordinates; the
+// ownership span stamped on a declaring-first partial property (issue
+// #731) has to move with the node's lines, or it names unrelated host
+// lines and the semantic tier admits stubs from the wrong region.
+func TestRazorCodeBlockRebasesOwnershipSpan(t *testing.T) {
+	const razor = `@page "/p"
+
+@code {
+    private Svc _c = new Svc();
+    public partial int P { get; set; }
+    public partial int P {
+        get { return _c.F(); }
+    }
+}
+`
+	res, err := NewRazorExtractor().Extract("Page.razor", []byte(razor))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var prop *graph.Node
+	for _, n := range res.Nodes {
+		if n.Name == "P" && n.Kind == graph.KindField {
+			prop = n
+		}
+	}
+	if prop == nil {
+		t.Fatal("partial property P not extracted from the @code block")
+	}
+	if prop.StartLine != 5 || prop.EndLine != 5 {
+		t.Errorf("P node lines = %d..%d, want 5..5 (host coordinates of the declaring fragment)", prop.StartLine, prop.EndLine)
+	}
+	if got, want := prop.Meta[graph.MetaOwnershipStartLine], 6; got != want {
+		t.Errorf("ownership_start_line = %v, want %d (host coordinates of the implementing fragment)", got, want)
+	}
+	if got, want := prop.Meta[graph.MetaOwnershipEndLine], 8; got != want {
+		t.Errorf("ownership_end_line = %v, want %d", got, want)
+	}
+	var callLine int
+	for _, e := range res.Edges {
+		if e.From == prop.ID && e.Kind == graph.EdgeCalls && strings.HasSuffix(e.To, ".F") {
+			callLine = e.Line
+		}
+	}
+	if callLine != 7 {
+		t.Errorf("P's body call line = %d, want 7 (inside the stamped span, outside the node's)", callLine)
+	}
+}
+
 // TestRazorUsingExtraction pins `@using` directive extraction (with the
 // `@using static` member-import form skipped to its namespace) and the
 // path-derived component namespace.

--- a/internal/semantic/tstypes/csharp_owner_span_test.go
+++ b/internal/semantic/tstypes/csharp_owner_span_test.go
@@ -1,0 +1,119 @@
+package tstypes
+
+// Pins for issue #731: the extractor owns a C# property's calls by the
+// span it RECORDED (the body-bearing fragment of a partial property, the
+// body-bearing arm of a conditional-compilation pair), which can lie
+// outside the property NODE's lines (the first fragment's). buildIndex's
+// extent guard must test the stub against the recorded ownership span,
+// not the declaration span, or adoption never fires for exactly the
+// owner kind it exists to serve.
+
+import (
+	"testing"
+
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// C# 13 partial property, declaring fragment first: the node spans the
+// declaring line, the extractor's stub sits in the implementing fragment.
+func TestCSharp_PartialPropertyDeclaringFirstResolvesBodyCall(t *testing.T) {
+	g, dir := buildFixture(t, map[string]string{
+		"A/Svc.cs": csSvcInt,
+		"B/App.cs": `namespace B {
+    public partial class App {
+        private Svc worker;
+        public partial int Tick { get; set; }
+    }
+
+    public partial class App {
+        public partial int Tick {
+            get { worker.Run(); return 1; }
+        }
+    }
+}
+`,
+	})
+	p := NewProvider(CSharpSpec(), zap.NewNop())
+	res, err := p.Enrich(g, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tick := nodeByNameKind(t, g, "Tick", graph.KindField)
+	run := nodeByNameKind(t, g, "Run", graph.KindMethod)
+	e := callEdgeTo(g, tick.ID, run.ID)
+	if e == nil {
+		t.Fatalf("partial property's body call not resolved (EdgesConfirmed=%d); edges: %v", res.EdgesConfirmed, g.GetOutEdges(tick.ID))
+	}
+	assertASTProvenance(t, e, "csharp-types")
+	if got := callEdgesNamed(g, tick.ID, "Run"); len(got) != 1 {
+		t.Errorf("want exactly one Run edge on the property, got %d: %v", len(got), got)
+	}
+}
+
+// Conditional compilation: the same property declared in both arms of an
+// #if / #else (tree-sitter parses both); the body-bearing arm is second.
+func TestCSharp_ConditionalPropertySecondArmResolvesBodyCall(t *testing.T) {
+	g, dir := buildFixture(t, map[string]string{
+		"A/Svc.cs": csSvcInt,
+		"B/App.cs": `namespace B {
+    public class App {
+        private Svc worker;
+#if LEGACY
+        public int Tick { get; set; }
+#else
+        public int Tick { get { worker.Run(); return 1; } }
+#endif
+    }
+}
+`,
+	})
+	p := NewProvider(CSharpSpec(), zap.NewNop())
+	res, err := p.Enrich(g, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tick := nodeByNameKind(t, g, "Tick", graph.KindField)
+	run := nodeByNameKind(t, g, "Run", graph.KindMethod)
+	e := callEdgeTo(g, tick.ID, run.ID)
+	if e == nil {
+		t.Fatalf("conditional property's body call not resolved (EdgesConfirmed=%d); edges: %v", res.EdgesConfirmed, g.GetOutEdges(tick.ID))
+	}
+	assertASTProvenance(t, e, "csharp-types")
+	if got := callEdgesNamed(g, tick.ID, "Run"); len(got) != 1 {
+		t.Errorf("want exactly one Run edge on the property, got %d: %v", len(got), got)
+	}
+}
+
+// Control: implementing fragment FIRST. The node already spans the body,
+// no ownership stamp is needed, and the call resolves as before.
+func TestCSharp_PartialPropertyImplementingFirstStillResolves(t *testing.T) {
+	g, dir := buildFixture(t, map[string]string{
+		"A/Svc.cs": csSvcInt,
+		"B/App.cs": `namespace B {
+    public partial class App {
+        private Svc worker;
+        public partial int Tick {
+            get { worker.Run(); return 1; }
+        }
+    }
+
+    public partial class App {
+        public partial int Tick { get; set; }
+    }
+}
+`,
+	})
+	p := NewProvider(CSharpSpec(), zap.NewNop())
+	if _, err := p.Enrich(g, dir); err != nil {
+		t.Fatal(err)
+	}
+	tick := nodeByNameKind(t, g, "Tick", graph.KindField)
+	run := nodeByNameKind(t, g, "Run", graph.KindMethod)
+	if e := callEdgeTo(g, tick.ID, run.ID); e == nil {
+		t.Fatalf("implementing-first partial property's body call not resolved; edges: %v", g.GetOutEdges(tick.ID))
+	} else {
+		assertASTProvenance(t, e, "csharp-types")
+	}
+}

--- a/internal/semantic/tstypes/csharp_owner_span_test.go
+++ b/internal/semantic/tstypes/csharp_owner_span_test.go
@@ -9,12 +9,115 @@ package tstypes
 // owner kind it exists to serve.
 
 import (
+	"encoding/json"
 	"testing"
 
 	"go.uber.org/zap"
 
 	"github.com/zzet/gortex/internal/graph"
 )
+
+// The stamped span ADDS to the node's lines; it does not replace the
+// guard. A synthesized edge parked on a stamped property at a line
+// outside BOTH intervals must still be refused - here at the line of a
+// second property that authors the same call, where admitting it would
+// tie the two, and a tie between two properties has no containing
+// callable, so the real owner would lose its site.
+func TestCSharp_StampedPropertyStillRefusesEdgeOutsideBothSpans(t *testing.T) {
+	g, dir := buildFixture(t, map[string]string{
+		"A/Svc.cs": csSvcInt,
+		"B/App.cs": `namespace B {
+    public partial class App {
+        private Svc worker;
+        public partial int Tick { get; set; }
+    }
+
+    public partial class App {
+        public partial int Tick {
+            get { worker.Run(); return 1; }
+        }
+        public int Peek { get { worker.Run(); return 2; } }
+    }
+}
+`,
+	})
+	tick := nodeByNameKind(t, g, "Tick", graph.KindField)
+	peek := nodeByNameKind(t, g, "Peek", graph.KindField)
+	lo, hi, ok := recordedOwnershipSpan(tick)
+	if !ok {
+		t.Fatalf("Tick carries no ownership stamp; meta=%v", tick.Meta)
+	}
+	// The fixture's whole point: Peek's line lies outside BOTH of Tick's
+	// intervals (its node line and its stamped span).
+	if (peek.StartLine >= lo && peek.StartLine <= hi) || (peek.StartLine >= tick.StartLine && peek.StartLine <= tick.EndLine) {
+		t.Fatalf("fixture drift: Peek line %d inside Tick's node %d..%d or stamped span %d..%d", peek.StartLine, tick.StartLine, tick.EndLine, lo, hi)
+	}
+	g.AddEdge(&graph.Edge{
+		From:     tick.ID,
+		To:       "unresolved::*.Run",
+		Kind:     graph.EdgeCalls,
+		FilePath: "B/App.cs",
+		Line:     peek.StartLine, // outside Tick's node lines AND its stamped span
+	})
+	p := NewProvider(CSharpSpec(), zap.NewNop())
+	if _, err := p.Enrich(g, dir); err != nil {
+		t.Fatal(err)
+	}
+	run := nodeByNameKind(t, g, "Run", graph.KindMethod)
+	if e := callEdgeTo(g, peek.ID, run.ID); e == nil {
+		t.Errorf("synthesized edge outside both spans was admitted: Peek lost its call; edges: %v", g.GetOutEdges(peek.ID))
+	}
+	if got := callEdgesNamed(g, tick.ID, "Run"); len(got) != 2 {
+		// Tick's own resolved body call plus the untouched synthetic stub.
+		t.Errorf("Tick Run edges = %d, want 2 (own resolved call + refused synthetic stub): %v", len(got), got)
+	}
+	if e := callEdgeTo(g, tick.ID, run.ID); e == nil {
+		t.Errorf("Tick's own body call not resolved; edges: %v", g.GetOutEdges(tick.ID))
+	}
+}
+
+// The stamp reader: exact on the shapes the store hands back, lenient on
+// the ones another writer might, and ok=false on anything unusable.
+func TestRecordedOwnershipSpan_ReaderShapes(t *testing.T) {
+	cases := []struct {
+		name   string
+		lo, hi any
+		wantLo int
+		wantHi int
+		ok     bool
+	}{
+		{"ints", 10, 12, 10, 12, true},
+		{"int64", int64(10), int64(12), 10, 12, true},
+		{"float64", 10.0, 12.0, 10, 12, true},
+		{"json.Number", json.Number("10"), json.Number("12"), 10, 12, true},
+		{"strings", "10", "12", 10, 12, true},
+		{"single line", 7, 7, 7, 7, true},
+		{"missing end", 10, nil, 0, 0, false},
+		{"missing start", nil, 12, 0, 0, false},
+		{"inverted", 12, 10, 0, 0, false},
+		{"zero start", 0, 12, 0, 0, false},
+		{"garbage", "x", 12, 0, 0, false},
+		{"bool", true, 12, 0, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			n := &graph.Node{Meta: map[string]any{}}
+			if tc.lo != nil {
+				n.Meta[graph.MetaOwnershipStartLine] = tc.lo
+			}
+			if tc.hi != nil {
+				n.Meta[graph.MetaOwnershipEndLine] = tc.hi
+			}
+			lo, hi, ok := recordedOwnershipSpan(n)
+			if ok != tc.ok || lo != tc.wantLo || hi != tc.wantHi {
+				t.Fatalf("recordedOwnershipSpan = (%d, %d, %v), want (%d, %d, %v)", lo, hi, ok, tc.wantLo, tc.wantHi, tc.ok)
+			}
+		})
+	}
+	if _, _, ok := recordedOwnershipSpan(&graph.Node{}); ok {
+		t.Fatal("nil meta must read as unstamped")
+	}
+}
 
 // C# 13 partial property, declaring fragment first: the node spans the
 // declaring line, the extractor's stub sits in the implementing fragment.

--- a/internal/semantic/tstypes/engine.go
+++ b/internal/semantic/tstypes/engine.go
@@ -696,6 +696,7 @@ func (a *applier) buildIndex(facts *fileFacts) *fileIndex {
 			// branch loads file nodes a kind-filtered store would not).
 			continue
 		}
+		stampLo, stampHi, stamped := recordedOwnershipSpan(n)
 		for _, e := range a.outEdges(n.ID) {
 			if e == nil || e.Kind != graph.EdgeCalls || e.Line == 0 {
 				continue
@@ -703,14 +704,17 @@ func (a *applier) buildIndex(facts *fileFacts) *fileIndex {
 			if e.FilePath != "" && e.FilePath != facts.file {
 				continue
 			}
-			if lo, hi := ownerLineSpan(n); e.Line < lo || e.Line > hi {
+			inNode := e.Line >= n.StartLine && e.Line <= n.EndLine
+			inStamp := stamped && e.Line >= stampLo && e.Line <= stampHi
+			if !inNode && !inStamp {
 				// Framework-dispatch synthesis (Rails callbacks, Laravel
 				// middleware) parks an owner's edge on a line outside the
 				// owner's own span — not site evidence at that line. The
-				// span tested is the one the extractor attributed by, which
-				// is the node's unless it stamped a different one (see
-				// ownerLineSpan): a stub the extractor parked outside the
-				// node but inside its recorded span IS the authored site.
+				// owner's span is its node's lines plus, when the extractor
+				// recorded one elsewhere, the ownership span it stamped on
+				// the node (recordedOwnershipSpan): a stub parked there IS
+				// the authored site. Two intervals, never their hull — the
+				// lines between two fragments belong to other members.
 				continue
 			}
 			idx.stubsByLine[e.Line] = append(idx.stubsByLine[e.Line], stubRef{owner: n, to: e.To})
@@ -719,24 +723,26 @@ func (a *applier) buildIndex(facts *fileFacts) *fileIndex {
 	return idx
 }
 
-// ownerLineSpan is the line span an owner's snapshotted calls are tested
-// against: the ownership span the extractor recorded on the node
-// (`ownership_start_line` / `ownership_end_line`, stamped only when it
-// escapes the node's own lines) or, absent that, the node's lines. A C#
-// 13 partial property extracted declaring fragment first, or a property
-// declared in both arms of an #if / #else, keeps the first fragment's
-// lines on its node while its calls are owned by the body-bearing
-// fragment's span - the node's lines would refuse every stub the
-// extractor deliberately parked there (issue #731). The values are read
-// leniently because a persisted meta value comes back from the store as
-// a float64 or a string, not the int the extractor wrote.
-func ownerLineSpan(n *graph.Node) (int, int) {
-	if lo, ok := metaLine(n.Meta["ownership_start_line"]); ok {
-		if hi, ok := metaLine(n.Meta["ownership_end_line"]); ok && lo > 0 && hi >= lo {
-			return lo, hi
-		}
+// recordedOwnershipSpan reads the ownership span the extractor stamped on
+// a node (graph.MetaOwnershipStartLine / MetaOwnershipEndLine) when the
+// span it attributed the member's calls by is not contained by the node's
+// own lines: a C# 13 partial property extracted declaring fragment first,
+// or a property declared in both arms of an #if / #else, keeps the first
+// fragment's lines on its node while its calls are owned by the
+// body-bearing fragment's span - the node's lines alone would refuse
+// every stub the extractor deliberately parked there (issue #731). ok is
+// false when nothing is stamped or the pair is not a sane 1-based span,
+// and the caller then tests the node's lines only. The store's flat meta
+// codec hands an int back as an int and its JSON fallback normalizes an
+// integral number to int too, so the wider metaLine cases are a cheap
+// guard against another writer or a future codec, not an observed shape.
+func recordedOwnershipSpan(n *graph.Node) (lo, hi int, ok bool) {
+	lo, okLo := metaLine(n.Meta[graph.MetaOwnershipStartLine])
+	hi, okHi := metaLine(n.Meta[graph.MetaOwnershipEndLine])
+	if !okLo || !okHi || lo <= 0 || hi < lo {
+		return 0, 0, false
 	}
-	return n.StartLine, n.EndLine
+	return lo, hi, true
 }
 
 func metaLine(v any) (int, bool) {

--- a/internal/semantic/tstypes/engine.go
+++ b/internal/semantic/tstypes/engine.go
@@ -703,16 +703,60 @@ func (a *applier) buildIndex(facts *fileFacts) *fileIndex {
 			if e.FilePath != "" && e.FilePath != facts.file {
 				continue
 			}
-			if e.Line < n.StartLine || e.Line > n.EndLine {
+			if lo, hi := ownerLineSpan(n); e.Line < lo || e.Line > hi {
 				// Framework-dispatch synthesis (Rails callbacks, Laravel
 				// middleware) parks an owner's edge on a line outside the
-				// owner's own span — not site evidence at that line.
+				// owner's own span — not site evidence at that line. The
+				// span tested is the one the extractor attributed by, which
+				// is the node's unless it stamped a different one (see
+				// ownerLineSpan): a stub the extractor parked outside the
+				// node but inside its recorded span IS the authored site.
 				continue
 			}
 			idx.stubsByLine[e.Line] = append(idx.stubsByLine[e.Line], stubRef{owner: n, to: e.To})
 		}
 	}
 	return idx
+}
+
+// ownerLineSpan is the line span an owner's snapshotted calls are tested
+// against: the ownership span the extractor recorded on the node
+// (`ownership_start_line` / `ownership_end_line`, stamped only when it
+// escapes the node's own lines) or, absent that, the node's lines. A C#
+// 13 partial property extracted declaring fragment first, or a property
+// declared in both arms of an #if / #else, keeps the first fragment's
+// lines on its node while its calls are owned by the body-bearing
+// fragment's span - the node's lines would refuse every stub the
+// extractor deliberately parked there (issue #731). The values are read
+// leniently because a persisted meta value comes back from the store as
+// a float64 or a string, not the int the extractor wrote.
+func ownerLineSpan(n *graph.Node) (int, int) {
+	if lo, ok := metaLine(n.Meta["ownership_start_line"]); ok {
+		if hi, ok := metaLine(n.Meta["ownership_end_line"]); ok && lo > 0 && hi >= lo {
+			return lo, hi
+		}
+	}
+	return n.StartLine, n.EndLine
+}
+
+func metaLine(v any) (int, bool) {
+	switch x := v.(type) {
+	case int:
+		return x, true
+	case int64:
+		return int(x), true
+	case float64:
+		return int(x), true
+	case interface{ Int64() (int64, error) }:
+		if i, err := x.Int64(); err == nil {
+			return int(i), true
+		}
+	case string:
+		if i, err := strconv.Atoi(x); err == nil {
+			return i, true
+		}
+	}
+	return 0, false
 }
 
 // applyAll joins every analyzed file's facts against the graph in


### PR DESCRIPTION
Closes #731. Two commits: the extractor carries the span it attributed by onto the node, and the guard admits stubs inside that span as well as inside the node's lines - the fix you named.

## What the guard was testing

`buildIndex`'s extent guard compared the stub's line against the owner node's `StartLine..EndLine`. The C# extractor owns a property's calls by the span it RECORDED (`csharpOwnerRanges`: the body-bearing fragment of a partial property, the body-bearing arm of an `#if` / `#else` pair) while the node keeps its first declaration's lines. So whenever the body-bearing fragment was not first, the byte-precise stub sat outside the node, the guard dropped it as synthesized, `stubOwnersAt` answered no owner, `enclosingCallable` answered nil for a property, and the site was refused - both shapes from the issue, `EdgesConfirmed: 0`, the stub left `unresolved::*.Run` with empty `Origin`.

## Commit 1: the node carries the recorded ownership span

`csharpStampOwnershipSpans` runs once the emits are done and `funcLines` is final. For every field-kind node whose recorded span is not contained by its own lines it stamps `ownership_start_line` / `ownership_end_line` (1-based, the same numbers `csharpOwnerRanges` attributes by; the keys are `graph.MetaOwnershipStartLine` / `MetaOwnershipEndLine` so writer and reader compile against one spelling). Nothing is stamped when the node's lines already contain the span: the ordinary property, the implementing-first order, a field's declarator inside its declaration. So the meta of every node that was never affected is byte-for-byte as before.

The Razor code-block delegation rebases node lines and edge lines by the wrapper shift; it now rebases the two keys with them, so a `.razor` / `.cshtml` property carries the span in host coordinates like everything else on the node. Without that the stamp would have named wrapper lines, which on the host file belong to other members.

C# extractor version 22 -> 23, so already-indexed partial and conditionally-compiled properties pick the stamp up on the next reconcile (21 and 22 landed with #734 and #735; the `TestStaleLangsDetection` pin moved with it in the same commit).

## Commit 2: the guard admits the recorded span too

The guard keeps the node's lines and ADDS the stamped span when `recordedOwnershipSpan(n)` reads a sane pair - two intervals, never their hull, because the lines between two fragments belong to other members. A stub outside both is refused exactly as before, so the framework-dispatch edges the guard was written for (Rails callbacks, Laravel middleware, parked on function nodes that never carry the stamp) are unaffected. The span is read once per owner, outside the per-edge loop. The reader accepts int, int64, float64, json.Number and a numeric string; the store's flat meta codec hands the int back as an int and its JSON fallback normalizes an integral number to int, so the wider cases are a guard against another writer, not an observed shape. No other language stamps the keys, so the change is inert outside C#.

## Pins

- `TestCSharp_PartialPropertyDeclaringFirstResolvesBodyCall` and `TestCSharp_ConditionalPropertySecondArmResolvesBodyCall` are your two shapes verbatim (Svc / App, `worker.Run()` in the body-bearing fragment or arm): each resolves to `A/Svc.cs::Svc.Run` with ast provenance and exactly one edge on the property. Red on main with `EdgesConfirmed=0` on both.
- `TestCSharp_PartialPropertyImplementingFirstStillResolves` pins the order that already worked.
- `TestCSharp_StampedPropertyStillRefusesEdgeOutsideBothSpans`: a synthesized `unresolved::*.Run` edge parked on the stamped property at the line of a second property that authors the same call. Admitting it would tie two properties (no containing callable) and cost the real owner its site; it stays refused, the second property resolves, the first keeps exactly its own resolved call plus the untouched stub.
- `TestRecordedOwnershipSpan_ReaderShapes`: the reader's accepted and rejected value shapes.
- Parser side: `TestCSharpExtractor_PartialPropertyStampsOwnershipSpan` (node keeps line 7, stamp says 10..12, the owned call sits at 11), `TestCSharpExtractor_OwnershipSpanStampedOnlyWhenItDiffers` (implementing-first and an ordinary property carry no stamp), and `TestRazorCodeBlockRebasesOwnershipSpan` (a declaring-first partial property in a `@code` block: node at host line 5, stamp 6..8, call at 7).
- Both shape pins go red under exact revert of the guard; the parser stamp pin and both shape pins go red when the stamp is disabled; the Razor pin goes red when the keys are left in wrapper coordinates.

## Verification

- `./internal/semantic/tstypes` green including the apply golden (no drift: the golden fixture has neither shape); `./internal/parser/languages` and the indexer salt pins green; whole-tree Windows fail-name set diffed against a clean-main control at `d0433b26`: identical apart from the pre-existing nondeterministic `internal/eval` `TestHealthEndpoint`.
- My counted C# fixture repo, two cold labs over the same fixture commit, clean-main build vs this branch, both with LSP disabled (the bug is a missing resolution and the csharp-ls tier fills exactly that hole, so an LSP-on A/B cannot see it): four new cells shaped like the issue, every callee with a same-name decoy on the other type so only receiver-type evidence can land anything. Base: both issue shapes sit on unresolved stubs, the two controls pass. Branch: both resolve at 0.95 `ast_resolved`, exactly one edge each, controls unchanged. The two probe outputs differ only in those two cells (plus one existing decoy-less partial-property cell that moves from the 0.7 name-unique fallback to 0.95). The stamps were read back out of the branch lab's SQLite store on exactly the two affected properties and on nothing else, so the persisted round-trip is verified through the daemon, not only in the in-memory harness.
- Not extended to the single-owner or containment arms: they never consult the span; only the admission guard did.
