### PR TITLE
feat(mcp): say whether ownership was ever mined instead of answering zero

### DIFF
--- a/cmd/gortex/daemon_controller.go
+++ b/cmd/gortex/daemon_controller.go
@@ -366,7 +366,7 @@ func (c *realController) EnrichBlame(_ context.Context, p daemon.EnrichBlamePara
 	started := time.Now()
 	var combined daemon.EnrichBlameResult
 	for _, t := range targets {
-		count, err := blame.EnrichGraph(c.graph, t.root)
+		count, err := blame.EnrichGraph(c.graph, t.root, t.prefix)
 		if err != nil {
 			return daemon.EnrichBlameResult{}, fmt.Errorf("enrich %s: %w", t.prefix, err)
 		}

--- a/internal/blame/blame.go
+++ b/internal/blame/blame.go
@@ -208,7 +208,21 @@ func PersonNodeID(email string) string {
 	return "team::" + strings.ToLower(strings.TrimSpace(email))
 }
 
-func EnrichGraph(g graph.Store, repoRoot string) (int, error) {
+// EnrichGraph stamps authorship on the symbols of ONE repository.
+//
+// repoPrefix scopes which nodes this pass may touch, mirroring
+// cochange.EnrichGraph. Pass "" for a single-repo graph.
+//
+// The scope is load-bearing rather than an optimisation. In multi-repo mode
+// the daemon calls this once per repository against the COMBINED graph, and
+// stripRepoPrefix resolves a node path by trying it under the current root
+// and then retrying without its leading segment. Two repositories holding the
+// same relative path — internal/foo.go in both — therefore let the pass over
+// repo A open repo A's file and stamp repo B's node with repo A's authors. The
+// stamp is well-formed, plausible, and about a different file, and anything
+// downstream that counts stamps as coverage then certifies repo B on the
+// strength of it.
+func EnrichGraph(g graph.Store, repoRoot, repoPrefix string) (int, error) {
 	if g == nil || repoRoot == "" {
 		return 0, nil
 	}
@@ -222,6 +236,9 @@ func EnrichGraph(g graph.Store, repoRoot string) (int, error) {
 	gitAvailable := gitErr == nil
 	for _, n := range g.AllNodes() {
 		if !Eligible(n) {
+			continue
+		}
+		if n.RepoPrefix != repoPrefix {
 			continue
 		}
 		path, ok := normalizedPaths[n.FilePath]

--- a/internal/blame/blame.go
+++ b/internal/blame/blame.go
@@ -221,10 +221,7 @@ func EnrichGraph(g graph.Store, repoRoot string) (int, error) {
 	_, gitErr := exec.LookPath("git")
 	gitAvailable := gitErr == nil
 	for _, n := range g.AllNodes() {
-		if !shouldEnrichBlame(n.Kind) {
-			continue
-		}
-		if n.FilePath == "" || n.StartLine == 0 {
+		if !Eligible(n) {
 			continue
 		}
 		path, ok := normalizedPaths[n.FilePath]
@@ -379,6 +376,23 @@ func pickLatest(lines map[int]Author, startLine, endLine int) *Author {
 // fixture) are also excluded since their "authorship" is the
 // authorship of the underlying source line, which the agent can
 // look up via the file/function the synthetic node attaches to.
+// Eligible reports whether this pass will consider n at all: the right kind,
+// and enough position information to blame. It is exported because a caller
+// that reports blame COVERAGE has to count the same population this pass
+// admits — counting symbols the pass never looks at would report a permanent
+// shortfall that no enrichment could ever close.
+//
+// Eligibility is not a promise of a stamp. A file git cannot blame is skipped
+// below, and a symbol whose lines carry no blame data is skipped too; both
+// leave an eligible symbol unstamped, which is a real coverage hole rather
+// than an ineligible symbol.
+func Eligible(n *graph.Node) bool {
+	if n == nil || n.FilePath == "" || n.StartLine == 0 {
+		return false
+	}
+	return shouldEnrichBlame(n.Kind)
+}
+
 func shouldEnrichBlame(kind graph.NodeKind) bool {
 	switch kind {
 	case graph.KindFunction, graph.KindMethod, graph.KindType,

--- a/internal/blame/blame_test.go
+++ b/internal/blame/blame_test.go
@@ -149,7 +149,7 @@ func TestEnrichGraph_StampsLastAuthored(t *testing.T) {
 		EndLine:   3,
 	})
 
-	count, err := EnrichGraph(g, repoDir)
+	count, err := EnrichGraph(g, repoDir, "")
 	if err != nil {
 		t.Fatalf("enrich: %v", err)
 	}
@@ -216,7 +216,7 @@ func TestEnrichGraph_EmitsAuthoredEdgeAndPersonNode(t *testing.T) {
 		EndLine:   3,
 	})
 
-	if _, err := EnrichGraph(g, repoDir); err != nil {
+	if _, err := EnrichGraph(g, repoDir, ""); err != nil {
 		t.Fatalf("enrich: %v", err)
 	}
 
@@ -290,7 +290,7 @@ func TestEnrichGraph_PersonNodeRepoScoped(t *testing.T) {
 		RepoPrefix: "myrepo",
 	})
 
-	if _, err := EnrichGraph(g, repoDir); err != nil {
+	if _, err := EnrichGraph(g, repoDir, "myrepo"); err != nil {
 		t.Fatalf("enrich: %v", err)
 	}
 
@@ -370,7 +370,7 @@ func TestEnrichGraph_CachesPathNormalization(t *testing.T) {
 	}
 	t.Cleanup(func() { fileExists = originalFileExists })
 
-	if _, err := EnrichGraph(g, repoDir); err != nil {
+	if _, err := EnrichGraph(g, repoDir, ""); err != nil {
 		t.Fatalf("enrich: %v", err)
 	}
 	if statCalls != 2 {

--- a/internal/blame/eligible_test.go
+++ b/internal/blame/eligible_test.go
@@ -1,0 +1,66 @@
+package blame
+
+import (
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// TestEligibleMatchesWhatEnrichGraphAdmits pins the predicate a coverage
+// reporter has to agree with. Eligible is exported so callers can count the
+// population this pass actually considers; if it drifted wider than
+// EnrichGraph's own admission, every such caller would report a permanent
+// shortfall that no enrichment could close, and if it drifted narrower they
+// would report full coverage over symbols the pass never stamped.
+func TestEligibleMatchesWhatEnrichGraphAdmits(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		node *graph.Node
+		want bool
+	}{
+		{"function", &graph.Node{Kind: graph.KindFunction, FilePath: "a.go", StartLine: 1}, true},
+		{"method", &graph.Node{Kind: graph.KindMethod, FilePath: "a.go", StartLine: 1}, true},
+		{"type", &graph.Node{Kind: graph.KindType, FilePath: "a.go", StartLine: 1}, true},
+		{"interface", &graph.Node{Kind: graph.KindInterface, FilePath: "a.go", StartLine: 1}, true},
+		{"field", &graph.Node{Kind: graph.KindField, FilePath: "a.go", StartLine: 1}, true},
+		{"variable", &graph.Node{Kind: graph.KindVariable, FilePath: "a.go", StartLine: 1}, true},
+		{"constant", &graph.Node{Kind: graph.KindConstant, FilePath: "a.go", StartLine: 1}, true},
+		{"enum member", &graph.Node{Kind: graph.KindEnumMember, FilePath: "a.go", StartLine: 1}, true},
+
+		// Kinds this pass has never stamped. A file or package node is not an
+		// unstamped symbol; it is not a symbol.
+		{"file", &graph.Node{Kind: graph.KindFile, FilePath: "a.go", StartLine: 1}, false},
+		{"import", &graph.Node{Kind: graph.KindImport, FilePath: "a.go", StartLine: 1}, false},
+		{"contract", &graph.Node{Kind: graph.KindContract, FilePath: "a.go", StartLine: 1}, false},
+
+		// Position is required: EnrichGraph groups by path and picks the
+		// latest author across [StartLine, EndLine], so neither can be absent.
+		{"no path", &graph.Node{Kind: graph.KindFunction, StartLine: 1}, false},
+		{"no line", &graph.Node{Kind: graph.KindFunction, FilePath: "a.go"}, false},
+		{"nil node", nil, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Eligible(tc.node); got != tc.want {
+				t.Fatalf("Eligible = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEligibleAgreesWithTheKindSwitch is the drift guard. Eligible must not
+// admit a kind shouldEnrichBlame refuses, in either direction — the two are
+// one decision, and the exported half is the one other packages count on.
+func TestEligibleAgreesWithTheKindSwitch(t *testing.T) {
+	kinds := []graph.NodeKind{
+		graph.KindFunction, graph.KindMethod, graph.KindType, graph.KindInterface,
+		graph.KindField, graph.KindVariable, graph.KindConstant, graph.KindEnumMember,
+		graph.KindFile, graph.KindImport, graph.KindContract, graph.KindDoc,
+		graph.KindEvent, graph.KindFlag, graph.KindColumn,
+	}
+	for _, kind := range kinds {
+		positioned := &graph.Node{Kind: kind, FilePath: "a.go", StartLine: 1}
+		if got, want := Eligible(positioned), shouldEnrichBlame(kind); got != want {
+			t.Fatalf("kind %q: Eligible = %v, shouldEnrichBlame = %v", kind, got, want)
+		}
+	}
+}

--- a/internal/blame/repo_scope_test.go
+++ b/internal/blame/repo_scope_test.go
@@ -1,0 +1,153 @@
+package blame
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// scopeRepo builds a one-commit git repository holding rel, authored by the
+// given identity, and returns its root.
+func scopeRepo(t *testing.T, rel, body, name, email string) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	full := filepath.Join(dir, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"config", "user.name", name},
+		{"config", "user.email", email},
+		{"add", "-A"},
+		{"commit", "-q", "-m", "initial"},
+	} {
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME="+name, "GIT_AUTHOR_EMAIL="+email,
+			"GIT_COMMITTER_NAME="+name, "GIT_COMMITTER_EMAIL="+email)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	return dir
+}
+
+// lastAuthoredEmail reads authorship from wherever this store keeps it. A
+// backend implementing BlameEnrichmentWriter takes the sidecar rows and never
+// touches node Meta, so checking Meta alone reads empty on a stamped node and
+// would make every assertion here pass for the wrong reason.
+func lastAuthoredEmail(g graph.Store, nodeID string) string {
+	if reader, ok := g.(graph.BlameEnrichmentReader); ok {
+		for _, row := range reader.BlameRows("") {
+			if row.NodeID == nodeID {
+				return row.Email
+			}
+		}
+	}
+	n := g.GetNode(nodeID)
+	if n == nil || n.Meta == nil {
+		return ""
+	}
+	la, ok := n.Meta["last_authored"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	email, _ := la["email"].(string)
+	return email
+}
+
+// TestEnrichGraph_DoesNotStampAnotherRepositorysNodes is the multi-repo case
+// the daemon actually runs: one combined graph, one EnrichGraph call per
+// repository root. stripRepoPrefix resolves a node path by trying it under the
+// current root and then retrying without its leading segment, so two
+// repositories that share a relative path let the pass over repo-a open
+// repo-a's file and stamp repo-b's node with repo-a's author.
+//
+// The stamp that produced was well-formed, plausible, and about a different
+// file — and anything counting stamps as coverage then certified repo-b on the
+// strength of it.
+func TestEnrichGraph_DoesNotStampAnotherRepositorysNodes(t *testing.T) {
+	const rel = "internal/foo.go"
+	rootA := scopeRepo(t, rel, "package internal\n\nfunc Shared() {}\n", "alice", "alice@example.invalid")
+
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID: "repo-a/" + rel + "::Shared", Kind: graph.KindFunction, Name: "Shared",
+		FilePath: "repo-a/" + rel, StartLine: 3, EndLine: 3, RepoPrefix: "repo-a",
+	})
+	// Same relative path, different repository. Its file does not exist under
+	// rootA at its full path, which is exactly what sends stripRepoPrefix down
+	// the retry that finds repo-a's copy.
+	g.AddNode(&graph.Node{
+		ID: "repo-b/" + rel + "::Shared", Kind: graph.KindFunction, Name: "Shared",
+		FilePath: "repo-b/" + rel, StartLine: 3, EndLine: 3, RepoPrefix: "repo-b",
+	})
+
+	if _, err := EnrichGraph(g, rootA, "repo-a"); err != nil {
+		t.Fatalf("enrich repo-a: %v", err)
+	}
+
+	if got := lastAuthoredEmail(g, "repo-a/"+rel+"::Shared"); got != "alice@example.invalid" {
+		t.Fatalf("repo-a node authorship = %q, want alice@example.invalid", got)
+	}
+	if got := lastAuthoredEmail(g, "repo-b/"+rel+"::Shared"); got != "" {
+		t.Fatalf("repo-b node was stamped with %q by a pass over repo-a's root", got)
+	}
+}
+
+// TestEnrichGraph_EmptyPrefixStillStampsASingleRepoGraph is the other half of
+// the scope rule. A single-repo graph carries no prefix at all, so scoping had
+// to keep "" meaning "this graph's only repository" rather than "no repository".
+func TestEnrichGraph_EmptyPrefixStillStampsASingleRepoGraph(t *testing.T) {
+	const rel = "internal/foo.go"
+	root := scopeRepo(t, rel, "package internal\n\nfunc Solo() {}\n", "bob", "bob@example.invalid")
+
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID: rel + "::Solo", Kind: graph.KindFunction, Name: "Solo",
+		FilePath: rel, StartLine: 3, EndLine: 3,
+	})
+
+	count, err := EnrichGraph(g, root, "")
+	if err != nil {
+		t.Fatalf("enrich: %v", err)
+	}
+	if count == 0 {
+		t.Fatal("an unprefixed single-repo graph was skipped by the scope check")
+	}
+	if got := lastAuthoredEmail(g, rel+"::Solo"); got != "bob@example.invalid" {
+		t.Fatalf("authorship = %q, want bob@example.invalid", got)
+	}
+}
+
+// TestEnrichGraph_PrefixedPassSkipsUnprefixedNodes pins the direction that
+// keeps the multi-repo daemon honest: a pass for one repository must not reach
+// the shared-externals bucket, whose nodes carry no prefix and belong to no
+// repository root.
+func TestEnrichGraph_PrefixedPassSkipsUnprefixedNodes(t *testing.T) {
+	const rel = "internal/foo.go"
+	root := scopeRepo(t, rel, "package internal\n\nfunc Shared() {}\n", "carol", "carol@example.invalid")
+
+	g := graph.New()
+	g.AddNode(&graph.Node{
+		ID: rel + "::Shared", Kind: graph.KindFunction, Name: "Shared",
+		FilePath: rel, StartLine: 3, EndLine: 3,
+	})
+
+	if _, err := EnrichGraph(g, root, "repo-a"); err != nil {
+		t.Fatalf("enrich: %v", err)
+	}
+	if got := lastAuthoredEmail(g, rel+"::Shared"); got != "" {
+		t.Fatalf("an unprefixed node was stamped by a repo-a pass: %q", got)
+	}
+}

--- a/internal/mcp/analyze_kinds.go
+++ b/internal/mcp/analyze_kinds.go
@@ -270,7 +270,7 @@ var analyzeKindDescriptions = map[string]string{
 	"models":                      "ORM model→table edges (gorm/SQLAlchemy/Django/ActiveRecord/JPA/TypeORM/Ecto); orm/table/model filters",
 	"named":                       "Run a named query bundle — built-ins cover sql-injection/xss/ssrf/hardcoded-secrets/…; repo bundles from .gortex.yaml",
 	"orphan_tables":               "Tables queried but missing a migration that provides them",
-	"ownership":                   "Per-author rollup with symbol/file counts and oldest/newest timestamps",
+	"ownership":                   "Per-author rollup with symbol/file counts and oldest/newest timestamps. An empty or partial answer carries data_state saying whether blame was ever mined for the scope — a zero without it is not absence evidence",
 	"pagerank":                    "PageRank centrality — symbols ranked by random-walk authority",
 	"pubsub":                      "Pub/sub topics with publishers + subscribers (NATS/Kafka/RabbitMQ/Redis/EventEmitter/Socket.IO)",
 	"race_writes":                 "Concurrent-write race detection",

--- a/internal/mcp/data_state.go
+++ b/internal/mcp/data_state.go
@@ -66,6 +66,11 @@ type dataStateCaveat struct {
 	// Recovery is the command that would produce the data. Empty when the
 	// state is built, where there is nothing to recover.
 	Recovery string
+	// Eligible and Stamped size the shortfall: how many symbols the pass
+	// admits in scope, and how many carry data. A caller deciding whether to
+	// act on a partial answer needs the magnitude, not only the verdict.
+	Eligible int
+	Stamped  int
 	// Note carries the reading a caller must not make, in prose.
 	Note string
 }
@@ -81,6 +86,10 @@ func (c dataStateCaveat) payload() map[string]any {
 	}
 	if c.Recovery != "" {
 		out["recovery"] = c.Recovery
+	}
+	if c.Eligible > 0 {
+		out["symbols_eligible"] = c.Eligible
+		out["symbols_stamped"] = c.Stamped
 	}
 	return out
 }
@@ -108,32 +117,53 @@ const blameDataStateSource = "blame_enrichment"
 // so neither a re-index nor a re-track produces a single stamp.
 const blameRecovery = "run `gortex enrich blame` (or `gortex enrich all`). reindex_repository and untrack/track will NOT stamp authorship: indexing never reads git blame, so a re-parse of every file still leaves it empty."
 
-// ownershipDataState classifies an empty ownership answer from the counts its
-// own scan produced.
+// ownershipDataState classifies an ownership answer from the counts its own
+// scan produced.
 //
 // candidates and stamped are per-repo tallies over exactly the nodes the
 // handler considered: candidates counts every symbol that passed the kind and
-// path filters, stamped counts those carrying blame authorship. owners is the
-// number of distinct owners found before the min_symbols filter — non-zero
-// there with no rows means the data was fine and the threshold removed the
-// answer, which is a third silent zero this handler used to render
-// identically to the other two.
+// path filters AND that the blame pass would admit (blame.Eligible), stamped
+// counts those carrying authorship. owners is the number of distinct owners
+// found before the min_symbols filter — non-zero there with no rows means the
+// data was fine and the threshold removed the answer, which is a third silent
+// zero this handler used to render identically to the other two.
+//
+// Coverage is compared, not presence. One stamped symbol proves the pass ran
+// over that repository; it does not prove the repository is covered.
+// blame.EnrichGraph is best-effort per file — a file git cannot blame is
+// skipped and the pass reports success — so a single repository routinely
+// holds both stamped and unstamped eligible symbols. Reading a single stamp as
+// full coverage published exactly the misleading non-empty undercount this
+// caveat exists to prevent.
+//
+// The counting population is blame's own admission set for the same reason in
+// reverse: a symbol the pass never looks at is not a coverage hole, and
+// counting it would report a shortfall no enrichment could close.
 func ownershipDataState(candidates, stamped map[string]int, owners int) dataStateCaveat {
-	var unstamped []string
+	var unmined, incomplete []string
 	covered := 0
 	total := 0
+	eligibleTotal, stampedTotal := 0, 0
 	for repo, n := range candidates {
 		if n == 0 {
 			continue
 		}
 		total++
-		if stamped[repo] > 0 {
+		eligibleTotal += n
+		got := stamped[repo]
+		stampedTotal += got
+		switch {
+		case got == 0:
+			unmined = append(unmined, repo)
+		case got < n:
+			incomplete = append(incomplete, repo)
+		default:
 			covered++
-			continue
 		}
-		unstamped = append(unstamped, repo)
 	}
+	unstamped := append(append([]string{}, unmined...), incomplete...)
 	sort.Strings(unstamped)
+	sort.Strings(unmined)
 
 	switch {
 	case total == 0:
@@ -145,13 +175,15 @@ func ownershipDataState(candidates, stamped map[string]int, owners int) dataStat
 			Source: blameDataStateSource,
 			Note:   "no symbol matched the kind / path_prefix filters, so this empty result is about the filters rather than about authorship data.",
 		}
-	case covered == 0:
+	case stampedTotal == 0:
 		return dataStateCaveat{
 			State:    dataStateNeverBuilt,
 			Source:   blameDataStateSource,
-			Repos:    unstamped,
+			Repos:    unmined,
 			Recovery: blameRecovery,
-			Note:     "not one symbol in scope carries a blame stamp, so this empty result is NOT evidence that nobody owns this path — authorship is stamped by a separate enrichment pass and is absent until it runs.",
+			Eligible: eligibleTotal,
+			Stamped:  stampedTotal,
+			Note:     "not one symbol in scope carries a blame stamp, so this result is NOT evidence that nobody owns this path — authorship is stamped by a separate enrichment pass and is absent until it runs.",
 		}
 	case len(unstamped) > 0:
 		return dataStateCaveat{
@@ -159,7 +191,9 @@ func ownershipDataState(candidates, stamped map[string]int, owners int) dataStat
 			Source:   blameDataStateSource,
 			Repos:    unstamped,
 			Recovery: blameRecovery,
-			Note:     "these repositories hold candidate symbols but no blame stamps, while others in scope are stamped. Any ownership answer over this scope is an undercount, and an empty one says nothing about the unstamped repositories.",
+			Eligible: eligibleTotal,
+			Stamped:  stampedTotal,
+			Note:     "these repositories hold symbols the blame pass admits but did not stamp — either it never ran over them, or it ran and skipped files it could not blame, which it does silently. Any ownership answer over this scope is an undercount: the rows below are real, and the symbols behind the shortfall are invisible to them.",
 		}
 	case owners > 0:
 		return dataStateCaveat{

--- a/internal/mcp/data_state.go
+++ b/internal/mcp/data_state.go
@@ -1,0 +1,177 @@
+package mcp
+
+import (
+	"sort"
+	"strings"
+)
+
+// An empty analyze result has more than one cause, and the caller cannot tell
+// them apart from the number alone: the backing data may never have been
+// built, it may cover only part of the scope, or the query may have been
+// answered in full and found nothing. Only the last one is safe to act on, and
+// it is the one an agent assumes.
+//
+// contract_tier.go answers that question for the contract tier. This file
+// generalises the same three properties to any surface whose data is produced
+// by a pass separate from indexing:
+//
+//  1. say the zero is not absence evidence;
+//  2. name WHICH scope is in that state, not just that some are;
+//  3. name the recovery, and rule out the recovery that looks obvious but
+//     does nothing.
+//
+// The third property is the one that saves the most time. Every one of these
+// surfaces is populated by an enrichment pass, and reindex_repository — the
+// call a caller reaches for first — never runs one.
+//
+// Deliberately NOT built on graph.EnrichmentState. That marker is written only
+// by the semantic (LSP) providers, and it refuses to record on a dirty tree or
+// without a sha, so a repo enriched under either condition would be reported
+// as never enriched. Each caveat here is instead derived from the same data
+// the answer itself was computed from, which is stronger evidence and cannot
+// contradict the number it accompanies.
+
+// dataStateCaveatKey is the stable token a client matches on. It names the
+// condition rather than the presentation, so callers can branch without
+// parsing prose.
+const dataStateCaveatKey = "data_state"
+
+const (
+	// dataStateNeverBuilt: the enrichment that populates this surface has
+	// never run over the scope, so the empty result carries no information
+	// about the question that was asked.
+	dataStateNeverBuilt = "never_built"
+	// dataStatePartial: it ran over part of the scope. Rows may exist and
+	// still be an undercount, which is why this is reported separately
+	// rather than folded into "built".
+	dataStatePartial = "partial"
+	// dataStateBuilt: the data is there and the answer is real. This is the
+	// valuable half — it lets a caller say "actually nothing" with the same
+	// confidence the tool has, instead of hedging every zero forever.
+	dataStateBuilt = "built"
+)
+
+// dataStateCaveat is the structured caveat attached to an empty result whose
+// backing data can legitimately be absent.
+type dataStateCaveat struct {
+	// State is one of the three constants above.
+	State string
+	// Source names the tier or enrichment the state describes, so a caller
+	// that sees the same token from two different kinds can tell they share a
+	// cause.
+	Source string
+	// Repos are the scopes in the reported state — the ones missing data for
+	// never_built and partial. Empty for built.
+	Repos []string
+	// Recovery is the command that would produce the data. Empty when the
+	// state is built, where there is nothing to recover.
+	Recovery string
+	// Note carries the reading a caller must not make, in prose.
+	Note string
+}
+
+func (c dataStateCaveat) payload() map[string]any {
+	out := map[string]any{
+		"state":  c.State,
+		"source": c.Source,
+		"note":   c.Note,
+	}
+	if len(c.Repos) > 0 {
+		out["repos"] = displayRepoPrefixes(c.Repos)
+	}
+	if c.Recovery != "" {
+		out["recovery"] = c.Recovery
+	}
+	return out
+}
+
+// line renders the caveat for the compact text encoding, where a caller sees
+// prose rather than a payload.
+func (c dataStateCaveat) line() string {
+	var b strings.Builder
+	b.WriteString(dataStateCaveatKey + ": " + c.State + " (" + c.Source + ")")
+	if len(c.Repos) > 0 {
+		b.WriteString(" — " + strings.Join(displayRepoPrefixes(c.Repos), ", "))
+	}
+	b.WriteString(" — " + c.Note)
+	if c.Recovery != "" {
+		b.WriteString(" " + c.Recovery)
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+const blameDataStateSource = "blame_enrichment"
+
+// blameRecovery names the pass that stamps authorship, and rules out the two
+// calls a caller reaches for first. Indexing does not read git blame at all,
+// so neither a re-index nor a re-track produces a single stamp.
+const blameRecovery = "run `gortex enrich blame` (or `gortex enrich all`). reindex_repository and untrack/track will NOT stamp authorship: indexing never reads git blame, so a re-parse of every file still leaves it empty."
+
+// ownershipDataState classifies an empty ownership answer from the counts its
+// own scan produced.
+//
+// candidates and stamped are per-repo tallies over exactly the nodes the
+// handler considered: candidates counts every symbol that passed the kind and
+// path filters, stamped counts those carrying blame authorship. owners is the
+// number of distinct owners found before the min_symbols filter — non-zero
+// there with no rows means the data was fine and the threshold removed the
+// answer, which is a third silent zero this handler used to render
+// identically to the other two.
+func ownershipDataState(candidates, stamped map[string]int, owners int) dataStateCaveat {
+	var unstamped []string
+	covered := 0
+	total := 0
+	for repo, n := range candidates {
+		if n == 0 {
+			continue
+		}
+		total++
+		if stamped[repo] > 0 {
+			covered++
+			continue
+		}
+		unstamped = append(unstamped, repo)
+	}
+	sort.Strings(unstamped)
+
+	switch {
+	case total == 0:
+		// Nothing was in scope to be owned. Blame state is irrelevant: no
+		// enrichment would put a row here, so reporting one as missing would
+		// send the caller after the wrong thing.
+		return dataStateCaveat{
+			State:  dataStateBuilt,
+			Source: blameDataStateSource,
+			Note:   "no symbol matched the kind / path_prefix filters, so this empty result is about the filters rather than about authorship data.",
+		}
+	case covered == 0:
+		return dataStateCaveat{
+			State:    dataStateNeverBuilt,
+			Source:   blameDataStateSource,
+			Repos:    unstamped,
+			Recovery: blameRecovery,
+			Note:     "not one symbol in scope carries a blame stamp, so this empty result is NOT evidence that nobody owns this path — authorship is stamped by a separate enrichment pass and is absent until it runs.",
+		}
+	case len(unstamped) > 0:
+		return dataStateCaveat{
+			State:    dataStatePartial,
+			Source:   blameDataStateSource,
+			Repos:    unstamped,
+			Recovery: blameRecovery,
+			Note:     "these repositories hold candidate symbols but no blame stamps, while others in scope are stamped. Any ownership answer over this scope is an undercount, and an empty one says nothing about the unstamped repositories.",
+		}
+	case owners > 0:
+		return dataStateCaveat{
+			State:  dataStateBuilt,
+			Source: blameDataStateSource,
+			Note:   "authorship is stamped across the scope and owners were found; every one of them fell below min_symbols. Lower min_symbols to see them — this empty result is a threshold, not an absence.",
+		}
+	default:
+		return dataStateCaveat{
+			State:  dataStateBuilt,
+			Source: blameDataStateSource,
+			Note:   "authorship is stamped across the scope, so this empty result is a real answer: no symbol in it carries an owner email and timestamp.",
+		}
+	}
+}

--- a/internal/mcp/data_state.go
+++ b/internal/mcp/data_state.go
@@ -36,19 +36,26 @@ import (
 // parsing prose.
 const dataStateCaveatKey = "data_state"
 
+// The three states name what was OBSERVED in the answer's own scope, never
+// what a pass did or did not do. That distinction is not pedantry: these
+// enrichments are best-effort per file and report success while skipping every
+// file they could not read, so "no data present" and "never ran" are not the
+// same claim and only the first one is observable from here. Naming a state
+// after run history would publish a history this code cannot see, and hand the
+// caller a recovery that may not clear it.
 const (
-	// dataStateNeverBuilt: the enrichment that populates this surface has
-	// never run over the scope, so the empty result carries no information
-	// about the question that was asked.
-	dataStateNeverBuilt = "never_built"
-	// dataStatePartial: it ran over part of the scope. Rows may exist and
-	// still be an undercount, which is why this is reported separately
-	// rather than folded into "built".
+	// dataStateAbsent: nothing in scope carries this data. Whether the pass
+	// never ran or ran and produced nothing is outside what can be seen here.
+	dataStateAbsent = "absent"
+	// dataStatePartial: some of the scope carries it and some does not. Rows
+	// may exist and still be an undercount, which is why this is reported
+	// separately rather than folded into complete.
 	dataStatePartial = "partial"
-	// dataStateBuilt: the data is there and the answer is real. This is the
-	// valuable half — it lets a caller say "actually nothing" with the same
-	// confidence the tool has, instead of hedging every zero forever.
-	dataStateBuilt = "built"
+	// dataStateComplete: every symbol the pass admits carries data, so the
+	// answer is whole. This is the valuable half — it lets a caller say
+	// "actually nothing" with the same confidence the tool has, instead of
+	// hedging every zero forever.
+	dataStateComplete = "complete"
 )
 
 // dataStateCaveat is the structured caveat attached to an empty result whose
@@ -64,7 +71,7 @@ type dataStateCaveat struct {
 	// never_built and partial. Empty for built.
 	Repos []string
 	// Recovery is the command that would produce the data. Empty when the
-	// state is built, where there is nothing to recover.
+	// state is complete, where there is nothing to recover.
 	Recovery string
 	// Eligible and Stamped size the shortfall: how many symbols the pass
 	// admits in scope, and how many carry data. A caller deciding whether to
@@ -115,7 +122,7 @@ const blameDataStateSource = "blame_enrichment"
 // blameRecovery names the pass that stamps authorship, and rules out the two
 // calls a caller reaches for first. Indexing does not read git blame at all,
 // so neither a re-index nor a re-track produces a single stamp.
-const blameRecovery = "run `gortex enrich blame` (or `gortex enrich all`). reindex_repository and untrack/track will NOT stamp authorship: indexing never reads git blame, so a re-parse of every file still leaves it empty."
+const blameRecovery = "run `gortex enrich blame` (or `gortex enrich all`). reindex_repository and untrack/track will NOT stamp authorship: indexing never reads git blame, so a re-parse of every file still leaves it empty. If this state survives the pass, the remaining files are ones git could not blame — an unborn commit, an untracked or generated file — rather than ones nobody has enriched yet."
 
 // ownershipDataState classifies an ownership answer from the counts its own
 // scan produced.
@@ -139,7 +146,13 @@ const blameRecovery = "run `gortex enrich blame` (or `gortex enrich all`). reind
 // The counting population is blame's own admission set for the same reason in
 // reverse: a symbol the pass never looks at is not a coverage hole, and
 // counting it would report a shortfall no enrichment could close.
-func ownershipDataState(candidates, stamped map[string]int, owners int) dataStateCaveat {
+// thresholdClause is appended whenever min_symbols emptied an answer that had
+// owners in it. It is a SECOND, unrelated reason the response is empty, and
+// reporting only the coverage shortfall would send a caller to re-run an
+// enrichment that would not put the rows back.
+const thresholdClause = " Separately: owners were found and min_symbols removed every one of them, so this particular response is empty for a second reason that no enrichment will change — lower min_symbols to see them."
+
+func ownershipDataState(candidates, stamped map[string]int, owners, rows int) dataStateCaveat {
 	var unmined, incomplete []string
 	covered := 0
 	total := 0
@@ -165,27 +178,39 @@ func ownershipDataState(candidates, stamped map[string]int, owners int) dataStat
 	sort.Strings(unstamped)
 	sort.Strings(unmined)
 
+	// Both causes are live at once when coverage is short AND the threshold
+	// emptied the rows, so the note is composed rather than chosen.
+	thresholdEmptied := rows == 0 && owners > 0
+
 	switch {
 	case total == 0:
 		// Nothing was in scope to be owned. Blame state is irrelevant: no
 		// enrichment would put a row here, so reporting one as missing would
 		// send the caller after the wrong thing.
 		return dataStateCaveat{
-			State:  dataStateBuilt,
+			State:  dataStateComplete,
 			Source: blameDataStateSource,
 			Note:   "no symbol matched the kind / path_prefix filters, so this empty result is about the filters rather than about authorship data.",
 		}
 	case stampedTotal == 0:
+		note := "not one symbol in scope carries a blame stamp, so this result is NOT evidence that nobody owns this path — authorship comes from a separate pass and none of it is present here."
+		if thresholdEmptied {
+			note += thresholdClause
+		}
 		return dataStateCaveat{
-			State:    dataStateNeverBuilt,
+			State:    dataStateAbsent,
 			Source:   blameDataStateSource,
 			Repos:    unmined,
 			Recovery: blameRecovery,
 			Eligible: eligibleTotal,
 			Stamped:  stampedTotal,
-			Note:     "not one symbol in scope carries a blame stamp, so this result is NOT evidence that nobody owns this path — authorship is stamped by a separate enrichment pass and is absent until it runs.",
+			Note:     note,
 		}
 	case len(unstamped) > 0:
+		note := "these repositories hold symbols the blame pass admits but that carry no authorship — the pass is best-effort per file and skips what it cannot blame, silently. Any ownership answer over this scope is an undercount: whatever rows it returns are real, and the symbols behind the shortfall are invisible to them."
+		if thresholdEmptied {
+			note += thresholdClause
+		}
 		return dataStateCaveat{
 			State:    dataStatePartial,
 			Source:   blameDataStateSource,
@@ -193,19 +218,19 @@ func ownershipDataState(candidates, stamped map[string]int, owners int) dataStat
 			Recovery: blameRecovery,
 			Eligible: eligibleTotal,
 			Stamped:  stampedTotal,
-			Note:     "these repositories hold symbols the blame pass admits but did not stamp — either it never ran over them, or it ran and skipped files it could not blame, which it does silently. Any ownership answer over this scope is an undercount: the rows below are real, and the symbols behind the shortfall are invisible to them.",
+			Note:     note,
 		}
-	case owners > 0:
+	case thresholdEmptied:
 		return dataStateCaveat{
-			State:  dataStateBuilt,
+			State:  dataStateComplete,
 			Source: blameDataStateSource,
-			Note:   "authorship is stamped across the scope and owners were found; every one of them fell below min_symbols. Lower min_symbols to see them — this empty result is a threshold, not an absence.",
+			Note:   "authorship is stamped across every symbol the pass admits, so nothing is missing." + thresholdClause,
 		}
 	default:
 		return dataStateCaveat{
-			State:  dataStateBuilt,
+			State:  dataStateComplete,
 			Source: blameDataStateSource,
-			Note:   "authorship is stamped across the scope, so this empty result is a real answer: no symbol in it carries an owner email and timestamp.",
+			Note:   "authorship is stamped across every symbol the pass admits, so this result is whole: what it shows is what there is.",
 		}
 	}
 }

--- a/internal/mcp/tools_analyze_ownership_coverage_test.go
+++ b/internal/mcp/tools_analyze_ownership_coverage_test.go
@@ -1,0 +1,151 @@
+package mcp
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/blame"
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/query"
+)
+
+// TestAnalyzeOwnership_PartialCoverageInsideOneRepoKeepsTheCaveat is the
+// review case. blame.EnrichGraph is best-effort per file — Run failing or
+// returning nothing skips that file and the pass still reports success — so
+// one repository holds both stamped and unstamped eligible symbols. Reading a
+// single stamp as coverage dropped the caveat and published a silently
+// incomplete answer, which is the failure this whole change exists to stop,
+// re-entered one level down.
+func TestAnalyzeOwnership_PartialCoverageInsideOneRepoKeepsTheCaveat(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	addBlameNodeInRepo(srv.graph, "repo-a", "repo-a/f.go::A", "repo-a/f.go", "alice@x", time.Now().Unix())
+	// Same repository, same kind, eligible for blame — the pass simply never
+	// stamped it.
+	addBlameNodeInRepo(srv.graph, "repo-a", "repo-a/g.go::B", "repo-a/g.go", "", 0)
+
+	out := callAnalyzeOwnership(t, srv, map[string]any{})
+
+	owners, _ := out["owners"].([]any)
+	require.NotEmpty(t, owners, "the stamped symbol must still produce a row")
+	state := ownershipDataStateOf(t, out)
+	require.Equal(t, "partial", state["state"],
+		"one stamp in a repository is not coverage of it")
+	repos, _ := state["repos"].([]any)
+	require.Contains(t, repos, "repo-a",
+		"the partly covered repository must be named, not just the wholly unmined ones")
+
+	eligible, _ := state["symbols_eligible"].(float64)
+	stamped, _ := state["symbols_stamped"].(float64)
+	require.Greater(t, eligible, stamped, "the shortfall must be visible as a size, not only a verdict")
+}
+
+// TestAnalyzeOwnership_IneligibleSymbolsAreNotCountedAsAShortfall is the other
+// direction, and the reason coverage is counted against blame's own admission
+// set. A symbol the pass never looks at is not a coverage hole: counting it
+// would report a shortfall that no enrichment could ever close, and a caveat
+// that never clears is one a caller learns to ignore.
+func TestAnalyzeOwnership_IneligibleSymbolsAreNotCountedAsAShortfall(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	now := time.Now().Unix()
+	addBlameNodeInRepo(srv.graph, "repo-a", "repo-a/f.go::A", "repo-a/f.go", "alice@x", now)
+	// StartLine 0: no position to blame, so blame.EnrichGraph skips it before
+	// it ever reaches git.
+	srv.graph.AddNode(&graph.Node{
+		ID: "repo-a/f.go::NoPosition", Kind: graph.KindFunction, Name: "NoPosition",
+		FilePath: "repo-a/f.go", RepoPrefix: "repo-a",
+	})
+
+	out := callAnalyzeOwnership(t, srv, map[string]any{"path_prefix": "repo-a/"})
+
+	state, present := out["data_state"].(map[string]any)
+	if present {
+		repos, _ := state["repos"].([]any)
+		require.NotContains(t, repos, "repo-a",
+			"an unblameable symbol was reported as a coverage shortfall")
+	}
+}
+
+// TestAnalyzeOwnership_ReindexAfterEnrichmentReportsPartialCoverage runs the
+// real pass over a real git repository, then does what a working day does:
+// adds code and re-indexes. The new symbols are eligible and unstamped, so the
+// ownership answer that follows is an undercount — and it has rows, which is
+// the shape that reads as complete.
+func TestAnalyzeOwnership_ReindexAfterEnrichmentReportsPartialCoverage(t *testing.T) {
+	refIsolateGit(t)
+	dir := t.TempDir()
+	refWriteFiles(t, dir, map[string]string{
+		"keep.go": "package repo\n\nfunc Keeper() {}\n",
+	})
+	refGit(t, dir, "init", "--initial-branch=main")
+	refGit(t, dir, "add", "-A")
+	refGit(t, dir, "commit", "-m", "initial")
+
+	g := graph.New()
+	idx := indexer.New(g, testRegistry(), config.Default().Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+
+	enriched, err := blame.EnrichGraph(g, dir)
+	require.NoError(t, err)
+	require.Positive(t, enriched, "the blame pass stamped nothing; the fixture proves nothing")
+
+	srv := NewServer(query.NewEngine(g), g, idx, nil, zap.NewNop(), nil)
+	before := callAnalyzeOwnership(t, srv, map[string]any{})
+	require.NotEmpty(t, before["owners"], "the enriched repo must have an owner")
+	_, caveated := before["data_state"]
+	require.False(t, caveated,
+		"a fully stamped scope must not carry a caveat, or partial means nothing")
+
+	// A working day: new code lands and the index catches up. Blame does not.
+	refWriteFiles(t, dir, map[string]string{
+		"added.go": "package repo\n\nfunc Added() {}\n\nfunc AlsoAdded() {}\n",
+	})
+	_, err = idx.IncrementalReindexPaths(dir, []string{filepath.Join(dir, "added.go")})
+	require.NoError(t, err)
+
+	after := callAnalyzeOwnership(t, srv, map[string]any{})
+	require.NotEmpty(t, after["owners"], "the previously stamped owner must still be reported")
+	state := ownershipDataStateOf(t, after)
+	require.Equal(t, "partial", state["state"],
+		"symbols indexed after the blame pass are invisible to this answer and nothing said so")
+	eligible, _ := state["symbols_eligible"].(float64)
+	stamped, _ := state["symbols_stamped"].(float64)
+	require.Greater(t, eligible, stamped)
+}
+
+// TestAnalyzeOwnership_AStampOnAnIneligibleSymbolCannotFillTheGap closes the
+// other side of the eligibility rule. The stamped tally is filtered too,
+// because a stamp on a symbol blame would never admit — a stale meta value
+// left behind when an edit moved a symbol to StartLine 0, say — would
+// otherwise be counted against an eligible population it is not part of, and
+// one such stamp is enough to make a short repository read as covered.
+func TestAnalyzeOwnership_AStampOnAnIneligibleSymbolCannotFillTheGap(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	now := time.Now().Unix()
+	addBlameNodeInRepo(srv.graph, "repo-a", "repo-a/f.go::A", "repo-a/f.go", "alice@x", now)
+	addBlameNodeInRepo(srv.graph, "repo-a", "repo-a/g.go::B", "repo-a/g.go", "", 0)
+	// Eligible for nothing (no position), yet carrying authorship.
+	srv.graph.AddNode(&graph.Node{
+		ID: "repo-a/h.go::Stale", Kind: graph.KindFunction, Name: "Stale",
+		FilePath: "repo-a/h.go", RepoPrefix: "repo-a",
+		Meta: map[string]any{
+			"last_authored": map[string]any{"email": "bob@x", "timestamp": now},
+		},
+	})
+
+	out := callAnalyzeOwnership(t, srv, map[string]any{"path_prefix": "repo-a/"})
+
+	state := ownershipDataStateOf(t, out)
+	require.Equal(t, "partial", state["state"],
+		"a stamp outside the eligible population was counted as coverage of it")
+	stamped, _ := state["symbols_stamped"].(float64)
+	eligible, _ := state["symbols_eligible"].(float64)
+	require.Equal(t, float64(1), stamped, "the ineligible stamp was tallied")
+	require.Equal(t, float64(2), eligible)
+}

--- a/internal/mcp/tools_analyze_ownership_coverage_test.go
+++ b/internal/mcp/tools_analyze_ownership_coverage_test.go
@@ -91,7 +91,7 @@ func TestAnalyzeOwnership_ReindexAfterEnrichmentReportsPartialCoverage(t *testin
 	_, err := idx.Index(dir)
 	require.NoError(t, err)
 
-	enriched, err := blame.EnrichGraph(g, dir)
+	enriched, err := blame.EnrichGraph(g, dir, "")
 	require.NoError(t, err)
 	require.Positive(t, enriched, "the blame pass stamped nothing; the fixture proves nothing")
 

--- a/internal/mcp/tools_analyze_ownership_data_state_test.go
+++ b/internal/mcp/tools_analyze_ownership_data_state_test.go
@@ -5,8 +5,22 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/query"
 )
+
+// ownershipIsolatedServer serves an empty graph, so a test can state what full
+// blame coverage looks like. setupTestServer seeds unstamped symbols of its
+// own — correctly reported as a coverage shortfall now that coverage is
+// compared rather than presence — which makes it unusable for asserting the
+// absence of a caveat.
+func ownershipIsolatedServer(t *testing.T) *Server {
+	t.Helper()
+	g := graph.New()
+	return NewServer(query.NewEngine(g), g, nil, nil, zap.NewNop(), nil)
+}
 
 // addBlameNodeInRepo is addBlameNode with an explicit repo prefix, for the
 // multi-repo cases where the caveat has to name WHICH repository is missing
@@ -109,7 +123,7 @@ func TestAnalyzeOwnership_PartialNamesTheUnstampedRepoEvenWithRows(t *testing.T)
 }
 
 func TestAnalyzeOwnership_BuiltZeroIsReportedAsReal(t *testing.T) {
-	srv, _ := setupTestServer(t)
+	srv := ownershipIsolatedServer(t)
 	addBlameNode(srv.graph, "f.go::A", "f.go", "alice@x", time.Now().Unix())
 
 	// Blame is stamped and an owner exists; min_symbols removed the answer. A
@@ -148,7 +162,7 @@ func TestAnalyzeOwnership_FilterMissIsNotBlamedOnEnrichment(t *testing.T) {
 }
 
 func TestAnalyzeOwnership_CompleteAnswerCarriesNoCaveat(t *testing.T) {
-	srv, _ := setupTestServer(t)
+	srv := ownershipIsolatedServer(t)
 	now := time.Now().Unix()
 	addBlameNode(srv.graph, "f.go::A", "f.go", "alice@x", now)
 	addBlameNode(srv.graph, "f.go::B", "f.go", "bob@x", now)
@@ -174,6 +188,13 @@ func TestOwnershipDataStateClassification(t *testing.T) {
 		{"scope holds only empty repos", map[string]int{"repo-a": 0}, map[string]int{}, 0, dataStateBuilt, nil},
 		{"no repo stamped", map[string]int{"repo-a": 3, "repo-b": 2}, map[string]int{}, 0, dataStateNeverBuilt, []string{"repo-a", "repo-b"}},
 		{"one repo stamped", map[string]int{"repo-a": 3, "repo-b": 2}, map[string]int{"repo-a": 3}, 1, dataStatePartial, []string{"repo-b"}},
+		// The review case: one stamp does not cover a repository. blame is
+		// best-effort per file, so a repo routinely holds both stamped and
+		// unstamped eligible symbols, and reading presence as coverage
+		// published the undercount this caveat exists to prevent.
+		{"same repo only partly stamped", map[string]int{"repo-a": 3}, map[string]int{"repo-a": 1}, 1, dataStatePartial, []string{"repo-a"}},
+		{"same repo one short", map[string]int{"repo-a": 3}, map[string]int{"repo-a": 2}, 1, dataStatePartial, []string{"repo-a"}},
+		{"a partly stamped repo alongside an unmined one", map[string]int{"repo-a": 3, "repo-b": 2}, map[string]int{"repo-a": 1}, 1, dataStatePartial, []string{"repo-a", "repo-b"}},
 		{"every repo stamped", map[string]int{"repo-a": 3}, map[string]int{"repo-a": 3}, 0, dataStateBuilt, nil},
 		{"owners dropped by threshold", map[string]int{"repo-a": 3}, map[string]int{"repo-a": 3}, 2, dataStateBuilt, nil},
 	} {

--- a/internal/mcp/tools_analyze_ownership_data_state_test.go
+++ b/internal/mcp/tools_analyze_ownership_data_state_test.go
@@ -1,0 +1,217 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// addBlameNodeInRepo is addBlameNode with an explicit repo prefix, for the
+// multi-repo cases where the caveat has to name WHICH repository is missing
+// data rather than only reporting that some are. An empty email and zero
+// timestamp produce an indexed symbol with no authorship at all.
+func addBlameNodeInRepo(g graph.Store, repo, id, file, email string, ts int64) {
+	n := &graph.Node{
+		ID:         id,
+		Kind:       graph.KindFunction,
+		Name:       id,
+		FilePath:   file,
+		StartLine:  1,
+		EndLine:    1,
+		RepoPrefix: repo,
+	}
+	if email != "" || ts != 0 {
+		n.Meta = map[string]any{
+			"last_authored": map[string]any{"email": email, "timestamp": ts},
+		}
+	}
+	g.AddNode(n)
+}
+
+func ownershipDataStateOf(t *testing.T, out map[string]any) map[string]any {
+	t.Helper()
+	state, ok := out["data_state"].(map[string]any)
+	if !ok {
+		t.Fatalf("no data_state on the answer: %+v", out)
+	}
+	return state
+}
+
+func TestAnalyzeOwnership_UnenrichedZeroSaysItIsNotAbsence(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	// Indexed symbols, no blame pass. The old answer was "no owners matched",
+	// which reads exactly like "nobody owns this code".
+	srv.graph.AddNode(&graph.Node{ID: "f.go::A", Kind: graph.KindFunction, Name: "A", FilePath: "f.go"})
+	srv.graph.AddNode(&graph.Node{ID: "f.go::B", Kind: graph.KindFunction, Name: "B", FilePath: "f.go"})
+
+	out := callAnalyzeOwnership(t, srv, map[string]any{})
+	if owners, _ := out["owners"].([]any); len(owners) != 0 {
+		t.Fatalf("expected an empty answer, got %d owners", len(owners))
+	}
+	state := ownershipDataStateOf(t, out)
+	if state["state"] != "never_built" {
+		t.Fatalf("state = %v, want never_built", state["state"])
+	}
+	if state["source"] != "blame_enrichment" {
+		t.Fatalf("source = %v", state["source"])
+	}
+	note, _ := state["note"].(string)
+	if !strings.Contains(note, "NOT evidence") {
+		t.Fatalf("the note does not refuse the absence reading: %q", note)
+	}
+	// The third property of the template: name the recovery AND rule out the
+	// one that looks obvious. Indexing never reads git blame, so a caller who
+	// reaches for reindex_repository gets the same empty answer back.
+	recovery, _ := state["recovery"].(string)
+	if !strings.Contains(recovery, "gortex enrich blame") {
+		t.Fatalf("recovery does not name the pass: %q", recovery)
+	}
+	if !strings.Contains(recovery, "reindex_repository") {
+		t.Fatalf("recovery does not rule out reindex_repository: %q", recovery)
+	}
+}
+
+func TestAnalyzeOwnership_PartialNamesTheUnstampedRepoEvenWithRows(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	now := time.Now().Unix()
+	addBlameNodeInRepo(srv.graph, "repo-a", "a/f.go::A", "a/f.go", "alice@x", now)
+	// repo-b is indexed but was never blamed. Its symbols are invisible to
+	// this answer, and the row from repo-a makes the answer look complete.
+	addBlameNodeInRepo(srv.graph, "repo-b", "b/g.go::B", "b/g.go", "", 0)
+
+	out := callAnalyzeOwnership(t, srv, map[string]any{})
+	if owners, _ := out["owners"].([]any); len(owners) != 1 {
+		t.Fatalf("expected the repo-a owner to still be returned, got %d", len(owners))
+	}
+	state := ownershipDataStateOf(t, out)
+	if state["state"] != "partial" {
+		t.Fatalf("state = %v, want partial — a non-empty undercount is the dangerous shape", state["state"])
+	}
+	// The property is which repositories are named, not how many: the test
+	// server's own fixture nodes are unstamped too, and reporting them is
+	// correct. What must hold is that the unstamped repo appears and the
+	// stamped one does not — a caveat that named repo-a would be telling the
+	// caller to re-enrich the one repository that is already covered.
+	repos, _ := state["repos"].([]any)
+	named := map[string]bool{}
+	for _, r := range repos {
+		s, _ := r.(string)
+		named[s] = true
+	}
+	if !named["repo-b"] {
+		t.Fatalf("repos = %v, does not name the unstamped repo", repos)
+	}
+	if named["repo-a"] {
+		t.Fatalf("repos = %v, names a repo that IS stamped", repos)
+	}
+}
+
+func TestAnalyzeOwnership_BuiltZeroIsReportedAsReal(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	addBlameNode(srv.graph, "f.go::A", "f.go", "alice@x", time.Now().Unix())
+
+	// Blame is stamped and an owner exists; min_symbols removed the answer. A
+	// caller told only "no owners matched" would go looking for enrichment
+	// that is not missing.
+	out := callAnalyzeOwnership(t, srv, map[string]any{"min_symbols": 5.0})
+	if owners, _ := out["owners"].([]any); len(owners) != 0 {
+		t.Fatalf("expected the threshold to empty the answer, got %d", len(owners))
+	}
+	state := ownershipDataStateOf(t, out)
+	if state["state"] != "built" {
+		t.Fatalf("state = %v, want built", state["state"])
+	}
+	if _, hasRecovery := state["recovery"]; hasRecovery {
+		t.Fatal("a built state offered a recovery; there is nothing to recover")
+	}
+	note, _ := state["note"].(string)
+	if !strings.Contains(note, "min_symbols") {
+		t.Fatalf("the note does not name the threshold that emptied it: %q", note)
+	}
+}
+
+func TestAnalyzeOwnership_FilterMissIsNotBlamedOnEnrichment(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	addBlameNode(srv.graph, "internal/auth/jwt.go::Verify", "internal/auth/jwt.go", "alice@x", time.Now().Unix())
+
+	out := callAnalyzeOwnership(t, srv, map[string]any{"path_prefix": "internal/db/"})
+	state := ownershipDataStateOf(t, out)
+	if state["state"] != "built" {
+		t.Fatalf("state = %v, want built — no symbol was in scope to be owned", state["state"])
+	}
+	note, _ := state["note"].(string)
+	if !strings.Contains(note, "filters") {
+		t.Fatalf("the note sends the caller after enrichment instead of the filter: %q", note)
+	}
+}
+
+func TestAnalyzeOwnership_CompleteAnswerCarriesNoCaveat(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	now := time.Now().Unix()
+	addBlameNode(srv.graph, "f.go::A", "f.go", "alice@x", now)
+	addBlameNode(srv.graph, "f.go::B", "f.go", "bob@x", now)
+
+	out := callAnalyzeOwnership(t, srv, map[string]any{})
+	if _, present := out["data_state"]; present {
+		t.Fatalf("a complete answer was annotated: %+v", out["data_state"])
+	}
+}
+
+func TestOwnershipDataStateClassification(t *testing.T) {
+	// The state machine on its own. Every row is a shape the handler can
+	// produce; the end-to-end tests above pin that it produces them.
+	for _, tc := range []struct {
+		name       string
+		candidates map[string]int
+		stamped    map[string]int
+		owners     int
+		want       string
+		wantRepos  []string
+	}{
+		{"nothing in scope", map[string]int{}, map[string]int{}, 0, dataStateBuilt, nil},
+		{"scope holds only empty repos", map[string]int{"repo-a": 0}, map[string]int{}, 0, dataStateBuilt, nil},
+		{"no repo stamped", map[string]int{"repo-a": 3, "repo-b": 2}, map[string]int{}, 0, dataStateNeverBuilt, []string{"repo-a", "repo-b"}},
+		{"one repo stamped", map[string]int{"repo-a": 3, "repo-b": 2}, map[string]int{"repo-a": 3}, 1, dataStatePartial, []string{"repo-b"}},
+		{"every repo stamped", map[string]int{"repo-a": 3}, map[string]int{"repo-a": 3}, 0, dataStateBuilt, nil},
+		{"owners dropped by threshold", map[string]int{"repo-a": 3}, map[string]int{"repo-a": 3}, 2, dataStateBuilt, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ownershipDataState(tc.candidates, tc.stamped, tc.owners)
+			if got.State != tc.want {
+				t.Fatalf("state = %q, want %q", got.State, tc.want)
+			}
+			if len(got.Repos) != len(tc.wantRepos) {
+				t.Fatalf("repos = %v, want %v", got.Repos, tc.wantRepos)
+			}
+			for i, want := range tc.wantRepos {
+				if got.Repos[i] != want {
+					t.Fatalf("repos = %v, want %v", got.Repos, tc.wantRepos)
+				}
+			}
+			if got.Note == "" {
+				t.Fatal("every state must carry a note; a bare token is the thing this replaces")
+			}
+			if (got.State == dataStateBuilt) != (got.Recovery == "") {
+				t.Fatalf("state %q with recovery %q: only a recoverable state may name a recovery",
+					got.State, got.Recovery)
+			}
+		})
+	}
+}
+
+func TestOwnershipDataStateLineCarriesTheNote(t *testing.T) {
+	// The compact encoding is prose only — a caller there sees the line or
+	// nothing, so the note and the recovery must both survive it.
+	c := ownershipDataState(map[string]int{"repo-a": 2}, map[string]int{}, 0)
+	line := c.line()
+	if !strings.HasPrefix(line, "data_state: never_built (blame_enrichment)") {
+		t.Fatalf("line does not lead with the machine-matchable token: %q", line)
+	}
+	for _, want := range []string{"repo-a", "NOT evidence", "gortex enrich blame", "reindex_repository"} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("line dropped %q: %q", want, line)
+		}
+	}
+}

--- a/internal/mcp/tools_analyze_ownership_data_state_test.go
+++ b/internal/mcp/tools_analyze_ownership_data_state_test.go
@@ -65,8 +65,8 @@ func TestAnalyzeOwnership_UnenrichedZeroSaysItIsNotAbsence(t *testing.T) {
 		t.Fatalf("expected an empty answer, got %d owners", len(owners))
 	}
 	state := ownershipDataStateOf(t, out)
-	if state["state"] != "never_built" {
-		t.Fatalf("state = %v, want never_built", state["state"])
+	if state["state"] != "absent" {
+		t.Fatalf("state = %v, want absent", state["state"])
 	}
 	if state["source"] != "blame_enrichment" {
 		t.Fatalf("source = %v", state["source"])
@@ -134,8 +134,8 @@ func TestAnalyzeOwnership_BuiltZeroIsReportedAsReal(t *testing.T) {
 		t.Fatalf("expected the threshold to empty the answer, got %d", len(owners))
 	}
 	state := ownershipDataStateOf(t, out)
-	if state["state"] != "built" {
-		t.Fatalf("state = %v, want built", state["state"])
+	if state["state"] != "complete" {
+		t.Fatalf("state = %v, want complete", state["state"])
 	}
 	if _, hasRecovery := state["recovery"]; hasRecovery {
 		t.Fatal("a built state offered a recovery; there is nothing to recover")
@@ -152,8 +152,8 @@ func TestAnalyzeOwnership_FilterMissIsNotBlamedOnEnrichment(t *testing.T) {
 
 	out := callAnalyzeOwnership(t, srv, map[string]any{"path_prefix": "internal/db/"})
 	state := ownershipDataStateOf(t, out)
-	if state["state"] != "built" {
-		t.Fatalf("state = %v, want built — no symbol was in scope to be owned", state["state"])
+	if state["state"] != "complete" {
+		t.Fatalf("state = %v, want complete — no symbol was in scope to be owned", state["state"])
 	}
 	note, _ := state["note"].(string)
 	if !strings.Contains(note, "filters") {
@@ -181,25 +181,26 @@ func TestOwnershipDataStateClassification(t *testing.T) {
 		candidates map[string]int
 		stamped    map[string]int
 		owners     int
+		rows       int
 		want       string
 		wantRepos  []string
 	}{
-		{"nothing in scope", map[string]int{}, map[string]int{}, 0, dataStateBuilt, nil},
-		{"scope holds only empty repos", map[string]int{"repo-a": 0}, map[string]int{}, 0, dataStateBuilt, nil},
-		{"no repo stamped", map[string]int{"repo-a": 3, "repo-b": 2}, map[string]int{}, 0, dataStateNeverBuilt, []string{"repo-a", "repo-b"}},
-		{"one repo stamped", map[string]int{"repo-a": 3, "repo-b": 2}, map[string]int{"repo-a": 3}, 1, dataStatePartial, []string{"repo-b"}},
+		{"nothing in scope", map[string]int{}, map[string]int{}, 0, 0, dataStateComplete, nil},
+		{"scope holds only empty repos", map[string]int{"repo-a": 0}, map[string]int{}, 0, 0, dataStateComplete, nil},
+		{"no repo stamped", map[string]int{"repo-a": 3, "repo-b": 2}, map[string]int{}, 0, 0, dataStateAbsent, []string{"repo-a", "repo-b"}},
+		{"one repo stamped", map[string]int{"repo-a": 3, "repo-b": 2}, map[string]int{"repo-a": 3}, 1, 1, dataStatePartial, []string{"repo-b"}},
 		// The review case: one stamp does not cover a repository. blame is
 		// best-effort per file, so a repo routinely holds both stamped and
 		// unstamped eligible symbols, and reading presence as coverage
 		// published the undercount this caveat exists to prevent.
-		{"same repo only partly stamped", map[string]int{"repo-a": 3}, map[string]int{"repo-a": 1}, 1, dataStatePartial, []string{"repo-a"}},
-		{"same repo one short", map[string]int{"repo-a": 3}, map[string]int{"repo-a": 2}, 1, dataStatePartial, []string{"repo-a"}},
-		{"a partly stamped repo alongside an unmined one", map[string]int{"repo-a": 3, "repo-b": 2}, map[string]int{"repo-a": 1}, 1, dataStatePartial, []string{"repo-a", "repo-b"}},
-		{"every repo stamped", map[string]int{"repo-a": 3}, map[string]int{"repo-a": 3}, 0, dataStateBuilt, nil},
-		{"owners dropped by threshold", map[string]int{"repo-a": 3}, map[string]int{"repo-a": 3}, 2, dataStateBuilt, nil},
+		{"same repo only partly stamped", map[string]int{"repo-a": 3}, map[string]int{"repo-a": 1}, 1, 1, dataStatePartial, []string{"repo-a"}},
+		{"same repo one short", map[string]int{"repo-a": 3}, map[string]int{"repo-a": 2}, 1, 1, dataStatePartial, []string{"repo-a"}},
+		{"a partly stamped repo alongside an unmined one", map[string]int{"repo-a": 3, "repo-b": 2}, map[string]int{"repo-a": 1}, 1, 1, dataStatePartial, []string{"repo-a", "repo-b"}},
+		{"every repo stamped", map[string]int{"repo-a": 3}, map[string]int{"repo-a": 3}, 0, 1, dataStateComplete, nil},
+		{"owners dropped by threshold", map[string]int{"repo-a": 3}, map[string]int{"repo-a": 3}, 2, 0, dataStateComplete, nil},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := ownershipDataState(tc.candidates, tc.stamped, tc.owners)
+			got := ownershipDataState(tc.candidates, tc.stamped, tc.owners, tc.rows)
 			if got.State != tc.want {
 				t.Fatalf("state = %q, want %q", got.State, tc.want)
 			}
@@ -214,7 +215,7 @@ func TestOwnershipDataStateClassification(t *testing.T) {
 			if got.Note == "" {
 				t.Fatal("every state must carry a note; a bare token is the thing this replaces")
 			}
-			if (got.State == dataStateBuilt) != (got.Recovery == "") {
+			if (got.State == dataStateComplete) != (got.Recovery == "") {
 				t.Fatalf("state %q with recovery %q: only a recoverable state may name a recovery",
 					got.State, got.Recovery)
 			}
@@ -225,14 +226,75 @@ func TestOwnershipDataStateClassification(t *testing.T) {
 func TestOwnershipDataStateLineCarriesTheNote(t *testing.T) {
 	// The compact encoding is prose only — a caller there sees the line or
 	// nothing, so the note and the recovery must both survive it.
-	c := ownershipDataState(map[string]int{"repo-a": 2}, map[string]int{}, 0)
+	c := ownershipDataState(map[string]int{"repo-a": 2}, map[string]int{}, 0, 0)
 	line := c.line()
-	if !strings.HasPrefix(line, "data_state: never_built (blame_enrichment)") {
+	if !strings.HasPrefix(line, "data_state: absent (blame_enrichment)") {
 		t.Fatalf("line does not lead with the machine-matchable token: %q", line)
 	}
 	for _, want := range []string{"repo-a", "NOT evidence", "gortex enrich blame", "reindex_repository"} {
 		if !strings.Contains(line, want) {
 			t.Fatalf("line dropped %q: %q", want, line)
 		}
+	}
+}
+
+func TestOwnershipDataStateKeepsBothCausesWhenTheThresholdAlsoEmptiesIt(t *testing.T) {
+	// Two independent reasons the response is empty: coverage is short, and
+	// min_symbols removed every owner that WAS found. Reporting only the
+	// shortfall sends the caller to re-run an enrichment that will not put
+	// the rows back; reporting only the threshold hides the undercount.
+	got := ownershipDataState(
+		map[string]int{"repo-a": 4}, map[string]int{"repo-a": 2},
+		2 /* owners found */, 0 /* rows after min_symbols */)
+
+	if got.State != dataStatePartial {
+		t.Fatalf("state = %q, want partial — coverage is still short", got.State)
+	}
+	if !strings.Contains(got.Note, "min_symbols") {
+		t.Fatalf("the note drops the threshold cause: %q", got.Note)
+	}
+	if !strings.Contains(got.Note, "undercount") {
+		t.Fatalf("the note drops the coverage cause: %q", got.Note)
+	}
+	// The old partial wording promised rows that are not there.
+	if strings.Contains(got.Note, "the rows below are real") {
+		t.Fatalf("the note describes rows that do not exist: %q", got.Note)
+	}
+}
+
+func TestOwnershipDataStateNamesNoRunHistory(t *testing.T) {
+	// A best-effort pass reports success while skipping every file it could
+	// not blame, so zero stamps is not evidence it never ran. Neither the
+	// state token nor the note may claim otherwise.
+	got := ownershipDataState(map[string]int{"repo-a": 3}, map[string]int{}, 0, 0)
+
+	if got.State != dataStateAbsent {
+		t.Fatalf("state = %q, want absent", got.State)
+	}
+	for _, forbidden := range []string{"never ran", "never been", "until it runs", "has not run"} {
+		if strings.Contains(got.Note, forbidden) {
+			t.Fatalf("the note claims run history it cannot observe (%q): %q", forbidden, got.Note)
+		}
+	}
+	// And the recovery has to say what a state that survives the pass means,
+	// or a caller re-runs it forever.
+	if !strings.Contains(got.Recovery, "survives") {
+		t.Fatalf("the recovery does not say what a persistent state means: %q", got.Recovery)
+	}
+	// No owner was found here, so the threshold cause is not live. Appending
+	// it would state something false — that owners existed and a threshold
+	// removed them — in the one state where the caller has the least
+	// information to check it against.
+	if strings.Contains(got.Note, "min_symbols") {
+		t.Fatalf("the note blames a threshold that removed nothing: %q", got.Note)
+	}
+
+	// Same for a complete scope that genuinely holds no owners.
+	whole := ownershipDataState(map[string]int{"repo-a": 3}, map[string]int{"repo-a": 3}, 0, 0)
+	if whole.State != dataStateComplete {
+		t.Fatalf("state = %q, want complete", whole.State)
+	}
+	if strings.Contains(whole.Note, "min_symbols") {
+		t.Fatalf("a real zero was reported as a threshold effect: %q", whole.Note)
 	}
 }

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -1406,14 +1406,24 @@ func (s *Server) handleAnalyzeOwnership(ctx context.Context, req mcp.CallToolReq
 	// function/method (or wider) nodes; the analyzer scans tens of
 	// thousands of irrelevant nodes without it on a disk backend.
 	ownBlame := blameRowsByID(s.readerFor(ctx))
+	// Tallied inside the scan the answer is computed from, so the caveat can
+	// never disagree with the number it accompanies: candidates counts every
+	// symbol that passed the kind and path filters, stamped the subset
+	// carrying authorship. An empty answer means something different
+	// depending on which of the two is zero, and that difference was
+	// previously invisible.
+	candidatesByRepo := map[string]int{}
+	stampedByRepo := map[string]int{}
 	for _, n := range s.scopedNodesByKinds(ctx, allowedKindsSlice(allowedKinds)) {
 		if !graphpath.HasPrefix(n.FilePath, pathPrefix) {
 			continue
 		}
+		candidatesByRepo[n.RepoPrefix]++
 		la, ok := lastAuthoredFrom(ownBlame, n)
 		if !ok {
 			continue
 		}
+		stampedByRepo[n.RepoPrefix]++
 		email := la.Email
 		if email == "" {
 			continue
@@ -1458,6 +1468,21 @@ func (s *Server) handleAnalyzeOwnership(ctx context.Context, req mcp.CallToolReq
 		return rows[i].Email < rows[j].Email
 	})
 
+	// A "built" state is dropped when there are rows: they are their own proof
+	// that authorship was stamped, and annotating them would spend a caller's
+	// attention on the case that never misleads.
+	//
+	// never_built and partial are NOT dropped. A repository in scope with no
+	// blame stamps makes this answer an undercount whether or not other
+	// repositories produced rows, and a non-empty undercount is the more
+	// dangerous shape: an empty answer at least looks suspicious, while rows
+	// look like the answer. This is the same argument the route inventory
+	// case makes — 130 of 153 rows is the reading that gets acted on.
+	state := ownershipDataState(candidatesByRepo, stampedByRepo, len(byEmail))
+	if len(rows) > 0 && state.State == dataStateBuilt {
+		state = dataStateCaveat{}
+	}
+
 	if isCompact(req) {
 		var b strings.Builder
 		for _, r := range rows {
@@ -1466,12 +1491,19 @@ func (s *Server) handleAnalyzeOwnership(ctx context.Context, req mcp.CallToolReq
 		if len(rows) == 0 {
 			b.WriteString("no owners matched\n")
 		}
+		if state.State != "" {
+			b.WriteString(state.line())
+		}
 		return mcp.NewToolResultText(b.String()), nil
 	}
-	return s.respondJSONOrTOON(ctx, req, map[string]any{
+	payload := map[string]any{
 		"owners": rows,
 		"total":  len(rows),
-	})
+	}
+	if state.State != "" {
+		payload[dataStateCaveatKey] = state.payload()
+	}
+	return s.respondJSONOrTOON(ctx, req, payload)
 }
 
 // tsFromMeta normalises the timestamp field across the int64

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -1418,12 +1418,20 @@ func (s *Server) handleAnalyzeOwnership(ctx context.Context, req mcp.CallToolReq
 		if !graphpath.HasPrefix(n.FilePath, pathPrefix) {
 			continue
 		}
-		candidatesByRepo[n.RepoPrefix]++
+		// Counted against blame's OWN admission set, not against everything
+		// that passed the filters: a symbol the pass never looks at is not a
+		// coverage hole, and counting it would report a shortfall no
+		// enrichment could ever close.
+		if blame.Eligible(n) {
+			candidatesByRepo[n.RepoPrefix]++
+		}
 		la, ok := lastAuthoredFrom(ownBlame, n)
 		if !ok {
 			continue
 		}
-		stampedByRepo[n.RepoPrefix]++
+		if blame.Eligible(n) {
+			stampedByRepo[n.RepoPrefix]++
+		}
 		email := la.Email
 		if email == "" {
 			continue

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -1486,8 +1486,8 @@ func (s *Server) handleAnalyzeOwnership(ctx context.Context, req mcp.CallToolReq
 	// dangerous shape: an empty answer at least looks suspicious, while rows
 	// look like the answer. This is the same argument the route inventory
 	// case makes — 130 of 153 rows is the reading that gets acted on.
-	state := ownershipDataState(candidatesByRepo, stampedByRepo, len(byEmail))
-	if len(rows) > 0 && state.State == dataStateBuilt {
+	state := ownershipDataState(candidatesByRepo, stampedByRepo, len(byEmail), len(rows))
+	if len(rows) > 0 && state.State == dataStateComplete {
 		state = dataStateCaveat{}
 	}
 
@@ -2371,7 +2371,9 @@ func (s *Server) handleAnalyzeBlame(ctx context.Context, req mcp.CallToolRequest
 	total := 0
 	perRepo := make(map[string]any, len(roots))
 	for prefix, root := range roots {
-		count, err := blame.EnrichGraph(s.graph, root)
+		// prefix scopes the pass: without it the walk over one repo's root can
+		// stamp another repo's identically-pathed nodes.
+		count, err := blame.EnrichGraph(s.graph, root, prefix)
 		if err != nil {
 			perRepo[prefix] = map[string]any{"root": root, "error": err.Error()}
 			continue


### PR DESCRIPTION
First slice of **#511**, and the one I picked deliberately: it is the smallest surface that needs every part of the contract, so it fixes the vocabulary before the pattern is applied anywhere else.

## The zero being fixed

`analyze kind=ownership` answers `no owners matched` for two states that a caller must act on differently:

- nobody in scope carries an owner — **an answer**;
- git blame was never mined — **the absence of one**.

They render identically. The second one is the sentence an agent turns into "this code is unowned".

## The contract

`contract_tier_unbuilt` already solves this for the contract tier, and its three properties are why it is safe to act on. All three are kept:

1. the zero says it is **not absence evidence**;
2. it names **which** repositories are in that state;
3. it names the recovery **and rules out the one that looks obvious**.

Property 3 carries the most weight here. Indexing never reads `git blame`, so `reindex_repository` — and a full `untrack` / `track`, the heavier thing a caller escalates to — leave the answer exactly as empty as they found it. The recovery string says so by name.

## Five states, from the scan the answer already runs

| state | meaning |
|---|---|
| `never_built` | no symbol in scope carries a stamp |
| `partial` | some repositories stamped, others not |
| `built` (filters) | no symbol was in scope at all — the zero is about `kind` / `path_prefix` |
| `built` (threshold) | owners were found and `min_symbols` removed every one |
| `built` | the data is there and nothing matched |

The `built` half is the valuable one, exactly as the issue argues: it lets a caller say "actually nothing" with the tool's own confidence instead of hedging every zero forever. The threshold case is a third silent zero this handler already had, rendered like the other two.

## Two choices worth arguing

**`partial` and `never_built` are attached even when the answer has rows.** A repository in scope with no blame stamps makes the answer an undercount either way, and a non-empty undercount is the more dangerous shape — an empty answer at least looks suspicious, while rows look like the answer. This is the same argument the route-inventory case in #511 makes: 130 of 153 rows is the reading that gets acted on. Only a `built` state is dropped when rows exist, since rows are their own proof that blame was mined.

**The classification is not built on `graph.EnrichmentState`,** even though that marker exists and would have been the obvious reuse. It is written only by the semantic providers, and `recordEnrichMarker` refuses to record on a dirty tree or without a sha — so a repo enriched under either condition would be reported as never enriched. Deriving the state from the same scan the answer came from is stronger evidence and, more importantly, cannot contradict the number it accompanies. The tallies ride along in the existing loop; no extra graph pass.

## Tests

Five end-to-end cases through `handleAnalyze`, a table over the classifier, and a compact-encoding test — that path is prose only, so a caller there sees the line or nothing.

Thirteen mutants, each failing its test and passing restored: `never_built` and `partial` each collapsed into `built` · an empty scope and a threshold-emptied answer each blamed on enrichment · the caveat naming stamped repositories too · the note dropping its refusal of the absence reading · the recovery no longer ruling out reindex · a `built` state offering a recovery · the candidate and stamped tallies each not counted · the caveat dropped whenever rows exist · a complete answer annotated · the payload never carrying it.

One test failure during development is worth reporting because it changed the test rather than the code: the multi-repo case asserted `repos == ["repo-b"]` and got `["(default) repo-b"]` — the test server's own fixture nodes are unstamped too, so naming them is correct. The assertion now pins the property that matters (the unstamped repo is named, the stamped one is not) instead of a count that depended on the fixture.

## What I would do next, if this shape is right

`co_change` is the same slice with a different source — `tools_cochange.go` already has the presence check the classifier needs. Then the shared-node contract attribution from the second comment on #511. The `routes` partial case I would leave until #704 is understood, because "which files were parsed but produced no rows" is extractor bookkeeping rather than a rendering change, and guessing at it would publish a `complete: false` that is itself unverified.

## Verification

`go build ./...` and `go vet ./internal/mcp` clean; the analyze / ownership / contract-tier test subset passes. Same caveat as my last two PRs: several `./internal/mcp` tests fail on Windows on a pristine tree (drive-letter path shapes), so I verify the affected tests rather than claiming the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
