### PR TITLE
fix: align hook protocols with current clients

### DIFF
--- a/cmd/gortex/testdata/agent-render/kiro.txt
+++ b/cmd/gortex/testdata/agent-render/kiro.txt
@@ -1,38 +1,49 @@
 === project/root/.kiro/hooks/gortex-post-edit.json ===
 {
-  "name": "Gortex: Post-Edit Check",
-  "version": "1.0.0",
-  "description": "Check impact and tests after a source edit.",
-  "when": {
-    "type": "fileEdited",
-    "patterns": ["**/*.go", "**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.py", "**/*.rs", "**/*.java", "**/*.kt", "**/*.scala", "**/*.swift", "**/*.rb", "**/*.cs", "**/*.php"]
-  },
-  "then": {
-    "type": "askAgent",
-    "prompt": "Call Gortex change with operation detect for unstaged changes. Use its affected symbol IDs with operations tests, guards, and contract; run the selected tests and report every result."
-  }
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "Gortex: Post-Edit Check",
+      "description": "Check impact and tests after a source edit.",
+      "trigger": "PostFileSave",
+      "matcher": "\\.(go|ts|tsx|js|jsx|py|rs|java|kt|scala|swift|rb|cs|php)$",
+      "action": {
+        "type": "agent",
+        "prompt": "Call Gortex change with operation detect for unstaged changes. Use its affected symbol IDs with operations tests, guards, and contract; run the selected tests and report every result."
+      }
+    }
+  ]
 }
 === project/root/.kiro/hooks/gortex-pre-read.json ===
 {
-  "name": "Gortex: Enrich Source Read",
-  "version": "1.0.0",
-  "description": "Use indexed source context before a raw source-file read.",
-  "when": {"type": "preToolUse", "toolTypes": ["read"]},
-  "then": {
-    "type": "askAgent",
-    "prompt": "For indexed source code, use Gortex read with operation editing_context or source instead of a raw file read. Skip generated files, metadata, documentation, configuration, and non-source assets."
-  }
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "Gortex: Enrich Source Read",
+      "description": "Use indexed source context before a raw source-file read.",
+      "trigger": "PreToolUse",
+      "matcher": "read",
+      "action": {
+        "type": "agent",
+        "prompt": "For indexed source code, use Gortex read with operation editing_context or source instead of a raw file read. Skip generated files, metadata, documentation, configuration, and non-source assets."
+      }
+    }
+  ]
 }
 === project/root/.kiro/hooks/gortex-smart-context.json ===
 {
-  "name": "Gortex: Task Context",
-  "version": "1.0.0",
-  "description": "Localize each coding task with the graph before opening files.",
-  "when": {"type": "userTriggered"},
-  "then": {
-    "type": "askAgent",
-    "prompt": "For a coding task, call Gortex explore with operation task and the user's task text before reading or searching files. Skip this only for non-coding conversation."
-  }
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "Gortex: Task Context",
+      "description": "Localize each coding task with the graph before opening files.",
+      "trigger": "UserPromptSubmit",
+      "action": {
+        "type": "agent",
+        "prompt": "For a coding task, call Gortex explore with operation task and the user's task text before reading or searching files. Skip this only for non-coding conversation."
+      }
+    }
+  ]
 }
 === project/root/.kiro/settings/mcp.json ===
 {

--- a/internal/agents/kiro/adapter.go
+++ b/internal/agents/kiro/adapter.go
@@ -1,11 +1,13 @@
 package kiro
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"github.com/zzet/gortex/internal/agents"
@@ -125,15 +127,21 @@ func (a *Adapter) Apply(env agents.Env, opts agents.ApplyOpts) (*agents.Result, 
 }
 
 func writeKiroArtifact(w io.Writer, path, content string, opts agents.ApplyOpts) (agents.FileAction, error) {
-	if existing, err := os.ReadFile(path); err == nil && isLegacyKiroArtifact(string(existing)) {
+	if existing, err := os.ReadFile(path); err == nil && isLegacyKiroArtifact(path, string(existing)) {
 		return agents.WriteOwnedFile(w, path, content, opts)
 	}
 	return agents.WriteIfNotExists(w, path, content, opts)
 }
 
-func isLegacyKiroArtifact(body string) bool {
-	owned := strings.Contains(body, "# Gortex") || strings.Contains(body, `"name": "Gortex:`)
-	if !owned {
+func isLegacyKiroArtifact(path, body string) bool {
+	if legacy, ok := legacyHookFiles[filepath.Base(path)]; ok {
+		return sameJSONDocument(body, legacy)
+	}
+
+	// Steering files predate managed-file markers. Keep their narrow textual
+	// fingerprint, but never apply it to hook paths where user JSON may contain
+	// similar words in a customized prompt.
+	if !strings.Contains(body, "# Gortex") {
 		return false
 	}
 	for _, legacy := range []string{"smart_context", "search_symbols", "get_editing_context", "detect_changes"} {
@@ -142,6 +150,17 @@ func isLegacyKiroArtifact(body string) bool {
 		}
 	}
 	return false
+}
+
+func sameJSONDocument(left, right string) bool {
+	var leftValue, rightValue any
+	if err := json.Unmarshal([]byte(left), &leftValue); err != nil {
+		return false
+	}
+	if err := json.Unmarshal([]byte(right), &rightValue); err != nil {
+		return false
+	}
+	return reflect.DeepEqual(leftValue, rightValue)
 }
 
 // mcpConfigPath returns the mcp.json path for the given Env's

--- a/internal/agents/kiro/content.go
+++ b/internal/agents/kiro/content.go
@@ -19,6 +19,54 @@ var HookFiles = map[string]string{
 	"gortex-pre-read.json":      hookPreRead,
 }
 
+// legacyHookFiles contains only the exact Kiro hook payloads Gortex shipped
+// before Kiro's v1 schema. Semantic comparison permits whitespace changes but
+// preserves any user customization instead of claiming ownership by filename.
+var legacyHookFiles = map[string]string{
+	"gortex-smart-context.json": legacyHookTaskContext,
+	"gortex-post-edit.json":     legacyHookPostEdit,
+	"gortex-pre-read.json":      legacyHookPreRead,
+}
+
+const legacyHookTaskContext = `{
+  "name": "Gortex: Task Context",
+  "version": "1.0.0",
+  "description": "Localize each coding task with the graph before opening files.",
+  "when": {"type": "userTriggered"},
+  "then": {
+    "type": "askAgent",
+    "prompt": "For a coding task, call Gortex explore with operation task and the user's task text before reading or searching files. Skip this only for non-coding conversation."
+  }
+}
+`
+
+const legacyHookPostEdit = `{
+  "name": "Gortex: Post-Edit Check",
+  "version": "1.0.0",
+  "description": "Check impact and tests after a source edit.",
+  "when": {
+    "type": "fileEdited",
+    "patterns": ["**/*.go", "**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.py", "**/*.rs", "**/*.java", "**/*.kt", "**/*.scala", "**/*.swift", "**/*.rb", "**/*.cs", "**/*.php"]
+  },
+  "then": {
+    "type": "askAgent",
+    "prompt": "Call Gortex change with operation detect for unstaged changes. Use its affected symbol IDs with operations tests, guards, and contract; run the selected tests and report every result."
+  }
+}
+`
+
+const legacyHookPreRead = `{
+  "name": "Gortex: Enrich Source Read",
+  "version": "1.0.0",
+  "description": "Use indexed source context before a raw source-file read.",
+  "when": {"type": "preToolUse", "toolTypes": ["read"]},
+  "then": {
+    "type": "askAgent",
+    "prompt": "For indexed source code, use Gortex read with operation editing_context or source instead of a raw file read. Skip generated files, metadata, documentation, configuration, and non-source assets."
+  }
+}
+`
+
 const steeringWorkflow = `---
 inclusion: always
 ---
@@ -92,41 +140,52 @@ inclusion: manual
 `
 
 const hookTaskContext = `{
-  "name": "Gortex: Task Context",
-  "version": "1.0.0",
-  "description": "Localize each coding task with the graph before opening files.",
-  "when": {"type": "userTriggered"},
-  "then": {
-    "type": "askAgent",
-    "prompt": "For a coding task, call Gortex explore with operation task and the user's task text before reading or searching files. Skip this only for non-coding conversation."
-  }
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "Gortex: Task Context",
+      "description": "Localize each coding task with the graph before opening files.",
+      "trigger": "UserPromptSubmit",
+      "action": {
+        "type": "agent",
+        "prompt": "For a coding task, call Gortex explore with operation task and the user's task text before reading or searching files. Skip this only for non-coding conversation."
+      }
+    }
+  ]
 }
 `
 
 const hookPostEdit = `{
-  "name": "Gortex: Post-Edit Check",
-  "version": "1.0.0",
-  "description": "Check impact and tests after a source edit.",
-  "when": {
-    "type": "fileEdited",
-    "patterns": ["**/*.go", "**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.py", "**/*.rs", "**/*.java", "**/*.kt", "**/*.scala", "**/*.swift", "**/*.rb", "**/*.cs", "**/*.php"]
-  },
-  "then": {
-    "type": "askAgent",
-    "prompt": "Call Gortex change with operation detect for unstaged changes. Use its affected symbol IDs with operations tests, guards, and contract; run the selected tests and report every result."
-  }
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "Gortex: Post-Edit Check",
+      "description": "Check impact and tests after a source edit.",
+      "trigger": "PostFileSave",
+      "matcher": "\\.(go|ts|tsx|js|jsx|py|rs|java|kt|scala|swift|rb|cs|php)$",
+      "action": {
+        "type": "agent",
+        "prompt": "Call Gortex change with operation detect for unstaged changes. Use its affected symbol IDs with operations tests, guards, and contract; run the selected tests and report every result."
+      }
+    }
+  ]
 }
 `
 
 const hookPreRead = `{
-  "name": "Gortex: Enrich Source Read",
-  "version": "1.0.0",
-  "description": "Use indexed source context before a raw source-file read.",
-  "when": {"type": "preToolUse", "toolTypes": ["read"]},
-  "then": {
-    "type": "askAgent",
-    "prompt": "For indexed source code, use Gortex read with operation editing_context or source instead of a raw file read. Skip generated files, metadata, documentation, configuration, and non-source assets."
-  }
+  "version": "v1",
+  "hooks": [
+    {
+      "name": "Gortex: Enrich Source Read",
+      "description": "Use indexed source context before a raw source-file read.",
+      "trigger": "PreToolUse",
+      "matcher": "read",
+      "action": {
+        "type": "agent",
+        "prompt": "For indexed source code, use Gortex read with operation editing_context or source instead of a raw file read. Skip generated files, metadata, documentation, configuration, and non-source assets."
+      }
+    }
+  ]
 }
 `
 

--- a/internal/agents/kiro/hook_schema_test.go
+++ b/internal/agents/kiro/hook_schema_test.go
@@ -1,0 +1,144 @@
+package kiro
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/agents"
+	"github.com/zzet/gortex/internal/agents/agentstest"
+)
+
+func TestHookFilesUseKiroV1Schema(t *testing.T) {
+	type action struct {
+		Type   string `json:"type"`
+		Prompt string `json:"prompt"`
+	}
+	type hook struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		Trigger     string `json:"trigger"`
+		Matcher     string `json:"matcher"`
+		Action      action `json:"action"`
+	}
+	type document struct {
+		Version string `json:"version"`
+		Hooks   []hook `json:"hooks"`
+	}
+
+	want := map[string]struct {
+		trigger string
+		matcher string
+	}{
+		"gortex-smart-context.json": {trigger: "UserPromptSubmit"},
+		"gortex-post-edit.json":     {trigger: "PostFileSave", matcher: `\.(go|ts|tsx|js|jsx|py|rs|java|kt|scala|swift|rb|cs|php)$`},
+		"gortex-pre-read.json":      {trigger: "PreToolUse", matcher: "read"},
+	}
+
+	for name, expected := range want {
+		t.Run(name, func(t *testing.T) {
+			body, ok := HookFiles[name]
+			if !ok {
+				t.Fatalf("missing hook file %q", name)
+			}
+			var doc document
+			if err := json.Unmarshal([]byte(body), &doc); err != nil {
+				t.Fatalf("invalid hook JSON: %v\n%s", err, body)
+			}
+			if doc.Version != "v1" || len(doc.Hooks) != 1 {
+				t.Fatalf("hook envelope = %#v, want version v1 and one hook", doc)
+			}
+			hook := doc.Hooks[0]
+			if hook.Name == "" || hook.Description == "" || hook.Trigger != expected.trigger || hook.Matcher != expected.matcher {
+				t.Fatalf("hook = %#v, want trigger %q matcher %q", hook, expected.trigger, expected.matcher)
+			}
+			if hook.Action.Type != "agent" || hook.Action.Prompt == "" {
+				t.Fatalf("hook action = %#v, want non-empty agent prompt", hook.Action)
+			}
+			var raw map[string]any
+			if err := json.Unmarshal([]byte(body), &raw); err != nil {
+				t.Fatal(err)
+			}
+			if _, oldWhen := raw["when"]; oldWhen {
+				t.Fatal("legacy when field remains in Kiro v1 hook")
+			}
+			if _, oldThen := raw["then"]; oldThen {
+				t.Fatal("legacy then field remains in Kiro v1 hook")
+			}
+		})
+	}
+}
+
+func TestKiroMigratesExactLegacyHookSchemas(t *testing.T) {
+	for name, legacy := range legacyHookFiles {
+		t.Run(name, func(t *testing.T) {
+			env, _ := agentstest.NewEnv(t)
+			path := filepath.Join(env.Root, ".kiro", "hooks", name)
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+
+			// Reformat the shipped document to prove ownership is semantic, not
+			// dependent on byte-for-byte whitespace.
+			var document any
+			if err := json.Unmarshal([]byte(legacy), &document); err != nil {
+				t.Fatal(err)
+			}
+			reformatted, err := json.Marshal(document)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, reformatted, 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			a := New()
+			if _, err := a.Apply(env, agents.ApplyOpts{}); err != nil {
+				t.Fatalf("apply: %v", err)
+			}
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != HookFiles[name] {
+				t.Fatalf("legacy Kiro hook was not migrated:\n%s", got)
+			}
+			agentstest.AssertIdempotent(t, a, env)
+		})
+	}
+}
+
+func TestKiroPreservesCustomizedLegacyHook(t *testing.T) {
+	for name, body := range map[string]string{
+		"modified prompt":      strings.Replace(legacyHookPreRead, "For indexed source code", "Follow the team policy, then use indexed source code", 1),
+		"modified description": strings.Replace(legacyHookPreRead, "Use indexed source context", "Use company source context", 1),
+		"extra field":          strings.Replace(legacyHookPreRead, `  "version"`, "  \"custom\": true,\n  \"version\"", 1),
+		"custom name":          strings.Replace(legacyHookPreRead, "Gortex: Enrich Source Read", "Gortex: Custom Source Read", 1),
+		"malformed JSON":       `{"name":"Gortex: Enrich Source Read"`,
+		"current v1":           HookFiles["gortex-pre-read.json"],
+	} {
+		t.Run(name, func(t *testing.T) {
+			env, _ := agentstest.NewEnv(t)
+			path := filepath.Join(env.Root, ".kiro", "hooks", "gortex-pre-read.json")
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := New().Apply(env, agents.ApplyOpts{}); err != nil {
+				t.Fatalf("apply: %v", err)
+			}
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != body {
+				t.Fatalf("customized hook was overwritten:\n--- got ---\n%s\n--- want ---\n%s", got, body)
+			}
+		})
+	}
+}

--- a/internal/hooks/codex.go
+++ b/internal/hooks/codex.go
@@ -117,7 +117,7 @@ func runCodex(data []byte, port int, selected ...CodexMode) {
 		case CodexModeRewrite:
 			runCodexBashRewrite(data, port)
 		default:
-			runPreToolUse(data, port, ModeEnrich)
+			runPreToolUseForHost(data, port, ModeEnrich, preToolUseCodex)
 		}
 	case peek.HookEventName == "PreToolUse" && codexLocalizationPreToolUseTool(peek.ToolName):
 		runCodexLocalizationPreToolUse(data, mode)
@@ -352,10 +352,16 @@ func runCodexLocalizationPreToolUse(data []byte, mode CodexMode) {
 		AdditionalContext: ctx,
 		UpdatedInput:      updatedInput,
 	}
+	if updatedInput != nil {
+		// Codex requires every input rewrite to carry an explicit allow.
+		// Unlike Claude Code, it does not accept ask with updatedInput.
+		hso.PermissionDecision = "allow"
+	}
 	if ctx != "" {
 		switch mode {
 		case CodexModeDeny:
 			hso.AdditionalContext = ""
+			hso.UpdatedInput = nil
 			hso.PermissionDecision = "deny"
 			hso.PermissionDecisionReason = ctx
 		case CodexModeRewrite:

--- a/internal/hooks/localization_terminal_receipt_test.go
+++ b/internal/hooks/localization_terminal_receipt_test.go
@@ -301,7 +301,10 @@ func TestLocalizationAuthPreservesPreToolUsePolicyBranches(t *testing.T) {
 		wantConsulted  bool
 	}{
 		{name: "permissive auto approve", mode: ModeDeny, permissionMode: "auto", wantDecision: "allow"},
-		{name: "consult unlock marker", mode: ModeConsultUnlock, wantConsulted: true},
+		{name: "accept edits auto approve", mode: ModeDeny, permissionMode: "acceptEdits", wantDecision: "allow"},
+		{name: "default preserves prompt", mode: ModeDeny, permissionMode: "default", wantDecision: "ask"},
+		{name: "plan preserves prompt", mode: ModeDeny, permissionMode: "plan", wantDecision: "ask"},
+		{name: "consult unlock marker", mode: ModeConsultUnlock, wantDecision: "ask", wantConsulted: true},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			configureLocalizationTerminalTestHome(t)
@@ -534,6 +537,9 @@ func TestLocalizationProblemRewriteDirectAndPluginIsIdempotent(t *testing.T) {
 				var decoded HookOutput
 				if err := json.Unmarshal([]byte(output), &decoded); err != nil || decoded.HookSpecificOutput == nil {
 					t.Fatalf("invalid PreToolUse output: %v\n%s", err, output)
+				}
+				if got := decoded.HookSpecificOutput.PermissionDecision; got != "ask" {
+					t.Fatalf("rewrite permission decision = %q, want ask", got)
 				}
 				updated := decoded.HookSpecificOutput.UpdatedInput
 				if updated["task"] != problemStatement {
@@ -864,7 +870,7 @@ func captureTerminalAuthToken(
 		t.Fatalf("incompatible PreToolUse auth envelope: %#v", decoded)
 	}
 	hso := decoded.HookSpecificOutput
-	if hso.HookEventName != "PreToolUse" || hso.PermissionDecision != "" || hso.AdditionalContext != "" {
+	if hso.HookEventName != "PreToolUse" || hso.PermissionDecision != "ask" || hso.AdditionalContext != "" {
 		t.Fatalf("auth injection changed hook policy: %#v", hso)
 	}
 	raw, ok := hso.UpdatedInput[localizationauth.ArgumentKey]

--- a/internal/hooks/pretooluse.go
+++ b/internal/hooks/pretooluse.go
@@ -77,6 +77,10 @@ const gortexMCPToolPrefix = "mcp__gortex__"
 // alternative but the original call still runs and PostToolUse can layer
 // graph context on the actual output.
 func runPreToolUse(data []byte, gortexPort int, mode Mode) {
+	runPreToolUseForHost(data, gortexPort, mode, preToolUseClaude)
+}
+
+func runPreToolUseForHost(data []byte, gortexPort int, mode Mode, host preToolUseHost) {
 	started := time.Now()
 	var input HookInput
 	if err := json.Unmarshal(data, &input); err != nil {
@@ -161,7 +165,7 @@ func runPreToolUse(data []byte, gortexPort int, mode Mode) {
 			hso.UpdatedInput = updatedInput
 		}
 		emitted = hso.AdditionalContext != "" || hso.PermissionDecisionReason != ""
-		emitPreToolUse(HookOutput{HookSpecificOutput: hso})
+		emitPreToolUseForHost(host, input.PermissionMode, HookOutput{HookSpecificOutput: hso})
 		return
 	}
 
@@ -172,7 +176,7 @@ func runPreToolUse(data []byte, gortexPort int, mode Mode) {
 	if mode == ModeConsultUnlock && isGortexMCP {
 		markGraphConsulted(input.SessionID)
 		if updatedInput != nil {
-			emitPreToolUse(HookOutput{HookSpecificOutput: &HookSpecificOutput{
+			emitPreToolUseForHost(host, input.PermissionMode, HookOutput{HookSpecificOutput: &HookSpecificOutput{
 				HookEventName: "PreToolUse",
 				UpdatedInput:  updatedInput,
 			}})
@@ -201,7 +205,7 @@ func runPreToolUse(data []byte, gortexPort int, mode Mode) {
 			return
 		}
 		emitted = hso.AdditionalContext != ""
-		emitPreToolUse(HookOutput{HookSpecificOutput: hso})
+		emitPreToolUseForHost(host, input.PermissionMode, HookOutput{HookSpecificOutput: hso})
 		return
 	}
 
@@ -209,7 +213,7 @@ func runPreToolUse(data []byte, gortexPort int, mode Mode) {
 
 	if result.context == "" && !result.deny {
 		if updatedInput != nil {
-			emitPreToolUse(HookOutput{HookSpecificOutput: &HookSpecificOutput{
+			emitPreToolUseForHost(host, input.PermissionMode, HookOutput{HookSpecificOutput: &HookSpecificOutput{
 				HookEventName: "PreToolUse",
 				UpdatedInput:  updatedInput,
 			}})
@@ -234,7 +238,7 @@ func runPreToolUse(data []byte, gortexPort int, mode Mode) {
 	}
 
 	emitted = true
-	emitPreToolUse(output)
+	emitPreToolUseForHost(host, input.PermissionMode, output)
 }
 
 // enforceLocalizationTerminalPreToolUse applies only the local terminal
@@ -340,8 +344,64 @@ func markGraphConsulted(sessionID string) {
 	}
 }
 
+type preToolUseHost uint8
+
+const (
+	preToolUseClaude preToolUseHost = iota
+	preToolUseCodex
+)
+
+// normalizePreToolUseOutput applies the host-specific rewrite contract without
+// broadening the user's permission policy. Claude Code can ask while carrying
+// updatedInput; Codex requires allow for every rewrite and does not support ask.
+func normalizePreToolUseOutput(host preToolUseHost, permissionMode string, output HookOutput) HookOutput {
+	hso := output.HookSpecificOutput
+	if hso == nil || hso.HookEventName != "PreToolUse" {
+		return output
+	}
+
+	normalized := *hso
+	if normalized.UpdatedInput == nil {
+		// Codex rejects allow when there is no replacement input. Removing it
+		// restores the host's normal permission flow instead of broadening it.
+		if host == preToolUseCodex && normalized.PermissionDecision == "allow" {
+			normalized.PermissionDecision = ""
+			normalized.PermissionDecisionReason = ""
+		}
+		output.HookSpecificOutput = &normalized
+		return output
+	}
+
+	switch normalized.PermissionDecision {
+	case "":
+		if host == preToolUseCodex || isPermissivePermissionMode(permissionMode) {
+			normalized.PermissionDecision = "allow"
+		} else {
+			normalized.PermissionDecision = "ask"
+		}
+	case "allow":
+		// Valid for both hosts when paired with updatedInput.
+	case "ask":
+		if host == preToolUseCodex {
+			normalized.PermissionDecision = "deny"
+			normalized.PermissionDecisionReason = "[Gortex] Codex cannot safely apply an ask rewrite."
+			normalized.UpdatedInput = nil
+		}
+	default:
+		// A deny, defer, or future non-rewrite decision keeps its policy but
+		// cannot carry replacement input.
+		normalized.UpdatedInput = nil
+	}
+	output.HookSpecificOutput = &normalized
+	return output
+}
+
+func emitPreToolUseForHost(host preToolUseHost, permissionMode string, output HookOutput) {
+	emitPreToolUse(normalizePreToolUseOutput(host, permissionMode, output))
+}
+
 // emitPreToolUse marshals a PreToolUse HookOutput to stdout. A marshal
-// failure is swallowed — a hook must never block Claude Code's flow.
+// failure is swallowed — a hook must never block the host agent's flow.
 func emitPreToolUse(output HookOutput) {
 	out, err := json.Marshal(output)
 	if err != nil {

--- a/internal/hooks/pretooluse_output_test.go
+++ b/internal/hooks/pretooluse_output_test.go
@@ -1,0 +1,108 @@
+package hooks
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/zzet/gortex/internal/localizationauth"
+)
+
+func TestEmitPreToolUseNormalizesUpdatedInputByHost(t *testing.T) {
+	rewrite := map[string]any{"operation": "localize"}
+	for _, tt := range []struct {
+		name           string
+		host           preToolUseHost
+		permissionMode string
+		decision       string
+		updatedInput   map[string]any
+		wantDecision   string
+		wantUpdated    bool
+	}{
+		{name: "Claude default asks", host: preToolUseClaude, permissionMode: "default", updatedInput: rewrite, wantDecision: "ask", wantUpdated: true},
+		{name: "Claude plan asks", host: preToolUseClaude, permissionMode: "plan", updatedInput: rewrite, wantDecision: "ask", wantUpdated: true},
+		{name: "Claude acceptEdits allows", host: preToolUseClaude, permissionMode: "acceptEdits", updatedInput: rewrite, wantDecision: "allow", wantUpdated: true},
+		{name: "Claude auto allows", host: preToolUseClaude, permissionMode: "auto", updatedInput: rewrite, wantDecision: "allow", wantUpdated: true},
+		{name: "Claude explicit ask", host: preToolUseClaude, decision: "ask", updatedInput: rewrite, wantDecision: "ask", wantUpdated: true},
+		{name: "Codex decision-less rewrite allows", host: preToolUseCodex, updatedInput: rewrite, wantDecision: "allow", wantUpdated: true},
+		{name: "Codex explicit allow", host: preToolUseCodex, decision: "allow", updatedInput: rewrite, wantDecision: "allow", wantUpdated: true},
+		{name: "Codex ask fails closed", host: preToolUseCodex, decision: "ask", updatedInput: rewrite, wantDecision: "deny"},
+		{name: "deny discards rewrite", host: preToolUseClaude, decision: "deny", updatedInput: rewrite, wantDecision: "deny"},
+		{name: "defer discards rewrite", host: preToolUseClaude, decision: "defer", updatedInput: rewrite, wantDecision: "defer"},
+		{name: "Codex allow without rewrite restores prompt", host: preToolUseCodex, decision: "allow"},
+		{name: "advisory without rewrite", host: preToolUseClaude},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			encoded := captureHookStdout(t, func() {
+				emitPreToolUseForHost(tt.host, tt.permissionMode, HookOutput{HookSpecificOutput: &HookSpecificOutput{
+					HookEventName:      "PreToolUse",
+					PermissionDecision: tt.decision,
+					UpdatedInput:       tt.updatedInput,
+				}})
+			})
+			var output HookOutput
+			if err := json.Unmarshal([]byte(encoded), &output); err != nil || output.HookSpecificOutput == nil {
+				t.Fatalf("invalid PreToolUse output: %v\n%s", err, encoded)
+			}
+			hso := output.HookSpecificOutput
+			if hso.PermissionDecision != tt.wantDecision {
+				t.Fatalf("permission decision = %q, want %q", hso.PermissionDecision, tt.wantDecision)
+			}
+			if got := hso.UpdatedInput != nil; got != tt.wantUpdated {
+				t.Fatalf("updatedInput present = %v, want %v: %#v", got, tt.wantUpdated, hso)
+			}
+		})
+	}
+}
+
+func TestRunCodexLocalizationAuthRewriteAllowsInput(t *testing.T) {
+	configureLocalizationTerminalTestHome(t)
+	identity := beginTestLocalizationTurn(t, t.Name(), "prompt", t.TempDir())
+	input := map[string]any{
+		"operation": "localize",
+		"task":      "literal symptom",
+		"options":   map[string]any{"new_user_task": true, "keep": "value"},
+	}
+	payload := preToolPayload(t, gortexMCPToolPrefix+"explore", "tool-use", identity, input)
+	encoded := captureHookStdout(t, func() { runCodex(payload, 0, CodexModeEnrich) })
+	var output HookOutput
+	if err := json.Unmarshal([]byte(encoded), &output); err != nil || output.HookSpecificOutput == nil {
+		t.Fatalf("invalid Codex PreToolUse output: %v\n%s", err, encoded)
+	}
+	hso := output.HookSpecificOutput
+	if hso.PermissionDecision != "allow" {
+		t.Fatalf("Codex localization rewrite decision = %q, want allow", hso.PermissionDecision)
+	}
+	if token, ok := hso.UpdatedInput[localizationauth.ArgumentKey].(string); !ok || token == "" {
+		t.Fatalf("Codex localization rewrite lost auth token: %#v", hso.UpdatedInput)
+	}
+	for key, want := range input {
+		if got := hso.UpdatedInput[key]; !equalJSONValue(got, want) {
+			t.Fatalf("updatedInput[%q] = %#v, want %#v", key, got, want)
+		}
+	}
+}
+
+func TestRunCodexLocalizationDenyDropsAuthRewrite(t *testing.T) {
+	configureLocalizationTerminalTestHome(t)
+	identity := beginTestLocalizationTurn(t, t.Name(), "prompt", t.TempDir())
+	previousReachable := daemonReachableFn
+	daemonReachableFn = func() bool { return true }
+	t.Cleanup(func() { daemonReachableFn = previousReachable })
+
+	payload := preToolPayload(t, gortexMCPToolPrefix+"read", "tool-use", identity, map[string]any{
+		"operation": "file",
+		"target":    map[string]any{"file": "internal/hooks/pretooluse.go"},
+	})
+	encoded := captureHookStdout(t, func() { runCodex(payload, 0, CodexModeDeny) })
+	var output HookOutput
+	if err := json.Unmarshal([]byte(encoded), &output); err != nil || output.HookSpecificOutput == nil {
+		t.Fatalf("invalid Codex PreToolUse output: %v\n%s", err, encoded)
+	}
+	hso := output.HookSpecificOutput
+	if hso.PermissionDecision != "deny" {
+		t.Fatalf("Codex localization decision = %q, want deny", hso.PermissionDecision)
+	}
+	if hso.UpdatedInput != nil {
+		t.Fatalf("Codex deny carried incompatible updatedInput: %#v", hso.UpdatedInput)
+	}
+}


### PR DESCRIPTION
## Summary

- emit host-specific PreToolUse rewrite decisions: Codex receives the required allow decision, while Claude Code preserves normal permission prompts with ask outside auto and acceptEdits modes
- keep deny and defer decisions authoritative by removing incompatible rewritten input
- upgrade generated Kiro hooks from the retired 1.0.0 when/then envelope to the current v1 hooks/action schema
- migrate only the exact three historical Gortex Kiro payloads, while preserving customized, malformed, unknown, and current-v1 files
- audit the remaining client adapters against their current protocols; Kimi, Copilot CLI, Gemini, OpenCode stable, Pi, and Hermes retain their native independent paths

## Compatibility references

- Codex hooks: https://learn.chatgpt.com/docs/hooks
- Claude Code hooks: https://code.claude.com/docs/en/hooks
- Kiro migration guide: https://kiro.dev/docs/cli/v3/migration-guide/
- Kiro hooks: https://kiro.dev/docs/hooks/
- OpenCode plugins: https://opencode.ai/docs/plugins/

## Verification

- go test ./internal/hooks ./internal/agents/kiro -count=1
- go test ./internal/agents/... -count=1
- GORTEX_QUERY_LOG_DISABLE=1 go test ./cmd/gortex -count=1
- go build ./internal/agents/kiro/... ./internal/hooks/...
- go test -race ./internal/agents/kiro/... ./internal/hooks/... -count=1
- go test ./internal/indexer -run TestRefViewCoalescingAnswerNeedsNoWriter -count=1
- git diff --cached --check

The aggregate go test ./... run reached all packages and all affected packages passed. Its aggregate status was non-zero for two unrelated environment/load conditions: the live daemon changed the per-user query log during the command-package hermeticity check, and the indexer package exceeded its ten-minute package timeout under parallel load. The command package passed with query logging disabled, and the timed-out indexer test passed in isolation.

A second independent diff review found no blocking issues or broken contracts. No guard rules are configured.