### PR TITLE
feat(index): make framework synthesizers configurable

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -28,6 +28,23 @@ The full surface, grouped by concern. Each item links to the deeper reference wh
 - **Semantic enrichment** — pluggable SCIP, go/types, and LSP providers upgrade edge confidence from ~70-85% (tree-sitter) to 95-100% (compiler-verified). Additive: graceful degradation when external tools are unavailable. Per-language `connect: { network, address, fallback_spawn }` dials an already-running language server instead of spawning a duplicate.
 - **IMPLEMENTS inference** — structural interface satisfaction for Go, TypeScript, Java, Rust, C#, Scala, Swift, Protobuf. C# bases in another compilation unit are split into `extends` vs `implements` via a local-interface prescan + the `I`-prefix convention.
 - **Framework dynamic-dispatch synthesis** — a provenance-tagged synthesizer engine materialises the call edges frameworks wire at runtime that static resolution can't see: gRPC stub→handler, Temporal workflow→activity, in-process / native event channels, and the cross-language native bridges — Swift↔Objective-C selectors, React Native (`RCT_EXPORT_*` / `@ReactMethod` ↔ JS `NativeModules`), Expo (`Function(...)` DSL ↔ `requireNativeModule`), and Fabric codegen view managers. Every synthesized edge carries `synthesized_by` provenance; `analyze kind: "synthesizers"` rolls them up.
+
+  The framework pipeline is enabled in full when `index.framework_synthesizers`
+  is omitted. Set it to `[]` to skip the registry, census, claiming resolvers,
+  family gates, and receiver demotion before any framework graph scan. A
+  non-empty list is an allow-list of stable synthesizer names; for example:
+
+  ```yaml
+  index:
+    framework_synthesizers:
+      - value-ref
+      - fn-value-callback
+  ```
+
+  Allow-listed stages run in canonical registry order, not YAML order. Tail
+  correctness gates remain enabled for non-empty selections. Invalid or
+  duplicate names are rejected by the selection compiler and the indexer falls
+  back to the complete registry rather than silently dropping derived edges.
 - **Language-specific resolution** — Rust impl-block method-owner / `self`-receiver / `crate::`-`super::` module-path resolution; Kotlin companion-object static dispatch + lambda-parameter scoping. `analyze kind: "resolution_outcomes"` explains *why* a call/reference edge was left unresolved (`ambiguous_multi_match` / `candidate_out_of_scope` / `cross_language_only` / `stub_only` / `no_definition`).
 - **Per-reference contexts** — `find_usages` classifies every usage by the role it plays (`parameter_type` / `return_type` / `field` / `value` / `type` / `attribute` / `call`) and accepts a `context:` filter — e.g. "every place this type is used as a parameter".
 - **External-package call qualification** — calls into un-indexed third parties are retargeted onto stable per-package identity nodes (`dep::` / `stdlib::` / `external::`, per-language: Go / Rust / Java / Python / C# / TS), so call chains keep the external hop and a service's external surface aggregates across repos. On by default, incremental on the reindex hot path; opt out with `index.synthesize_external_calls: false`.

--- a/docs/multi-repo.md
+++ b/docs/multi-repo.md
@@ -70,6 +70,15 @@ The embedded MCP fallback is a machine-level, default-off policy. Enable `mcp.al
 
 `synthesize_external_calls: true` (opt-in, default off — set in `.gortex.yaml` or the global config) makes the resolver synthesize placeholder nodes for calls into un-indexed external packages or sibling services, so call-chains keep the external hop instead of terminating at the indexed boundary.
 
+`index.framework_synthesizers` controls framework-derived resolution work. An
+omitted key preserves the complete registry, `[]` disables the whole framework
+pipeline, and a non-empty list enables only those named synthesizers and
+claiming resolvers. For a shared graph pass, an omitted key in any participating
+repository enables the complete registry; otherwise Gortex uses the union of
+the participating repositories' allow-lists. This keeps a repository from
+silently losing framework edges requested by a sibling while allowing a
+workspace where every repository opts out to avoid the scans entirely.
+
 ## Daemon tuning (optional)
 
 The daemon's defaults handle typical workflows without configuration. These knobs exist for monorepos, branch-heavy workflows, or filesystems without fsnotify support.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -737,6 +737,10 @@ type IndexConfig struct {
 	// stdlib calls are filtered out regardless so the synthetic nodes
 	// only ever name genuine third-party packages.
 	SynthesizeExternalCalls *bool `mapstructure:"synthesize_external_calls" yaml:"synthesize_external_calls,omitempty"`
+	// FrameworkSynthesizers is an optional allow-list of framework resolver
+	// names. Nil preserves the complete registry; an explicit empty list
+	// disables the framework pipeline before it scans the graph.
+	FrameworkSynthesizers *[]string `mapstructure:"framework_synthesizers" yaml:"framework_synthesizers,omitempty" json:"framework_synthesizers,omitempty"`
 	// SynthesizeSpeculativeDispatch mints opt-in, best-guess `calls` edges for
 	// dynamic-dispatch blind spots (computed-member calls obj["foo"](),
 	// getattr, decorator registries). Unlike external-call synthesis it

--- a/internal/config/framework_synthesizers_test.go
+++ b/internal/config/framework_synthesizers_test.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFrameworkSynthesizers_AbsentPreservesDefaultRegistry(t *testing.T) {
+	cfg, err := Load(writeConfig(t, "index:\n  workers: 1\n"))
+	require.NoError(t, err)
+	assert.Nil(t, cfg.Index.FrameworkSynthesizers)
+}
+
+func TestFrameworkSynthesizers_ExplicitEmptyDisablesRegistry(t *testing.T) {
+	cfg, err := Load(writeConfig(t, "index:\n  framework_synthesizers: []\n"))
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Index.FrameworkSynthesizers)
+	assert.Empty(t, *cfg.Index.FrameworkSynthesizers)
+}
+
+func TestFrameworkSynthesizers_ExplicitAllowListRoundTrips(t *testing.T) {
+	cfg, err := Load(writeConfig(t, "index:\n  framework_synthesizers:\n    - value-ref\n    - fn-value-callback\n"))
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Index.FrameworkSynthesizers)
+	assert.Equal(t, []string{"value-ref", "fn-value-callback"}, *cfg.Index.FrameworkSynthesizers)
+}

--- a/internal/indexer/checkout_coordinator.go
+++ b/internal/indexer/checkout_coordinator.go
@@ -1764,7 +1764,14 @@ func servableGeneration(state store_sqlite.ViewGenerationState) bool {
 // with one built under these, so the digest is part of the build identity
 // rather than a diagnostic.
 func indexConfigHash(cfg config.IndexConfig) string {
-	encoded, err := json.Marshal(cfg)
+	normalized := cfg
+	if cfg.FrameworkSynthesizers != nil {
+		names := slices.Clone(*cfg.FrameworkSynthesizers)
+		slices.Sort(names)
+		names = slices.Compact(names)
+		normalized.FrameworkSynthesizers = &names
+	}
+	encoded, err := json.Marshal(normalized)
 	if err != nil {
 		// An unencodable configuration cannot be compared, and treating that
 		// as "matches everything" would reuse a payload built under rules

--- a/internal/indexer/framework_synthesizer_config_test.go
+++ b/internal/indexer/framework_synthesizer_config_test.go
@@ -1,0 +1,34 @@
+package indexer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zzet/gortex/internal/config"
+)
+
+func frameworkSynthesizerNamesPtr(names ...string) *[]string {
+	copyOfNames := append([]string(nil), names...)
+	return &copyOfNames
+}
+
+func TestIndexConfigHashDistinguishesOmittedAndExplicitEmptyFrameworkSelection(t *testing.T) {
+	omitted := indexConfigHash(config.IndexConfig{})
+	disabled := indexConfigHash(config.IndexConfig{
+		FrameworkSynthesizers: frameworkSynthesizerNamesPtr(),
+	})
+
+	assert.NotEqual(t, omitted, disabled)
+}
+
+func TestIndexConfigHashTreatsFrameworkSelectionAsASet(t *testing.T) {
+	first := indexConfigHash(config.IndexConfig{
+		FrameworkSynthesizers: frameworkSynthesizerNamesPtr("value-ref", "fn-value-callback"),
+	})
+	second := indexConfigHash(config.IndexConfig{
+		FrameworkSynthesizers: frameworkSynthesizerNamesPtr("fn-value-callback", "value-ref", "value-ref"),
+	})
+
+	assert.Equal(t, first, second)
+}

--- a/internal/indexer/framework_synthesizer_config_test.go
+++ b/internal/indexer/framework_synthesizer_config_test.go
@@ -4,8 +4,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/resolver"
 )
 
 func frameworkSynthesizerNamesPtr(names ...string) *[]string {
@@ -31,4 +34,57 @@ func TestIndexConfigHashTreatsFrameworkSelectionAsASet(t *testing.T) {
 	})
 
 	assert.Equal(t, first, second)
+}
+
+func TestMultiIndexerFrameworkSelectionDisablesPipelineWhenEveryRepoOptsOut(t *testing.T) {
+	mi := &MultiIndexer{indexers: map[string]*Indexer{
+		"first":  {config: config.IndexConfig{FrameworkSynthesizers: frameworkSynthesizerNamesPtr()}},
+		"second": {config: config.IndexConfig{FrameworkSynthesizers: frameworkSynthesizerNamesPtr()}},
+	}}
+
+	report := resolver.RunFrameworkSynthesizersWithSelection(
+		graph.New(), mi.frameworkSynthesizerSelection(nil),
+	)
+	assert.Empty(t, report.Per)
+}
+
+func TestMultiIndexerFrameworkSelectionUnionsParticipatingRepoLists(t *testing.T) {
+	mi := &MultiIndexer{indexers: map[string]*Indexer{
+		"first": {
+			config: config.IndexConfig{
+				FrameworkSynthesizers: frameworkSynthesizerNamesPtr("value-ref"),
+			},
+		},
+		"second": {
+			config: config.IndexConfig{
+				FrameworkSynthesizers: frameworkSynthesizerNamesPtr("fn-value-callback"),
+			},
+		},
+	}}
+
+	report := resolver.RunFrameworkSynthesizersWithSelection(
+		graph.New(), mi.frameworkSynthesizerSelection(nil),
+	)
+	require.Len(t, report.Per, 2)
+	names := []string{report.Per[0].Name, report.Per[1].Name}
+	assert.ElementsMatch(t, []string{"value-ref", "fn-value-callback"}, names)
+}
+
+func TestMultiIndexerFrameworkSelectionScopesOmittedConfigDominance(t *testing.T) {
+	mi := &MultiIndexer{indexers: map[string]*Indexer{
+		"disabled": {
+			config: config.IndexConfig{FrameworkSynthesizers: frameworkSynthesizerNamesPtr()},
+		},
+		"legacy": {config: config.IndexConfig{}},
+	}}
+
+	disabledReport := resolver.RunFrameworkSynthesizersWithSelection(
+		graph.New(), mi.frameworkSynthesizerSelection(map[string]bool{"disabled": true}),
+	)
+	assert.Empty(t, disabledReport.Per)
+
+	legacyReport := resolver.RunFrameworkSynthesizersWithSelection(
+		graph.New(), mi.frameworkSynthesizerSelection(nil),
+	)
+	assert.Len(t, legacyReport.Per, len(resolver.FrameworkSynthesizerNames()))
 }

--- a/internal/indexer/framework_synthesizers.go
+++ b/internal/indexer/framework_synthesizers.go
@@ -1,0 +1,77 @@
+package indexer
+
+import (
+	"sort"
+
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/resolver"
+)
+
+func (idx *Indexer) frameworkSynthesizerSelection() resolver.FrameworkSynthesizerSelection {
+	if idx == nil || idx.config.FrameworkSynthesizers == nil {
+		return resolver.AllFrameworkSynthesizers()
+	}
+	selection, err := resolver.NewFrameworkSynthesizerSelection(*idx.config.FrameworkSynthesizers)
+	if err == nil {
+		return selection
+	}
+	if idx.logger != nil {
+		idx.logger.Error(
+			"invalid index.framework_synthesizers; using the complete registry",
+			zap.Error(err),
+		)
+	}
+	return resolver.AllFrameworkSynthesizers()
+}
+
+// frameworkSynthesizerSelection combines the effective configuration of the
+// repositories participating in one shared-graph pass. An omitted selection in
+// any participating repository preserves the legacy all-enabled behavior;
+// otherwise the configured allow-lists are unioned. The pipeline is disabled
+// only when every participating repository explicitly configured an empty list.
+func (mi *MultiIndexer) frameworkSynthesizerSelection(
+	scope map[string]bool,
+) resolver.FrameworkSynthesizerSelection {
+	mi.mu.RLock()
+	selected := make(map[string]struct{})
+	participants := 0
+	all := false
+	for prefix, idx := range mi.indexers {
+		if len(scope) > 0 && !scope[prefix] {
+			continue
+		}
+		if idx == nil {
+			continue
+		}
+		participants++
+		if idx.config.FrameworkSynthesizers == nil {
+			all = true
+			break
+		}
+		for _, name := range *idx.config.FrameworkSynthesizers {
+			selected[name] = struct{}{}
+		}
+	}
+	mi.mu.RUnlock()
+
+	if all || participants == 0 {
+		return resolver.AllFrameworkSynthesizers()
+	}
+	names := make([]string, 0, len(selected))
+	for name := range selected {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	selection, err := resolver.NewFrameworkSynthesizerSelection(names)
+	if err == nil {
+		return selection
+	}
+	if mi.logger != nil {
+		mi.logger.Error(
+			"invalid index.framework_synthesizers; using the complete registry",
+			zap.Error(err),
+		)
+	}
+	return resolver.AllFrameworkSynthesizers()
+}

--- a/internal/indexer/incremental_derived.go
+++ b/internal/indexer/incremental_derived.go
@@ -260,8 +260,12 @@ func (mi *MultiIndexer) runIncrementalDerivedPassesTopologyHeld(
 	if merged.Flags.Has(DerivedInvalidatesDeclarations) ||
 		merged.Flags.Has(DerivedInvalidatesImports) ||
 		merged.Flags.Has(DerivedInvalidatesRuntime) {
-		framework := resolver.RunFrameworkSynthesizersScopedForFiles(
-			mi.graph, scopedPrefixes, merged.Files, merged.CSharpHierarchyChanged,
+		framework := resolver.RunFrameworkSynthesizersScopedForFilesWithSelection(
+			mi.graph,
+			scopedPrefixes,
+			merged.Files,
+			merged.CSharpHierarchyChanged,
+			mi.frameworkSynthesizerSelection(scopedPrefixes),
 		)
 		report.Framework = framework.Total
 		report.FrameworkPer = framework.Per

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -4003,7 +4003,9 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 			// deferGlobalPasses; the batch caller folds it into
 			// shared multi-repository global-pass pipeline.
 			reporter.Report("framework dispatch synthesis", 0, 0)
-			if rep := resolver.RunFrameworkSynthesizers(idx.graph); rep.Total > 0 {
+			if rep := resolver.RunFrameworkSynthesizersWithSelection(
+				idx.graph, idx.frameworkSynthesizerSelection(),
+			); rep.Total > 0 {
 				idx.logger.Info("framework dispatch calls synthesized",
 					zap.Int("edges", rep.Total),
 					zap.Any("per_synthesizer", rep.Per),
@@ -4914,7 +4916,7 @@ func (idx *Indexer) ResolveAll() {
 	// Framework dynamic-dispatch synthesis (gRPC / Temporal / event
 	// channels / native bridges) depends on InferImplements (the
 	// interface-satisfaction signals) having run first.
-	resolver.RunFrameworkSynthesizers(idx.graph)
+	resolver.RunFrameworkSynthesizersWithSelection(idx.graph, idx.frameworkSynthesizerSelection())
 	// External-call placeholder synthesis (opt-in) — runs after the
 	// resolver and stub passes so only genuinely un-indexed external
 	// targets remain to materialise.

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -1828,7 +1828,12 @@ func (mi *MultiIndexer) runGlobalGraphPassesTopologyHeld(
 	// carries the caller's detached census attestation: admission censuses read
 	// the raw whole store while synthesizer execution keeps the scoped view.
 	fwStart := time.Now()
-	fwRep := resolver.RunFrameworkSynthesizersScopedWithCensus(mi.graph, changedPrefixes, censusEligible)
+	fwRep := resolver.RunFrameworkSynthesizersScopedWithCensusAndSelection(
+		mi.graph,
+		changedPrefixes,
+		censusEligible,
+		mi.frameworkSynthesizerSelection(changedPrefixes),
+	)
 	mi.logger.Info("global pass: framework dispatch synthesis",
 		zap.Int("edges", fwRep.Total),
 		zap.Any("per_synthesizer", fwRep.Per),

--- a/internal/resolver/framework_synth.go
+++ b/internal/resolver/framework_synth.go
@@ -1,8 +1,10 @@
 package resolver
 
 import (
+	"fmt"
 	"iter"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -188,6 +190,82 @@ func UnstampSynthesized(e *graph.Edge) {
 // consume the changed-repo prefix set directly. Every other pass runs through
 // frameworkScopedStore on a partial invocation; no synthFunc is permitted to
 // fall back to the unfiltered workspace store.
+// FrameworkSynthesizerSelection is a compiled allow-list for the framework
+// pipeline. Its zero value preserves the historical behavior and enables the
+// complete registry. A selection constructed from an empty list disables the
+// entire pipeline.
+type FrameworkSynthesizerSelection struct {
+	configured bool
+	names      map[string]struct{}
+}
+
+// AllFrameworkSynthesizers returns the legacy, all-enabled selection.
+func AllFrameworkSynthesizers() FrameworkSynthesizerSelection {
+	return FrameworkSynthesizerSelection{}
+}
+
+// FrameworkSynthesizerNames returns every configurable registry name in
+// canonical execution order. Correctness-only tail gates are intentionally not
+// configurable independently.
+func FrameworkSynthesizerNames() []string {
+	synthesizers := defaultFrameworkSynthesizers()
+	claimers := defaultClaimingResolvers()
+	names := make([]string, 0, len(synthesizers)+len(claimers))
+	for _, synthesizer := range synthesizers {
+		names = append(names, synthesizer.Name())
+	}
+	for _, claimer := range claimers {
+		names = append(names, claimer.Name())
+	}
+	return names
+}
+
+// NewFrameworkSynthesizerSelection validates and compiles an explicit
+// allow-list. Passing an empty slice is distinct from
+// AllFrameworkSynthesizers and disables the complete framework pipeline.
+func NewFrameworkSynthesizerSelection(names []string) (FrameworkSynthesizerSelection, error) {
+	validNames := FrameworkSynthesizerNames()
+	valid := make(map[string]struct{}, len(validNames))
+	for _, name := range validNames {
+		valid[name] = struct{}{}
+	}
+
+	selected := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		if _, exists := selected[name]; exists {
+			return FrameworkSynthesizerSelection{}, fmt.Errorf("duplicate framework synthesizer %q", name)
+		}
+		if _, exists := valid[name]; !exists {
+			allowed := append([]string(nil), validNames...)
+			sort.Strings(allowed)
+			return FrameworkSynthesizerSelection{}, fmt.Errorf(
+				"unknown framework synthesizer %q (valid: %s)",
+				name, strings.Join(allowed, ", "),
+			)
+		}
+		selected[name] = struct{}{}
+	}
+	return FrameworkSynthesizerSelection{configured: true, names: selected}, nil
+}
+
+// ValidateFrameworkSynthesizers validates a configured allow-list.
+func ValidateFrameworkSynthesizers(names []string) error {
+	_, err := NewFrameworkSynthesizerSelection(names)
+	return err
+}
+
+func (s FrameworkSynthesizerSelection) allows(name string) bool {
+	if !s.configured {
+		return true
+	}
+	_, ok := s.names[name]
+	return ok
+}
+
+func (s FrameworkSynthesizerSelection) none() bool {
+	return s.configured && len(s.names) == 0
+}
+
 type synthFunc struct {
 	name     string
 	fn       func(graph.Store) int
@@ -1111,7 +1189,16 @@ type scopedSynthesizer interface {
 // over g, in registration order, and returns the per-synthesizer and
 // total landed-edge counts. A nil graph is a no-op.
 func RunFrameworkSynthesizers(g graph.Store) FrameworkSynthReport {
-	return RunFrameworkSynthesizersScoped(g, nil)
+	return RunFrameworkSynthesizersWithSelection(g, AllFrameworkSynthesizers())
+}
+
+// RunFrameworkSynthesizersWithSelection runs the framework pipeline using a
+// validated selection.
+func RunFrameworkSynthesizersWithSelection(
+	g graph.Store,
+	selection FrameworkSynthesizerSelection,
+) FrameworkSynthReport {
+	return runFrameworkSynthesizersScoped(g, nil, nil, false, true, selection)
 }
 
 // RunFrameworkSynthesizersScoped is RunFrameworkSynthesizers with an armed
@@ -1123,7 +1210,9 @@ func RunFrameworkSynthesizers(g graph.Store) FrameworkSynthReport {
 // passes use the changed repositories plus their exact reverse dependency
 // frontier; nil scope retains full/cold whole-graph reconciliation.
 func RunFrameworkSynthesizersScoped(g graph.Store, scope map[string]bool) FrameworkSynthReport {
-	return runFrameworkSynthesizersScoped(g, scope, nil, false, true)
+	return runFrameworkSynthesizersScoped(
+		g, scope, nil, false, true, AllFrameworkSynthesizers(),
+	)
 }
 
 // RunFrameworkSynthesizersScopedWithCensus is the full-coverage batch form:
@@ -1137,7 +1226,22 @@ func RunFrameworkSynthesizersScopedWithCensus(
 	scope map[string]bool,
 	censusEligible bool,
 ) FrameworkSynthReport {
-	return runFrameworkSynthesizersScoped(g, scope, nil, censusEligible, true)
+	return runFrameworkSynthesizersScoped(
+		g, scope, nil, censusEligible, true, AllFrameworkSynthesizers(),
+	)
+}
+
+// RunFrameworkSynthesizersScopedWithCensusAndSelection is the configurable
+// form used by graph-wide indexer passes.
+func RunFrameworkSynthesizersScopedWithCensusAndSelection(
+	g graph.Store,
+	scope map[string]bool,
+	censusEligible bool,
+	selection FrameworkSynthesizerSelection,
+) FrameworkSynthReport {
+	return runFrameworkSynthesizersScoped(
+		g, scope, nil, censusEligible, true, selection,
+	)
 }
 
 // RunFrameworkSynthesizersScopedForFiles is the exact incremental form. The
@@ -1150,7 +1254,23 @@ func RunFrameworkSynthesizersScopedForFiles(
 	filePaths []string,
 	csharpHierarchyChanged bool,
 ) FrameworkSynthReport {
-	return runFrameworkSynthesizersScoped(g, scope, filePaths, false, csharpHierarchyChanged)
+	return runFrameworkSynthesizersScoped(
+		g, scope, filePaths, false, csharpHierarchyChanged, AllFrameworkSynthesizers(),
+	)
+}
+
+// RunFrameworkSynthesizersScopedForFilesWithSelection is the configurable
+// exact incremental form used by the indexer.
+func RunFrameworkSynthesizersScopedForFilesWithSelection(
+	g graph.Store,
+	scope map[string]bool,
+	filePaths []string,
+	csharpHierarchyChanged bool,
+	selection FrameworkSynthesizerSelection,
+) FrameworkSynthReport {
+	return runFrameworkSynthesizersScoped(
+		g, scope, filePaths, false, csharpHierarchyChanged, selection,
+	)
 }
 
 func frameworkScopeForFiles(
@@ -1178,9 +1298,13 @@ func runFrameworkSynthesizersScoped(
 	filePaths []string,
 	censusEligible bool,
 	csharpHierarchyChanged bool,
+	selection FrameworkSynthesizerSelection,
 ) FrameworkSynthReport {
 	rep := FrameworkSynthReport{}
 	if g == nil {
+		return rep
+	}
+	if selection.none() {
 		return rep
 	}
 	// A changed-file frontier is always partial, even when a legacy caller lost
@@ -1218,6 +1342,10 @@ func runFrameworkSynthesizersScoped(
 	}
 	rep.ScopeMillis = time.Since(scopeStart).Milliseconds()
 	for _, s := range defaultFrameworkSynthesizers() {
+		if !selection.allows(s.Name()) {
+			candidates.streams.releasePass(s.Name(), nil)
+			continue
+		}
 		start := time.Now()
 		var n int
 		var bundle *frameworkPassCandidates
@@ -1282,9 +1410,15 @@ func runFrameworkSynthesizersScoped(
 	// external-call synthesis classifies the residual unresolved refs as
 	// external. Reported in registration order for determinism.
 	claimStart := time.Now()
-	claimed := RunClaimingResolversScoped(g, executionScope)
-	rep.ClaimMillis = time.Since(claimStart).Milliseconds()
+	claimingResolvers := make([]ClaimingResolver, 0, len(defaultClaimingResolvers()))
 	for _, r := range defaultClaimingResolvers() {
+		if selection.allows(r.Name()) {
+			claimingResolvers = append(claimingResolvers, r)
+		}
+	}
+	claimed := runClaimingResolversScoped(g, executionScope, claimingResolvers)
+	rep.ClaimMillis = time.Since(claimStart).Milliseconds()
+	for _, r := range claimingResolvers {
 		n := claimed[r.Name()]
 		rep.Per = append(rep.Per, SynthCount{Name: r.Name(), Edges: n})
 		rep.Total += n
@@ -1586,11 +1720,18 @@ func RunClaimingResolvers(g graph.Store) map[string]int {
 // references sourced by changed repositories. Resolver precedence is retained:
 // each registered resolver receives only edges not claimed by an earlier one.
 func RunClaimingResolversScoped(g graph.Store, scope map[string]bool) map[string]int {
+	return runClaimingResolversScoped(g, scope, defaultClaimingResolvers())
+}
+
+func runClaimingResolversScoped(
+	g graph.Store,
+	scope map[string]bool,
+	resolvers []ClaimingResolver,
+) map[string]int {
 	out := map[string]int{}
 	if g == nil {
 		return out
 	}
-	resolvers := defaultClaimingResolvers()
 	if len(resolvers) == 0 {
 		return out
 	}

--- a/internal/resolver/framework_synth_selection_test.go
+++ b/internal/resolver/framework_synth_selection_test.go
@@ -1,0 +1,65 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestFrameworkSynthesizerSelectionRejectsUnknownAndDuplicateNames(t *testing.T) {
+	_, err := NewFrameworkSynthesizerSelection([]string{"not-a-synthesizer"})
+	assert.ErrorContains(t, err, `unknown framework synthesizer "not-a-synthesizer"`)
+
+	name := defaultFrameworkSynthesizers()[0].Name()
+	_, err = NewFrameworkSynthesizerSelection([]string{name, name})
+	assert.ErrorContains(t, err, `duplicate framework synthesizer "`+name+`"`)
+}
+
+func TestFrameworkSynthesizerSelectionCatalogIsUnique(t *testing.T) {
+	seen := make(map[string]struct{})
+	for _, name := range FrameworkSynthesizerNames() {
+		if _, exists := seen[name]; exists {
+			t.Fatalf("duplicate framework registry name %q", name)
+		}
+		seen[name] = struct{}{}
+	}
+}
+
+func TestFrameworkSynthesizerSelectionExplicitEmptySkipsEveryGraphScan(t *testing.T) {
+	selection, err := NewFrameworkSynthesizerSelection([]string{})
+	require.NoError(t, err)
+	store := &countingFrameworkLightStore{Store: graph.New()}
+
+	report := RunFrameworkSynthesizersWithSelection(store, selection)
+
+	assert.Zero(t, report.Total)
+	assert.Empty(t, report.Per)
+	assert.Zero(t, store.nodeCalls)
+	assert.Zero(t, store.edgeCalls)
+}
+
+func TestFrameworkSynthesizerSelectionRunsOnlySelectedSynthesizer(t *testing.T) {
+	name := defaultFrameworkSynthesizers()[0].Name()
+	selection, err := NewFrameworkSynthesizerSelection([]string{name})
+	require.NoError(t, err)
+
+	report := RunFrameworkSynthesizersWithSelection(graph.New(), selection)
+
+	require.Len(t, report.Per, 1)
+	assert.Equal(t, name, report.Per[0].Name)
+}
+
+func TestFrameworkSynthesizerSelectionRunsOnlySelectedClaimingResolver(t *testing.T) {
+	require.NotEmpty(t, defaultClaimingResolvers())
+	name := defaultClaimingResolvers()[0].Name()
+	selection, err := NewFrameworkSynthesizerSelection([]string{name})
+	require.NoError(t, err)
+
+	report := RunFrameworkSynthesizersWithSelection(graph.New(), selection)
+
+	require.Len(t, report.Per, 1)
+	assert.Equal(t, name, report.Per[0].Name)
+}


### PR DESCRIPTION
Closes #659.

## Root cause

Framework census gated individual registry passes, but every index still entered the framework pipeline and paid for scope recovery, census, claiming resolvers, family gates, and demotion. In the reported workload, most synthesizers emitted no edges while still consuming substantial time.

## Changes

- Add tri-state `index.framework_synthesizers`: omitted runs all synthesizers, `[]` skips the entire framework pipeline before graph scans, and a non-empty list runs only named registry passes and claimers.
- Preserve existing public runner behavior while wiring the selection through full, global multi-repo, and incremental indexing paths.
- Aggregate multi-repo selections conservatively: an omitted repo enables all; otherwise use the union; all explicit-empty repos disable the pipeline.
- Normalize configured names for semantic config hashing, while preserving nil versus explicit-empty behavior.
- Document the option and add tests for config decoding, validation, zero-scan disablement, subset filtering, claimant filtering, aggregation, and hashing.

## Verification

- `go test ./internal/config ./internal/resolver ./internal/indexer -count=1`
- `go test -race ./internal/resolver ./internal/indexer -run FrameworkSynthesizer\|IndexConfigHash -count=1`
- `go vet ./internal/config ./internal/resolver ./internal/indexer`
- `git diff --check origin/main...HEAD`

The implementation is split into three atomic commits: config and resolver behavior, indexer integration, and documentation.