### PR TITLE
fix(store): pin receiver-rebind join order and repair poisoned planner statistics

### DIFF
--- a/internal/graph/store_sqlite/method_receiver_rebind.go
+++ b/internal/graph/store_sqlite/method_receiver_rebind.go
@@ -23,12 +23,35 @@ var (
 // replacement all come from the same corpus. The phantom-target probe rides in
 // the LEFT JOIN's ON clause rather than the WHERE, so a target that exists only
 // in another generation reads as absent instead of dropping the row.
+//
+// Both queries use CROSS JOIN, and that keyword is load-bearing (issue #651).
+// INDEXED BY pins which index a relation is read through, but it does not pin
+// the order of the nested loops: the planner still picks the outer relation
+// from sqlite_stat1. When the partial receiver index nodes_go_receiver_type
+// carried a tiny or zero believed cardinality — the literal '0 0 0 0 0' row
+// that ANALYZE writes when no Go type/interface node exists yet is the common
+// case, and a believed 1-3 rows flips the same way — SQLite chose to SCAN the
+// receiver index outermost and re-drove the member_of side once per receiver
+// type: O(types * member_of), hours on a real store. CROSS JOIN is SQLite's
+// documented join-order constraint (the right relation is always the inner
+// loop), so the plan below is independent of statistics at every believed
+// cardinality. Only the two inner joins carry the keyword: t can never precede
+// e because it depends on e, so the LEFT JOIN cannot become the driver whether
+// or not it is pinned. The keyword is needed only to stop c (and m) from being
+// hoisted above e. Pinning t ahead of c is not a cost regression — t is one
+// primary-key probe per surviving (e, m) row wherever it sits in the loop
+// order — and the plan it yields is e, m, t, c.
+//
+// goMethodReceiverCandidatesForFilesSQL in method_receiver_rebind_batch.go
+// uses the same construct, and for the same reason, to pin its
+// frontier -> method -> edge -> receiver chain; the batch_frontier_zero_row
+// plan lock holds that one to the seek plan.
 const goMethodReceiverCandidatesGlobalSQL = `
 SELECT e.id, MIN(c.id)
 FROM edges AS e INDEXED BY edges_by_kind
-JOIN nodes AS m ON m.id = e.from_id AND m.view_gen = ?
+CROSS JOIN nodes AS m ON m.id = e.from_id AND m.view_gen = ?
 LEFT JOIN nodes AS t ON t.id = e.to_id AND t.view_gen = ?
-JOIN nodes AS c INDEXED BY nodes_go_receiver_type
+CROSS JOIN nodes AS c INDEXED BY nodes_go_receiver_type
   ON c.repo_prefix = m.repo_prefix
  AND c.file_dir = e.member_receiver_dir
  AND c.name = e.member_receiver
@@ -50,16 +73,19 @@ HAVING COUNT(*) = 1 AND MIN(c.id) <> e.to_id`
 // The scoped sibling starts from nodes_by_file and reaches member_of through
 // edges_by_from. This matters for partial indexing: repeatedly scanning the
 // global member index once per changed file would turn the streaming tail back
-// into O(files*all_methods).
+// into O(files*all_methods). The CROSS JOINs keep that method-first order
+// fixed for the same reason the global query needs them: the file-scoped
+// method set must stay the outermost loop no matter what sqlite_stat1
+// believes about the receiver or edge indexes.
 const goMethodReceiverCandidatesForFileSQL = `
 SELECT e.id, MIN(c.id)
 FROM nodes AS m INDEXED BY nodes_by_file
-JOIN edges AS e INDEXED BY edges_by_from
+CROSS JOIN edges AS e INDEXED BY edges_by_from
   ON e.from_id = m.id
  AND e.kind = 'member_of'
  AND e.view_gen = ?
 LEFT JOIN nodes AS t ON t.id = e.to_id AND t.view_gen = ?
-JOIN nodes AS c INDEXED BY nodes_go_receiver_type
+CROSS JOIN nodes AS c INDEXED BY nodes_go_receiver_type
   ON c.repo_prefix = m.repo_prefix
  AND c.file_dir = e.member_receiver_dir
  AND c.name = e.member_receiver

--- a/internal/graph/store_sqlite/method_receiver_rebind_batch.go
+++ b/internal/graph/store_sqlite/method_receiver_rebind_batch.go
@@ -14,13 +14,22 @@ const goMethodReceiverFileTableSQL = `CREATE TEMP TABLE IF NOT EXISTS go_receive
 // sibling does (see method_receiver_rebind.go): the edge, the owning method,
 // the current target and the canonical replacement are all held to the writing
 // handle's generation, and the target probe stays in the LEFT JOIN's ON clause.
+//
+// Every join that could otherwise be hoisted above the frontier carries CROSS
+// JOIN for the same reason the global query does (issue #651): INDEXED BY pins
+// which index a relation is read through, never the order of the nested loops,
+// so a tiny or zero believed cardinality on nodes_go_receiver_type would let
+// the planner drive from `c` and re-read the frontier once per receiver type.
+// Pinning `c` costs nothing — it is a three-column seek per surviving (m, e)
+// row wherever it sits — and the plan is now f, m, e, t, c at every believed
+// cardinality rather than only at the ones measured so far.
 const goMethodReceiverCandidatesForFilesSQL = `
 SELECT e.id, MIN(c.id)
 FROM temp.go_receiver_rebind_files AS f
 CROSS JOIN nodes AS m INDEXED BY nodes_by_file
 CROSS JOIN edges AS e INDEXED BY edges_by_from
 LEFT JOIN nodes AS t ON t.id = e.to_id AND t.view_gen = ?
-JOIN nodes AS c INDEXED BY nodes_go_receiver_type
+CROSS JOIN nodes AS c INDEXED BY nodes_go_receiver_type
   ON c.repo_prefix = m.repo_prefix
  AND c.file_dir = e.member_receiver_dir
  AND c.name = e.member_receiver

--- a/internal/graph/store_sqlite/method_receiver_rebind_plan_lock_test.go
+++ b/internal/graph/store_sqlite/method_receiver_rebind_plan_lock_test.go
@@ -1,0 +1,589 @@
+package store_sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Receiver-rebind access-path plan locks.
+//
+// The two receiver candidate queries pin their indexes with INDEXED BY, but
+// INDEXED BY pins the index, never the loop order. When sqlite_stat1 claims
+// the partial index nodes_go_receiver_type holds a handful of rows — a
+// literal '0 0 0 0 0' row written by ANALYZE while the store held no Go
+// type/interface node, or an honest '1 ...' row captured before the types
+// landed — the planner drives the join from `c` and re-reads every member_of
+// edge once per receiver type. That is O(types x member_of): minutes to hours
+// on a production store, and the reason issue #651's rebind pass never
+// finished.
+//
+// These locks therefore run the SAME two production queries under four
+// distinct statistics regimes and require the same seek-driven shape from all
+// four. The plan must be driven by the edge kind index (global) or the file
+// index (scoped); `c` must always be the inner, probed relation.
+//
+// Test names carry "PlanLock" because the Windows CI leg runs only
+// -run 'PlanLock|PlansLocked|PlansNeverScan' in this package.
+func TestReceiverRebindPlanLockAcrossStatisticsRegimes(t *testing.T) {
+	// One full-corpus store serves four of the five regimes. Building it once
+	// is worth real time (the fixture costs ~88s of -race wall clock per
+	// build) and costs no coverage, because each regime only rewrites
+	// sqlite_stat1 — never the corpus. What it does cost is ORDER, so the
+	// subtests below run sequentially and their order is load bearing:
+	//
+	//	no_stats                 first, and only first: sqlite_stat1 cannot be
+	//	                         dropped once ANALYZE has created it.
+	//	refreshed                honest statistics, before anything poisons them.
+	//	zero_row_from_old_engine poisons the receiver row (and runs the real
+	//	                         rebind, which mutates edges).
+	//	batch_frontier_zero_row  reuses that poisoned row.
+	//
+	// tiny_row_natural needs a differently seeded corpus (one type at ANALYZE
+	// time), so it keeps its own store.
+	s, methodFile, disarmClose := newReceiverPlanLockStore(t, receiverPlanLockAllTypes)
+
+	// Set together with disarmClose when a rebind is abandoned mid-flight.
+	// RebindGoMethodReceivers holds s.writeMu for its whole run, so once the
+	// budget below expires that gate is held by a goroutine nobody can stop:
+	// any later subtest that takes it would block until the package timeout
+	// and bury the failure that was already recorded. Later subtests on this
+	// shared store skip instead.
+	var rebindAbandoned atomic.Bool
+
+	t.Run("no_stats", func(t *testing.T) {
+		if statsTableExists(t, s) {
+			t.Fatal("fixture created sqlite_stat1 without an explicit refresh")
+		}
+		withReceiverPlanLockWriter(t, s, func(ctx context.Context, conn *sql.Conn) {
+			assertReceiverRebindPlansLocked(t, ctx, conn, methodFile)
+		})
+	})
+
+	t.Run("refreshed", func(t *testing.T) {
+		refreshReceiverPlanLockStats(t, s)
+		stat := receiverStatOnReader(t, s)
+		if stat == "" {
+			t.Fatal("refresh wrote no receiver stat row; the healthy-statistics regime is not under test")
+		}
+		if got := statRowCount(t, stat); got < receiverPlanLockTypes-50 {
+			t.Fatalf("refreshed receiver stat = %q (count %d), want a healthy count >= %d",
+				stat, got, receiverPlanLockTypes-50)
+		}
+
+		withReceiverPlanLockWriter(t, s, func(ctx context.Context, conn *sql.Conn) {
+			assertReceiverRebindPlansLocked(t, ctx, conn, methodFile)
+		})
+	})
+
+	// A store poisoned before the upgrade: ANALYZE ran while the graph held no
+	// Go type at all and wrote the degenerate all-zero row, which then survived
+	// every later load because nothing re-analyzed the index.
+	t.Run("zero_row_from_old_engine", func(t *testing.T) {
+		withReceiverPlanLockWriter(t, s, func(ctx context.Context, conn *sql.Conn) {
+			// Hand-edited sqlite_stat1 rows only reach a connection's planner
+			// after ANALYZE sqlite_schema on that same connection, so poison
+			// and reload on the connection the EXPLAINs (and the real rebind)
+			// run on.
+			//
+			// sqlite_stat1 carries no UNIQUE constraint, so INSERT OR REPLACE
+			// would silently append a second row for the same index and leave
+			// the honest one in front of it. Delete, then insert.
+			if _, err := conn.ExecContext(ctx, `DELETE FROM sqlite_stat1 WHERE idx = 'nodes_go_receiver_type'`); err != nil {
+				t.Fatalf("clear receiver stat row: %v", err)
+			}
+			if _, err := conn.ExecContext(ctx, `INSERT INTO sqlite_stat1(tbl, idx, stat) VALUES ('nodes', 'nodes_go_receiver_type', '0 0 0 0 0')`); err != nil {
+				t.Fatalf("poison receiver stat row: %v", err)
+			}
+			if _, err := conn.ExecContext(ctx, `ANALYZE sqlite_schema`); err != nil {
+				t.Fatalf("reload poisoned statistics: %v", err)
+			}
+			if got := receiverStatOnConn(t, ctx, conn); got != "0 0 0 0 0" {
+				t.Fatalf("receiver stat = %q, want the poisoned zero row", got)
+			}
+			assertReceiverRebindPlansLocked(t, ctx, conn, methodFile)
+		})
+
+		// The plan lock is only half the guarantee: the query must still be
+		// correct (and terminate) on the poisoned store. Skip it once the plan
+		// already failed — the misplan is the diagnosis, and running the pass
+		// under it only burns the budget below.
+		if t.Failed() {
+			return
+		}
+		type rebindResult struct {
+			changed int
+			err     error
+		}
+		done := make(chan rebindResult, 1)
+		go func() {
+			changed, err := s.RebindGoMethodReceivers("")
+			done <- rebindResult{changed: changed, err: err}
+		}()
+		select {
+		case got := <-done:
+			if got.err != nil {
+				t.Fatalf("rebind on a poisoned-statistics store: %v", got.err)
+			}
+			if got.changed != receiverPlanLockPhantomEdges {
+				t.Fatalf("rebind changed = %d, want %d phantom receiver edges", got.changed, receiverPlanLockPhantomEdges)
+			}
+		case <-time.After(receiverPlanLockRebindBudget):
+			// The pass is still running and still holds the write gate.
+			// Closing the store would block on it forever, so abandon the
+			// handle and let the failure print. Every later subtest on this
+			// store takes the same gate, so mark the store unusable too.
+			disarmClose()
+			rebindAbandoned.Store(true)
+			t.Errorf("receiver rebind did not finish within %s on a poisoned-statistics store", receiverPlanLockRebindBudget)
+		}
+	})
+
+	// The batched frontier sibling shares the same receiver join and pins its
+	// whole f -> m -> e -> c chain with CROSS JOIN, so its loop order is
+	// statistics-independent for the same reason the global query's is. This
+	// lock is the enforcement: without it the batch query could quietly drift
+	// back to the state the global one was in before #651.
+	t.Run("batch_frontier_zero_row", func(t *testing.T) {
+		if rebindAbandoned.Load() {
+			t.Skip("previous subtest abandoned a rebind still holding the write gate; this store is unusable")
+		}
+		withReceiverPlanLockWriter(t, s, func(ctx context.Context, conn *sql.Conn) {
+			if _, err := conn.ExecContext(ctx, `DELETE FROM sqlite_stat1 WHERE idx = 'nodes_go_receiver_type'`); err != nil {
+				t.Fatalf("clear receiver stat row: %v", err)
+			}
+			if _, err := conn.ExecContext(ctx, `INSERT INTO sqlite_stat1(tbl, idx, stat) VALUES ('nodes', 'nodes_go_receiver_type', '0 0 0 0 0')`); err != nil {
+				t.Fatalf("poison receiver stat row: %v", err)
+			}
+			if _, err := conn.ExecContext(ctx, `ANALYZE sqlite_schema`); err != nil {
+				t.Fatalf("reload poisoned statistics: %v", err)
+			}
+			// The frontier table is connection-local, so provision it on the
+			// connection the EXPLAIN runs on, and fill it: an empty frontier
+			// is not the shape production plans against.
+			if _, err := conn.ExecContext(ctx, goMethodReceiverFileTableSQL); err != nil {
+				t.Fatalf("create frontier table: %v", err)
+			}
+			for j := 0; j < receiverPlanLockFrontierFiles; j++ {
+				if _, err := conn.ExecContext(ctx, `INSERT OR IGNORE INTO temp.go_receiver_rebind_files(file_path) VALUES (?)`, receiverPlanLockMethodFile(j)); err != nil {
+					t.Fatalf("seed frontier table: %v", err)
+				}
+			}
+
+			plan := explainOnConn(t, ctx, conn, goMethodReceiverCandidatesForFilesSQL,
+				baseViewGeneration, baseViewGeneration, baseViewGeneration, baseViewGeneration)
+			joined := strings.Join(plan, "\n")
+			probed := false
+			for _, line := range plan {
+				if strings.HasPrefix(trimPlanLine(line), "SCAN c") {
+					t.Errorf("batch: receiver type table drives the join (O(types x member_of)):\n%s", joined)
+				}
+				if strings.Contains(line, "SEARCH c USING INDEX nodes_go_receiver_type") {
+					probed = true
+				}
+			}
+			if !probed {
+				t.Errorf("batch: receiver type table is not probed through nodes_go_receiver_type:\n%s", joined)
+			}
+		})
+	})
+
+	// An honest but stale row: ANALYZE captured the index while exactly one Go
+	// type existed, and the other 299 landed afterwards. Nothing about this
+	// store is corrupt — the planner is simply working from an old count.
+	//
+	// This regime needs its own store: the corpus must be seeded with a single
+	// type so ANALYZE writes a genuinely tiny row, which no amount of
+	// sqlite_stat1 editing on the shared store would reproduce honestly.
+	t.Run("tiny_row_natural", func(t *testing.T) {
+		tiny, methodFile, _ := newReceiverPlanLockStore(t, receiverPlanLockOneType)
+		refreshReceiverPlanLockStats(t, tiny)
+		// Assert the regime rather than reporting it: a fixture that quietly
+		// stopped producing a tiny row would leave this subtest running the
+		// same healthy-statistics plan as `refreshed` while still passing.
+		stat := receiverStatOnReader(t, tiny)
+		if stat == "" {
+			t.Fatal("single-type fixture wrote no receiver stat row; the tiny-row regime is not under test")
+		}
+		if got := statRowCount(t, stat); got > 3 {
+			t.Fatalf("natural single-type receiver stat = %q (count %d), want <= 3 — the tiny-row regime is not under test",
+				stat, got)
+		}
+		addReceiverPlanLockRemainingTypes(tiny)
+
+		withReceiverPlanLockWriter(t, tiny, func(ctx context.Context, conn *sql.Conn) {
+			assertReceiverRebindPlansLocked(t, ctx, conn, methodFile)
+		})
+	})
+}
+
+// withReceiverPlanLockWriter runs fn against the store's writer connection —
+// the one RebindGoMethodReceivers itself uses, and the only one that sees a
+// writer-side ANALYZE.
+//
+// The gate and the connection are released with defer, and that is load
+// bearing: t.Fatalf unwinds through runtime.Goexit, which runs this frame's
+// defers but would otherwise leave writeMu held. Store.Close takes the same
+// gate, so a plan assertion that failed while holding it would deadlock the
+// t.Cleanup that closes the store and turn a one-line failure into a package
+// timeout.
+func withReceiverPlanLockWriter(t *testing.T, s *Store, fn func(ctx context.Context, conn *sql.Conn)) {
+	t.Helper()
+	ctx := context.Background()
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	conn, release, err := s.activeWriteConnLocked(ctx)
+	if err != nil {
+		t.Fatalf("acquire writer connection: %v", err)
+	}
+	defer release()
+	fn(ctx, conn)
+}
+
+// assertReceiverRebindPlansLocked runs both production candidate queries on the
+// writer connection — the connection RebindGoMethodReceivers itself uses, and
+// the only one that sees writer-side ANALYZE — and locks the join order.
+func assertReceiverRebindPlansLocked(t *testing.T, ctx context.Context, conn *sql.Conn, methodFile string) {
+	t.Helper()
+
+	globalPlan := explainOnConn(t, ctx, conn, goMethodReceiverCandidatesGlobalSQL,
+		baseViewGeneration, baseViewGeneration, baseViewGeneration, baseViewGeneration)
+	assertPlanShape(t, "global", globalPlan, "e USING INDEX edges_by_kind",
+		// `c` must be reached as a probe through its partial index, not
+		// merely "not scanned": an autoindex or a covering-key probe would
+		// pass the negative assertion while abandoning the vetted path.
+		[]string{"SEARCH c USING INDEX nodes_go_receiver_type"},
+		[]string{"USE TEMP B-TREE"})
+
+	// The scoped sibling binds (view_gen, view_gen, view_gen, file_path, view_gen).
+	filePlan := explainOnConn(t, ctx, conn, goMethodReceiverCandidatesForFileSQL,
+		baseViewGeneration, baseViewGeneration, baseViewGeneration, methodFile, baseViewGeneration)
+	// A scoped GROUP BY over one file's member edges may legitimately
+	// materialise a temp B-tree: it is bounded by that single file.
+	assertPlanShape(t, "scoped", filePlan, "m USING INDEX nodes_by_file",
+		// The file-scoped method set reaches member_of through edges_by_from;
+		// losing that seek is what would turn the streaming tail back into
+		// O(files * all_methods).
+		[]string{
+			"SEARCH e USING INDEX edges_by_from",
+			"SEARCH c USING INDEX nodes_go_receiver_type",
+		},
+		nil)
+}
+
+// assertPlanShape requires the outermost loop (EXPLAIN QUERY PLAN emits rows in
+// loop-nesting order, so row 0 is the outer driver) to be the vetted seek,
+// requires every `want` substring somewhere in the joined plan (the
+// plan_lock_test.go convention), and forbids the receiver type table from ever
+// becoming a driving scan.
+//
+// It reports with Errorf rather than Fatalf so a regression prints BOTH the
+// global and the scoped plan in one run: the two queries fail together and
+// seeing only the first would hide half the diagnosis.
+func assertPlanShape(t *testing.T, label string, plan []string, wantOuter string, want []string, forbid []string) {
+	t.Helper()
+	joined := strings.Join(plan, "\n")
+	if len(plan) == 0 {
+		t.Errorf("%s: empty query plan", label)
+		return
+	}
+	if !strings.Contains(plan[0], wantOuter) {
+		t.Errorf("%s: outermost loop = %q, want it to contain %q\nfull plan:\n%s", label, plan[0], wantOuter, joined)
+	}
+	for _, wanted := range want {
+		if !strings.Contains(joined, wanted) {
+			t.Errorf("%s: plan missing %q:\n%s", label, wanted, joined)
+		}
+	}
+	for _, line := range plan {
+		if strings.HasPrefix(trimPlanLine(line), "SCAN c") {
+			t.Errorf("%s: receiver type table drives the join (O(types x member_of)):\n%s", label, joined)
+			break
+		}
+	}
+	for _, forbidden := range forbid {
+		for _, line := range plan {
+			if strings.Contains(line, forbidden) {
+				t.Errorf("%s: plan contains forbidden %q:\n%s", label, forbidden, joined)
+				break
+			}
+		}
+	}
+}
+
+// trimPlanLine strips the tree-drawing prefix some SQLite builds prepend to
+// EXPLAIN QUERY PLAN details so a prefix match sees the opcode itself.
+func trimPlanLine(line string) string {
+	return strings.TrimLeft(line, " \t|-`+")
+}
+
+// explainOnConn runs EXPLAIN QUERY PLAN on an already-held writer connection.
+// Never issue s.writerDB.Exec / QueryRow while holding one: the writer pool is
+// limited to a single connection and would deadlock.
+func explainOnConn(t *testing.T, ctx context.Context, conn *sql.Conn, query string, args ...any) []string {
+	t.Helper()
+	rows, err := conn.QueryContext(ctx, "EXPLAIN QUERY PLAN "+query, args...)
+	if err != nil {
+		t.Fatalf("explain query plan: %v", err)
+	}
+	var plan []string
+	for rows.Next() {
+		var id, parent, notused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &notused, &detail); err != nil {
+			_ = rows.Close()
+			t.Fatalf("scan plan row: %v", err)
+		}
+		plan = append(plan, detail)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		t.Fatalf("iterate plan rows: %v", err)
+	}
+	if err := rows.Close(); err != nil {
+		t.Fatalf("close plan rows: %v", err)
+	}
+	return plan
+}
+
+const (
+	receiverPlanLockRepo    = "repo"
+	receiverPlanLockDirs    = 100
+	receiverPlanLockTypes   = 300
+	receiverPlanLockMethods = 3000
+	receiverPlanLockFanout  = 7
+	// Every hundredth member_of edge points at a type node that does not
+	// exist; those are exactly the rows the rebind pass must repair.
+	receiverPlanLockPhantomEdges = receiverPlanLockMethods / 100
+	// Budget for the functional rebind on the poisoned store. The misplan it
+	// guards against is O(types x member_of) — minutes on this fixture, hours
+	// on a real store — so the bound only has to be far below that while
+	// staying well clear of a loaded or -race CI box. Two minutes still
+	// discriminates by more than an order of magnitude against a misplan the
+	// healthy plan finishes in well under a second, and the ubuntu CI legs are
+	// slow enough that a tighter bound buys nothing but flakes. Raise this
+	// constant if it ever flakes; do NOT shrink the fixture, a smaller one
+	// stops reproducing the misplan at all.
+	receiverPlanLockRebindBudget = 2 * time.Minute
+	// Frontier files handed to the batched sibling's TEMP table.
+	receiverPlanLockFrontierFiles = 200
+)
+
+type receiverPlanLockTypeSeed int
+
+const (
+	receiverPlanLockAllTypes receiverPlanLockTypeSeed = iota
+	receiverPlanLockOneType
+)
+
+func receiverPlanLockDir(typeIndex int) string {
+	return fmt.Sprintf("%s/pkg/d%02d", receiverPlanLockRepo, typeIndex%receiverPlanLockDirs)
+}
+
+func receiverPlanLockTypeName(typeIndex int) string {
+	return fmt.Sprintf("T%03d", typeIndex)
+}
+
+func receiverPlanLockTypeNode(typeIndex int) *graph.Node {
+	dir := receiverPlanLockDir(typeIndex)
+	name := receiverPlanLockTypeName(typeIndex)
+	file := dir + "/types.go"
+	return &graph.Node{
+		ID:         file + "::" + name,
+		Name:       name,
+		Kind:       graph.KindType,
+		FilePath:   file,
+		Language:   "go",
+		RepoPrefix: receiverPlanLockRepo,
+		StartLine:  typeIndex + 1,
+		EndLine:    typeIndex + 4,
+	}
+}
+
+func receiverPlanLockMethodFile(methodIndex int) string {
+	return fmt.Sprintf("%s/m%04d.go", receiverPlanLockDir(methodIndex%receiverPlanLockTypes), methodIndex)
+}
+
+// newReceiverPlanLockStore builds a production-shaped Go workspace: many
+// packages, receiver types split across their package's types.go, methods in
+// their own files, a sprinkling of phantom receiver targets, and a dense call
+// graph so edges_by_kind is genuinely selective for 'member_of'.
+//
+// It returns the store, one method file path for the scoped query's bind, and
+// a disarm func for the cleanup close. Disarming is for one situation only: a
+// query left running on the write gate. Store.Close takes that gate, so the
+// cleanup would block until the package timeout instead of letting the already
+// recorded failure print. Leaking the handle costs a Windows TempDir removal
+// error on a run that has already failed; a deadlock costs the whole report.
+func newReceiverPlanLockStore(t *testing.T, seed receiverPlanLockTypeSeed) (*Store, string, func()) {
+	t.Helper()
+	s, err := Open(filepath.Join(t.TempDir(), "receiver_plan_lock.sqlite"))
+	if err != nil {
+		t.Fatalf("open receiver plan-lock store: %v", err)
+	}
+	var abandoned atomic.Bool
+	// Registered after t.TempDir() so LIFO cleanup closes the database before
+	// the directory is removed — Windows cannot unlink an open file.
+	t.Cleanup(func() {
+		if abandoned.Load() {
+			return
+		}
+		_ = s.Close()
+	})
+	disarm := func() { abandoned.Store(true) }
+
+	var nodes []*graph.Node
+	if seed == receiverPlanLockAllTypes {
+		for i := 0; i < receiverPlanLockTypes; i++ {
+			nodes = append(nodes, receiverPlanLockTypeNode(i))
+		}
+	} else {
+		nodes = append(nodes, receiverPlanLockTypeNode(0))
+	}
+
+	var edges []*graph.Edge
+	for j := 0; j < receiverPlanLockMethods; j++ {
+		typeIndex := j % receiverPlanLockTypes
+		dir := receiverPlanLockDir(typeIndex)
+		typeName := receiverPlanLockTypeName(typeIndex)
+		file := receiverPlanLockMethodFile(j)
+		methodName := fmt.Sprintf("M%04d", j)
+		methodID := file + "::" + typeName + "." + methodName
+		nodes = append(nodes, &graph.Node{
+			ID:         methodID,
+			Name:       methodName,
+			Kind:       graph.KindMethod,
+			FilePath:   file,
+			Language:   "go",
+			RepoPrefix: receiverPlanLockRepo,
+			StartLine:  1,
+			EndLine:    9,
+		})
+		target := dir + "/types.go::" + typeName
+		if j%100 == 0 {
+			target = dir + "/phantom.go::" + typeName
+		}
+		edges = append(edges, &graph.Edge{
+			From:     methodID,
+			To:       target,
+			Kind:     graph.EdgeMemberOf,
+			FilePath: file,
+			Line:     1,
+		})
+	}
+	// Dense call edges so 'member_of' is a small slice of edges_by_kind: a
+	// fixture where every edge is a member edge would make the wrong plan look
+	// cheap for the wrong reason.
+	for j := 0; j < receiverPlanLockMethods; j++ {
+		file := receiverPlanLockMethodFile(j)
+		typeName := receiverPlanLockTypeName(j % receiverPlanLockTypes)
+		from := file + "::" + typeName + "." + fmt.Sprintf("M%04d", j)
+		for n := 1; n <= receiverPlanLockFanout; n++ {
+			callee := (j + n*37) % receiverPlanLockMethods
+			calleeType := receiverPlanLockTypeName(callee % receiverPlanLockTypes)
+			edges = append(edges, &graph.Edge{
+				From:     from,
+				To:       receiverPlanLockMethodFile(callee) + "::" + calleeType + "." + fmt.Sprintf("M%04d", callee),
+				Kind:     graph.EdgeCalls,
+				FilePath: file,
+				Line:     10 + n,
+			})
+		}
+	}
+	s.AddBatch(nodes, edges)
+
+	wantTypes := receiverPlanLockTypes
+	if seed != receiverPlanLockAllTypes {
+		wantTypes = 1
+	}
+	assertReceiverPlanLockFixtureLanded(t, s, wantTypes)
+	return s, receiverPlanLockMethodFile(1), disarm
+}
+
+// assertReceiverPlanLockFixtureLanded pins the corpus these plan locks are
+// measured against. Everything below depends on the two cardinalities the
+// misplan is a product of, and both are silent when wrong: a corpus that
+// landed twice (or half) still EXPLAINs, just against a shape nobody chose.
+// The receiver count is read THROUGH the partial index with the index's own
+// predicate, so it also proves the index the plans probe is populated.
+func assertReceiverPlanLockFixtureLanded(t *testing.T, s *Store, wantTypes int) {
+	t.Helper()
+	var types int
+	if err := s.db.QueryRow(`SELECT count(*) FROM nodes INDEXED BY nodes_go_receiver_type WHERE ` +
+		nodesGoReceiverTypePredicate).Scan(&types); err != nil {
+		t.Fatalf("count receiver index entries: %v", err)
+	}
+	if types != wantTypes {
+		t.Fatalf("nodes_go_receiver_type holds %d entries, want %d receiver types", types, wantTypes)
+	}
+	var memberEdges int
+	if err := s.db.QueryRow(`SELECT count(*) FROM edges WHERE kind = 'member_of'`).Scan(&memberEdges); err != nil {
+		t.Fatalf("count member_of edges: %v", err)
+	}
+	if memberEdges != receiverPlanLockMethods {
+		t.Fatalf("fixture holds %d member_of edges, want %d (one per method)", memberEdges, receiverPlanLockMethods)
+	}
+}
+
+// addReceiverPlanLockRemainingTypes lands the 299 receiver types that were
+// deliberately withheld from the initial batch, leaving the freshly written
+// sqlite_stat1 row honestly describing a one-row index.
+func addReceiverPlanLockRemainingTypes(s *Store) {
+	var nodes []*graph.Node
+	for i := 1; i < receiverPlanLockTypes; i++ {
+		nodes = append(nodes, receiverPlanLockTypeNode(i))
+	}
+	s.AddBatch(nodes, nil)
+}
+
+func refreshReceiverPlanLockStats(t *testing.T, s *Store) {
+	t.Helper()
+	s.writeMu.Lock()
+	err := s.refreshPlannerStatsLocked(context.Background())
+	s.writeMu.Unlock()
+	if err != nil {
+		t.Fatalf("refresh planner stats: %v", err)
+	}
+}
+
+func statsTableExists(t *testing.T, s *Store) bool {
+	t.Helper()
+	var exists bool
+	if err := s.db.QueryRow(`SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'sqlite_stat1')`).Scan(&exists); err != nil {
+		t.Fatalf("probe sqlite_stat1: %v", err)
+	}
+	return exists
+}
+
+func receiverStatOnConn(t *testing.T, ctx context.Context, conn *sql.Conn) string {
+	t.Helper()
+	var stat sql.NullString
+	err := conn.QueryRowContext(ctx, `SELECT stat FROM sqlite_stat1 WHERE idx = 'nodes_go_receiver_type'`).Scan(&stat)
+	if err == sql.ErrNoRows {
+		return ""
+	}
+	if err != nil {
+		t.Fatalf("read receiver stat: %v", err)
+	}
+	return stat.String
+}
+
+func receiverStatOnReader(t *testing.T, s *Store) string {
+	t.Helper()
+	var stat sql.NullString
+	err := s.db.QueryRow(`SELECT stat FROM sqlite_stat1 WHERE idx = 'nodes_go_receiver_type'`).Scan(&stat)
+	if err == sql.ErrNoRows {
+		return ""
+	}
+	if err != nil {
+		t.Fatalf("read receiver stat: %v", err)
+	}
+	return stat.String
+}

--- a/internal/graph/store_sqlite/plan_lock_test.go
+++ b/internal/graph/store_sqlite/plan_lock_test.go
@@ -29,6 +29,10 @@ import (
 //   - stream scoped edges      → streamScopedEdges keyset cursor
 //     (scoped projection tests lock the no-temp-btree property)
 //   - BFS adjacency expansion  → store_bfs.go builders (store_bfs_test.go)
+//   - rebind receiver candidates → goMethodReceiverCandidates{Global,ForFile,ForFiles}SQL
+//     (method_receiver_rebind_plan_lock_test.go locks the join ORDER, not just
+//     the index: those queries run under four statistics regimes because a
+//     tiny sqlite_stat1 row inverts the order INDEXED BY cannot pin)
 //
 // A new hot query lands with a row in this table. Rows run against a
 // realistically-shaped fixture WITH planner statistics (ANALYZE), because

--- a/internal/graph/store_sqlite/planner_stats.go
+++ b/internal/graph/store_sqlite/planner_stats.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -47,6 +48,106 @@ JOIN critical ON critical.name = schema_index.name
 WHERE schema_index.type = 'index'
   AND schema_index.sql IS NOT NULL
 ORDER BY schema_index.name`
+
+// plannerStatsTableExistsQuery probes the catalog: sqlite_stat1 is created by
+// the first ANALYZE and does not exist before it.
+const plannerStatsTableExistsQuery = `SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'sqlite_stat1')`
+
+// nodesGoReceiverTypePredicate mirrors the WHERE clause of the
+// nodes_go_receiver_type DDL in bulk_load.go (bulkAlwaysLiveIndexes).
+const nodesGoReceiverTypePredicate = `language = 'go' AND kind IN ('type', 'interface') AND name <> '' AND file_path <> ''`
+
+// plannerStatsSuspectRows bounds the believed cardinality that is worth a
+// synchronous verification count on Open.
+//
+// Only a believed cardinality of a few rows can invert a join order: the
+// literal zero row ANALYZE writes for an empty partial index, or a natural row
+// captured while the index held 1-3 entries that later grew. Plans are correct
+// from a believed count in the single digits on every fixture measured here,
+// and well before 64. Anything larger is ordinary staleness, which must not
+// buy a synchronous whole-index ANALYZE (about 1.8 GiB of index pages on a
+// 12 GB store) at every daemon start. Keeping statistics fresh as a store
+// grows at runtime is a separate follow-up; this rule exists only to catch the
+// misplanning regime.
+const plannerStatsSuspectRows = 64
+
+// plannerStatsIndexProbe describes how to interrogate one critical index. For
+// a non-partial index "does it hold entries" is just "is the owning table
+// non-empty"; for a partial index every question must repeat the index's own
+// predicate and read through INDEXED BY, so the answer is the index's
+// population rather than the table's.
+//
+// The predicate is stored once and BOTH the existence probe and the bounded
+// verification count are derived from it, so the two can never drift apart.
+type plannerStatsIndexProbe struct {
+	// table is the relation the index is defined on.
+	table string
+	// predicate is the partial index's WHERE clause, verbatim from its DDL.
+	// Empty for non-partial indexes.
+	predicate string
+	// partial marks the indexes whose DDL carries a WHERE clause. Only these
+	// can be legitimately empty over a non-empty table, which is exactly the
+	// state that must never be recorded as a zero stat row.
+	partial bool
+}
+
+// existsQuery builds the single-column EXISTS probe returning 0/1.
+func (p plannerStatsIndexProbe) existsQuery(index string) string {
+	if !p.partial {
+		return `SELECT EXISTS(SELECT 1 FROM ` + p.table + `)`
+	}
+	return `SELECT EXISTS(SELECT 1 FROM ` + p.table + ` INDEXED BY ` + quoteSQLiteIdentifier(index) +
+		` WHERE ` + p.predicate + `)`
+}
+
+// countQuery builds a bounded count of the entries the partial index actually
+// holds. The count is NOT index-only: language, kind and file_path are not
+// index columns, so satisfying the predicate probes the WITHOUT ROWID nodes
+// table once per index entry. The LIMIT is what makes it affordable on every
+// Open — the caller binds at most 2*plannerStatsSuspectRows+1, so the scan
+// stops after a couple of hundred table probes no matter how large the index
+// is. It is also the only way to tell a truthful small stat row apart from the
+// poisoned '0 0 0 0 0' row that flips the receiver-rebind join order
+// (issue #651).
+func (p plannerStatsIndexProbe) countQuery(index string) string {
+	return `SELECT count(*) FROM (SELECT 1 FROM ` + p.table + ` INDEXED BY ` + quoteSQLiteIdentifier(index) +
+		` WHERE ` + p.predicate + ` LIMIT ?)`
+}
+
+// plannerStatsIndexProbes must stay paired with the index DDL in bulk_load.go
+// (bulkDroppableIndexes / bulkAlwaysLiveIndexes) and with the critical list in
+// plannerStatsIndexQuery above. A drifted predicate fails loudly rather than
+// silently: SQLite rejects INDEXED BY when the partial index cannot serve the
+// stated WHERE clause, so the probe errors instead of reporting a wrong
+// population.
+var plannerStatsIndexProbes = map[string]plannerStatsIndexProbe{
+	// Non-partial edge indexes.
+	"edges_by_from_line":      {table: "edges"},
+	"edges_by_from_line_kind": {table: "edges"},
+	"edges_by_kind":           {table: "edges"},
+	// Non-partial node indexes.
+	"nodes_by_file":      {table: "nodes"},
+	"nodes_by_kind":      {table: "nodes"},
+	"nodes_by_name":      {table: "nodes"},
+	"nodes_by_repo_kind": {table: "nodes"},
+	// Partial node indexes: every question is asked through the index with
+	// its own predicate.
+	"nodes_by_repo": {
+		table:     "nodes",
+		predicate: `repo_prefix <> ''`,
+		partial:   true,
+	},
+	"nodes_by_repo_language_name": {
+		table:     "nodes",
+		predicate: `name <> ''`,
+		partial:   true,
+	},
+	"nodes_go_receiver_type": {
+		table:     "nodes",
+		predicate: nodesGoReceiverTypePredicate,
+		partial:   true,
+	},
+}
 
 // refreshPlannerStatsLocked recomputes sqlite_stat1 for the named graph
 // indexes on the active write connection. Callers hold writeMu. PRAGMA optimize
@@ -91,9 +192,69 @@ func refreshPlannerStatsOnConn(ctx context.Context, conn *sql.Conn) error {
 		return err
 	}
 
+	// Probe the catalog once: sqlite_stat1 may not exist yet, and if it does
+	// not, no stale row can exist for any index either. The probe is part of
+	// the best-effort hygiene described below, so a failure is logged rather
+	// than returned: assuming the table exists costs at most a DELETE that
+	// matches nothing, while failing here would abort a cold load.
+	hasStatTable := true
+	if err := conn.QueryRowContext(ctx, plannerStatsTableExistsQuery).Scan(&hasStatTable); err != nil {
+		log.Printf("store_sqlite: planner stats catalog probe failed error=%q", err)
+		hasStatTable = true
+	}
+
+	// ANALYZE on an empty partial index writes a literal '0 0 0 0 0' stat row,
+	// and a believed-zero cardinality is worse than no statistics at all: with
+	// no row SQLite falls back to its default cost model, which plans these
+	// queries correctly, while a zero row convinces the planner the index is
+	// free to scan and it hoists that relation to the outermost loop (issue
+	// #651 turned the receiver rebind into O(types * member_of) that way).
+	// So never ANALYZE an empty partial critical index; drop any row it left
+	// behind instead.
+	//
+	// Every step of that hygiene is best-effort by design. ANALYZE itself
+	// stays a hard error as it always was, but a failed probe, a failed
+	// DELETE or a failed reload must not fail the caller:
+	// Store.EndCoordinatedBulkLoad joins this function's error into the
+	// cold-load result, and the multi-repo pipeline aborts on it. Losing a
+	// statistics refinement is a planning regression; aborting a cold load
+	// loses the index.
+	removedStatRow := false
 	for _, name := range indexes {
+		if spec, known := plannerStatsIndexProbes[name]; known && spec.partial {
+			var hasRows bool
+			if err := conn.QueryRowContext(ctx, spec.existsQuery(name)).Scan(&hasRows); err != nil {
+				// Fall through to the plain ANALYZE: without a usable probe
+				// the safest assumption is that the index is populated, which
+				// is the branch that behaves exactly as it did before this
+				// hygiene existed.
+				log.Printf("store_sqlite: planner stats probe failed index=%s error=%q", name, err)
+			} else if !hasRows {
+				if hasStatTable {
+					// Index names are unique across the whole schema, so
+					// matching on idx alone is exact today and stays exact
+					// if a partial critical index ever lands on edges.
+					res, err := conn.ExecContext(ctx, `DELETE FROM sqlite_stat1 WHERE idx = ?`, name)
+					if err != nil {
+						log.Printf("store_sqlite: planner stats clear failed index=%s error=%q", name, err)
+					} else if affected, err := res.RowsAffected(); err == nil && affected > 0 {
+						removedStatRow = true
+					}
+				}
+				continue
+			}
+		}
 		if _, err := conn.ExecContext(ctx, `ANALYZE `+quoteSQLiteIdentifier(name)); err != nil {
 			return fmt.Errorf("analyze graph index %s: %w", name, err)
+		}
+	}
+	if removedStatRow {
+		// A direct DELETE from sqlite_stat1 is invisible to the connection's
+		// cached statistics until they are reloaded. ANALYZE on the schema
+		// table reloads sqlite_stat1 without recomputing anything, so this
+		// connection stops planning against the row that was just removed.
+		if _, err := conn.ExecContext(ctx, `ANALYZE sqlite_schema`); err != nil {
+			log.Printf("store_sqlite: planner stats reload failed error=%q", err)
 		}
 	}
 	return nil
@@ -103,46 +264,199 @@ func quoteSQLiteIdentifier(name string) string {
 	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 }
 
-// healPlannerStats backfills sqlite_stat1 for populated stores opened without
-// graph-index statistics. Cold loads refresh stats at coordinated-bulk finalize;
-// a warm restart of a store written before the engine kept planner statistics
-// would otherwise plan blind for the rest of its life. Never fatal: a store
-// without stats still answers every query, just through the default cost model.
-func healPlannerStats(db *sql.DB) {
+// plannerStatsRepairReason decides whether an already-open store needs its
+// graph-index statistics rebuilt, and names why. It repairs rather than merely
+// backfills: a store can carry statistics that exist and are actively wrong.
+//
+// The rules, all cheap catalog / index-only probes:
+//
+//	R0 sqlite_stat1 absent entirely                          -> "no_stats"
+//	R1 a critical index present in the schema has no stat row
+//	   while the index actually holds entries                -> "missing:<idx>"
+//	R2 a partial critical index carries a stat row believing
+//	   at most plannerStatsSuspectRows entries while it holds
+//	   more than twice that many (the '0 0 0 0 0' row ANALYZE
+//	   writes for an empty partial index is the common case)  -> "tiny_stat:<idx> …"
+//	R3 a partial critical index carries a stat row while
+//	   holding no entries at all                              -> "stale_stat:<idx>"
+//
+// R3 is the leftover of an older engine that did ANALYZE an empty partial
+// index: the row believes zero (or near zero) and nothing about the index has
+// changed, so R2's "holds materially more" test can never fire. Absence is the
+// correct state for an empty partial index — SQLite falls back to a sane
+// default cost model with no row and believes a zero one — so the repair is a
+// deletion, which refreshPlannerStatsOnConn already performs on the same
+// no-entries branch. The next Open then converges: no row plus no entries is
+// R1's "nothing to do". The extra EXISTS costs one probe per partial critical
+// index and is only reached when the believed count is already suspect.
+//
+// R1 subsumes the older existence check on nodes_by_file / edges_by_from_line_kind
+// and extends it to every critical index. R2 is what the older check could not
+// see at all: the row was present, so the store looked healthy while the
+// receiver-rebind join order stayed inverted (issue #651). R2 runs over every
+// partial critical index rather than the receiver index alone — the same
+// degenerate row can be written for any of them — but only when the believed
+// count is already small enough to invert a join order, so ordinary staleness
+// on a large index never buys a synchronous ANALYZE.
+//
+// The caller still gates on a non-empty nodes table; an empty store has
+// nothing to analyze. Errors are never fatal — an unreadable probe reports
+// "no repair needed" and the store keeps running on whatever stats it has.
+func plannerStatsRepairReason(ctx context.Context, db *sql.DB) (string, bool) {
 	var hasTable bool
 	// sqlite_stat1 does not exist until the first ANALYZE, so probe the catalog
-	// before the table. Warm stores with edges must have both the original hot
-	// file stat and the bounded exact-site stat; Open may have just created the
-	// latter index on a pre-upgrade database. Empty edge tables emit no sibling
-	// stat and need no edge-plan repair.
-	if err := db.QueryRow(`SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'sqlite_stat1')`).Scan(&hasTable); err != nil {
-		return
+	// before the table.
+	if err := db.QueryRowContext(ctx, plannerStatsTableExistsQuery).Scan(&hasTable); err != nil {
+		return "", false
 	}
-	if hasTable {
-		var populated bool
-		if err := db.QueryRow(`
-SELECT EXISTS(SELECT 1 FROM sqlite_stat1 WHERE idx = 'nodes_by_file')
-   AND (
-       NOT EXISTS(SELECT 1 FROM edges LIMIT 1)
-       OR EXISTS(SELECT 1 FROM sqlite_stat1 WHERE idx = 'edges_by_from_line_kind')
-   )`).Scan(&populated); err == nil && populated {
-			return
+	if !hasTable {
+		return "no_stats", true
+	}
+
+	// Materialize the critical-index list before probing. The writer pool is a
+	// single-connection pool: issuing another query while this cursor is open
+	// would deadlock.
+	rows, err := db.QueryContext(ctx, plannerStatsIndexQuery)
+	if err != nil {
+		return "", false
+	}
+	var indexes []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			_ = rows.Close()
+			return "", false
+		}
+		indexes = append(indexes, name)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return "", false
+	}
+	if err := rows.Close(); err != nil {
+		return "", false
+	}
+
+	// R1: a critical index that holds entries but has no stat row at all.
+	statPresent := make(map[string]bool, len(indexes))
+	for _, name := range indexes {
+		spec, known := plannerStatsIndexProbes[name]
+		if !known {
+			continue
+		}
+		var hasStat bool
+		if err := db.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM sqlite_stat1 WHERE idx = ?)`, name).Scan(&hasStat); err != nil {
+			return "", false
+		}
+		if hasStat {
+			statPresent[name] = true
+			continue
+		}
+		var hasRows bool
+		if err := db.QueryRowContext(ctx, spec.existsQuery(name)).Scan(&hasRows); err != nil {
+			return "", false
+		}
+		if hasRows {
+			return "missing:" + name, true
 		}
 	}
+
+	// R2: a partial critical index whose stat row believes a handful of
+	// entries while the index holds materially more. The bounded count reads
+	// at most believed*2+1 entries, so the literal zero row costs a single
+	// probe and the largest suspect row costs a couple of hundred.
+	for _, name := range indexes {
+		spec, known := plannerStatsIndexProbes[name]
+		if !known || !spec.partial || !statPresent[name] {
+			continue
+		}
+		believed := plannerStatsBelievedRows(ctx, db, name)
+		if believed > plannerStatsSuspectRows {
+			continue
+		}
+		// R3: the row describes an index that holds nothing. The bounded
+		// count below could not tell this apart from a truthful small row,
+		// because both report actual <= believed*2.
+		var hasRows bool
+		if err := db.QueryRowContext(ctx, spec.existsQuery(name)).Scan(&hasRows); err != nil {
+			return "", false
+		}
+		if !hasRows {
+			return "stale_stat:" + name, true
+		}
+		limit := believed*2 + 1
+		var actual int64
+		if err := db.QueryRowContext(ctx, spec.countQuery(name), limit).Scan(&actual); err != nil {
+			return "", false
+		}
+		if actual > 0 && believed*2 < actual {
+			return fmt.Sprintf("tiny_stat:%s believed=%d actual>=%d", name, believed, actual), true
+		}
+	}
+	return "", false
+}
+
+// plannerStatsBelievedRows reads the cardinality SQLite currently believes an
+// index has: sqlite_stat1.stat is a space-separated list whose first token is
+// the estimated row count. A missing or unparsable row reads as zero, which is
+// the value that matters — zero is exactly the poisoned state.
+//
+// sqlite_stat1 carries no UNIQUE constraint, so a hand-edited store can hold
+// two rows for one index. Order by the leading count and take the smallest:
+// SQLite's CAST reads the numeric prefix of the text, so this is the row that
+// would misplan worst, and a duplicate can therefore only trigger a repair,
+// never hide one. ANALYZE rewrites the index's rows, so the repair also
+// collapses the duplicate.
+func plannerStatsBelievedRows(ctx context.Context, db *sql.DB, index string) int64 {
+	var stat sql.NullString
+	if err := db.QueryRowContext(ctx, `SELECT stat FROM sqlite_stat1 WHERE idx = ? ORDER BY CAST(stat AS INTEGER) LIMIT 1`, index).Scan(&stat); err != nil {
+		return 0
+	}
+	if !stat.Valid {
+		return 0
+	}
+	fields := strings.Fields(stat.String)
+	if len(fields) == 0 {
+		return 0
+	}
+	believed, err := strconv.ParseInt(fields[0], 10, 64)
+	if err != nil || believed < 0 {
+		return 0
+	}
+	return believed
+}
+
+// healPlannerStats repairs sqlite_stat1 for populated stores opened without —
+// or with actively misleading — graph-index statistics. Cold loads refresh
+// stats at coordinated-bulk finalize; a warm restart of a store written before
+// the engine kept planner statistics, or one whose receiver-index stat row was
+// written while the index was still empty, would otherwise plan badly for the
+// rest of its life. Never fatal: a store without stats still answers every
+// query, just through the default cost model.
+//
+// It reports whether sqlite_stat1 was actually rewritten, because the rewrite
+// is only visible to the connection that performed it: the caller has to
+// recycle the read pool for the repair to reach readers at all.
+func healPlannerStats(db *sql.DB) (repaired bool) {
+	ctx := context.Background()
+	reason, needsRepair := plannerStatsRepairReason(ctx, db)
+	if !needsRepair {
+		return false
+	}
 	var hasNodes bool
-	if err := db.QueryRow(`SELECT EXISTS(SELECT 1 FROM nodes)`).Scan(&hasNodes); err != nil || !hasNodes {
-		return
+	if err := db.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM nodes)`).Scan(&hasNodes); err != nil || !hasNodes {
+		return false
 	}
 	started := time.Now()
-	ctx := context.Background()
 	conn, err := db.Conn(ctx)
 	if err != nil {
-		return
+		return false
 	}
 	defer conn.Close()
 	if err := refreshPlannerStatsOnConn(ctx, conn); err != nil {
 		log.Printf("store_sqlite: planner stats heal failed error=%q", err)
-		return
+		return false
 	}
-	log.Printf("store_sqlite: planner stats heal elapsed=%s", time.Since(started))
+	log.Printf("store_sqlite: planner stats repair reason=%s elapsed=%s", reason, time.Since(started))
+	return true
 }

--- a/internal/graph/store_sqlite/planner_stats_repair_test.go
+++ b/internal/graph/store_sqlite/planner_stats_repair_test.go
@@ -1,0 +1,709 @@
+package store_sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// Planner-statistics repair at Open.
+//
+// healPlannerStats is the only thing standing between a warm restart and a
+// permanently misplanned store: cold loads refresh statistics at coordinated
+// bulk finalize, and nothing else ever re-analyzes. Its historical predicate
+// asked only "does a nodes_by_file row exist, and an edges_by_from_line_kind
+// row when edges exist" — which is satisfied by a store whose
+// nodes_go_receiver_type row says the partial index holds zero (or one) rows.
+// That degenerate row is exactly what turns the Go receiver rebind into an
+// O(types x member_of) scan, so a store carrying one must be repaired, not
+// accepted.
+
+// seedGoReceiverStatsFixture writes a small but genuinely Go-shaped graph:
+// receiver types in their package's types.go, methods in their own files, and
+// member_of edges connecting them. Only such a store has a non-empty
+// nodes_go_receiver_type partial index.
+func seedGoReceiverStatsFixture(s *Store, types int) {
+	var nodes []*graph.Node
+	var edges []*graph.Edge
+	for i := 0; i < types; i++ {
+		dir := fmt.Sprintf("repo/pkg/p%02d", i)
+		name := fmt.Sprintf("T%03d", i)
+		typeFile := dir + "/types.go"
+		typeID := typeFile + "::" + name
+		methodFile := dir + "/methods.go"
+		methodID := methodFile + "::" + name + ".M"
+		nodes = append(nodes,
+			&graph.Node{ID: typeID, Name: name, Kind: graph.KindType, FilePath: typeFile, Language: "go", RepoPrefix: "repo"},
+			&graph.Node{ID: methodID, Name: "M", Kind: graph.KindMethod, FilePath: methodFile, Language: "go", RepoPrefix: "repo"},
+		)
+		edges = append(edges, &graph.Edge{
+			From: methodID, To: methodFile + "::" + name, Kind: graph.EdgeMemberOf,
+			FilePath: methodFile, Line: i + 1,
+		})
+	}
+	s.AddBatch(nodes, edges)
+}
+
+// statsRepairClosed records which handles openStatsRepairStore handed out have
+// already been closed. Every one of them gets a t.Cleanup close, so a t.Fatalf
+// anywhere in these tests cannot leak an open database (which on Windows also
+// blocks the TempDir removal). reopenAfterStatMutation still has to close its
+// outgoing handle in the middle of a test, and both paths go through
+// closeStatsRepairStore so the cleanup's second close is a no-op rather than a
+// final WAL checkpoint against already-closed pools.
+var (
+	statsRepairClosedMu sync.Mutex
+	statsRepairClosed   = map[*Store]bool{}
+)
+
+func closeStatsRepairStore(s *Store) error {
+	statsRepairClosedMu.Lock()
+	already := statsRepairClosed[s]
+	statsRepairClosed[s] = true
+	statsRepairClosedMu.Unlock()
+	if already {
+		return nil
+	}
+	return s.Close()
+}
+
+func openStatsRepairStore(t *testing.T, path string) *Store {
+	t.Helper()
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("open store %s: %v", path, err)
+	}
+	// Registered after the caller's t.TempDir() so LIFO cleanup closes the
+	// database before the directory is removed.
+	t.Cleanup(func() { _ = closeStatsRepairStore(s) })
+	return s
+}
+
+func statRowFor(t *testing.T, s *Store, index string) (string, bool) {
+	t.Helper()
+	var stat sql.NullString
+	err := s.db.QueryRow(`SELECT stat FROM sqlite_stat1 WHERE idx = ?`, index).Scan(&stat)
+	if err == sql.ErrNoRows {
+		return "", false
+	}
+	if err != nil {
+		t.Fatalf("read %s planner stat: %v", index, err)
+	}
+	return stat.String, true
+}
+
+// statRowCount returns the leading token of a sqlite_stat1 row: SQLite's
+// estimate of how many entries the index holds.
+func statRowCount(t *testing.T, stat string) int {
+	t.Helper()
+	fields := strings.Fields(stat)
+	if len(fields) == 0 {
+		t.Fatalf("planner stat %q has no leading row count", stat)
+	}
+	var n int
+	if _, err := fmt.Sscanf(fields[0], "%d", &n); err != nil {
+		t.Fatalf("planner stat %q leading token is not a count: %v", stat, err)
+	}
+	return n
+}
+
+// indexDDLByName finds the CREATE INDEX statement the engine itself uses, so a
+// test that drops an index rebuilds byte-identical DDL.
+func indexDDLByName(t *testing.T, name string) string {
+	t.Helper()
+	for _, group := range [][]bulkDroppableIndex{bulkDroppableIndexes, bulkAlwaysLiveIndexes} {
+		for _, idx := range group {
+			if idx.name == name {
+				return idx.ddl
+			}
+		}
+	}
+	t.Fatalf("no DDL registered for index %q", name)
+	return ""
+}
+
+func reopenAfterStatMutation(t *testing.T, s *Store, path string) *Store {
+	t.Helper()
+	if err := closeStatsRepairStore(s); err != nil {
+		t.Fatalf("close store before reopen: %v", err)
+	}
+	return openStatsRepairStore(t, path)
+}
+
+// A store poisoned with the degenerate all-zero receiver row must not be
+// accepted as "already has statistics" — that row is precisely what misplans
+// the receiver rebind.
+func TestOpenRepairsZeroReceiverStat(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "stats_zero_receiver.sqlite")
+	s := openStatsRepairStore(t, path)
+	seedGoReceiverStatsFixture(s, 100)
+	s.writeMu.Lock()
+	err := s.refreshPlannerStatsLocked(context.Background())
+	s.writeMu.Unlock()
+	if err != nil {
+		t.Fatalf("seed planner stats: %v", err)
+	}
+	if _, err := s.writerDB.Exec(`UPDATE sqlite_stat1 SET stat = '0 0 0 0 0' WHERE idx = 'nodes_go_receiver_type'`); err != nil {
+		t.Fatalf("poison receiver stat: %v", err)
+	}
+
+	reopened := reopenAfterStatMutation(t, s, path)
+	stat, ok := statRowFor(t, reopened, "nodes_go_receiver_type")
+	if !ok {
+		t.Fatal("reopen dropped the receiver stat row instead of repairing it")
+	}
+	if got := statRowCount(t, stat); got < 50 {
+		t.Fatalf("receiver stat after reopen = %q (count %d), want a repaired count >= 50", stat, got)
+	}
+}
+
+// The same repair must fire for an honest-but-stale tiny row: ANALYZE captured
+// the index while a single type existed and the planner has been driving the
+// join from `c` ever since.
+func TestOpenRepairsTinyReceiverStat(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "stats_tiny_receiver.sqlite")
+	s := openStatsRepairStore(t, path)
+	seedGoReceiverStatsFixture(s, 100)
+	s.writeMu.Lock()
+	err := s.refreshPlannerStatsLocked(context.Background())
+	s.writeMu.Unlock()
+	if err != nil {
+		t.Fatalf("seed planner stats: %v", err)
+	}
+	if _, err := s.writerDB.Exec(`UPDATE sqlite_stat1 SET stat = '1 1 1 1 1' WHERE idx = 'nodes_go_receiver_type'`); err != nil {
+		t.Fatalf("shrink receiver stat: %v", err)
+	}
+
+	reopened := reopenAfterStatMutation(t, s, path)
+	stat, ok := statRowFor(t, reopened, "nodes_go_receiver_type")
+	if !ok {
+		t.Fatal("reopen dropped the receiver stat row instead of repairing it")
+	}
+	if got := statRowCount(t, stat); got < 50 {
+		t.Fatalf("receiver stat after reopen = %q (count %d), want a repaired count >= 50", stat, got)
+	}
+}
+
+// An index recreated by a schema upgrade carries no statistics. The heal
+// predicate must notice any missing critical stat row, not only the two it was
+// originally written for.
+func TestOpenRepairsMissingCriticalStatRow(t *testing.T) {
+	for _, index := range []string{"edges_by_kind", "nodes_go_receiver_type"} {
+		t.Run(index, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "stats_missing_"+index+".sqlite")
+			s := openStatsRepairStore(t, path)
+			seedGoReceiverStatsFixture(s, 100)
+			s.writeMu.Lock()
+			err := s.refreshPlannerStatsLocked(context.Background())
+			s.writeMu.Unlock()
+			if err != nil {
+				t.Fatalf("seed planner stats: %v", err)
+			}
+			if _, ok := statRowFor(t, s, index); !ok {
+				t.Fatalf("fixture never produced a %s stat row", index)
+			}
+			// DROP INDEX removes the index's sqlite_stat1 row; recreating it
+			// leaves the store exactly as a schema upgrade would.
+			if _, err := s.writerDB.Exec(`DROP INDEX ` + index); err != nil {
+				t.Fatalf("drop %s: %v", index, err)
+			}
+			if _, err := s.writerDB.Exec(indexDDLByName(t, index)); err != nil {
+				t.Fatalf("recreate %s: %v", index, err)
+			}
+			if _, ok := statRowFor(t, s, index); ok {
+				t.Fatalf("fixture kept a %s stat row across DROP/CREATE", index)
+			}
+
+			reopened := reopenAfterStatMutation(t, s, path)
+			if _, ok := statRowFor(t, reopened, index); !ok {
+				t.Fatalf("open did not heal the missing %s planner stat", index)
+			}
+		})
+	}
+}
+
+// The repair must stay narrow: a healthy refreshed store reopens without
+// paying for another ANALYZE, so its statistics come back untouched.
+func TestOpenKeepsFreshStats(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "stats_fresh.sqlite")
+	s := openStatsRepairStore(t, path)
+	seedGoReceiverStatsFixture(s, 100)
+	s.writeMu.Lock()
+	err := s.refreshPlannerStatsLocked(context.Background())
+	s.writeMu.Unlock()
+	if err != nil {
+		t.Fatalf("seed planner stats: %v", err)
+	}
+	before := allPlannerStats(t, s)
+	if len(before) == 0 {
+		t.Fatal("fixture produced no planner statistics")
+	}
+
+	reopened := reopenAfterStatMutation(t, s, path)
+	after := allPlannerStats(t, reopened)
+	if strings.Join(before, "\n") != strings.Join(after, "\n") {
+		t.Fatalf("reopen rewrote healthy planner statistics:\nbefore:\n%s\nafter:\n%s",
+			strings.Join(before, "\n"), strings.Join(after, "\n"))
+	}
+	// Byte-identical rows alone are weak evidence: ANALYZE is deterministic
+	// for a fixed corpus, so a needless re-refresh would reproduce them. Ask
+	// the predicate itself whether it wanted to spend that ANALYZE.
+	if reason, needsRepair := plannerStatsRepairReason(context.Background(), reopened.writerDB); needsRepair {
+		t.Fatalf("healthy refreshed store asked for repair reason=%q", reason)
+	}
+}
+
+// sqlite_stat1 has no UNIQUE constraint. A store carrying both an honest row
+// and a poisoned one for the same index must be read pessimistically, or the
+// repair silently depends on which row the engine happens to return first.
+func TestOpenRepairsDuplicateReceiverStatRows(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "stats_duplicate_receiver.sqlite")
+	s := openStatsRepairStore(t, path)
+	seedGoReceiverStatsFixture(s, 100)
+	s.writeMu.Lock()
+	err := s.refreshPlannerStatsLocked(context.Background())
+	s.writeMu.Unlock()
+	if err != nil {
+		t.Fatalf("seed planner stats: %v", err)
+	}
+	honest, ok := statRowFor(t, s, "nodes_go_receiver_type")
+	if !ok {
+		t.Fatal("fixture never produced a receiver stat row")
+	}
+	if got := statRowCount(t, honest); got < 50 {
+		t.Fatalf("fixture receiver stat = %q (count %d), want the honest count", honest, got)
+	}
+	// Append a second, poisoned row behind the honest one.
+	if _, err := s.writerDB.Exec(`INSERT INTO sqlite_stat1(tbl, idx, stat) VALUES ('nodes', 'nodes_go_receiver_type', '0 0 0 0 0')`); err != nil {
+		t.Fatalf("append duplicate receiver stat row: %v", err)
+	}
+
+	reopened := reopenAfterStatMutation(t, s, path)
+	stats := 0
+	for _, row := range allPlannerStats(t, reopened) {
+		if strings.Contains(row, "|nodes_go_receiver_type|") {
+			stats++
+			if got := statRowCount(t, row[strings.LastIndex(row, "|")+1:]); got < 50 {
+				t.Fatalf("receiver stat row after reopen = %q, want the repaired count", row)
+			}
+		}
+	}
+	if stats != 1 {
+		t.Fatalf("reopen left %d receiver stat rows, want exactly one repaired row", stats)
+	}
+}
+
+// A store with no Go types at all leaves nodes_go_receiver_type empty. ANALYZE
+// on an empty partial index writes the degenerate all-zero row, which is worse
+// than no row: SQLite falls back to sane defaults when a stat row is absent,
+// but believes a zero row. Absence is the correct state; the row must appear
+// only once the index has entries.
+func TestRefreshLeavesEmptyPartialIndexWithoutRow(t *testing.T) {
+	s := openStatsRepairStore(t, filepath.Join(t.TempDir(), "stats_empty_partial.sqlite"))
+
+	var nodes []*graph.Node
+	for i := 0; i < 100; i++ {
+		file := fmt.Sprintf("repo/py/mod%02d.py", i)
+		nodes = append(nodes, &graph.Node{
+			ID:         file + "::" + fmt.Sprintf("fn%02d", i),
+			Name:       fmt.Sprintf("fn%02d", i),
+			Kind:       graph.KindFunction,
+			FilePath:   file,
+			Language:   "python",
+			RepoPrefix: "repo",
+		})
+	}
+	s.AddBatch(nodes, nil)
+	s.writeMu.Lock()
+	err := s.refreshPlannerStatsLocked(context.Background())
+	s.writeMu.Unlock()
+	if err != nil {
+		t.Fatalf("refresh planner stats on a Go-free store: %v", err)
+	}
+	if _, ok := statRowFor(t, s, "nodes_by_file"); !ok {
+		t.Fatal("refresh wrote no nodes_by_file stat row")
+	}
+	if stat, ok := statRowFor(t, s, "nodes_go_receiver_type"); ok {
+		t.Fatalf("refresh wrote a stat row %q for an empty partial index; absence is the correct state", stat)
+	}
+
+	// Not writing the row is only half the hygiene: a row an older engine
+	// already left behind must be cleared. Plant one and refresh again while
+	// the index is still empty. This is the only path that exercises the
+	// DELETE-matched-a-row branch and the `ANALYZE sqlite_schema` reload that
+	// makes the deletion visible to the writer connection's planner.
+	if _, err := s.writerDB.Exec(`INSERT INTO sqlite_stat1(tbl, idx, stat) VALUES ('nodes', 'nodes_go_receiver_type', '0 0 0 0 0')`); err != nil {
+		t.Fatalf("plant a stale zero row on the empty partial index: %v", err)
+	}
+	s.writeMu.Lock()
+	err = s.refreshPlannerStatsLocked(context.Background())
+	s.writeMu.Unlock()
+	if err != nil {
+		t.Fatalf("refresh planner stats over a planted zero row: %v", err)
+	}
+	if stat, ok := statRowFor(t, s, "nodes_go_receiver_type"); ok {
+		t.Fatalf("refresh kept a stale stat row %q for an empty partial index; it must be deleted", stat)
+	}
+
+	// Once Go receiver types exist the row must come back, describing them.
+	seedGoReceiverStatsFixture(s, 100)
+	s.writeMu.Lock()
+	err = s.refreshPlannerStatsLocked(context.Background())
+	s.writeMu.Unlock()
+	if err != nil {
+		t.Fatalf("refresh planner stats after Go types landed: %v", err)
+	}
+	stat, ok := statRowFor(t, s, "nodes_go_receiver_type")
+	if !ok {
+		t.Fatal("refresh skipped a now-populated nodes_go_receiver_type")
+	}
+	if got := statRowCount(t, stat); got <= 0 {
+		t.Fatalf("populated receiver stat = %q (count %d), want a positive count", stat, got)
+	}
+}
+
+// A zero row left behind by an older engine on an index that is still empty is
+// invisible to the tiny-stat rule: the index really does hold what the row
+// claims, so "believes a handful while holding materially more" is false and
+// the row survives every reopen. It is still a poisoned row — SQLite plans an
+// absent stat row correctly and a zero one catastrophically — so Open must
+// notice the row/emptiness pairing itself and clear it.
+func TestOpenRepairsStaleStatRowOnEmptyPartialIndex(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "stats_stale_empty_partial.sqlite")
+	s := openStatsRepairStore(t, path)
+	// No Go nodes at all, so nodes_go_receiver_type stays empty while the rest
+	// of the store is ordinary and populated.
+	var nodes []*graph.Node
+	for i := 0; i < 100; i++ {
+		file := fmt.Sprintf("repo/py/mod%02d.py", i)
+		nodes = append(nodes, &graph.Node{
+			ID:         file + "::" + fmt.Sprintf("fn%02d", i),
+			Name:       fmt.Sprintf("fn%02d", i),
+			Kind:       graph.KindFunction,
+			FilePath:   file,
+			Language:   "python",
+			RepoPrefix: "repo",
+		})
+	}
+	s.AddBatch(nodes, nil)
+	s.writeMu.Lock()
+	err := s.refreshPlannerStatsLocked(context.Background())
+	s.writeMu.Unlock()
+	if err != nil {
+		t.Fatalf("seed planner stats: %v", err)
+	}
+	// The row an older engine's unconditional ANALYZE would have written.
+	if _, err := s.writerDB.Exec(`INSERT INTO sqlite_stat1(tbl, idx, stat) VALUES ('nodes', 'nodes_go_receiver_type', '0 0 0 0 0')`); err != nil {
+		t.Fatalf("plant a stale zero row on the empty partial index: %v", err)
+	}
+	if reason, needsRepair := plannerStatsRepairReason(context.Background(), s.writerDB); !needsRepair {
+		t.Fatal("a stat row over an empty partial index asked for no repair")
+	} else if !strings.HasPrefix(reason, "stale_stat:nodes_go_receiver_type") {
+		t.Fatalf("repair reason = %q, want stale_stat:nodes_go_receiver_type", reason)
+	}
+
+	reopened := reopenAfterStatMutation(t, s, path)
+	if stat, ok := statRowFor(t, reopened, "nodes_go_receiver_type"); ok {
+		t.Fatalf("reopen kept the stale stat row %q over an empty partial index; absence is the correct state", stat)
+	}
+	// And it converges: with the row gone and the index still empty there is
+	// nothing left to repair, so the next Open must not ANALYZE again.
+	if reason, needsRepair := plannerStatsRepairReason(context.Background(), reopened.writerDB); needsRepair {
+		t.Fatalf("the cleared store still asks for repair reason=%q; the rule does not converge", reason)
+	}
+}
+
+// The tiny-stat rule is generic over partial critical indexes, not a
+// receiver-index special case: the same degenerate row can be written for
+// nodes_by_repo, and it misplans repository projections the same way.
+func TestOpenRepairsZeroRepoStat(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "stats_zero_repo.sqlite")
+	s := openStatsRepairStore(t, path)
+	seedGoReceiverStatsFixture(s, 100)
+	s.writeMu.Lock()
+	err := s.refreshPlannerStatsLocked(context.Background())
+	s.writeMu.Unlock()
+	if err != nil {
+		t.Fatalf("seed planner stats: %v", err)
+	}
+	var nodeCount int
+	if err := s.db.QueryRow(`SELECT count(*) FROM nodes`).Scan(&nodeCount); err != nil {
+		t.Fatalf("count fixture nodes: %v", err)
+	}
+	if nodeCount == 0 {
+		t.Fatal("fixture wrote no nodes")
+	}
+	if _, ok := statRowFor(t, s, "nodes_by_repo"); !ok {
+		t.Fatal("fixture never produced a nodes_by_repo stat row")
+	}
+	// sqlite_stat1 has no UNIQUE constraint, so an INSERT OR REPLACE would
+	// append rather than replace. Delete, then insert. nodes_by_repo keys one
+	// column, so its honest row carries two tokens.
+	if _, err := s.writerDB.Exec(`DELETE FROM sqlite_stat1 WHERE idx = 'nodes_by_repo'`); err != nil {
+		t.Fatalf("clear repo stat row: %v", err)
+	}
+	if _, err := s.writerDB.Exec(`INSERT INTO sqlite_stat1(tbl, idx, stat) VALUES ('nodes', 'nodes_by_repo', '0 0')`); err != nil {
+		t.Fatalf("poison repo stat row: %v", err)
+	}
+
+	reopened := reopenAfterStatMutation(t, s, path)
+	stat, ok := statRowFor(t, reopened, "nodes_by_repo")
+	if !ok {
+		t.Fatal("reopen dropped the nodes_by_repo stat row instead of repairing it")
+	}
+	if got := statRowCount(t, stat); got < nodeCount/2 {
+		t.Fatalf("nodes_by_repo stat after reopen = %q (count %d), want a repaired count >= %d",
+			stat, got, nodeCount/2)
+	}
+}
+
+// The counterweight to the repair rules: a store whose statistics are merely
+// out of date must NOT buy a synchronous whole-index ANALYZE at every Open.
+// Only a believed cardinality small enough to invert a join order qualifies,
+// and this fixture's believed 100 is far above that gate even though the index
+// has since quadrupled.
+func TestOpenIgnoresOrdinaryStaleness(t *testing.T) {
+	const seeded = 100
+	const grownBy = 300
+	if seeded <= plannerStatsSuspectRows {
+		t.Fatalf("fixture believed count %d is inside the suspect gate %d; the test would not pin it",
+			seeded, plannerStatsSuspectRows)
+	}
+	path := filepath.Join(t.TempDir(), "stats_stale.sqlite")
+	s := openStatsRepairStore(t, path)
+	seedGoReceiverStatsFixture(s, seeded)
+	s.writeMu.Lock()
+	err := s.refreshPlannerStatsLocked(context.Background())
+	s.writeMu.Unlock()
+	if err != nil {
+		t.Fatalf("seed planner stats: %v", err)
+	}
+	stat, ok := statRowFor(t, s, "nodes_go_receiver_type")
+	if !ok {
+		t.Fatal("fixture never produced a receiver stat row")
+	}
+	if got := statRowCount(t, stat); got != seeded {
+		t.Fatalf("fixture receiver stat = %q (count %d), want the honest %d", stat, got, seeded)
+	}
+
+	// The index quadruples behind the statistics. Ordinary staleness.
+	var grown []*graph.Node
+	for i := 0; i < grownBy; i++ {
+		file := fmt.Sprintf("repo/pkg/late%03d/types.go", i)
+		name := fmt.Sprintf("L%03d", i)
+		grown = append(grown, &graph.Node{
+			ID:         file + "::" + name,
+			Name:       name,
+			Kind:       graph.KindType,
+			FilePath:   file,
+			Language:   "go",
+			RepoPrefix: "repo",
+		})
+	}
+	s.AddBatch(grown, nil)
+
+	reopened := reopenAfterStatMutation(t, s, path)
+	if reason, needsRepair := plannerStatsRepairReason(context.Background(), reopened.writerDB); needsRepair {
+		t.Fatalf("ordinary staleness asked for a repair reason=%q; only a suspect (<= %d) believed count may",
+			reason, plannerStatsSuspectRows)
+	}
+	after, ok := statRowFor(t, reopened, "nodes_go_receiver_type")
+	if !ok {
+		t.Fatal("reopen dropped the receiver stat row")
+	}
+	if got := statRowCount(t, after); got != seeded {
+		t.Fatalf("receiver stat after reopen = %q (count %d), want the untouched %d", after, got, seeded)
+	}
+}
+
+// A repair that only the writer connection can see is half a repair. SQLite
+// bumps the schema cookie when sqlite_stat1 is CREATED, never when its rows are
+// rewritten, so a reader connection opened before the repair (openSQLiteReadPool
+// pings one into existence during Open) keeps planning against the poisoned
+// statistics for as long as it lives — on a daemon, forever. Open must
+// therefore recycle the read pool's idle connections after a repair, and must
+// not pay for that on a healthy store.
+func TestOpenRecyclesReadPoolAfterPlannerStatsRepair(t *testing.T) {
+	seedRefreshed := func(t *testing.T, path string) *Store {
+		t.Helper()
+		s := openStatsRepairStore(t, path)
+		seedGoReceiverStatsFixture(s, 100)
+		s.writeMu.Lock()
+		err := s.refreshPlannerStatsLocked(context.Background())
+		s.writeMu.Unlock()
+		if err != nil {
+			t.Fatalf("seed planner stats: %v", err)
+		}
+		return s
+	}
+
+	t.Run("repaired", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "stats_recycle_repaired.sqlite")
+		s := seedRefreshed(t, path)
+		if _, err := s.writerDB.Exec(`UPDATE sqlite_stat1 SET stat = '0 0 0 0 0' WHERE idx = 'nodes_go_receiver_type'`); err != nil {
+			t.Fatalf("poison receiver stat: %v", err)
+		}
+
+		reopened := reopenAfterStatMutation(t, s, path)
+		// Read the pool's counters before anything else touches it: the very
+		// next reader query would check a fresh connection back in as idle.
+		stats := reopened.db.Stats()
+		if stats.MaxIdleClosed == 0 {
+			t.Errorf("read pool kept its pre-repair connection (MaxIdleClosed=0, Idle=%d); "+
+				"it would plan against the poisoned statistics for the life of the store",
+				stats.Idle)
+		}
+		if stats.Idle != 0 {
+			t.Errorf("read pool holds %d idle connection(s) after a repair, want 0", stats.Idle)
+		}
+		// The recycle must not have broken the pool it just emptied.
+		if stat, ok := statRowFor(t, reopened, "nodes_go_receiver_type"); !ok {
+			t.Error("reader cannot read sqlite_stat1 after the pool was recycled")
+		} else if got := statRowCount(t, stat); got < 50 {
+			t.Errorf("receiver stat after reopen = %q (count %d), want a repaired count >= 50", stat, got)
+		}
+	})
+
+	t.Run("healthy", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "stats_recycle_healthy.sqlite")
+		s := seedRefreshed(t, path)
+
+		reopened := reopenAfterStatMutation(t, s, path)
+		if stats := reopened.db.Stats(); stats.MaxIdleClosed != 0 {
+			t.Errorf("healthy reopen recycled the read pool (MaxIdleClosed=%d); "+
+				"the recycle must be paid for only by a store that was actually repaired",
+				stats.MaxIdleClosed)
+		}
+	})
+}
+
+// plannerStatsCriticalIndexNames parses the VALUES list out of
+// plannerStatsIndexQuery. Parsing the constant rather than querying a store
+// makes the pairing check independent of which indexes a given schema happens
+// to have materialised.
+func plannerStatsCriticalIndexNames(t *testing.T) []string {
+	t.Helper()
+	names := regexp.MustCompile(`\('([a-z0-9_]+)'\)`).FindAllStringSubmatch(plannerStatsIndexQuery, -1)
+	if len(names) == 0 {
+		t.Fatal("plannerStatsIndexQuery exposes no critical index names; the VALUES list shape changed")
+	}
+	out := make([]string, 0, len(names))
+	for _, m := range names {
+		out = append(out, m[1])
+	}
+	return out
+}
+
+// The probe table and the index DDL are two hand-written copies of the same
+// facts. A predicate that drifts from its DDL does not fail loudly — it
+// silently reports the wrong population, and the wrong population is what
+// decides whether a stat row is written at all. Pin them together.
+func TestPlannerStatsProbesPairedWithIndexDDL(t *testing.T) {
+	critical := plannerStatsCriticalIndexNames(t)
+	criticalSet := make(map[string]bool, len(critical))
+	for _, name := range critical {
+		criticalSet[name] = true
+	}
+
+	for _, name := range critical {
+		spec, known := plannerStatsIndexProbes[name]
+		if !known {
+			t.Errorf("critical index %q has no plannerStatsIndexProbes entry", name)
+			continue
+		}
+		ddl := indexDDLByName(t, name)
+		wantPartial := strings.Contains(ddl, " WHERE ")
+		if spec.partial != wantPartial {
+			t.Errorf("index %q: probe partial = %v, DDL says %v\nDDL: %s", name, spec.partial, wantPartial, ddl)
+			continue
+		}
+		if !spec.partial {
+			if spec.predicate != "" {
+				t.Errorf("index %q: non-partial probe carries predicate %q", name, spec.predicate)
+			}
+			continue
+		}
+		if spec.predicate == "" {
+			t.Errorf("index %q: partial probe carries no predicate", name)
+			continue
+		}
+		if !strings.Contains(ddl, spec.predicate) {
+			t.Errorf("index %q: probe predicate %q is not a substring of its DDL\nDDL: %s", name, spec.predicate, ddl)
+		}
+	}
+
+	// An orphan entry is dead weight that outlives the index it describes.
+	for name := range plannerStatsIndexProbes {
+		if !criticalSet[name] {
+			t.Errorf("plannerStatsIndexProbes entry %q names no critical index", name)
+		}
+	}
+
+	// Substring agreement with the DDL is necessary but not sufficient. A
+	// probe can quote its predicate correctly and still be unusable against a
+	// live schema — a conjunct SQLite cannot match to the index's own WHERE
+	// clause, a column the index no longer keys, an index that is not
+	// materialised at all — and SQLite only rejects INDEXED BY at prepare
+	// time. Production swallows that rejection: refreshPlannerStatsOnConn logs
+	// the failed probe and falls through to the plain ANALYZE, which is
+	// precisely the silent degradation (a zero row written for an empty
+	// partial index) that this whole file exists to prevent. So run the
+	// engine's own probes and require them to prepare.
+	s := openStatsRepairStore(t, filepath.Join(t.TempDir(), "probe_pairing.sqlite"))
+	seedGoReceiverStatsFixture(s, 8)
+	for _, name := range critical {
+		spec, known := plannerStatsIndexProbes[name]
+		if !known {
+			continue
+		}
+		existsSQL := spec.existsQuery(name)
+		var exists bool
+		if err := s.db.QueryRow(existsSQL).Scan(&exists); err != nil {
+			t.Errorf("index %q: existence probe is unusable: %v\nSQL: %s", name, err, existsSQL)
+		}
+		if !spec.partial {
+			// countQuery repeats the index's own WHERE clause, so it is only
+			// ever built — and only ever executed — for a partial index.
+			continue
+		}
+		countSQL := spec.countQuery(name)
+		var actual int64
+		if err := s.db.QueryRow(countSQL, plannerStatsSuspectRows).Scan(&actual); err != nil {
+			t.Errorf("index %q: bounded count probe is unusable: %v\nSQL: %s", name, err, countSQL)
+		}
+	}
+}
+
+func allPlannerStats(t *testing.T, s *Store) []string {
+	t.Helper()
+	rows, err := s.db.Query(`SELECT tbl, COALESCE(idx, ''), COALESCE(stat, '') FROM sqlite_stat1`)
+	if err != nil {
+		t.Fatalf("read sqlite_stat1: %v", err)
+	}
+	var out []string
+	for rows.Next() {
+		var tbl, idx, stat string
+		if err := rows.Scan(&tbl, &idx, &stat); err != nil {
+			_ = rows.Close()
+			t.Fatalf("scan sqlite_stat1 row: %v", err)
+		}
+		out = append(out, tbl+"|"+idx+"|"+stat)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		t.Fatalf("iterate sqlite_stat1: %v", err)
+	}
+	if err := rows.Close(); err != nil {
+		t.Fatalf("close sqlite_stat1 rows: %v", err)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -621,7 +621,19 @@ func openWithObserver(path string, current int, migrations []schemaMigration, al
 	}
 	// A populated store opened without planner statistics would plan blind
 	// until its next cold bulk load; backfill sqlite_stat1 once here.
-	healPlannerStats(db)
+	if healPlannerStats(db) && readDB != db {
+		// The repair ran on a writer connection, and SQLite bumps the schema
+		// cookie only when sqlite_stat1 is first CREATED — never when its rows
+		// are rewritten. Every reader connection already open (openSQLiteReadPool
+		// pings one into existence above) therefore keeps the pre-repair
+		// statistics for as long as it lives, which on a long-running daemon is
+		// forever. Drop the pool's idle connections so the next reader is a
+		// fresh physical connection that loads the repaired rows on open.
+		// Skipped when the two pools are the same handle: an in-memory store
+		// would lose the database with its last connection.
+		readDB.SetMaxIdleConns(0)
+		readDB.SetMaxIdleConns(sqliteMaxIdleConns)
+	}
 	// In-memory databases have no WAL file to drain, so the periodic
 	// checkpoint is pointless there (and would leak a goroutine per
 	// short-lived test store). Only run it for on-disk stores.


### PR DESCRIPTION
## Summary

Fixes the multi-hour stall in `RebindGoMethodReceivers` reported in #651 by making the two receiver-candidate queries independent of SQLite planner statistics, and by repairing the statistics that caused it on existing stores at the next daemon start.

## Root cause

`goMethodReceiverCandidatesGlobalSQL` and `goMethodReceiverCandidatesForFileSQL` used plain `JOIN` with `INDEXED BY`. That pins which index each table uses, but not the loop order. When `sqlite_stat1` believes the partial index `nodes_go_receiver_type` holds only a handful of rows, SQLite makes the receiver-type scan the outermost loop and re-scans every `member_of` edge per receiver type, evaluating the `member_receiver_dir` generated column each time. That is O(types × member_of): hours on a multi-repo store, which matches the goroutine dump in the third report (active execution inside `rtrim()`).

The believed cardinality gets that small in a normal lifecycle:

- `ANALYZE` on a partial index that currently matches no rows writes a literal zero row. The healer at `Open` and the coordinated cold finalize both run `ANALYZE` store-wide, so a store whose first repository had no Go types, or whose Go repository was tracked later, gets `nodes_go_receiver_type | 0 0 0 0 0`.
- Nothing refreshed it afterwards. Statistics were refreshed only at coordinated cold finalize and by `healPlannerStats`, whose predicate checked only that rows existed for two unrelated indexes. Draining a new repository into a non-empty store, single-repo bulk loads, incremental reindex, and view-generation builds never touch `sqlite_stat1`.

Measured on the exact v20 schema with 300 receiver types and 10k `member_of` edges: believed-zero plan 56 s, no statistics 0.15 s, refreshed 0.25 s. With plain joins the global query flips at a believed cardinality of 0–1 and the per-file query at 0–3; `CROSS JOIN` keeps the seek plan at every value.

## Changes

- `method_receiver_rebind.go` and `method_receiver_rebind_batch.go`: all three candidate queries pin their loop order with `CROSS JOIN`, SQLite's documented join-order constraint. The global query stays edges → method → target → receiver; the per-file query stays file-scoped method → edge → target → receiver, so incremental indexing keeps its file-first plan; the batch query already pinned its frontier and now pins the receiver relation too. Every `INDEXED BY`, predicate, and bind is unchanged.
- `store.go`: after a repair at `Open`, the read pool's idle connections are recycled. SQLite bumps the schema cookie only when `sqlite_stat1` is first created, so a reader opened before the repair would otherwise keep the old statistics for the daemon's life.
- `planner_stats.go`: `healPlannerStats` now repairs, not just backfills. It refreshes when any critical index present in the schema lacks a stat row while the index has rows, or when a partial critical index's believed cardinality is tiny (at most 64 rows) while the index actually holds more than twice that. The actual count is bounded by a `LIMIT` of twice the believed count plus one, so a healthy large store pays a handful of index entries at `Open` and ordinary growth never triggers a whole-index `ANALYZE` on the startup path.
- `planner_stats.go`: `refreshPlannerStatsOnConn` no longer writes a zero row. An empty partial critical index is skipped and any stale row for it deleted, then the connection reloads its statistics; an absent row falls back to SQLite's default costs, which plan correctly. These hygiene steps are best-effort: a probe or delete failure logs and falls through, so a coordinated cold load cannot be aborted by statistics maintenance.

## Tests

- New plan locks for both queries, run on the writer connection where the rebind executes, across four statistics states: no statistics, a zero row as written by an older engine, a natural tiny row that later grew, and refreshed. Each asserts the outermost loop and forbids a receiver-index scan. Reverting the `CROSS JOIN` makes the zero-row and tiny-row subtests fail.
- Healer tests: a zero row, a tiny row, a zero row on the repository index, and a missing critical row are repaired on reopen; ordinary growth past the believed count does not trigger a repair; a healthy store reopens with byte-identical statistics and no repair reason; a refresh on a store without Go types leaves the receiver index without a row rather than a zero row, and removes a stale zero row left by an older engine. A pairing test checks every critical index against its DDL so a partial index cannot be added without its probe.

## Follow-ups (separate PRs)

- Growth-based statistics freshness at runtime (post-drain refresh, reader-pool recycling, believed-versus-actual in index health).
- Context-taking rebind capability with a deadline on the candidate query, and routing the inline indexer resolve through the context-aware entry.

Fixes #651.
