### PR TITLE
feat(mcp): disclose when search_text was bound by limit, and make the ceiling configurable

### DIFF
--- a/internal/mcp/tools_analysis.go
+++ b/internal/mcp/tools_analysis.go
@@ -67,7 +67,7 @@ func (s *Server) registerAnalysisTools() {
 			mcp.WithDescription("Trigram-accelerated literal (or regexp) code search across the indexed repository — the alt grep backbone. Each hit carries the enclosing graph symbol (symbol_id / symbol_name) so you see which function or method a match landed in without a follow-up call. A trigram index narrows the candidate files, so a repo-wide search costs roughly the size of the matching files, not the whole tree. Use for literal-string / regexp lookups; use search_symbols for symbol-name / concept queries."),
 			mcp.WithString("query", mcp.Description("Literal substring (case-sensitive) to search for — or a regular expression when regexp=true.")),
 			mcp.WithBoolean("regexp", mcp.Description("Treat query as a regular expression instead of a literal substring. An invalid pattern is returned as a tool error. Default false.")),
-			mcp.WithNumber("limit", mcp.Description("Max matching lines to return (default 100, capped at 1000; raise the cap with GORTEX_SEARCH_TEXT_MAX_LIMIT). A result bound by the limit carries _truncated_by_limit and count_is_exact=false — read those before treating count as a total, because a `path` filter cannot recover the remainder.")),
+			mcp.WithNumber("limit", mcp.Description("Max matching lines to return (default 100, capped at 1000). A bound result sets _truncated_by_limit.")),
 			mcp.WithString("path", mcp.Description("Restrict matches to one or more sub-paths (comma-separated) -- a monorepo-service slice. Anchored, slash-segment-boundary prefixes relative to the repo root.")),
 			mcp.WithString("repo", mcp.Description("Restrict matches to a single repository prefix.")),
 			mcp.WithString("project", mcp.Description("Restrict matches to repositories in a specific project.")),

--- a/internal/mcp/tools_analysis.go
+++ b/internal/mcp/tools_analysis.go
@@ -67,7 +67,7 @@ func (s *Server) registerAnalysisTools() {
 			mcp.WithDescription("Trigram-accelerated literal (or regexp) code search across the indexed repository — the alt grep backbone. Each hit carries the enclosing graph symbol (symbol_id / symbol_name) so you see which function or method a match landed in without a follow-up call. A trigram index narrows the candidate files, so a repo-wide search costs roughly the size of the matching files, not the whole tree. Use for literal-string / regexp lookups; use search_symbols for symbol-name / concept queries."),
 			mcp.WithString("query", mcp.Description("Literal substring (case-sensitive) to search for — or a regular expression when regexp=true.")),
 			mcp.WithBoolean("regexp", mcp.Description("Treat query as a regular expression instead of a literal substring. An invalid pattern is returned as a tool error. Default false.")),
-			mcp.WithNumber("limit", mcp.Description("Max matching lines to return (default 100, capped at 1000).")),
+			mcp.WithNumber("limit", mcp.Description("Max matching lines to return (default 100, capped at 1000; raise the cap with GORTEX_SEARCH_TEXT_MAX_LIMIT). A result bound by the limit carries _truncated_by_limit and count_is_exact=false — read those before treating count as a total, because a `path` filter cannot recover the remainder.")),
 			mcp.WithString("path", mcp.Description("Restrict matches to one or more sub-paths (comma-separated) -- a monorepo-service slice. Anchored, slash-segment-boundary prefixes relative to the repo root.")),
 			mcp.WithString("repo", mcp.Description("Restrict matches to a single repository prefix.")),
 			mcp.WithString("project", mcp.Description("Restrict matches to repositories in a specific project.")),

--- a/internal/mcp/tools_search_text.go
+++ b/internal/mcp/tools_search_text.go
@@ -2,7 +2,9 @@ package mcp
 
 import (
 	"context"
+	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -49,8 +51,13 @@ func (s *Server) handleSearchText(ctx context.Context, req mcp.CallToolRequest) 
 	if limit < 1 {
 		limit = 100
 	}
-	if limit > 1000 {
-		limit = 1000
+	// The requested value is kept so the response can say the ceiling chose
+	// the effective limit rather than the caller: a caller who asked for
+	// 100000 and silently got 1000 has no way to tell that from a corpus that
+	// held exactly 1000 matches.
+	requestedLimit := limit
+	if maxLimit := searchTextMaxLimit(); limit > maxLimit {
+		limit = maxLimit
 	}
 
 	// Multi-repo mode: the daemon owns a MultiIndexer and the per-repo
@@ -101,6 +108,13 @@ func (s *Server) handleSearchText(ctx context.Context, req mcp.CallToolRequest) 
 		matches = s.indexer.GrepText(query, limit)
 	}
 
+	// Counted BEFORE the filters below, and that ordering is the whole point.
+	// The searcher stops at `limit`; the path and scope filters then run over
+	// what survived, so a response holding 952 matches can be a truncated
+	// 1000 rather than a complete 952. Measuring after the filters would miss
+	// exactly the case a caller cannot detect on its own.
+	rawMatches := len(matches)
+
 	// Sub-path scoping: a `path` argument or a `scope:`-named saved
 	// scope's paths narrow the literal hits to a monorepo service
 	// slice. In multi-repo mode MultiIndexer.GrepText stamps a repo
@@ -125,6 +139,20 @@ func (s *Server) handleSearchText(ctx context.Context, req mcp.CallToolRequest) 
 		"matches": enriched,
 		"count":   len(enriched),
 	}
+	// A result bound by `limit` was byte-indistinguishable from a complete
+	// one: `count` was set to the same ceiling the array stopped at, so the
+	// two corroborated each other at the wrong number. The byte budget has
+	// always disclosed its own truncation (`_truncated_by_budget`); this is
+	// the limit path's equivalent.
+	if searchTextBoundByLimit(rawMatches, limit) {
+		resp["_truncated_by_limit"] = true
+		resp["_limit_applied"] = limit
+		resp["count_is_exact"] = false
+		resp["truncation_note"] = searchTextTruncationNote
+		if requestedLimit > limit {
+			resp["_limit_requested"] = requestedLimit
+		}
+	}
 	// Body-visible disclosure for a repo-narrowed zero (the _meta scope
 	// fields are invisible in CLI output and most clients). No recheck
 	// here — the note still names the scope and the widen escape hatch.
@@ -132,6 +160,45 @@ func (s *Server) handleSearchText(ctx context.Context, req mcp.CallToolRequest) 
 		resp["scope_note"] = scopeZeroNote(resolved, -1)
 	}
 	return s.respondScopedJSONOrTOON(ctx, req, resp, resolved)
+}
+
+// searchTextDefaultMaxLimit is the ceiling `limit` is clamped to. It has been
+// 1000 since search_text was added and is kept as the default so no existing
+// caller's response changes shape.
+const searchTextDefaultMaxLimit = 1000
+
+// searchTextMaxLimit returns the effective ceiling, overridable through
+// GORTEX_SEARCH_TEXT_MAX_LIMIT for the sweep this tool exists to serve —
+// search_text is the literal-search backbone agents reach for in place of
+// grep, where an unbounded pass is the normal request. An unset, unparseable
+// or non-positive value keeps the default rather than lifting the bound: a
+// typo must not turn into an unbounded scan.
+//
+// Raising it is not the fix on its own. Without the disclosure below a higher
+// ceiling only moves the silent cliff, which is why the flag lands with it.
+func searchTextMaxLimit() int {
+	v := strings.TrimSpace(os.Getenv("GORTEX_SEARCH_TEXT_MAX_LIMIT"))
+	if v == "" {
+		return searchTextDefaultMaxLimit
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 1 {
+		return searchTextDefaultMaxLimit
+	}
+	return n
+}
+
+const searchTextTruncationNote = "the search stopped at `limit`, so `count` is a floor rather than a total and the matches are a prefix of the real result set. Raise `limit` (or the GORTEX_SEARCH_TEXT_MAX_LIMIT ceiling) to widen. Narrowing with `path` will NOT recover the remainder: the path filter runs over what survived truncation, not over the corpus, so a subtree slice returns whatever was left of the global cut."
+
+// searchTextBoundByLimit reports whether the search stopped because of the
+// limit rather than because the corpus ran out.
+//
+// rawMatches is the count the searcher returned, before the path and scope
+// filters. Landing on the effective limit is the signal, and it can fire on a
+// corpus holding exactly that many matches — a spurious "verify this" is the
+// safe direction to be wrong in, against silently losing most of the result.
+func searchTextBoundByLimit(rawMatches, limit int) bool {
+	return limit > 0 && rawMatches >= limit
 }
 
 // filterTextMatchesByPath keeps only the trigram matches whose file

--- a/internal/mcp/tools_search_text_truncation_test.go
+++ b/internal/mcp/tools_search_text_truncation_test.go
@@ -1,0 +1,168 @@
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/query"
+)
+
+// searchTextServerWith indexes one file per given relative path, each holding
+// the same literal, and returns a server over the result. Every file matches,
+// so the number of matches is the number of paths — which is what lets these
+// tests reason about the limit exactly.
+func searchTextServerWith(t *testing.T, rels ...string) *Server {
+	t.Helper()
+	dir := t.TempDir()
+	for i, rel := range rels {
+		full := filepath.Join(dir, filepath.FromSlash(rel))
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full,
+			[]byte("package app\n\nfunc Target"+string(rune('A'+i))+"() {}\n"), 0o644))
+	}
+	g := graph.New()
+	idx := indexer.New(g, testRegistry(), config.Default().Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	return NewServer(query.NewEngine(g), g, idx, nil, zap.NewNop(), nil)
+}
+
+func searchTextResponse(t *testing.T, srv *Server, args map[string]any) map[string]any {
+	t.Helper()
+	res := callTool(t, srv, "search_text", args)
+	require.False(t, res.IsError, "%+v", res.Content)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal([]byte(res.Content[0].(mcplib.TextContent).Text), &out))
+	return out
+}
+
+func TestSearchText_LimitBoundResultDisclosesTruncation(t *testing.T) {
+	srv := searchTextServerWith(t, "a.go", "b.go", "c.go")
+
+	out := searchTextResponse(t, srv, map[string]any{"query": "package app", "limit": 2})
+
+	require.Equal(t, float64(2), out["count"])
+	require.Equal(t, true, out["_truncated_by_limit"],
+		"a result bound by limit is byte-indistinguishable from a complete one without this")
+	require.Equal(t, float64(2), out["_limit_applied"])
+	require.Equal(t, false, out["count_is_exact"],
+		"count is a floor here, and saying so is the half a caller can act on")
+	note, _ := out["truncation_note"].(string)
+	require.Contains(t, note, "floor")
+	// The recovery that looks obvious and does not work: `path` filters run
+	// over what survived truncation, so narrowing cannot recover the rest.
+	require.Contains(t, note, "path")
+	require.Contains(t, note, "NOT recover")
+}
+
+func TestSearchText_CompleteResultCarriesNoTruncationKeys(t *testing.T) {
+	srv := searchTextServerWith(t, "a.go", "b.go", "c.go")
+
+	out := searchTextResponse(t, srv, map[string]any{"query": "package app", "limit": 100})
+
+	require.Equal(t, float64(3), out["count"])
+	for _, key := range []string{"_truncated_by_limit", "_limit_applied", "count_is_exact", "truncation_note", "_limit_requested"} {
+		_, present := out[key]
+		require.False(t, present, "a complete result must not carry %q", key)
+	}
+}
+
+func TestSearchText_DisclosesThatTheCeilingChoseTheLimit(t *testing.T) {
+	// The ceiling, not the caller, decided the effective limit. Without
+	// _limit_requested a caller who asked for 50 and got 2 cannot tell that
+	// from a corpus holding exactly 2 matches.
+	t.Setenv("GORTEX_SEARCH_TEXT_MAX_LIMIT", "2")
+	srv := searchTextServerWith(t, "a.go", "b.go", "c.go")
+
+	out := searchTextResponse(t, srv, map[string]any{"query": "package app", "limit": 50})
+
+	require.Equal(t, true, out["_truncated_by_limit"])
+	require.Equal(t, float64(2), out["_limit_applied"], "the ceiling override was not applied")
+	require.Equal(t, float64(50), out["_limit_requested"],
+		"the response does not say the clamp chose the limit")
+}
+
+func TestSearchText_RequestWithinTheCeilingReportsNoRequestedLimit(t *testing.T) {
+	t.Setenv("GORTEX_SEARCH_TEXT_MAX_LIMIT", "10")
+	srv := searchTextServerWith(t, "a.go", "b.go", "c.go")
+
+	out := searchTextResponse(t, srv, map[string]any{"query": "package app", "limit": 2})
+
+	require.Equal(t, true, out["_truncated_by_limit"])
+	_, present := out["_limit_requested"]
+	require.False(t, present, "the caller's own limit bound this result; nothing was clamped")
+}
+
+func TestSearchText_TruncationIsMeasuredBeforeThePathFilter(t *testing.T) {
+	// The ordering this whole fix turns on. The searcher stops at `limit`,
+	// and the path filter then runs over what survived — so the count can sit
+	// below the limit while the result is still a truncated prefix. Measuring
+	// after the filter would miss exactly the case a caller cannot detect.
+	//
+	// Four matching files, limit 3, filtered to one directory of two: the
+	// searcher is bound whichever three it returns, and at most two survive
+	// the filter.
+	srv := searchTextServerWith(t, "a/1.go", "a/2.go", "b/1.go", "b/2.go")
+
+	out := searchTextResponse(t, srv, map[string]any{
+		"query": "package app", "limit": 3, "path": "a",
+	})
+
+	count, _ := out["count"].(float64)
+	require.Less(t, count, float64(3),
+		"the fixture must leave the count below the limit, or it proves nothing")
+	require.Equal(t, true, out["_truncated_by_limit"],
+		"a filtered result below the limit is still a truncated prefix of the corpus")
+}
+
+func TestSearchTextBoundByLimit(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		raw   int
+		limit int
+		want  bool
+	}{
+		{"corpus ran out first", 5, 10, false},
+		{"landed exactly on the limit", 10, 10, true},
+		// The fan-out searchers hand each repo the full limit, so the raw
+		// count can exceed it before the final trim.
+		{"searcher returned more than the limit", 25, 10, true},
+		{"no limit in force", 100, 0, false},
+		{"empty result", 0, 10, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, searchTextBoundByLimit(tc.raw, tc.limit))
+		})
+	}
+}
+
+func TestSearchTextMaxLimit(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		env  string
+		want int
+	}{
+		{"unset keeps the historical ceiling", "", searchTextDefaultMaxLimit},
+		{"an explicit ceiling is honored", "5000", 5000},
+		{"surrounding space is tolerated", "  2000  ", 2000},
+		// A typo must not turn into an unbounded scan, so every unusable
+		// value falls back rather than lifting the bound.
+		{"garbage falls back", "unlimited", searchTextDefaultMaxLimit},
+		{"zero falls back", "0", searchTextDefaultMaxLimit},
+		{"negative falls back", "-1", searchTextDefaultMaxLimit},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("GORTEX_SEARCH_TEXT_MAX_LIMIT", tc.env)
+			require.Equal(t, tc.want, searchTextMaxLimit())
+		})
+	}
+}


### PR DESCRIPTION
Closes **#674**, and the ceiling half of **#672**.

## The zero-cost failure

`search_text` is described as the alt grep backbone, and a result bound by `limit` was byte-indistinguishable from a complete one: `count` is `len(enriched)`, so the array and the count corroborated each other at the ceiling. On the repo in #672 that is `count: 1000` against a `git grep` truth of 8963, with no flag, no cursor, and nothing else in the payload to doubt.

The byte budget has always disclosed its own truncation (`_truncated_by_budget`). The limit path had no equivalent.

## What a truncated response now carries

```jsonc
{
  "count": 1000,
  "_truncated_by_limit": true,
  "_limit_applied": 1000,
  "count_is_exact": false,
  "_limit_requested": 100000,     // only when the ceiling, not the caller, chose it
  "truncation_note": "…"
}
```

The note follows the `contract_tier_unbuilt` shape that already works elsewhere in this codebase: say what the number means, say how to widen, **and rule out the widening that looks obvious but does not work**. Here that last part is `path`: the filter runs over what survived truncation rather than over the corpus, so slicing a subtree returns whatever was left of the global cut. #672 lists that as one of three workarounds it had to rule out by hand.

## The ordering is the fix

`rawMatches` is counted **before** the path and scope filters, and that is the substance rather than an implementation detail:

```go
matches = <searcher>(query, …, limit)   // stops at limit
rawMatches := len(matches)              // ← here
matches = filterTextMatchesByPath(…)    // runs over what survived
matches = s.filterTextMatchesByResolvedScope(…)
```

A response holding 952 matches can be a truncated 1000. Measuring after the filters would miss exactly the case a caller cannot detect from the outside — and the 952 / 998 rows in #672's table are that shape, which is why the issue notes that even `len(matches) == 1000` is not a reliable client-side detector.

`TestSearchText_TruncationIsMeasuredBeforeThePathFilter` pins it with a fixture where the count necessarily lands below the limit: four matching files, `limit: 3`, filtered to a directory holding two. Whichever three the searcher returns, at most two survive, and the disclosure must still fire.

Landing on the effective limit is the signal, so this can fire on a corpus holding exactly `limit` matches. A spurious "verify this" is the safe direction to be wrong in.

## The ceiling

`GORTEX_SEARCH_TEXT_MAX_LIMIT`, defaulting to 1000 so no existing caller's response changes shape. An unset, unparseable or non-positive value keeps the default rather than lifting the bound — a typo must not become an unbounded scan.

Raising the ceiling without the disclosure only moves the silent cliff, which is why they land together. This is why I marked #674 as the one this closes and #672 as refs: the flag is the fix, the override is the affordance.

## Tests

Five end-to-end cases through the handler and tables over both pure helpers. Ten mutants, each failing its test and passing restored: the flag never published · `count_is_exact` always true · landing exactly on the limit not counted as truncation · truncation measured after the filters · the clamped request not disclosed · the disclosure riding on every response · the ceiling override ignored · an unusable ceiling value honored · the note dropping the recovery that does not work · the applied limit not reported.

Three of those initially came back as "nothing ran" rather than as failures — each mutation orphaned a variable and the package stopped compiling, which is a void result, not a dead mutant. They were re-run in compile-clean form (`if _ = rawMatches; …`) so all ten are real.

## Verification

`go build ./...` clean; the `SearchText` suite passes.

Two measurements worth reporting rather than asserting:

**The schema addition spends 41 of the 62 bytes the core preset has left.** My first version spent 233 and turned CI red on `TestToolsListByteCeilings` (`core` at 97671 against a 97500 baseline; `main` sits at 97438). The description now carries only the part an agent needs before calling — that a bound result sets `_truncated_by_limit` — and the recovery detail rides on the response in `truncation_note` instead. Both ceiling tests pass at 97479.

I had originally checked `TestCompactToolsListIsStaticAndBudgeted` instead, measured 14984 bytes on both trees, and reported that as evidence the addition was free. That number is about the facade surface, which `search_text` is not on; it was the wrong ceiling. Headroom as measured on `main`: **62 bytes** on the core preset, **16 bytes** on the facade list — both recorded on #685.

**One unrelated test is order-dependent.** `TestSearchTextRefusalIsTheCapabilityEvaluationsRefusal` failed for me, and I did not call it flaky until I had the mechanism: on a cold ref-view build it gets `view_building: … retry after 2s` instead of the `capability_unavailable` refusal it asserts, and on the next run — the build now cached under a content-hashed id that survives the per-test `t.TempDir()` — it passes. I reproduced both states on my branch and confirmed the pristine tree passes only in the warm state. Nothing in this change touches view building. Filing it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
