### PR TITLE
fix(mcp): select discovered worktrees by root path

### DIFF
--- a/internal/graphview/selector.go
+++ b/internal/graphview/selector.go
@@ -2,6 +2,7 @@ package graphview
 
 import (
 	"fmt"
+	"path/filepath"
 	"slices"
 	"strings"
 )
@@ -14,7 +15,7 @@ const (
 	SelectorAuto SelectorKind = "auto"
 	// SelectorBase pins a persisted base graph by id.
 	SelectorBase SelectorKind = "base"
-	// SelectorWorktree pins a registered checkout by id, including its
+	// SelectorWorktree pins a registered checkout by id or absolute path, including its
 	// working-tree edits.
 	SelectorWorktree SelectorKind = "worktree"
 	// SelectorGitRef pins the commit a full ref points at.
@@ -30,17 +31,25 @@ type Selector struct {
 	Kind       SelectorKind `json:"kind"`
 	GraphID    string       `json:"graph_id,omitempty"`
 	CheckoutID string       `json:"checkout_id,omitempty"`
+	Path       string       `json:"path,omitempty"`
 	Value      string       `json:"value,omitempty"`
 }
 
-// ParseSelector validates a raw selector from the wire.
+// ParseSelector validates an ID-based selector from the wire. Use
+// ParseSelectorWithPath to also accept an absolute worktree path.
+func ParseSelector(kind, graphID, checkoutID, value string) (Selector, error) {
+	return ParseSelectorWithPath(kind, graphID, checkoutID, value, "")
+}
+
+// ParseSelectorWithPath validates a raw selector from the wire.
 //
 // An empty kind means auto: a caller that omits the field asks for the default
 // view. Every other kind must be one of the SelectorKind constants.
 //
 //   - auto     — takes no other field.
 //   - base     — requires graphID.
-//   - worktree — requires checkoutID.
+//   - worktree — requires exactly one of checkoutID or an absolute path on
+//     the daemon host. Path resolution and registration are checked by the server.
 //   - git_ref  — requires value: a FULL ref name under refs/heads/,
 //     refs/tags/, or refs/remotes/. Short names ("main"), HEAD, and revision
 //     expressions ("main~1", "a..b", "x@{1}") are rejected: they resolve
@@ -57,12 +66,12 @@ type Selector struct {
 // CodeSelectorConflict. Values are never trimmed — leading or trailing
 // whitespace in a ref name or an object id is a malformed value, not a typo to
 // paper over.
-func ParseSelector(kind, graphID, checkoutID, value string) (Selector, error) {
+func ParseSelectorWithPath(kind, graphID, checkoutID, value, path string) (Selector, error) {
 	k := SelectorKind(strings.TrimSpace(kind))
 	if k == "" {
 		k = SelectorAuto
 	}
-	s := Selector{Kind: k, GraphID: graphID, CheckoutID: checkoutID, Value: value}
+	s := Selector{Kind: k, GraphID: graphID, CheckoutID: checkoutID, Path: path, Value: value}
 
 	switch k {
 	case SelectorAuto:
@@ -77,11 +86,17 @@ func ParseSelector(kind, graphID, checkoutID, value string) (Selector, error) {
 			return Selector{}, err
 		}
 	case SelectorWorktree:
-		if checkoutID == "" {
-			return Selector{}, NewViewError(CodeInvalidViewSelector, "worktree selector requires a checkout id")
+		if checkoutID != "" && path != "" {
+			return Selector{}, NewViewError(CodeSelectorConflict, "worktree selector requires exactly one of checkout_id or path")
 		}
-		if err := rejectUnused(s, "checkout_id"); err != nil {
+		if checkoutID == "" && path == "" {
+			return Selector{}, NewViewError(CodeInvalidViewSelector, "worktree selector requires checkout_id or an absolute path")
+		}
+		if err := rejectUnused(s, "checkout_id", "path"); err != nil {
 			return Selector{}, err
+		}
+		if path != "" && (strings.TrimSpace(path) != path || !filepath.IsAbs(path) || strings.ContainsRune(path, 0)) {
+			return Selector{}, NewViewError(CodeInvalidViewSelector, "worktree selector path must be absolute on the daemon host without leading or trailing whitespace")
 		}
 	case SelectorGitRef:
 		if err := rejectUnused(s, "graph_id", "value"); err != nil {
@@ -113,6 +128,9 @@ func (s Selector) String() string {
 	case SelectorBase:
 		return string(s.Kind) + ":" + s.GraphID
 	case SelectorWorktree:
+		if s.Path != "" {
+			return string(s.Kind) + ":path:" + s.Path
+		}
 		return string(s.Kind) + ":" + s.CheckoutID
 	case SelectorGitRef, SelectorCommit:
 		if s.GraphID != "" {
@@ -133,6 +151,7 @@ func rejectUnused(s Selector, used ...string) error {
 	}{
 		{"graph_id", s.GraphID},
 		{"checkout_id", s.CheckoutID},
+		{"path", s.Path},
 		{"value", s.Value},
 	}
 	for _, f := range fields {

--- a/internal/graphview/selector_path_test.go
+++ b/internal/graphview/selector_path_test.go
@@ -1,0 +1,87 @@
+package graphview
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseSelectorWithPath(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "worktree with spaces")
+	const checkoutID = "01a06e0e-f84d-7e39-9228-f8d22b8ca1dd"
+	const oid = "0123456789abcdef0123456789abcdef01234567"
+	tests := []struct {
+		name, kind, graphID, checkoutID, value, path, errText string
+	}{
+		{name: "absolute path", kind: "worktree", path: root},
+		{name: "checkout ID", kind: "worktree", checkoutID: checkoutID},
+		{name: "both", kind: "worktree", checkoutID: checkoutID, path: root, errText: "exactly one"},
+		{name: "neither", kind: "worktree", errText: "requires checkout_id or an absolute path"},
+		{name: "relative", kind: "worktree", path: "worktrees/feature", errText: "must be absolute"},
+		{name: "dot relative", kind: "worktree", path: "./feature", errText: "must be absolute"},
+		{name: "whitespace", kind: "worktree", path: " \t", errText: "must be absolute"},
+		{name: "leading whitespace", kind: "worktree", path: " " + root, errText: "must be absolute"},
+		{name: "trailing whitespace", kind: "worktree", path: root + "\n", errText: "must be absolute"},
+		{name: "nul", kind: "worktree", path: root + "\x00", errText: "must be absolute"},
+		{name: "extra graph ID", kind: "worktree", path: root, graphID: "graph-1", errText: "does not take graph_id"},
+		{name: "extra value", kind: "worktree", path: root, value: "refs/heads/main", errText: "does not take value"},
+		{name: "auto", kind: "auto", path: root, errText: "does not take path"},
+		{name: "implicit auto", path: root, errText: "does not take path"},
+		{name: "base", kind: "base", graphID: "graph-1", path: root, errText: "does not take path"},
+		{name: "ref", kind: "git_ref", value: "refs/heads/main", path: root, errText: "does not take path"},
+		{name: "commit", kind: "commit", value: oid, path: root, errText: "does not take path"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseSelectorWithPath(tt.kind, tt.graphID, tt.checkoutID, tt.value, tt.path)
+			if tt.errText != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.errText) {
+					t.Fatalf("ParseSelectorWithPath() error = %v, want containing %q", err, tt.errText)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Kind != SelectorWorktree || got.Path != tt.path || got.CheckoutID != tt.checkoutID {
+				t.Fatalf("selector changed input: %+v", got)
+			}
+		})
+	}
+}
+
+func TestWorktreeSelectorPathIdentity(t *testing.T) {
+	root := t.TempDir()
+	pathSelector, err := ParseSelectorWithPath("worktree", "", "", "", root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idSelector, err := ParseSelector("worktree", "", "01a06e0e-f84d-7e39-9228-f8d22b8ca1dd", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pathSelector.String() != "worktree:path:"+root {
+		t.Fatalf("path rider = %q", pathSelector.String())
+	}
+	if idSelector.String() != "worktree:01a06e0e-f84d-7e39-9228-f8d22b8ca1dd" || idSelector.Path != "" {
+		t.Fatalf("existing ID selector changed: %+v", idSelector)
+	}
+	if pathSelector.Equal(idSelector) || pathSelector.Equal(Selector{Kind: SelectorWorktree, Path: root + "-other"}) {
+		t.Fatal("different selectors compare equal")
+	}
+	encoded, err := json.Marshal(pathSelector)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded Selector
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if !pathSelector.Equal(decoded) {
+		t.Fatalf("selector JSON lost path: %s", encoded)
+	}
+	if strings.Contains(string(encoded), "checkout_id") {
+		t.Fatalf("path selector JSON contains empty checkout ID: %s", encoded)
+	}
+}

--- a/internal/mcp/facade_checkouts_test.go
+++ b/internal/mcp/facade_checkouts_test.go
@@ -1,0 +1,182 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/indexer"
+)
+
+func TestWorkspaceCheckoutsFacadeDiscovery(t *testing.T) {
+	registry := newFacadeRegistry()
+	spec, ok := registry.operation("workspace", "checkouts")
+	if !ok {
+		t.Fatal("workspace checkouts operation is not registered")
+	}
+	if spec.Legacy != "list_checkouts" || spec.Effect != facadeEffectRead || spec.Hidden {
+		t.Fatalf("workspace checkouts must expose the read-only checkout inventory: %+v", spec)
+	}
+	if len(spec.Fixed) != 0 {
+		t.Fatalf("checkout inventory arguments must not be overridden: %#v", spec.Fixed)
+	}
+
+	domain, operation, ok := PublicOperationForLegacy("list_checkouts")
+	if !ok || domain != "workspace" || operation != "checkouts" {
+		t.Fatalf("checkout inventory has no public migration path: %q %q %v", domain, operation, ok)
+	}
+
+	// Agents discover operations from tools/list before asking capabilities
+	// for their argument schema. A backend-only mapping is insufficient.
+	encoded, err := json.Marshal(facadeToolDefinition("workspace"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var definition struct {
+		InputSchema struct {
+			Properties map[string]struct {
+				Enum []string `json:"enum"`
+			} `json:"properties"`
+		} `json:"inputSchema"`
+	}
+	if err := json.Unmarshal(encoded, &definition); err != nil {
+		t.Fatal(err)
+	}
+	for _, operation := range definition.InputSchema.Properties["operation"].Enum {
+		if operation == "checkouts" {
+			return
+		}
+	}
+	t.Fatal("workspace tools/list schema does not advertise checkouts")
+}
+
+func TestWorkspaceCheckoutsFacadeDispatchPreservesFilters(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	var received map[string]any
+	srv.facades.capture(mcpgo.NewTool("list_checkouts",
+		mcpgo.WithString("family"),
+	), func(_ context.Context, req mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		received = req.GetArguments()
+		return mcpgo.NewToolResultText("checkout-inventory-sentinel"), nil
+	})
+
+	filters := map[string]any{
+		"family": "family-fixture",
+	}
+	req := mcpgo.CallToolRequest{}
+	req.Params.Name = "workspace"
+	req.Params.Arguments = map[string]any{
+		"operation": "checkouts", "arguments": filters,
+		"output": map[string]any{"format": "json"},
+	}
+	result, err := srv.handleFacade(context.Background(), "workspace", req)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.False(t, result.IsError)
+	require.NotNil(t, received, "the public workspace operation must reach the inventory handler")
+	for key, expected := range filters {
+		require.Equal(t, expected, received[key], "inventory filter %s must retain its scope", key)
+	}
+	require.Equal(t, "json", received["format"])
+	require.NotContains(t, received, "operation")
+	require.NotContains(t, received, "arguments")
+	require.Contains(t, result.Content, mcpgo.TextContent{Type: "text", Text: "checkout-inventory-sentinel"})
+}
+
+func TestWorkspaceCheckoutsFacadeCapabilitiesExposeFilters(t *testing.T) {
+	srv, _ := setupTestServer(t)
+	srv.facades.capture(mcpgo.NewTool("list_checkouts",
+		mcpgo.WithString("family", mcpgo.Description("Git family filter")),
+	), func(context.Context, mcpgo.CallToolRequest) (*mcpgo.CallToolResult, error) {
+		t.Fatal("capability discovery must not invoke the inventory handler")
+		return nil, nil
+	})
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"domain": "workspace", "operation": "checkouts", "detail": "schema",
+	}
+	result, err := srv.handleCapabilities(context.Background(), req)
+	require.NoError(t, err)
+	out := unmarshalResult(t, result)
+	require.Equal(t, "workspace", out["domain"])
+	require.Equal(t, "checkouts", out["operation"])
+	require.Equal(t, true, out["available"])
+	inputSchema := out["input_schema"].(map[string]any)
+	properties := inputSchema["properties"].(map[string]any)
+	arguments := properties["arguments"].(map[string]any)
+	argumentProperties := arguments["properties"].(map[string]any)
+	property, ok := argumentProperties["family"].(map[string]any)
+	require.True(t, ok, "capabilities must expose the backend family filter")
+	require.Equal(t, "string", property["type"])
+	require.Equal(t, "Git family filter", property["description"])
+}
+
+func TestCheckoutOverviewWorkspaceScope(t *testing.T) {
+	overview := indexer.FamiliesOverview{Families: []indexer.FamilyOverview{
+		{
+			FamilyID: "shared", CommonDir: "/primary/.git", PrimaryGraphID: "primary", PrimaryRepoPrefix: "repo-primary",
+			Graphs: []indexer.GraphOverview{
+				{GraphID: "primary", RepoPrefix: "repo-primary", IsPrimary: true},
+				{GraphID: "separate", RepoPrefix: "repo-separate"},
+			},
+			Checkouts: []indexer.CheckoutOverview{
+				{CheckoutID: "primary-owner", RootPath: "/primary", GraphID: "primary"},
+				{CheckoutID: "dormant-overlay", RootPath: "/overlay"},
+				{CheckoutID: "active-overlay", RootPath: "/active", Route: &indexer.RouteOverview{GraphID: "primary"}},
+				{CheckoutID: "other-owner", RootPath: "/separate-secret", GitDir: "/separate-secret/.git", GraphID: "separate"},
+				{CheckoutID: "stale-route", RootPath: "/stale-secret", GraphID: "primary", Route: &indexer.RouteOverview{GraphID: "separate"}},
+			},
+			RefViews: []indexer.RefViewOverview{
+				{RefViewID: "primary-ref", GraphID: "primary"},
+				{RefViewID: "other-ref-secret", GraphID: "separate"},
+			},
+		},
+		{
+			FamilyID: "foreign-secret", CommonDir: "/foreign-secret/.git", PrimaryGraphID: "foreign",
+			Graphs:    []indexer.GraphOverview{{GraphID: "foreign", RepoPrefix: "repo-foreign"}},
+			Checkouts: []indexer.CheckoutOverview{{CheckoutID: "foreign-checkout", RootPath: "/foreign-secret", GraphID: "foreign"}},
+		},
+	}}
+	original, err := json.Marshal(overview)
+	require.NoError(t, err)
+
+	t.Run("primary and automatic overlays only", func(t *testing.T) {
+		visible := checkoutOverviewInScope(overview, map[string]bool{"repo-primary": true}, true)
+		require.Len(t, visible.Families, 1)
+		family := visible.Families[0]
+		require.Len(t, family.Graphs, 1)
+		require.Len(t, family.Checkouts, 3)
+		require.Equal(t, "dormant-overlay", family.Checkouts[1].CheckoutID)
+		require.Equal(t, "active-overlay", family.Checkouts[2].CheckoutID)
+		require.Len(t, family.RefViews, 1)
+		raw, err := json.Marshal(visible)
+		require.NoError(t, err)
+		require.NotContains(t, string(raw), "secret")
+	})
+	t.Run("independent dedicated graph excludes primary", func(t *testing.T) {
+		visible := checkoutOverviewInScope(overview, map[string]bool{"repo-separate": true}, true)
+		require.Len(t, visible.Families, 1)
+		family := visible.Families[0]
+		require.Empty(t, family.CommonDir)
+		require.Empty(t, family.PrimaryGraphID)
+		require.Empty(t, family.PrimaryRepoPrefix)
+		require.Len(t, family.Graphs, 1)
+		require.Len(t, family.Checkouts, 1)
+		require.Equal(t, "other-owner", family.Checkouts[0].CheckoutID)
+		require.Len(t, family.RefViews, 1)
+		require.Equal(t, "other-ref-secret", family.RefViews[0].RefViewID)
+	})
+	t.Run("bound empty scope fails closed", func(t *testing.T) {
+		visible := checkoutOverviewInScope(overview, nil, true)
+		require.Empty(t, visible.Families)
+	})
+	t.Run("unbound administration retains full inventory", func(t *testing.T) {
+		require.Equal(t, overview, checkoutOverviewInScope(overview, nil, false))
+	})
+	after, err := json.Marshal(overview)
+	require.NoError(t, err)
+	require.Equal(t, original, after, "scoping a response must not mutate the shared catalog snapshot")
+}

--- a/internal/mcp/facade_registry.go
+++ b/internal/mcp/facade_registry.go
@@ -420,7 +420,7 @@ func facadeOperationSpecs() []facadeOperationSpec {
 		Effect: facadeEffectLocalWrite, Fixed: map[string]any{"ack": true},
 	})
 	addFacadeGroup(&specs, "workspace", facadeEffectRead, map[string]string{
-		"active_project": "get_active_project", "graph": "graph_stats", "index": "index_health",
+		"active_project": "get_active_project", "checkouts": "list_checkouts", "graph": "graph_stats", "index": "index_health",
 		"info": "workspace_info", "project": "query_project", "proxy": "proxy_status",
 		"repos": "list_repos", "scopes": "list_scopes",
 	})

--- a/internal/mcp/facade_tools_test.go
+++ b/internal/mcp/facade_tools_test.go
@@ -34,7 +34,7 @@ func TestFacadeRegistryCoversRegisteredLegacyCatalog(t *testing.T) {
 		}
 	}
 	require.Empty(t, missing, "every registered legacy tool must map into facade-v1")
-	require.Len(t, srv.facades.byLegacy, 179, "facade-v1 migration table must cover the full legacy catalog")
+	require.Len(t, srv.facades.byLegacy, 180, "facade-v1 migration table must cover the full legacy catalog")
 	require.Len(t, facadeToolNames(), 21)
 	for _, name := range facadeToolNames() {
 		if name == "capabilities" {

--- a/internal/mcp/guide.go
+++ b/internal/mcp/guide.go
@@ -126,7 +126,11 @@ The session CWD selects an automatically discovered checkout overlay. Do not cal
 
 Every response carries freshness metadata. ` + "`exact:false`" + ` means the requested view was not served, and every fallback is read-only. Set ` + "`require_exact:true`" + ` to reject fallback, ` + "`require_fresh:true`" + ` to wait for current filesystem state, and bound waiting with an absolute RFC3339 ` + "`wait_deadline`" + `.
 
-When CWD is not the target, select it explicitly: ` + "`view:{kind:\"worktree\",checkout_id:\"…\"}`" + ` or ` + "`view:{kind:\"git_ref\",value:\"refs/heads/release\",graph_id:\"…\"}`" + `. Inactive ref/commit views have committed source and structural graph only—no working-copy LSP, ` + "`search.text`" + `, or edits. Exact worktree edits are allowed only through the approved coordinator-backed path; fallback and ref/commit views are read-only.
+An existing session keeps its CWD when another worktree is created. To use the new worktree, select its absolute root on the daemon host: ` + "`view:{kind:\"worktree\",path:\"/absolute/path/to/worktree\"}`" + `. Automatic discovery may still be pending immediately after creation; retry the request once discovery completes. Do not track or restart the daemon to make the worktree visible.
+
+For checkout IDs and discovery state, use ` + "`workspace(operation:\"checkouts\")`" + `. You can also select ` + "`view:{kind:\"worktree\",checkout_id:\"…\"}`" + `, where checkout_id is the opaque identifier from that inventory, not a filesystem path. Supply exactly one of path or checkout_id.
+
+For an inactive ref, use ` + "`view:{kind:\"git_ref\",value:\"refs/heads/release\",graph_id:\"…\"}`" + `. Inactive ref/commit views have committed source and structural graph only—no working-copy LSP, ` + "`search.text`" + `, or edits. Exact worktree edits are allowed only through the approved coordinator-backed path; fallback and ref/commit views are read-only.
 
 Checkout administration previews destructive effects by default. Before primary closure, family forget, or set-primary, inspect the preview and obtain explicit user confirmation before sending confirm.`
 

--- a/internal/mcp/tools_checkouts.go
+++ b/internal/mcp/tools_checkouts.go
@@ -32,12 +32,12 @@ import (
 func (s *Server) registerCheckoutAdminTools() {
 	s.addTool(
 		mcp.NewTool("list_checkouts",
-			mcp.WithDescription("List the checkout families this daemon tracks. Each family reports its "+
+			mcp.WithDescription("List checkout families visible to this session's workspace. Unbound administrative clients see the daemon-wide inventory. Each family reports its "+
 				"primary corpus and epoch, its dedicated graphs, every registered working copy (mode, "+
 				"state, both reconciler clocks with their deadlines, path evidence, route and whether a "+
 				"build coordinator is live for it), and the named views rooted in its graphs. Reads the "+
 				"catalog only — run reconcile_checkouts for a fresh look at the filesystem."),
-			mcp.WithString("family", mcp.Description("Narrow to one family: a family id, a graph id, a repo prefix, or a path inside a tracked repository. Omit for every family.")),
+			mcp.WithString("family", mcp.Description("Narrow to one visible family: a family id, a graph id, a repo prefix, or a path inside a tracked repository. Omit for every visible family.")),
 			mcp.WithString("format", mcp.Description("Output format: json (default), gcx (GCX1 compact wire format), or toon")),
 			mcp.WithString("fields", mcp.Description("Comma-separated family fields to keep (for example family_id,primary_graph_id,checkouts). Drops the rest before response budgeting.")),
 			mcp.WithNumber("max_bytes", mcp.Description("Cap the marshaled response at this many bytes; truncation metadata rides on the response.")),
@@ -106,12 +106,64 @@ func (s *Server) handleListCheckouts(ctx context.Context, req mcp.CallToolReques
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
+	repos, bound := s.sessionWorkspaceRepoSet(ctx)
+	overview = checkoutOverviewInScope(overview, repos, bound)
 	if s.isTOON(ctx, req) || s.isGCX(ctx, req) {
 		_, payload := prepareCheckoutOverviewResponseWithSizer(req, overview, checkoutOverviewTOONSize)
 		return returnTOON(payload)
 	}
 	renderReq, payload := prepareCheckoutOverviewResponse(req, overview)
 	return s.respondJSONOrTOON(ctx, renderReq, payload)
+}
+
+// checkoutOverviewInScope applies the same repository boundary as checkout
+// selection before formatting or response projection can expose path metadata.
+// A family may contain independently dedicated graphs in other workspaces, so
+// retaining an authorized family does not authorize every row nested inside it.
+// Unbound administrative clients retain the daemon-wide inventory.
+func checkoutOverviewInScope(overview indexer.FamiliesOverview, repos map[string]bool, bound bool) indexer.FamiliesOverview {
+	if !bound {
+		return overview
+	}
+	result := indexer.FamiliesOverview{Families: make([]indexer.FamilyOverview, 0)}
+	for _, family := range overview.Families {
+		visible := make(map[string]bool)
+		filtered := family
+		filtered.Graphs = nil
+		filtered.Checkouts = nil
+		filtered.RefViews = nil
+		for _, graph := range family.Graphs {
+			if repos[graph.RepoPrefix] {
+				visible[graph.GraphID] = true
+				filtered.Graphs = append(filtered.Graphs, graph)
+			}
+		}
+		if len(visible) == 0 {
+			continue
+		}
+		for _, checkout := range family.Checkouts {
+			graphID := checkout.GraphID
+			if graphID == "" {
+				graphID = family.PrimaryGraphID
+			}
+			if !visible[graphID] || (checkout.Route != nil && !visible[checkout.Route.GraphID]) {
+				continue
+			}
+			filtered.Checkouts = append(filtered.Checkouts, checkout)
+		}
+		for _, ref := range family.RefViews {
+			if visible[ref.GraphID] {
+				filtered.RefViews = append(filtered.RefViews, ref)
+			}
+		}
+		if !visible[family.PrimaryGraphID] {
+			filtered.PrimaryGraphID = ""
+			filtered.PrimaryRepoPrefix = ""
+			filtered.CommonDir = ""
+		}
+		result.Families = append(result.Families, filtered)
+	}
+	return result
 }
 
 type checkoutOverviewSizer func(any) (int, error)

--- a/internal/mcp/view_request.go
+++ b/internal/mcp/view_request.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"slices"
 	"sync"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/zzet/gortex/internal/graph/store_sqlite"
 	"github.com/zzet/gortex/internal/graphview"
 	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/pathkey"
 	"github.com/zzet/gortex/internal/query"
 	"github.com/zzet/gortex/internal/reconcile"
 	"github.com/zzet/gortex/internal/viewmetrics"
@@ -174,7 +176,7 @@ const viewArgName = "view"
 // else is a typo the caller must see, not a field to ignore — an ignored
 // selector field would silently answer about a different view.
 var viewSelectorFields = map[string]bool{
-	"kind": true, "graph_id": true, "checkout_id": true, "value": true,
+	"kind": true, "graph_id": true, "checkout_id": true, "value": true, "path": true,
 }
 
 // viewSelectorSchema is the single public schema for the request-level view
@@ -209,8 +211,12 @@ func viewSelectorSchema() map[string]any {
 			}, "kind", "graph_id"),
 			object(map[string]any{
 				"kind":        kind(string(graphview.SelectorWorktree)),
-				"checkout_id": text("Registered checkout identifier."),
+				"checkout_id": text("Registered checkout identifier, available from workspace.checkouts. For a filesystem path use view.path instead."),
 			}, "kind", "checkout_id"),
+			object(map[string]any{
+				"kind": kind(string(graphview.SelectorWorktree)),
+				"path": text("Absolute root path of an automatically discovered worktree. No explicit tracking is needed."),
+			}, "kind", "path"),
 			object(map[string]any{
 				"kind":     kind(string(graphview.SelectorGitRef)),
 				"graph_id": text("Optional dedicated graph identifier."),
@@ -283,7 +289,17 @@ func takeViewSelector(req *mcp.CallToolRequest) (graphview.Selector, error) {
 		}
 		fields[name] = text
 	}
-	return graphview.ParseSelector(fields["kind"], fields["graph_id"], fields["checkout_id"], fields["value"])
+	if _, hasPath := obj["path"]; hasPath {
+		if _, hasID := obj["checkout_id"]; hasID {
+			return graphview.Selector{}, graphview.NewViewError(graphview.CodeSelectorConflict,
+				"worktree selector requires exactly one of checkout_id or path")
+		}
+		if fields["path"] == "" {
+			return graphview.Selector{}, graphview.NewViewError(graphview.CodeInvalidViewSelector,
+				"view.path must be a non-empty absolute worktree root")
+		}
+	}
+	return graphview.ParseSelectorWithPath(fields["kind"], fields["graph_id"], fields["checkout_id"], fields["value"], fields["path"])
 }
 
 // requestViewPolicy carries the operation-level guarantees that affect view
@@ -549,14 +565,38 @@ func (s *Server) viewForWorktreeSelector(
 	policy requestViewPolicy,
 ) (*requestView, error) {
 	catalog := s.materializer.Catalog
-	checkout, found, err := catalog.GetCheckout(ctx, selector.CheckoutID)
+	var checkout store_sqlite.Checkout
+	var found bool
+	var err error
+	subject := selector.CheckoutID
+	if selector.Path != "" {
+		subject = selector.Path
+		root := canonicalWorktreeSelectorRoot(selector.Path)
+		checkout, found, err = graphview.CheckoutForPath(ctx, catalog, s.viewFamilies(ctx), root)
+		// A new nested worktree must not be mistaken for its already-indexed
+		// parent while discovery is pending. Path selectors name roots, unlike
+		// implicit session-CWD binding which also accepts directories inside one.
+		if err == nil && found {
+			found = pathkey.EqualPaths(root, canonicalWorktreeSelectorRoot(checkout.RootPath))
+		}
+	} else {
+		checkout, found, err = catalog.GetCheckout(ctx, selector.CheckoutID)
+	}
 	switch {
 	case err != nil:
 		return nil, graphview.WrapViewError(graphview.CodeCheckoutInaccessible,
-			fmt.Sprintf("read checkout %q", selector.CheckoutID), err)
+			fmt.Sprintf("read checkout %q", subject), err)
 	case !found:
+		if selector.Path == "" && filepath.IsAbs(selector.CheckoutID) {
+			return nil, graphview.NewViewError(graphview.CodeInvalidViewSelector,
+				fmt.Sprintf("view.checkout_id expects a registered identifier, not a filesystem path; use view:{kind:\"worktree\",path:%q} or workspace(operation:\"checkouts\") to find its checkout_id", selector.CheckoutID))
+		}
+		if selector.Path != "" {
+			return nil, graphview.NewViewError(graphview.CodeCheckoutInaccessible,
+				fmt.Sprintf("no registered worktree root matches path %q; supply the worktree root, and if automatic discovery is pending inspect workspace(operation:\"checkouts\") and retry", selector.Path))
+		}
 		return nil, graphview.NewViewError(graphview.CodeCheckoutInaccessible,
-			fmt.Sprintf("checkout %q is not registered", selector.CheckoutID))
+			fmt.Sprintf("checkout %q is not registered; use view.path for a filesystem path or workspace(operation:\"checkouts\") to find its checkout_id", selector.CheckoutID))
 	}
 	if checkout.State != store_sqlite.CheckoutStateReady {
 		stateErr := graphview.NewViewError(graphview.CodeCheckoutInaccessible,
@@ -594,6 +634,16 @@ func (s *Server) viewForWorktreeSelector(
 		return nil, err
 	}
 	return s.materializeRequestView(ctx, selector, checkout, true)
+}
+
+// Resolve aliases before containment lookup, so a symlink inside the primary
+// pointing to a sibling checkout selects the sibling. Keep the lexical root
+// when unavailable so removal-grace requests still reach the existing policy.
+func canonicalWorktreeSelectorRoot(root string) string {
+	if resolved, err := filepath.EvalSymlinks(root); err == nil {
+		return resolved
+	}
+	return filepath.Clean(root)
 }
 
 func checkoutStateAllowsBaseFallback(state store_sqlite.CheckoutState) bool {

--- a/internal/mcp/view_schema_test.go
+++ b/internal/mcp/view_schema_test.go
@@ -10,29 +10,58 @@ import (
 
 func TestViewSelectorSchemaMatchesRuntimeShapes(t *testing.T) {
 	schema := viewSelectorSchema()
+	worktreePath := t.TempDir()
 	valid := map[string]map[string]any{
 		"implicit_auto": {},
 		"explicit_auto": {"kind": "auto"},
 		"base":          {"kind": "base", "graph_id": "graph-1"},
 		"worktree":      {"kind": "worktree", "checkout_id": "checkout-1"},
+		"worktree_path": {"kind": "worktree", "path": worktreePath},
 		"git_ref":       {"kind": "git_ref", "graph_id": "graph-1", "value": "refs/heads/main"},
 		"commit":        {"kind": "commit", "value": "0123456789012345678901234567890123456789"},
 	}
 	for name, value := range valid {
 		t.Run("accepts_"+name, func(t *testing.T) {
 			require.NoError(t, validateFacadeSchema(schema, value, "$.view"))
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = map[string]any{"view": value}
+			_, err := takeViewSelector(&req)
+			require.NoError(t, err)
 		})
 	}
 
 	invalid := map[string]map[string]any{
-		"unknown_kind":       {"kind": "snapshot"},
-		"base_without_graph": {"kind": "base"},
-		"mixed_identifiers":  {"kind": "worktree", "checkout_id": "checkout-1", "graph_id": "graph-1"},
-		"unknown_field":      {"kind": "auto", "branch": "main"},
+		"unknown_kind":               {"kind": "snapshot"},
+		"base_without_graph":         {"kind": "base"},
+		"mixed_identifiers":          {"kind": "worktree", "checkout_id": "checkout-1", "graph_id": "graph-1"},
+		"worktree_id_and_path":       {"kind": "worktree", "checkout_id": "checkout-1", "path": worktreePath},
+		"worktree_id_and_empty_path": {"kind": "worktree", "checkout_id": "checkout-1", "path": ""},
+		"worktree_path_and_empty_id": {"kind": "worktree", "checkout_id": "", "path": worktreePath},
+		"worktree_without_identity":  {"kind": "worktree"},
+		"auto_with_path":             {"kind": "auto", "path": worktreePath},
+		"auto_with_empty_path":       {"kind": "auto", "path": ""},
+		"base_with_path":             {"kind": "base", "graph_id": "graph-1", "path": worktreePath},
+		"git_ref_with_path":          {"kind": "git_ref", "value": "refs/heads/main", "path": worktreePath},
+		"commit_with_path":           {"kind": "commit", "value": "0123456789012345678901234567890123456789", "path": worktreePath},
+		"unknown_field":              {"kind": "auto", "branch": "main"},
 	}
 	for name, value := range invalid {
 		t.Run("rejects_"+name, func(t *testing.T) {
 			require.Error(t, validateFacadeSchema(schema, value, "$.view"))
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = map[string]any{"view": value}
+			_, err := takeViewSelector(&req)
+			require.Error(t, err)
+		})
+	}
+	// Host-specific path semantics are enforced by the runtime parser. The
+	// compact facade validator checks schema shapes, not every string constraint.
+	for _, path := range []string{"", "worktrees/feature", " " + worktreePath, worktreePath + " "} {
+		t.Run("rejects_runtime_path_"+path, func(t *testing.T) {
+			req := mcpgo.CallToolRequest{}
+			req.Params.Arguments = map[string]any{"view": map[string]any{"kind": "worktree", "path": path}}
+			_, err := takeViewSelector(&req)
+			require.Error(t, err)
 		})
 	}
 }
@@ -66,7 +95,7 @@ func TestViewSelectorPublishedOnEveryToolSchema(t *testing.T) {
 				capability := srv.facadeCapability(spec, true)
 				schema := facadeSchemaMapForTest(t, capability["input_schema"])
 				published := requirePublishedViewSelector(t, schema["properties"].(map[string]any))
-				require.Len(t, published["oneOf"], 5, "capability must publish every selector shape")
+				require.Len(t, published["oneOf"], 6, "capability must publish every selector shape, including worktree ID and path alternatives")
 				require.Equal(t, facadeSchemaMapForTest(t, viewSelectorSchema()), facadeSchemaMapForTest(t, published))
 			})
 		}

--- a/internal/mcp/view_worktree_path_test.go
+++ b/internal/mcp/view_worktree_path_test.go
@@ -1,0 +1,228 @@
+package mcp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/graphview"
+)
+
+func TestWorktreePathSelectorReadsFileThroughFacade(t *testing.T) {
+	t.Setenv("GORTEX_TOOLS", "facade-v1")
+	stack := newViewStack(t)
+	const base = "package fixture\nconst Marker = \"primary-checkout-content\"\n"
+	const overlay = "package fixture\nconst Marker = \"selected-worktree-content\"\n"
+	for root, content := range map[string]string{stack.repoRoot: base, stack.worktreeRoot: overlay} {
+		if err := os.WriteFile(filepath.Join(root, "path-selection.go"), []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	args := map[string]any{
+		"operation": "file",
+		"target": map[string]any{
+			"file": filepath.Join(stack.worktreeRoot, "path-selection.go"),
+		},
+		"view":          map[string]any{"kind": "worktree", "path": stack.worktreeRoot},
+		"require_exact": true,
+		"output":        map[string]any{"format": "json"},
+	}
+	res, err := stack.callWithView(t, stack.repoRoot, "read", args, func(ctx context.Context) (*mcpgo.CallToolResult, error) {
+		req := mcpgo.CallToolRequest{}
+		req.Params.Name = "read"
+		req.Params.Arguments = args
+		return stack.srv.handleFacade(ctx, "read", req)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	text, ok := singleTextContent(res)
+	if res.IsError || !ok || !strings.Contains(text, "selected-worktree-content") || strings.Contains(text, "primary-checkout-content") {
+		t.Fatalf("facade did not read the selected worktree file: %+v", res)
+	}
+	freshness := resultFreshness(t, res)
+	if freshness["exact"] != true || freshness["checkout_id"] != viewTestWorktree {
+		t.Fatalf("file read lost the resolved checkout identity: %v", freshness)
+	}
+}
+
+// An agent that creates a sibling worktree keeps its original MCP session.
+// Its next request must be able to select the automatically catalogued working
+// copy by the path it knows, without guessing a generated checkout identifier.
+func TestWorktreePathSelectorFromExistingPrimarySession(t *testing.T) {
+	stack := newViewStack(t)
+	for _, path := range []string{stack.worktreeRoot, stack.worktreeRoot + string(filepath.Separator)} {
+		t.Run(path, func(t *testing.T) {
+			var reader graph.Reader
+			res, err := stack.callWithView(t, stack.repoRoot, "get_symbol", map[string]any{
+				"view": map[string]any{"kind": "worktree", "path": path},
+			}, captureReader(stack.srv, &reader))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if res.IsError || reader == nil {
+				t.Fatalf("path selector did not route the worktree: %+v", res)
+			}
+			for _, id := range []string{"repo/added.go::Fresh", "repo/edit.go::New", "repo/keep.go::Dirty"} {
+				if !hasNode(reader, id) {
+					t.Errorf("selected worktree is missing %s", id)
+				}
+			}
+			if hasNode(reader, "repo/edit.go::Old") {
+				t.Error("replaced base symbol leaked through path selection")
+			}
+			freshness := resultFreshness(t, res)
+			if freshness["exact"] != true || freshness["checkout_id"] != viewTestWorktree {
+				t.Fatalf("path was not bound to the exact checkout: %v", freshness)
+			}
+			if freshness["requested_view"] != "worktree:path:"+path {
+				t.Fatalf("requested path was lost: %v", freshness)
+			}
+		})
+	}
+}
+
+func TestWorktreePathSelectorCanonicalizesAliasInsidePrimary(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("creating symlinks requires additional Windows privileges")
+	}
+	stack := newViewStack(t)
+	alias := filepath.Join(stack.repoRoot, "worktree-alias")
+	if err := os.Symlink(stack.worktreeRoot, alias); err != nil {
+		t.Fatal(err)
+	}
+	var reader graph.Reader
+	res, err := stack.callWithView(t, stack.repoRoot, "get_symbol", map[string]any{
+		"view": map[string]any{"kind": "worktree", "path": alias},
+	}, captureReader(stack.srv, &reader))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError || reader == nil || !hasNode(reader, "repo/added.go::Fresh") {
+		t.Fatalf("alias selected the primary instead of the worktree: %+v", res)
+	}
+	if freshness := resultFreshness(t, res); freshness["checkout_id"] != viewTestWorktree || freshness["exact"] != true {
+		t.Fatalf("alias did not select the exact worktree: %v", freshness)
+	}
+}
+
+func TestWorktreePathSelectorNeverSubstitutesRegisteredParent(t *testing.T) {
+	stack := newViewStack(t)
+	for _, parent := range []string{stack.repoRoot, stack.worktreeRoot} {
+		path := filepath.Join(parent, "new-nested-worktree")
+		if err := os.Mkdir(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		var reader graph.Reader
+		res, err := stack.callWithView(t, stack.repoRoot, "get_symbol", map[string]any{
+			"view": map[string]any{"kind": "worktree", "path": path},
+		}, captureReader(stack.srv, &reader))
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertToolError(t, res, graphview.CodeCheckoutInaccessible)
+		if reader != nil {
+			t.Fatalf("unknown nested worktree selected its parent %s", parent)
+		}
+	}
+}
+
+func TestWorktreePathSelectorPreservesWorkspaceBoundary(t *testing.T) {
+	stack := newViewStack(t)
+	var reader graph.Reader
+	res, err := stack.callWithView(t, stack.otherRoot, "get_symbol", map[string]any{
+		"view": map[string]any{"kind": "worktree", "path": stack.worktreeRoot},
+	}, captureReader(stack.srv, &reader))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertToolError(t, res, graphview.CodeSelectorOutOfScope)
+	if reader != nil {
+		t.Fatal("out-of-scope path reached the query handler")
+	}
+}
+
+func TestWorktreePathSelectorDoesNotMatchSiblingPrefix(t *testing.T) {
+	stack := newViewStack(t)
+	var reader graph.Reader
+	res, err := stack.callWithView(t, stack.repoRoot, "get_symbol", map[string]any{
+		"view": map[string]any{"kind": "worktree", "path": stack.worktreeRoot + "-other"},
+	}, captureReader(stack.srv, &reader))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertToolError(t, res, graphview.CodeCheckoutInaccessible)
+	if reader != nil {
+		t.Fatal("unknown sibling path reached the query handler")
+	}
+}
+
+func TestWorktreePathSelectorKeepsUnavailableFileReadStrict(t *testing.T) {
+	stack := newViewStack(t)
+	stack.setWorktreeState(t, store_sqlite.CheckoutStateRemovalGrace)
+	var reader graph.Reader
+	res, err := stack.callWithView(t, stack.repoRoot, "read_file", map[string]any{
+		"view": map[string]any{"kind": "worktree", "path": stack.worktreeRoot},
+		"file": filepath.Join(stack.worktreeRoot, "src", "file.go"),
+	}, captureReader(stack.srv, &reader))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertToolError(t, res, graphview.CodeCheckoutInaccessible)
+	if reader != nil {
+		t.Fatal("unavailable worktree path reached a file reader")
+	}
+}
+
+func TestWorktreePathSelectorPreservesMutationGuard(t *testing.T) {
+	stack := newViewStack(t)
+	var reader graph.Reader
+	res, err := stack.callWithView(t, stack.repoRoot, "edit_file", map[string]any{
+		"view": map[string]any{"kind": "worktree", "path": stack.worktreeRoot},
+		"path": filepath.Join(stack.worktreeRoot, "edit.go"),
+	}, captureReader(stack.srv, &reader))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertToolError(t, res, graphview.CodeViewReadOnly)
+	if reader != nil {
+		t.Fatal("path selector bypassed the routed mutation guard")
+	}
+}
+
+func TestWorktreePathInCheckoutIDExplainsCorrectSelector(t *testing.T) {
+	stack := newViewStack(t)
+	var reader graph.Reader
+	res, err := stack.callWithView(t, stack.repoRoot, "get_symbol", map[string]any{
+		"view": map[string]any{"kind": "worktree", "checkout_id": stack.worktreeRoot},
+	}, captureReader(stack.srv, &reader))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertToolError(t, res, graphview.CodeInvalidViewSelector)
+	text, ok := singleTextContent(res)
+	if !ok || !strings.Contains(text, "path:") || !strings.Contains(text, "checkouts") {
+		t.Fatalf("refusal must explain path selection and inventory: %+v", res)
+	}
+	if reader != nil {
+		t.Fatal("invalid selector reached the query handler")
+	}
+}
+
+func BenchmarkCanonicalWorktreeSelectorRoot(b *testing.B) {
+	root := b.TempDir()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if canonicalWorktreeSelectorRoot(root) == "" {
+			b.Fatal("lost worktree root")
+		}
+	}
+}


### PR DESCRIPTION
An agent can create a linked worktree after its MCP session starts, but previously could not select it using the filesystem path it knows. `checkout_id` required an opaque identifier, and the compact MCP surface did not expose the inventory needed to obtain it. Supplying the path produced a misleading “not registered” error even after automatic discovery succeeded.

This change adds `view: {kind: "worktree", path: "/absolute/worktree/root"}` and exposes read-only `workspace(operation: "checkouts")`.

- Resolve symlinks before selecting the registered root. Never silently select an indexed parent for an undiscovered nested worktree.
- Preserve ID-based selection, workspace boundaries, overlay precedence, unavailable-view policy, and existing mutation guards. Reject ambiguous or empty selectors and explain how to correct a path passed as an ID.
- Filter inventory by the session's authorized repositories, including dedicated graphs, automatic overlays, routes, and inactive refs within mixed-workspace families. Unbound administrative clients retain daemon-wide inventory.
- Document path selection and retrying pending automatic discovery. No explicit tracking or schema migration is required.

Validation:

- Full MCP, graphview, and CLI package tests with an isolated user-state directory.
- Full graphview race suite and an earlier focused MCP routing/grace/inventory race run passed. The final expanded race rerun could not link because the local filesystem ran out of space (`ld: write() failed, errno=28`); it did not reach test execution.
- Facade file-read regression verifies that an existing primary session reads the sibling worktree's distinct content and reports its exact checkout identity.
- Schema/dispatch, cross-workspace inventory, symlink, nested-worktree, and mutation-guard regressions.
- `golangci-lint run ./internal/graphview/... ./internal/mcp/...`: no issues.
- Worktree-root canonicalization benchmark: 11.5–11.7 µs/op on Apple M1 Pro (38 allocations, 3328 B/op).

Automatic discovery can still be pending immediately after creation; that case returns an actionable refusal and can be retried. This PR does not change the existing restrictions on source mutations through routed worktree views.
