### PR TITLE
fix: surface unreadable files as degraded indexing

### DIFF
--- a/cmd/gortex/daemon.go
+++ b/cmd/gortex/daemon.go
@@ -1336,6 +1336,8 @@ func renderDaemonHeader(w io.Writer, st daemon.StatusResponse) {
 	t.AppendRow(table.Row{"socket", st.SocketPath})
 	t.AppendRow(table.Row{"uptime", formatDuration(time.Duration(st.UptimeSeconds) * time.Second)})
 	switch {
+	case st.Ready && st.IndexDegraded:
+		t.AppendRow(table.Row{"state", fmt.Sprintf("degraded — %d failed files (%d unreadable); queryable", st.FailedFiles, st.UnreadableFiles)})
 	case st.Ready && st.EnrichmentComplete:
 		t.AppendRow(table.Row{
 			"state",
@@ -1350,6 +1352,9 @@ func renderDaemonHeader(w io.Writer, st daemon.StatusResponse) {
 		})
 	default:
 		t.AppendRow(table.Row{"state", "warming up (socket reachable, resolving references)"})
+	}
+	if !st.Ready && st.IndexDegraded {
+		t.AppendRow(table.Row{"index", fmt.Sprintf("degraded — %d failed files (%d unreadable)", st.FailedFiles, st.UnreadableFiles)})
 	}
 	t.AppendRow(table.Row{"sessions", st.Sessions})
 	if st.MemoryBytes > 0 {
@@ -1561,7 +1566,7 @@ func renderDaemonRepos(w io.Writer, st daemon.StatusResponse) {
 	// so it stays hidden.
 	showState := false
 	for _, r := range rows {
-		if r.Missing || r.Unloaded || repoIndexIsEmpty(r) {
+		if r.Missing || r.Unloaded || r.FailedFiles > 0 || repoIndexIsEmpty(r) {
 			showState = true
 			break
 		}
@@ -1632,6 +1637,7 @@ func renderDaemonRepos(w io.Writer, st daemon.StatusResponse) {
 	t.Render()
 	renderMissingRepoWarning(w, rows)
 	renderEmptyIndexWarning(w, rows)
+	renderIndexFailureWarning(w, rows)
 }
 
 // repoStateLabel names a tracked repo's inventory state for the status
@@ -1644,6 +1650,8 @@ func repoStateLabel(r daemon.TrackedRepoStatus) string {
 		return "MISSING"
 	case r.Unloaded:
 		return "not indexed"
+	case r.FailedFiles > 0:
+		return "DEGRADED"
 	case repoIndexIsEmpty(r):
 		return "EMPTY"
 	default:

--- a/cmd/gortex/daemon.go
+++ b/cmd/gortex/daemon.go
@@ -1336,6 +1336,8 @@ func renderDaemonHeader(w io.Writer, st daemon.StatusResponse) {
 	t.AppendRow(table.Row{"socket", st.SocketPath})
 	t.AppendRow(table.Row{"uptime", formatDuration(time.Duration(st.UptimeSeconds) * time.Second)})
 	switch {
+	case st.Ready && st.IndexHealthError != "":
+		t.AppendRow(table.Row{"state", "degraded — index health unavailable; queryable"})
 	case st.Ready && st.IndexDegraded:
 		t.AppendRow(table.Row{"state", fmt.Sprintf("degraded — %d failed files (%d unreadable); queryable", st.FailedFiles, st.UnreadableFiles)})
 	case st.Ready && st.EnrichmentComplete:
@@ -1353,7 +1355,9 @@ func renderDaemonHeader(w io.Writer, st daemon.StatusResponse) {
 	default:
 		t.AppendRow(table.Row{"state", "warming up (socket reachable, resolving references)"})
 	}
-	if !st.Ready && st.IndexDegraded {
+	if !st.Ready && st.IndexHealthError != "" {
+		t.AppendRow(table.Row{"index", "degraded — index health unavailable"})
+	} else if !st.Ready && st.IndexDegraded {
 		t.AppendRow(table.Row{"index", fmt.Sprintf("degraded — %d failed files (%d unreadable)", st.FailedFiles, st.UnreadableFiles)})
 	}
 	t.AppendRow(table.Row{"sessions", st.Sessions})
@@ -1566,7 +1570,7 @@ func renderDaemonRepos(w io.Writer, st daemon.StatusResponse) {
 	// so it stays hidden.
 	showState := false
 	for _, r := range rows {
-		if r.Missing || r.Unloaded || r.FailedFiles > 0 || repoIndexIsEmpty(r) {
+		if r.Missing || r.Unloaded || r.FailedFiles > 0 || r.IndexHealthError != "" || repoIndexIsEmpty(r) {
 			showState = true
 			break
 		}
@@ -1650,7 +1654,7 @@ func repoStateLabel(r daemon.TrackedRepoStatus) string {
 		return "MISSING"
 	case r.Unloaded:
 		return "not indexed"
-	case r.FailedFiles > 0:
+	case r.FailedFiles > 0 || r.IndexHealthError != "":
 		return "DEGRADED"
 	case repoIndexIsEmpty(r):
 		return "EMPTY"

--- a/cmd/gortex/daemon_controller.go
+++ b/cmd/gortex/daemon_controller.go
@@ -982,6 +982,21 @@ func (c *realController) status(ctx context.Context, waitForAggregate bool) (dae
 		ToolPresetMode:     agg.toolPresetMode,
 		LearnedTools:       agg.learnedTools,
 	}
+	if g != nil {
+		applyIndexFailureStatus(&resp, func(prefix string) (int, int, error) {
+			failures, err := indexer.LoadFileIndexFailuresWithError(g, prefix)
+			if err != nil {
+				return 0, 0, err
+			}
+			unreadable := 0
+			for _, failure := range failures {
+				if failure.PermissionDenied {
+					unreadable++
+				}
+			}
+			return len(failures), unreadable, nil
+		})
+	}
 	if cached {
 		// Say which half is a snapshot. Without the marker a stale repo
 		// table is indistinguishable from a current one, and an empty one

--- a/cmd/gortex/daemon_index_health.go
+++ b/cmd/gortex/daemon_index_health.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"runtime"
+
+	"github.com/zzet/gortex/internal/daemon"
+)
+
+// applyIndexFailureStatus refreshes file health separately from the cached
+// aggregate. Ready describes whether queries can run, not whether every file
+// could be indexed; leave it intact so a denied file cannot block startup.
+func applyIndexFailureStatus(st *daemon.StatusResponse, counts func(string) (int, int)) {
+	st.FailedFiles, st.UnreadableFiles = 0, 0
+	for i := range st.TrackedRepos {
+		r := &st.TrackedRepos[i]
+		r.FailedFiles, r.UnreadableFiles = counts(r.Prefix)
+		r.IndexDegraded = r.FailedFiles > 0
+		st.FailedFiles += r.FailedFiles
+		st.UnreadableFiles += r.UnreadableFiles
+	}
+	st.IndexDegraded = st.FailedFiles > 0
+}
+
+func renderIndexFailureWarning(w io.Writer, rows []daemon.TrackedRepoStatus) {
+	unreadable := false
+	for _, r := range rows {
+		if r.FailedFiles == 0 {
+			continue
+		}
+		fmt.Fprintf(w, "\n%s: index degraded — %d failed files (%d unreadable); search results may be incomplete.\n",
+			r.Prefix, r.FailedFiles, r.UnreadableFiles)
+		unreadable = unreadable || r.UnreadableFiles > 0
+	}
+	if unreadable && runtime.GOOS == "darwin" {
+		fmt.Fprintln(w, "Check the daemon's Documents / Full Disk Access permission in System Settings → Privacy & Security.")
+	}
+}

--- a/cmd/gortex/daemon_index_health.go
+++ b/cmd/gortex/daemon_index_health.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"runtime"
+	"strings"
 
 	"github.com/zzet/gortex/internal/daemon"
 )
@@ -11,21 +12,32 @@ import (
 // applyIndexFailureStatus refreshes file health separately from the cached
 // aggregate. Ready describes whether queries can run, not whether every file
 // could be indexed; leave it intact so a denied file cannot block startup.
-func applyIndexFailureStatus(st *daemon.StatusResponse, counts func(string) (int, int)) {
+func applyIndexFailureStatus(st *daemon.StatusResponse, counts func(string) (int, int, error)) {
 	st.FailedFiles, st.UnreadableFiles = 0, 0
+	var healthErrors []string
 	for i := range st.TrackedRepos {
 		r := &st.TrackedRepos[i]
-		r.FailedFiles, r.UnreadableFiles = counts(r.Prefix)
-		r.IndexDegraded = r.FailedFiles > 0
+		var err error
+		r.FailedFiles, r.UnreadableFiles, err = counts(r.Prefix)
+		r.IndexHealthError = ""
+		if err != nil {
+			r.IndexHealthError = err.Error()
+			healthErrors = append(healthErrors, r.Prefix+": "+err.Error())
+		}
+		r.IndexDegraded = r.FailedFiles > 0 || err != nil
 		st.FailedFiles += r.FailedFiles
 		st.UnreadableFiles += r.UnreadableFiles
 	}
-	st.IndexDegraded = st.FailedFiles > 0
+	st.IndexHealthError = strings.Join(healthErrors, "; ")
+	st.IndexDegraded = st.FailedFiles > 0 || st.IndexHealthError != ""
 }
 
 func renderIndexFailureWarning(w io.Writer, rows []daemon.TrackedRepoStatus) {
 	unreadable := false
 	for _, r := range rows {
+		if r.IndexHealthError != "" {
+			fmt.Fprintf(w, "\n%s: file indexing health unavailable: %s; search results may be incomplete.\n", r.Prefix, r.IndexHealthError)
+		}
 		if r.FailedFiles == 0 {
 			continue
 		}

--- a/cmd/gortex/daemon_index_health_test.go
+++ b/cmd/gortex/daemon_index_health_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/daemon"
+)
+
+func TestIndexFailureStatusRecoveryKeepsQueryReadiness(t *testing.T) {
+	st := daemon.StatusResponse{
+		Ready: true,
+		TrackedRepos: []daemon.TrackedRepoStatus{
+			{Prefix: "denied", Files: 12},
+			{Prefix: "healthy", Files: 8},
+		},
+	}
+	applyIndexFailureStatus(&st, func(prefix string) (int, int) {
+		if prefix == "denied" {
+			return 3, 2
+		}
+		return 0, 0
+	})
+	if !st.Ready || !st.IndexDegraded || st.FailedFiles != 3 || st.UnreadableFiles != 2 {
+		t.Fatalf("unexpected status: %+v", st)
+	}
+	if !st.TrackedRepos[0].IndexDegraded || st.TrackedRepos[1].IndexDegraded || st.TrackedRepos[1].FailedFiles != 0 {
+		t.Fatalf("failures leaked across repository scope: %+v", st.TrackedRepos)
+	}
+	// A cached table may still carry the previous failure counts. A fresh
+	// ledger read after recovery must clear both its rows and its totals.
+	applyIndexFailureStatus(&st, func(string) (int, int) { return 0, 0 })
+	if !st.Ready || st.IndexDegraded || st.FailedFiles != 0 || st.UnreadableFiles != 0 || st.TrackedRepos[0].IndexDegraded || st.TrackedRepos[0].FailedFiles != 0 {
+		t.Fatalf("recovered status retained failure state: %+v", st)
+	}
+}
+
+func TestIndexFailureStatusRendering(t *testing.T) {
+	row := daemon.TrackedRepoStatus{Prefix: "denied", Files: 12, FailedFiles: 3, UnreadableFiles: 2, IndexDegraded: true}
+	st := daemon.StatusResponse{Ready: true, EnrichmentComplete: true, IndexDegraded: true, FailedFiles: 3, UnreadableFiles: 2, TrackedRepos: []daemon.TrackedRepoStatus{row}}
+	var out bytes.Buffer
+	renderDaemonHeader(&out, st)
+	renderDaemonRepos(&out, st)
+	for _, want := range []string{"degraded", "DEGRADED", "3 failed files (2 unreadable)", "search results may be incomplete"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("status is missing %q: %s", want, out.String())
+		}
+	}
+	if got := repoItemState(row); !strings.Contains(got, "3 failed, 2 unreadable") {
+		t.Errorf("TUI omitted failure counts: %s", got)
+	}
+	if got := repoStateLabel(daemon.TrackedRepoStatus{Missing: true, FailedFiles: 3}); got != "MISSING" {
+		t.Errorf("failure state hid missing path: %s", got)
+	}
+	out.Reset()
+	renderIndexFailureWarning(&out, []daemon.TrackedRepoStatus{{Prefix: "healthy", Files: 8}})
+	if out.Len() != 0 {
+		t.Fatalf("healthy repo produced a warning: %s", out.String())
+	}
+}

--- a/cmd/gortex/daemon_index_health_test.go
+++ b/cmd/gortex/daemon_index_health_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 
@@ -16,11 +17,11 @@ func TestIndexFailureStatusRecoveryKeepsQueryReadiness(t *testing.T) {
 			{Prefix: "healthy", Files: 8},
 		},
 	}
-	applyIndexFailureStatus(&st, func(prefix string) (int, int) {
+	applyIndexFailureStatus(&st, func(prefix string) (int, int, error) {
 		if prefix == "denied" {
-			return 3, 2
+			return 3, 2, nil
 		}
-		return 0, 0
+		return 0, 0, nil
 	})
 	if !st.Ready || !st.IndexDegraded || st.FailedFiles != 3 || st.UnreadableFiles != 2 {
 		t.Fatalf("unexpected status: %+v", st)
@@ -30,9 +31,27 @@ func TestIndexFailureStatusRecoveryKeepsQueryReadiness(t *testing.T) {
 	}
 	// A cached table may still carry the previous failure counts. A fresh
 	// ledger read after recovery must clear both its rows and its totals.
-	applyIndexFailureStatus(&st, func(string) (int, int) { return 0, 0 })
+	applyIndexFailureStatus(&st, func(string) (int, int, error) { return 0, 0, nil })
 	if !st.Ready || st.IndexDegraded || st.FailedFiles != 0 || st.UnreadableFiles != 0 || st.TrackedRepos[0].IndexDegraded || st.TrackedRepos[0].FailedFiles != 0 {
 		t.Fatalf("recovered status retained failure state: %+v", st)
+	}
+}
+
+func TestIndexFailureStatusDisclosesUnavailableLedger(t *testing.T) {
+	st := daemon.StatusResponse{Ready: true, TrackedRepos: []daemon.TrackedRepoStatus{{Prefix: "repo", Files: 8}}}
+	applyIndexFailureStatus(&st, func(string) (int, int, error) { return 0, 0, errors.New("ledger read failed") })
+	if !st.Ready || !st.IndexDegraded || !st.TrackedRepos[0].IndexDegraded || !strings.Contains(st.IndexHealthError, "ledger read failed") {
+		t.Fatalf("unavailable ledger reported as healthy: %+v", st)
+	}
+	var out bytes.Buffer
+	renderDaemonHeader(&out, st)
+	renderIndexFailureWarning(&out, st.TrackedRepos)
+	if !strings.Contains(out.String(), "index health unavailable") || !strings.Contains(out.String(), "ledger read failed") {
+		t.Fatalf("missing health read error: %s", out.String())
+	}
+	applyIndexFailureStatus(&st, func(string) (int, int, error) { return 0, 0, nil })
+	if st.IndexDegraded || st.IndexHealthError != "" || st.TrackedRepos[0].IndexHealthError != "" {
+		t.Fatalf("recovered ledger retained unknown state: %+v", st)
 	}
 }
 
@@ -49,6 +68,16 @@ func TestIndexFailureStatusRendering(t *testing.T) {
 	}
 	if got := repoItemState(row); !strings.Contains(got, "3 failed, 2 unreadable") {
 		t.Errorf("TUI omitted failure counts: %s", got)
+	}
+	tui := statusTUI{hasStatus: true, status: st}
+	if got := tui.headerRightCol(); !strings.Contains(got, "degraded") || !strings.Contains(got, "3 failed (2 unreadable)") {
+		t.Errorf("TUI header hid degraded indexing: %s", got)
+	}
+	out.Reset()
+	st.Ready = false
+	renderDaemonHeader(&out, st)
+	if !strings.Contains(out.String(), "warming up") || !strings.Contains(out.String(), "3 failed files (2 unreadable)") {
+		t.Errorf("warming header lost readiness or indexing state: %s", out.String())
 	}
 	if got := repoStateLabel(daemon.TrackedRepoStatus{Missing: true, FailedFiles: 3}); got != "MISSING" {
 		t.Errorf("failure state hid missing path: %s", got)

--- a/cmd/gortex/daemon_status_tui.go
+++ b/cmd/gortex/daemon_status_tui.go
@@ -62,8 +62,8 @@ func (r repoItem) FilterValue() string {
 
 type repoDelegate struct{ width int }
 
-func (d repoDelegate) Height() int                         { return 1 }
-func (d repoDelegate) Spacing() int                        { return 0 }
+func (d repoDelegate) Height() int                             { return 1 }
+func (d repoDelegate) Spacing() int                            { return 0 }
 func (d repoDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
 func (d repoDelegate) Render(w io.Writer, m list.Model, index int, listItem list.Item) {
 	r, ok := listItem.(repoItem)
@@ -119,6 +119,8 @@ func repoItemState(r daemon.TrackedRepoStatus) string {
 		return "MISSING — path deleted"
 	case r.Unloaded:
 		return "not indexed"
+	case r.FailedFiles > 0:
+		return fmt.Sprintf("DEGRADED — %d failed, %d unreadable", r.FailedFiles, r.UnreadableFiles)
 	case repoIndexIsEmpty(r):
 		return "EMPTY — 0 files indexed"
 	default:
@@ -275,9 +277,9 @@ func (m statusTUI) View() string {
 		}
 	}
 
-	gap(1)               // top breathing room
+	gap(1) // top breathing room
 	push(m.renderHeader())
-	gap(2)               // logo gets extra space below
+	gap(2) // logo gets extra space below
 	if w := m.renderWorkspaces(); w != "" {
 		push(w)
 		gap(1)

--- a/cmd/gortex/daemon_status_tui.go
+++ b/cmd/gortex/daemon_status_tui.go
@@ -119,6 +119,8 @@ func repoItemState(r daemon.TrackedRepoStatus) string {
 		return "MISSING — path deleted"
 	case r.Unloaded:
 		return "not indexed"
+	case r.IndexHealthError != "":
+		return "DEGRADED — file indexing health unavailable"
 	case r.FailedFiles > 0:
 		return fmt.Sprintf("DEGRADED — %d failed, %d unreadable", r.FailedFiles, r.UnreadableFiles)
 	case repoIndexIsEmpty(r):
@@ -351,6 +353,8 @@ func (m statusTUI) headerRightCol() string {
 	state := tuiAccent.Render("ready")
 	if !st.Ready {
 		state = lipgloss.NewStyle().Foreground(progress.ColorWarn).Render("warming")
+	} else if st.IndexDegraded {
+		state = lipgloss.NewStyle().Foreground(progress.ColorWarn).Render("degraded")
 	}
 	row1 := tuiTitle.Render("gortex daemon")
 	row2 := strings.Join([]string{
@@ -361,6 +365,11 @@ func (m statusTUI) headerRightCol() string {
 	}, tuiHint.Render(" · "))
 	row3Cells := []string{
 		tuiKey.Render(humanizeBytes(st.Runtime.Alloc)) + tuiSub.Render(" alloc"),
+	}
+	if st.IndexHealthError != "" {
+		row3Cells = append(row3Cells, tuiSub.Render("index health unavailable"))
+	} else if st.IndexDegraded {
+		row3Cells = append(row3Cells, tuiSub.Render(fmt.Sprintf("%d failed (%d unreadable)", st.FailedFiles, st.UnreadableFiles)))
 	}
 	// Omitted entirely when the backend has no real count to report —
 	// its only figure would be a since-construction Add/Remove delta,

--- a/cmd/gortex/status.go
+++ b/cmd/gortex/status.go
@@ -124,6 +124,10 @@ func runStatusViaDaemon(cmd *cobra.Command) error {
 			suffix = "MISSING — path no longer exists on disk"
 		case r.Unloaded:
 			suffix = "(not indexed — tracked in config, no index held)"
+		case r.IndexHealthError != "":
+			suffix = "DEGRADED — file indexing health unavailable"
+		case r.FailedFiles > 0:
+			suffix = fmt.Sprintf("DEGRADED — %d failed files (%d unreadable)", r.FailedFiles, r.UnreadableFiles)
 		case repoIndexIsEmpty(r):
 			suffix = "EMPTY — indexed 0 files; no parsable source, or an ignore rule excluded all of it"
 		}
@@ -139,6 +143,7 @@ func runStatusViaDaemon(cmd *cobra.Command) error {
 	}
 	renderMissingRepoWarning(w, st.TrackedRepos)
 	renderEmptyIndexWarning(w, st.TrackedRepos)
+	renderIndexFailureWarning(w, st.TrackedRepos)
 	return nil
 }
 

--- a/internal/daemon/proto.go
+++ b/internal/daemon/proto.go
@@ -299,11 +299,13 @@ type StatusResponse struct {
 	UptimeSeconds int64               `json:"uptime_seconds"`
 	SocketPath    string              `json:"socket_path"`
 	TrackedRepos  []TrackedRepoStatus `json:"tracked_repos"`
-	// IndexDegraded distinguishes query readiness from complete file indexing.
-	IndexDegraded   bool `json:"index_degraded,omitempty"`
-	FailedFiles     int  `json:"failed_files,omitempty"`
-	UnreadableFiles int  `json:"unreadable_files,omitempty"`
-	Sessions        int  `json:"sessions"`
+	// File indexing health is independent of query readiness. A health read
+	// error means completeness is unknown, not that indexing succeeded.
+	IndexHealthError string `json:"index_health_error,omitempty"`
+	IndexDegraded    bool   `json:"index_degraded,omitempty"`
+	FailedFiles      int    `json:"failed_files,omitempty"`
+	UnreadableFiles  int    `json:"unreadable_files,omitempty"`
+	Sessions         int    `json:"sessions"`
 	// MemoryBytes is runtime.MemStats.Alloc — live allocated heap.
 	// Retained for backwards compatibility with older clients; new
 	// clients should read from Runtime.
@@ -825,10 +827,11 @@ type TrackedRepoStatus struct {
 	// and `gortex repos` report the same inventory instead of one view
 	// dropping a repo the other still lists. Counts are zero.
 	Unloaded bool `json:"unloaded,omitempty"`
-	// FailedFiles counts unresolved indexing failures, including permission denials.
-	FailedFiles     int  `json:"failed_files,omitempty"`
-	UnreadableFiles int  `json:"unreadable_files,omitempty"`
-	IndexDegraded   bool `json:"index_degraded,omitempty"`
+	// File indexing health includes unresolved failures and ledger read errors.
+	IndexHealthError string `json:"index_health_error,omitempty"`
+	FailedFiles      int    `json:"failed_files,omitempty"`
+	UnreadableFiles  int    `json:"unreadable_files,omitempty"`
+	IndexDegraded    bool   `json:"index_degraded,omitempty"`
 }
 
 // WorkspaceSummary aggregates per-workspace stats so `gortex daemon

--- a/internal/daemon/proto.go
+++ b/internal/daemon/proto.go
@@ -299,7 +299,11 @@ type StatusResponse struct {
 	UptimeSeconds int64               `json:"uptime_seconds"`
 	SocketPath    string              `json:"socket_path"`
 	TrackedRepos  []TrackedRepoStatus `json:"tracked_repos"`
-	Sessions      int                 `json:"sessions"`
+	// IndexDegraded distinguishes query readiness from complete file indexing.
+	IndexDegraded   bool `json:"index_degraded,omitempty"`
+	FailedFiles     int  `json:"failed_files,omitempty"`
+	UnreadableFiles int  `json:"unreadable_files,omitempty"`
+	Sessions        int  `json:"sessions"`
 	// MemoryBytes is runtime.MemStats.Alloc — live allocated heap.
 	// Retained for backwards compatibility with older clients; new
 	// clients should read from Runtime.
@@ -821,6 +825,10 @@ type TrackedRepoStatus struct {
 	// and `gortex repos` report the same inventory instead of one view
 	// dropping a repo the other still lists. Counts are zero.
 	Unloaded bool `json:"unloaded,omitempty"`
+	// FailedFiles counts unresolved indexing failures, including permission denials.
+	FailedFiles     int  `json:"failed_files,omitempty"`
+	UnreadableFiles int  `json:"unreadable_files,omitempty"`
+	IndexDegraded   bool `json:"index_degraded,omitempty"`
 }
 
 // WorkspaceSummary aggregates per-workspace stats so `gortex daemon

--- a/internal/graph/file_index_failures.go
+++ b/internal/graph/file_index_failures.go
@@ -1,0 +1,60 @@
+package graph
+
+import "sort"
+
+// FileIndexFailure records a file that could not be indexed, including files
+// which have never produced a node or a successful file metadata row.
+type FileIndexFailure struct {
+	Path             string `json:"path"`
+	Error            string `json:"error"`
+	PermissionDenied bool   `json:"permission_denied,omitempty"`
+	RepoPrefix       string `json:"repo_prefix"`
+	WorkspaceID      string `json:"workspace_id,omitempty"`
+	ProjectID        string `json:"project_id,omitempty"`
+}
+
+// FileIndexFailureReader is an optional, generation-scoped health capability.
+type FileIndexFailureReader interface {
+	FileIndexFailuresForRepo(repoPrefix string) ([]FileIndexFailure, error)
+}
+
+// FileIndexFailureWriter replaces one repository's complete failure snapshot.
+// An empty snapshot clears failures after recovery without touching graph data.
+type FileIndexFailureWriter interface {
+	ReplaceFileIndexFailures(repoPrefix string, failures []FileIndexFailure) error
+}
+
+func (g *Graph) FileIndexFailuresForRepo(repoPrefix string) ([]FileIndexFailure, error) {
+	g.fileIndexFailuresMu.Lock()
+	defer g.fileIndexFailuresMu.Unlock()
+	out := make([]FileIndexFailure, 0, len(g.fileIndexFailures[repoPrefix]))
+	for _, failure := range g.fileIndexFailures[repoPrefix] {
+		out = append(out, failure)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+	return out, nil
+}
+
+func (g *Graph) ReplaceFileIndexFailures(repoPrefix string, failures []FileIndexFailure) error {
+	byPath := make(map[string]FileIndexFailure, len(failures))
+	for _, failure := range failures {
+		failure.RepoPrefix = repoPrefix
+		byPath[failure.Path] = failure
+	}
+	g.fileIndexFailuresMu.Lock()
+	defer g.fileIndexFailuresMu.Unlock()
+	if len(byPath) == 0 {
+		delete(g.fileIndexFailures, repoPrefix)
+		return nil
+	}
+	if g.fileIndexFailures == nil {
+		g.fileIndexFailures = make(map[string]map[string]FileIndexFailure)
+	}
+	g.fileIndexFailures[repoPrefix] = byPath
+	return nil
+}
+
+var (
+	_ FileIndexFailureReader = (*Graph)(nil)
+	_ FileIndexFailureWriter = (*Graph)(nil)
+)

--- a/internal/graph/file_index_failures_test.go
+++ b/internal/graph/file_index_failures_test.go
@@ -1,0 +1,48 @@
+package graph
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFileIndexFailuresIsolationAndRecovery(t *testing.T) {
+	g := &Graph{}
+	failures := []FileIndexFailure{{Path: "repo/b.go", Error: "permission denied", PermissionDenied: true}, {Path: "repo/a.go", Error: "read failed"}}
+	if err := g.ReplaceFileIndexFailures("repo", failures); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.ReplaceFileIndexFailures("other", []FileIndexFailure{{Path: "other/a.go", Error: "other failure"}}); err != nil {
+		t.Fatal(err)
+	}
+	failures[0].Error = "caller changed input"
+	got, err := g.FileIndexFailuresForRepo("repo")
+	if err != nil || len(got) != 2 || got[0].Path != "repo/a.go" || got[1].Error != "permission denied" || got[1].RepoPrefix != "repo" {
+		t.Fatalf("failure snapshot = %#v, %v", got, err)
+	}
+	got[0].Error = "caller changed output"
+	again, _ := g.FileIndexFailuresForRepo("repo")
+	if again[0].Error != "read failed" {
+		t.Fatal("caller mutation leaked into the stored snapshot")
+	}
+	if err := g.ReplaceFileIndexFailures("repo", nil); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = g.FileIndexFailuresForRepo("repo")
+	if got == nil || len(got) != 0 {
+		t.Fatalf("recovered repository failures = %#v", got)
+	}
+	other, _ := g.FileIndexFailuresForRepo("other")
+	if len(other) != 1 {
+		t.Fatalf("other repository changed: %#v", other)
+	}
+}
+
+func TestFileIndexFailuresEvictRepoWithoutNodes(t *testing.T) {
+	g := &Graph{}
+	_ = g.ReplaceFileIndexFailures("repo", []FileIndexFailure{{Path: "repo/unreadable.go", Error: "permission denied"}})
+	g.EvictRepo("repo")
+	got, err := g.FileIndexFailuresForRepo("repo")
+	if err != nil || !reflect.DeepEqual(got, []FileIndexFailure{}) {
+		t.Fatalf("evicted repository failures = %#v, %v", got, err)
+	}
+}

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -550,6 +550,9 @@ type Graph struct {
 	fileMetasMu sync.Mutex
 	fileMetas   map[string]map[string]FileMetaRow
 
+	fileIndexFailuresMu sync.Mutex
+	fileIndexFailures   map[string]map[string]FileIndexFailure
+
 	// mutationReceipts backs the optional, in-memory-only mutation receipt
 	// capability used to bound post-enrichment resolution. It is intentionally
 	// absent from disk stores until they can provide the same completeness
@@ -3940,6 +3943,7 @@ func (g *Graph) EvictRepo(repoPrefix string) (nodesRemoved, edgesRemoved int) {
 	if repoPrefix == "" {
 		return 0, 0
 	}
+	_ = g.ReplaceFileIndexFailures(repoPrefix, nil)
 	receiptActive := g.beginReceiptMutation()
 	if receiptActive {
 		defer g.endReceiptMutation()

--- a/internal/graph/overlay_file_index_failures.go
+++ b/internal/graph/overlay_file_index_failures.go
@@ -1,0 +1,34 @@
+package graph
+
+// FileIndexFailureLayerReader identifies a layer whose failure snapshot is
+// authoritative for a repository, including when the snapshot is empty.
+// Filesystem access belongs to a checkout, not to its shared symbol identities.
+type FileIndexFailureLayerReader interface {
+	FileIndexFailureReader
+	OwnsFileIndexFailures(repoPrefix string) bool
+}
+
+func (v *OverlaidView) FileIndexFailuresForRepo(repoPrefix string) ([]FileIndexFailure, error) {
+	if layer, ok := v.layer.(FileIndexFailureLayerReader); ok && layer.OwnsFileIndexFailures(repoPrefix) {
+		return layer.FileIndexFailuresForRepo(repoPrefix)
+	}
+	reader, ok := v.base.(FileIndexFailureReader)
+	if !ok {
+		return nil, nil
+	}
+	failures, err := reader.FileIndexFailuresForRepo(repoPrefix)
+	if err != nil || v.layer == nil {
+		return failures, err
+	}
+	// An editor buffer or tombstone supersedes the base file's content.
+	// Do not qualify that replacement with the hidden base file's failure.
+	visible := make([]FileIndexFailure, 0, len(failures))
+	for _, failure := range failures {
+		if !v.layer.HasFile(failure.Path) {
+			visible = append(visible, failure)
+		}
+	}
+	return visible, nil
+}
+
+var _ FileIndexFailureReader = (*OverlaidView)(nil)

--- a/internal/graph/overlay_file_index_failures_test.go
+++ b/internal/graph/overlay_file_index_failures_test.go
@@ -1,0 +1,60 @@
+package graph
+
+import (
+	"errors"
+	"testing"
+)
+
+type failureSnapshotLayer struct {
+	OverlayLayerReader
+	repo          string
+	authoritative bool
+	failures      []FileIndexFailure
+	covered       map[string]bool
+	err           error
+}
+
+func (l *failureSnapshotLayer) OwnsFileIndexFailures(repo string) bool {
+	return l.authoritative && l.repo == repo
+}
+func (l *failureSnapshotLayer) FileIndexFailuresForRepo(string) ([]FileIndexFailure, error) {
+	return l.failures, l.err
+}
+func (l *failureSnapshotLayer) HasFile(path string) bool { return l.covered[path] }
+
+func TestOverlaidFileIndexFailuresRespectCheckoutAndTombstones(t *testing.T) {
+	base := New()
+	for _, repo := range []string{"repo", "other"} {
+		if err := base.ReplaceFileIndexFailures(repo, []FileIndexFailure{{Path: repo + "/denied.go", RepoPrefix: repo, Error: "permission denied", PermissionDenied: true}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	layer := &failureSnapshotLayer{repo: "repo", authoritative: true}
+	view := NewOverlaidViewWithLayer(base, layer)
+	rows, err := view.FileIndexFailuresForRepo("repo")
+	if err != nil || len(rows) != 0 {
+		t.Fatalf("healthy checkout inherited primary failures: %+v, %v", rows, err)
+	}
+	rows, err = view.FileIndexFailuresForRepo("other")
+	if err != nil || len(rows) != 1 || rows[0].Path != "other/denied.go" {
+		t.Fatalf("unrelated repo lost base failures: %+v, %v", rows, err)
+	}
+	layer.failures = []FileIndexFailure{{Path: "repo/checkout.go", RepoPrefix: "repo", Error: "I/O error"}}
+	rows, err = view.FileIndexFailuresForRepo("repo")
+	if err != nil || len(rows) != 1 || rows[0].Path != "repo/checkout.go" {
+		t.Fatalf("checkout did not supply its own failures: %+v, %v", rows, err)
+	}
+	// Unsaved buffers and deletions mask only covered files; they are not
+	// authoritative for the rest of the repository's disk state.
+	buffer := &failureSnapshotLayer{covered: map[string]bool{"repo/checkout.go": true}}
+	top := NewOverlaidViewWithLayer(view, buffer)
+	rows, err = top.FileIndexFailuresForRepo("repo")
+	if err != nil || len(rows) != 0 {
+		t.Fatalf("covered base failure remained visible: %+v, %v", rows, err)
+	}
+	wantErr := errors.New("failure ledger unavailable")
+	layer.err = wantErr
+	if _, err := view.FileIndexFailuresForRepo("repo"); !errors.Is(err, wantErr) {
+		t.Fatalf("lost ledger read error: %v", err)
+	}
+}

--- a/internal/graph/store_sqlite/file_batch_evict.go
+++ b/internal/graph/store_sqlite/file_batch_evict.go
@@ -154,8 +154,12 @@ func (s *Store) evictByPredicateResult(predicate string, arg any, scope evictSco
 	if _, err := tx.ExecContext(ctx, `DELETE FROM semantic_binding_types WHERE `+scoped, scopeArgs...); err != nil {
 		return 0, 0, err
 	}
-	if _, err := tx.ExecContext(ctx, `DELETE FROM file_index_failures WHERE `+scoped, scopeArgs...); err != nil {
-		return 0, 0, err
+	// File eviction is also used while reparsing. Keep its failure ledger until
+	// the indexer confirms that indexing succeeded or the file was deleted.
+	if predicate == evictRepoPredicate || predicate == evictNonEmptyRepoPredicate {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM file_index_failures WHERE `+scoped, scopeArgs...); err != nil {
+			return 0, 0, err
+		}
 	}
 	scopedNodes := `SELECT id FROM nodes WHERE ` + scoped
 	for _, column := range []string{"from_id", "to_id"} {

--- a/internal/graph/store_sqlite/file_batch_evict.go
+++ b/internal/graph/store_sqlite/file_batch_evict.go
@@ -154,6 +154,9 @@ func (s *Store) evictByPredicateResult(predicate string, arg any, scope evictSco
 	if _, err := tx.ExecContext(ctx, `DELETE FROM semantic_binding_types WHERE `+scoped, scopeArgs...); err != nil {
 		return 0, 0, err
 	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM file_index_failures WHERE `+scoped, scopeArgs...); err != nil {
+		return 0, 0, err
+	}
 	scopedNodes := `SELECT id FROM nodes WHERE ` + scoped
 	for _, column := range []string{"from_id", "to_id"} {
 		result, err := tx.ExecContext(ctx, `DELETE FROM edges WHERE `+column+` IN (`+scopedNodes+`)`+edgeScope, edgeArgs...)

--- a/internal/graph/store_sqlite/schema.go
+++ b/internal/graph/store_sqlite/schema.go
@@ -1234,6 +1234,11 @@ const contentFTSRowidTableBody = ` (
 // scoping runs through the docid maps below them.
 var viewGenSidecars = []viewGenSidecar{
 	{
+		table:   "file_index_failures",
+		body:    fileIndexFailuresTableBody,
+		columns: `repo_prefix, file_path, error, permission_denied, workspace_id, project_id`,
+	},
+	{
 		table:   "file_mtimes",
 		body:    fileMtimesTableBody,
 		columns: `repo_prefix, file_path, mtime_ns`,

--- a/internal/graph/store_sqlite/schema_sidecar_view_gen_test.go
+++ b/internal/graph/store_sqlite/schema_sidecar_view_gen_test.go
@@ -211,6 +211,9 @@ func seedSidecarRows(t *testing.T, store *Store) {
 	}, nil)
 
 	mustNoErr(t, "file mtimes", store.BulkSetFileMtimes(sidecarSeedRepo, map[string]int64{"a.go": 11}))
+	mustNoErr(t, "file indexing failures", store.ReplaceFileIndexFailures(sidecarSeedRepo, []graph.FileIndexFailure{{
+		Path: "repo/unreadable.go", Error: "permission denied", PermissionDenied: true,
+	}}))
 	mustNoErr(t, "repo index state", store.SetRepoIndexState(graph.RepoIndexState{
 		RepoPrefix: sidecarSeedRepo, IndexedSHA: "sha-1", Dirty: true, IndexedAt: 42,
 		WorkspaceFP: "fp-1", NodeCount: 3, EdgeCount: 0, ExtractorVersions: `{"go":1}`,
@@ -280,6 +283,11 @@ func mustNoErr(t *testing.T, what string, err error) {
 func downgradeSidecarsToV14(t *testing.T, db *sql.DB) {
 	t.Helper()
 	for _, sidecar := range viewGenSidecars {
+		if sidecar.table == "file_index_failures" {
+			// This sidecar was introduced at v21; v14 had no table or rows.
+			execDDL(t, db, `DROP TABLE file_index_failures`)
+			continue
+		}
 		legacy, ok := legacySidecarShapes[sidecar.table]
 		if !ok {
 			t.Fatalf("no v14 fixture shape for sidecar %q", sidecar.table)
@@ -416,6 +424,12 @@ func TestSchemaV14StoreGainsSidecarViewGenerationKeys(t *testing.T) {
 	// Every sidecar kept exactly its seeded rows, all at the base generation.
 	for _, sidecar := range viewGenSidecars {
 		gens := rowViewGens(t, migrated.writerDB, sidecar.table)
+		if sidecar.table == "file_index_failures" {
+			if len(gens) != 0 {
+				t.Fatal("new failure sidecar must start empty after migrating v14")
+			}
+			continue
+		}
 		if len(gens) == 0 {
 			t.Fatalf("%s lost every row across the migration", sidecar.table)
 		}

--- a/internal/graph/store_sqlite/schema_version.go
+++ b/internal/graph/store_sqlite/schema_version.go
@@ -34,7 +34,7 @@ import (
 // index changes in a way an old on-disk DB would not already have, and append a
 // matching schemaMigrations entry describing how to bring an older store
 // forward (in place, or by rebuild).
-const currentSchemaVersion = 20
+const currentSchemaVersion = 21
 
 // schemaMigration is one forward step. Exactly one strategy applies:
 //   - rebuild=true: the change introduces structure/data that can only come
@@ -117,6 +117,7 @@ var schemaMigrations = []schemaMigration{
 	{version: 18, name: "add sparse generation ownership masks", inPlace: createGenerationMaskTables},
 	{version: 19, name: "purge legacy slash-spelled coverage artifacts", inPlace: purgeLegacyCoverageSpellings},
 	{version: 20, name: "purge unresolved derived tests edges", inPlace: purgeUnresolvedTestsEdges},
+	{version: 21, name: "persist per-file indexing failures", inPlace: createFileIndexFailuresTable},
 }
 
 // createGenerationMaskTables is the explicit v18 migration. The mask tables are

--- a/internal/graph/store_sqlite/store_file_index_failures.go
+++ b/internal/graph/store_sqlite/store_file_index_failures.go
@@ -1,0 +1,76 @@
+package store_sqlite
+
+import (
+	"database/sql"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+const fileIndexFailuresTableBody = ` (
+    view_gen          INTEGER NOT NULL DEFAULT 0,
+    repo_prefix       TEXT NOT NULL,
+    file_path         TEXT NOT NULL,
+    error             TEXT NOT NULL,
+    permission_denied INTEGER NOT NULL DEFAULT 0,
+    workspace_id      TEXT NOT NULL DEFAULT '',
+    project_id        TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (view_gen, repo_prefix, file_path)
+) WITHOUT ROWID`
+
+func createFileIndexFailuresTable(tx *sql.Tx) error {
+	_, err := tx.Exec("CREATE TABLE IF NOT EXISTS file_index_failures" + fileIndexFailuresTableBody)
+	return err
+}
+
+func (s *Store) FileIndexFailuresForRepo(repoPrefix string) ([]graph.FileIndexFailure, error) {
+	rows, err := s.db.Query(`SELECT file_path, error, permission_denied, workspace_id, project_id
+FROM file_index_failures WHERE view_gen = ? AND repo_prefix = ? ORDER BY file_path`, s.viewGen, repoPrefix)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []graph.FileIndexFailure{}
+	for rows.Next() {
+		failure := graph.FileIndexFailure{RepoPrefix: repoPrefix}
+		if err := rows.Scan(&failure.Path, &failure.Error, &failure.PermissionDenied, &failure.WorkspaceID, &failure.ProjectID); err != nil {
+			return nil, err
+		}
+		out = append(out, failure)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) ReplaceFileIndexFailures(repoPrefix string, failures []graph.FileIndexFailure) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	tx, err := s.beginWrite()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback() //nolint:errcheck // rollback after Commit is a no-op
+	if _, err := tx.Exec(`DELETE FROM file_index_failures WHERE view_gen = ? AND repo_prefix = ?`, s.viewGen, repoPrefix); err != nil {
+		return err
+	}
+	// Seven parameters per row; share the bounded file-metadata batch size.
+	for start := 0; start < len(failures); start += fileMetaChunk {
+		batch := failures[start:min(start+fileMetaChunk, len(failures))]
+		stmt := []byte("INSERT OR REPLACE INTO file_index_failures (view_gen, repo_prefix, file_path, error, permission_denied, workspace_id, project_id) VALUES ")
+		args := make([]any, 0, len(batch)*7)
+		for i, failure := range batch {
+			if i > 0 {
+				stmt = append(stmt, ',')
+			}
+			stmt = append(stmt, "(?, ?, ?, ?, ?, ?, ?)"...)
+			args = append(args, s.viewGen, repoPrefix, failure.Path, failure.Error, failure.PermissionDenied, failure.WorkspaceID, failure.ProjectID)
+		}
+		if _, err := tx.Exec(string(stmt), args...); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
+var (
+	_ graph.FileIndexFailureReader = (*Store)(nil)
+	_ graph.FileIndexFailureWriter = (*Store)(nil)
+)

--- a/internal/graph/store_sqlite/store_file_index_failures_test.go
+++ b/internal/graph/store_sqlite/store_file_index_failures_test.go
@@ -9,6 +9,43 @@ import (
 	"github.com/zzet/gortex/internal/graph"
 )
 
+func TestFileIndexFailuresSurviveFileEviction(t *testing.T) {
+	s, err := Open(t.TempDir() + "/graph.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	const repo = "example/repo"
+	failures := []graph.FileIndexFailure{
+		{Path: "unreadable.go", Error: "permission denied", PermissionDenied: true},
+		{Path: "other.go", Error: "read failed"},
+	}
+	if err := s.ReplaceFileIndexFailures(repo, failures); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, paths := range [][]string{{"unreadable.go"}, {"unreadable.go", "other.go"}} {
+		s.EvictFiles(paths)
+		got, err := s.FileIndexFailuresForRepo(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != len(failures) {
+			t.Fatalf("EvictFiles(%v) cleared unresolved failures: got %+v", paths, got)
+		}
+	}
+
+	s.EvictRepo(repo)
+	got, err := s.FileIndexFailuresForRepo(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("repository eviction retained failures: %+v", got)
+	}
+}
+
 func TestFileIndexFailuresPersistAndScope(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "graph.db")
 	s, err := Open(path)

--- a/internal/graph/store_sqlite/store_file_index_failures_test.go
+++ b/internal/graph/store_sqlite/store_file_index_failures_test.go
@@ -1,0 +1,113 @@
+package store_sqlite
+
+import (
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestFileIndexFailuresPersistAndScope(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "graph.db")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []graph.FileIndexFailure{{Path: "repo/unreadable.go", Error: "open: permission denied", PermissionDenied: true, RepoPrefix: "repo", WorkspaceID: "workspace", ProjectID: "project"}}
+	if err := s.ReplaceFileIndexFailures("repo", want); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ReplaceFileIndexFailures("other", []graph.FileIndexFailure{{Path: "other/a.go", Error: "other failure"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	s, err = Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	got, err := s.FileIndexFailuresForRepo("repo")
+	if err != nil || !reflect.DeepEqual(got, want) {
+		t.Fatalf("reopened failures = %#v, %v; want %#v", got, err, want)
+	}
+	// A different generation must treat its empty ledger as authoritative.
+	otherView := *s
+	otherView.viewGen = 17
+	otherView.ownsCore = false
+	got, err = otherView.FileIndexFailuresForRepo("repo")
+	if err != nil || got == nil || len(got) != 0 {
+		t.Fatalf("healthy generation inherited failures: %#v, %v", got, err)
+	}
+	if err := otherView.ReplaceFileIndexFailures("repo", []graph.FileIndexFailure{{Path: "repo/different.go", Error: "generation failure"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ReplaceFileIndexFailures("repo", nil); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = otherView.FileIndexFailuresForRepo("repo")
+	if len(got) != 1 || got[0].Path != "repo/different.go" {
+		t.Fatalf("base recovery changed another generation: %#v", got)
+	}
+	if err := s.PurgeRepo("repo"); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = otherView.FileIndexFailuresForRepo("repo")
+	if len(got) != 0 {
+		t.Fatalf("purge left generation failures: %#v", got)
+	}
+	got, _ = s.FileIndexFailuresForRepo("other")
+	if len(got) != 1 {
+		t.Fatalf("purge changed another repository: %#v", got)
+	}
+}
+
+func TestFileIndexFailuresReplacementIsAtomic(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "graph.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	want := []graph.FileIndexFailure{{Path: "repo/original.go", Error: "original", RepoPrefix: "repo"}}
+	if err := s.ReplaceFileIndexFailures("repo", want); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.writerDB.Exec(`CREATE TRIGGER reject_failure BEFORE INSERT ON file_index_failures
+WHEN NEW.error = 'reject' BEGIN SELECT RAISE(ABORT, 'test failure'); END`); err != nil {
+		t.Fatal(err)
+	}
+	batch := make([]graph.FileIndexFailure, fileMetaChunk+1)
+	for i := range batch {
+		batch[i] = graph.FileIndexFailure{Path: fmt.Sprintf("repo/%03d.go", i), Error: "failure"}
+	}
+	batch[len(batch)-1].Error = "reject"
+	if err := s.ReplaceFileIndexFailures("repo", batch); err == nil {
+		t.Fatal("expected replacement to fail")
+	}
+	got, err := s.FileIndexFailuresForRepo("repo")
+	if err != nil || !reflect.DeepEqual(got, want) {
+		t.Fatalf("failed replacement changed snapshot: %#v, %v", got, err)
+	}
+}
+
+func TestFileIndexFailuresEvictWithoutNodes(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "graph.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	if err := s.ReplaceFileIndexFailures("repo", []graph.FileIndexFailure{{Path: "repo/unreadable.go", Error: "permission denied"}}); err != nil {
+		t.Fatal(err)
+	}
+	if got := s.OrphanRepoPrefixes(nil); !reflect.DeepEqual(got, []string{"repo"}) {
+		t.Fatalf("failure-only orphan was not found: %v", got)
+	}
+	s.EvictRepo("repo")
+	got, err := s.FileIndexFailuresForRepo("repo")
+	if err != nil || len(got) != 0 {
+		t.Fatalf("eviction left failures: %#v, %v", got, err)
+	}
+}

--- a/internal/graph/store_sqlite/store_generation_read_test.go
+++ b/internal/graph/store_sqlite/store_generation_read_test.go
@@ -1742,6 +1742,8 @@ func generationCapabilityChecklist() []capabilityCase {
 		{iface: (*graph.FileEditingContext)(nil), probe: "FileEditingContext"},
 		{iface: (*graph.FileImportAggregator)(nil), probe: "FileImportCounts"},
 		{iface: (*graph.FileImporters)(nil), probe: "FileImporters"},
+		{iface: (*graph.FileIndexFailureReader)(nil), skip: "v21 generation-keyed sidecar; read/write isolation and recovery covered by TestFileIndexFailuresPersistAndScope"},
+		{iface: (*graph.FileIndexFailureWriter)(nil), skip: "v21 generation-keyed sidecar; read/write isolation and recovery covered by TestFileIndexFailuresPersistAndScope"},
 		{iface: (*graph.FileLanguageNodeSequencer)(nil), probe: "NodesLightSeq"},
 		{iface: (*graph.FileMetaPathReader)(nil), skip: skipSidecar},
 		{iface: (*graph.FileMetaReader)(nil), skip: skipSidecar},

--- a/internal/graph/store_sqlite/store_purge.go
+++ b/internal/graph/store_sqlite/store_purge.go
@@ -41,6 +41,7 @@ import (
 // unlike the per-edit hot path. Vectors are repo-keyed too; deleting them by
 // repo_prefix is essential because synthetic chunk IDs are not graph node IDs.
 var purgeSidecarTables = []string{
+	"file_index_failures",
 	"file_mtimes",
 	"repo_index_state",
 	"symbol_fts_state",
@@ -149,6 +150,7 @@ func (s *Store) PurgeRepo(prefix string) error {
 // A prefix whose nodes are gone but whose sidecars remain is invisible to a
 // nodes-only scan, which is why the sidecar tables are unioned in.
 var orphanScanTables = []string{
+	"file_index_failures",
 	"nodes",
 	"file_mtimes",
 	"repo_index_state",
@@ -246,6 +248,7 @@ var rekeyMoveTables = []string{
 // too — their rows carry the old node ids, and UPDATE over an FTS5 UNINDEXED
 // column is awkward, so delete-then-reindex is the clean path.
 var rekeyDropTables = []string{
+	"file_index_failures",
 	"semantic_binding_types",
 	"clone_shingles",
 	"clone_corpus_state",

--- a/internal/graphview/file_index_failures.go
+++ b/internal/graphview/file_index_failures.go
@@ -1,0 +1,13 @@
+package graphview
+
+import "github.com/zzet/gortex/internal/graph"
+
+func (l *GenerationLayer) OwnsFileIndexFailures(repoPrefix string) bool {
+	return l.failureRepoScoped && l.failureRepoPrefix == repoPrefix
+}
+
+func (l *GenerationLayer) FileIndexFailuresForRepo(repoPrefix string) ([]graph.FileIndexFailure, error) {
+	return l.handle.FileIndexFailuresForRepo(repoPrefix)
+}
+
+var _ graph.FileIndexFailureLayerReader = (*GenerationLayer)(nil)

--- a/internal/graphview/file_index_failures_test.go
+++ b/internal/graphview/file_index_failures_test.go
@@ -1,0 +1,14 @@
+package graphview
+
+import "testing"
+
+func TestGenerationLayerFileFailureOwnership(t *testing.T) {
+	layer := &GenerationLayer{}
+	if layer.OwnsFileIndexFailures("") || layer.OwnsFileIndexFailures("repo") {
+		t.Fatal("unbound generation claimed checkout file health")
+	}
+	layer.failureRepoPrefix, layer.failureRepoScoped = "repo", true
+	if !layer.OwnsFileIndexFailures("repo") || layer.OwnsFileIndexFailures("other") {
+		t.Fatal("generation failure scope crossed repository boundaries")
+	}
+}

--- a/internal/graphview/generation_layer.go
+++ b/internal/graphview/generation_layer.go
@@ -88,6 +88,10 @@ import (
 // A GenerationLayer is safe for concurrent reads from one request.
 type GenerationLayer struct {
 	handle *store_sqlite.Store
+	// Set by the materializer before publication. A healthy checkout must
+	// not inherit filesystem failures from its designated primary.
+	failureRepoPrefix string
+	failureRepoScoped bool
 
 	// covered maps a covered graph path to what the generation claims
 	// about it. Both modes hide the layer below; only delete tombstones.

--- a/internal/graphview/materialize.go
+++ b/internal/graphview/materialize.go
@@ -488,6 +488,8 @@ func (m *Materializer) assemble(
 	open := func(generationID int64) (*store_sqlite.Store, *GenerationLayer, store_sqlite.ViewGeneration, error) {
 		handle, layer, row, openErr := m.openGeneration(ctx, generationID)
 		if openErr == nil {
+			layer.failureRepoPrefix = repoPrefix
+			layer.failureRepoScoped = true
 			handles = append(handles, handle)
 			sources = append(sources, GenerationSource{
 				Generation: generationID, Handle: handle, Layer: layer,

--- a/internal/indexer/checkout_coordinator_test.go
+++ b/internal/indexer/checkout_coordinator_test.go
@@ -1703,8 +1703,20 @@ func TestCheckoutLifecycleRunsACoordinatorPerAutomaticCheckout(t *testing.T) {
 
 	// The worktree leaves. The removal clock has to expire before the identity
 	// goes, and the coordinator goes with it.
-	if err := os.RemoveAll(worktree); err != nil {
-		t.Fatalf("remove the worktree: %v", err)
+	// The coordinator is deliberately still running: its asynchronous git
+	// samples can briefly hold the directory as a subprocess's working
+	// directory, which prevents removal on Windows. Wait for that transient
+	// handle to clear without closing the coordinator ahead of the sweep.
+	removeDeadline := time.Now().Add(5 * time.Second)
+	for {
+		err := os.RemoveAll(worktree)
+		if err == nil {
+			break
+		}
+		if time.Now().After(removeDeadline) {
+			t.Fatalf("remove the worktree: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 	if _, err := f.lc.Sweep(ctx); err != nil {
 		t.Fatalf("sweep after the removal: %v", err)

--- a/internal/indexer/file_delta.go
+++ b/internal/indexer/file_delta.go
@@ -49,6 +49,7 @@ type preparedExtraction struct {
 // fileDeltaProbe exposes phase timings and the three delta boundaries used by
 // the watcher: metadata-only, artifact-only, and semantic topology.
 type fileDeltaProbe struct {
+	readErr         error
 	fingerprints    fileDeltaFingerprints
 	derived         derivedFingerprints
 	read            time.Duration
@@ -90,6 +91,7 @@ func (idx *Indexer) prepareFileDeltaWithAdmission(filePath string, tryOnly bool)
 	} else {
 		parseLease, err = idx.acquireSharedParsePath(absPath)
 		if err != nil {
+			probe.readErr = err
 			return probe, false, false
 		}
 	}
@@ -115,6 +117,7 @@ func (idx *Indexer) prepareFileDeltaWithAdmission(filePath string, tryOnly bool)
 	src, readVersion, err := idx.readFileWithVersion(absPath)
 	probe.read = time.Since(started)
 	if err != nil {
+		probe.readErr = err
 		return probe, false, false
 	}
 	lang, ok := idx.effectiveLanguage(absPath, src)
@@ -581,15 +584,15 @@ func extractionFingerprints(result *parser.ExtractionResult) (fileDeltaFingerpri
 		}
 	}
 	return fileDeltaFingerprints{
-		metadata: stableFingerprintDigests(metadataRows),
-		semantic: stableFingerprintDigests(semanticRows),
-		core:     stableFingerprintDigests(coreRows),
-	}, derivedFingerprints{
-		declarations: stableFingerprintDigests(declarations),
-		imports:      stableFingerprintDigests(imports),
-		runtime:      stableFingerprintDigests(runtimeRows),
-		artifacts:    stableFingerprintDigests(artifacts),
-	}, true
+			metadata: stableFingerprintDigests(metadataRows),
+			semantic: stableFingerprintDigests(semanticRows),
+			core:     stableFingerprintDigests(coreRows),
+		}, derivedFingerprints{
+			declarations: stableFingerprintDigests(declarations),
+			imports:      stableFingerprintDigests(imports),
+			runtime:      stableFingerprintDigests(runtimeRows),
+			artifacts:    stableFingerprintDigests(artifacts),
+		}, true
 }
 
 func stampExtractionGraphFingerprints(result *parser.ExtractionResult, fingerprints fileDeltaFingerprints) {

--- a/internal/indexer/file_index_failures.go
+++ b/internal/indexer/file_index_failures.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer/source"
 	"go.uber.org/zap"
 )
 
@@ -20,24 +21,29 @@ type FileIndexFailure = graph.FileIndexFailure
 // LoadFileIndexFailures reads failures from the selected graph view. An absent
 // capability has no failure ledger; it must never fall back to another view.
 func LoadFileIndexFailures(g graph.Reader, repoPrefix string) []FileIndexFailure {
+	rows, _ := LoadFileIndexFailuresWithError(g, repoPrefix)
+	return rows
+}
+
+// LoadFileIndexFailuresWithError lets health consumers distinguish unavailable
+// failure state from a healthy, empty ledger.
+func LoadFileIndexFailuresWithError(g graph.Reader, repoPrefix string) ([]FileIndexFailure, error) {
 	reader, ok := g.(graph.FileIndexFailureReader)
 	if !ok {
-		return nil
+		return nil, nil
 	}
-	rows, err := reader.FileIndexFailuresForRepo(repoPrefix)
-	if err != nil {
-		return nil
-	}
-	return rows
+	return reader.FileIndexFailuresForRepo(repoPrefix)
 }
 
 type fileIndexFailureState struct {
 	mu               sync.Mutex
 	loaded           bool
+	loadErr          error
 	dirty            bool
 	permissionWarned bool
 	rows             map[string]FileIndexFailure
 	errors           map[string]error
+	cleared          map[string]struct{}
 }
 
 // The repository mutation lane serializes passes. The state mutex also covers
@@ -49,9 +55,12 @@ func (idx *Indexer) loadFileIndexFailuresLocked() {
 	}
 	state.rows = make(map[string]FileIndexFailure)
 	state.errors = make(map[string]error)
+	state.cleared = make(map[string]struct{})
+	state.loaded = true
 	if reader, ok := idx.graph.(graph.FileIndexFailureReader); ok {
 		rows, err := reader.FileIndexFailuresForRepo(idx.repoPrefix)
 		if err != nil {
+			state.loadErr = err
 			idx.logger.Warn("indexer: loading file failures failed", zap.String("repo", idx.repoPrefix), zap.Error(err))
 			return
 		}
@@ -59,12 +68,29 @@ func (idx *Indexer) loadFileIndexFailuresLocked() {
 			state.rows[row.Path] = row
 		}
 	}
-	state.loaded = true
 }
 
 func (idx *Indexer) loadFileIndexFailures() {
 	idx.fileIndexFailures.mu.Lock()
 	defer idx.fileIndexFailures.mu.Unlock()
+	state := &idx.fileIndexFailures
+	if state.loaded && state.loadErr != nil {
+		// Retry only at a pass boundary. A failed initial load must not turn
+		// every file into a store read or discard newly observed failures.
+		if reader, ok := idx.graph.(graph.FileIndexFailureReader); ok {
+			rows, err := reader.FileIndexFailuresForRepo(idx.repoPrefix)
+			if err == nil {
+				for _, row := range rows {
+					_, cleared := state.cleared[row.Path]
+					if _, observed := state.rows[row.Path]; !observed && !cleared {
+						state.rows[row.Path] = row
+					}
+				}
+				state.loadErr = nil
+				clear(state.cleared)
+			}
+		}
+	}
 	idx.loadFileIndexFailuresLocked()
 }
 
@@ -75,6 +101,10 @@ func (idx *Indexer) noteFileIndexFailure(path string, err error) {
 	defer state.mu.Unlock()
 	idx.loadFileIndexFailuresLocked()
 	if err == nil {
+		if state.loadErr != nil {
+			state.cleared[graphPath] = struct{}{}
+			state.dirty = true
+		}
 		if _, exists := state.rows[graphPath]; exists {
 			delete(state.rows, graphPath)
 			delete(state.errors, graphPath)
@@ -82,6 +112,7 @@ func (idx *Indexer) noteFileIndexFailure(path string, err error) {
 		}
 		return
 	}
+	delete(state.cleared, graphPath)
 	row := FileIndexFailure{
 		Path: graphPath, Error: err.Error(), PermissionDenied: errors.Is(err, os.ErrPermission),
 		RepoPrefix: idx.repoPrefix, WorkspaceID: idx.workspaceID, ProjectID: idx.projectID,
@@ -125,15 +156,18 @@ func (idx *Indexer) fileIndexFailurePaths() []string {
 }
 
 func (idx *Indexer) pruneMissingFileIndexFailures() {
-	if idx.contentSource() != nil {
-		return
-	}
 	for _, graphPath := range idx.fileIndexFailurePaths() {
 		relPath, ok := idx.graphPathRelKey(graphPath)
 		if !ok {
 			continue
 		}
 		path := filepath.Join(idx.rootPath, filepath.FromSlash(relPath))
+		if src := idx.contentSource(); src != nil {
+			if _, err := src.Stat(relPath); errors.Is(err, source.ErrNotInSource) {
+				idx.noteFileIndexFailure(path, nil)
+			}
+			continue
+		}
 		if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
 			idx.noteFileIndexFailure(path, nil)
 		}
@@ -159,7 +193,10 @@ func (idx *Indexer) flushFileIndexFailures() {
 			}
 		}
 	}
-	if state.dirty {
+	if state.dirty && state.loadErr != nil {
+		idx.logger.Warn("indexer: file failure state unavailable; retaining pending updates",
+			zap.String("repo", idx.repoPrefix), zap.Error(state.loadErr))
+	} else if state.dirty {
 		sort.Slice(rows, func(i, j int) bool { return rows[i].Path < rows[j].Path })
 		if writer, ok := idx.graph.(graph.FileIndexFailureWriter); ok {
 			if err := writer.ReplaceFileIndexFailures(idx.repoPrefix, rows); err != nil {

--- a/internal/indexer/file_index_failures.go
+++ b/internal/indexer/file_index_failures.go
@@ -1,0 +1,184 @@
+package indexer
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"sync"
+
+	"github.com/zzet/gortex/internal/graph"
+	"go.uber.org/zap"
+)
+
+// FileIndexFailure records an unsuccessful indexing attempt separately from
+// the last successful file snapshot.
+type FileIndexFailure = graph.FileIndexFailure
+
+// LoadFileIndexFailures reads failures from the selected graph view. An absent
+// capability has no failure ledger; it must never fall back to another view.
+func LoadFileIndexFailures(g graph.Reader, repoPrefix string) []FileIndexFailure {
+	reader, ok := g.(graph.FileIndexFailureReader)
+	if !ok {
+		return nil
+	}
+	rows, err := reader.FileIndexFailuresForRepo(repoPrefix)
+	if err != nil {
+		return nil
+	}
+	return rows
+}
+
+type fileIndexFailureState struct {
+	mu               sync.Mutex
+	loaded           bool
+	dirty            bool
+	permissionWarned bool
+	rows             map[string]FileIndexFailure
+	errors           map[string]error
+}
+
+// The repository mutation lane serializes passes. The state mutex also covers
+// full-index parse workers; persistence happens once after those workers join.
+func (idx *Indexer) loadFileIndexFailuresLocked() {
+	state := &idx.fileIndexFailures
+	if state.loaded {
+		return
+	}
+	state.rows = make(map[string]FileIndexFailure)
+	state.errors = make(map[string]error)
+	if reader, ok := idx.graph.(graph.FileIndexFailureReader); ok {
+		rows, err := reader.FileIndexFailuresForRepo(idx.repoPrefix)
+		if err != nil {
+			idx.logger.Warn("indexer: loading file failures failed", zap.String("repo", idx.repoPrefix), zap.Error(err))
+			return
+		}
+		for _, row := range rows {
+			state.rows[row.Path] = row
+		}
+	}
+	state.loaded = true
+}
+
+func (idx *Indexer) loadFileIndexFailures() {
+	idx.fileIndexFailures.mu.Lock()
+	defer idx.fileIndexFailures.mu.Unlock()
+	idx.loadFileIndexFailuresLocked()
+}
+
+func (idx *Indexer) noteFileIndexFailure(path string, err error) {
+	graphPath := idx.prefixPath(idx.relKey(path))
+	state := &idx.fileIndexFailures
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	idx.loadFileIndexFailuresLocked()
+	if err == nil {
+		if _, exists := state.rows[graphPath]; exists {
+			delete(state.rows, graphPath)
+			delete(state.errors, graphPath)
+			state.dirty = true
+		}
+		return
+	}
+	row := FileIndexFailure{
+		Path: graphPath, Error: err.Error(), PermissionDenied: errors.Is(err, os.ErrPermission),
+		RepoPrefix: idx.repoPrefix, WorkspaceID: idx.workspaceID, ProjectID: idx.projectID,
+	}
+	if old, exists := state.rows[graphPath]; !exists || old != row {
+		state.rows[graphPath] = row
+		state.dirty = true
+	}
+	state.errors[graphPath] = err
+}
+
+func (idx *Indexer) fileIndexFailureError(path string) error {
+	graphPath := idx.prefixPath(idx.relKey(path))
+	state := &idx.fileIndexFailures
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	idx.loadFileIndexFailuresLocked()
+	if err := state.errors[graphPath]; err != nil {
+		return err
+	}
+	if row, exists := state.rows[graphPath]; exists {
+		if row.PermissionDenied {
+			return fmt.Errorf("%s: %w", row.Error, os.ErrPermission)
+		}
+		return errors.New(row.Error)
+	}
+	return errFileVersionChanged
+}
+
+func (idx *Indexer) fileIndexFailurePaths() []string {
+	state := &idx.fileIndexFailures
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	idx.loadFileIndexFailuresLocked()
+	paths := make([]string, 0, len(state.rows))
+	for path := range state.rows {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func (idx *Indexer) pruneMissingFileIndexFailures() {
+	if idx.contentSource() != nil {
+		return
+	}
+	for _, graphPath := range idx.fileIndexFailurePaths() {
+		relPath, ok := idx.graphPathRelKey(graphPath)
+		if !ok {
+			continue
+		}
+		path := filepath.Join(idx.rootPath, filepath.FromSlash(relPath))
+		if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+			idx.noteFileIndexFailure(path, nil)
+		}
+	}
+}
+
+func (idx *Indexer) flushFileIndexFailures() {
+	state := &idx.fileIndexFailures
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if !state.loaded {
+		return
+	}
+	rows := make([]FileIndexFailure, 0, len(state.rows))
+	permissionCount := 0
+	var example FileIndexFailure
+	for _, row := range state.rows {
+		rows = append(rows, row)
+		if row.PermissionDenied {
+			permissionCount++
+			if example.Path == "" || row.Path < example.Path {
+				example = row
+			}
+		}
+	}
+	if state.dirty {
+		sort.Slice(rows, func(i, j int) bool { return rows[i].Path < rows[j].Path })
+		if writer, ok := idx.graph.(graph.FileIndexFailureWriter); ok {
+			if err := writer.ReplaceFileIndexFailures(idx.repoPrefix, rows); err != nil {
+				idx.logger.Warn("indexer: persisting file failures failed", zap.String("repo", idx.repoPrefix), zap.Error(err))
+				return
+			}
+			state.dirty = false
+		}
+	}
+	if permissionCount == 0 {
+		state.permissionWarned = false
+	} else if !state.permissionWarned {
+		hint := "Check file and directory permissions for the account running Gortex, then reindex."
+		if runtime.GOOS == "darwin" {
+			hint = "Check System Settings > Privacy & Security > Full Disk Access for the app or service running Gortex, then restart it and reindex."
+		}
+		idx.logger.Warn("indexer: repository indexing incomplete due to filesystem permissions",
+			zap.String("repo", idx.repoPrefix), zap.Int("unreadable_files", permissionCount),
+			zap.String("file", example.Path), zap.String("error", example.Error), zap.String("hint", hint))
+		state.permissionWarned = true
+	}
+}

--- a/internal/indexer/file_index_failures.go
+++ b/internal/indexer/file_index_failures.go
@@ -46,6 +46,44 @@ type fileIndexFailureState struct {
 	cleared          map[string]struct{}
 }
 
+// clearRecoveredParseErrors runs once after a completed incremental mutation,
+// not once per file. The final failed set wins over preliminary read or walk
+// successes, and only explicitly recovered/deleted paths lose old diagnostics.
+func (idx *Indexer) clearRecoveredParseErrors(successful, failed, deleted []string) {
+	if len(successful)+len(deleted) == 0 {
+		return
+	}
+	key := func(path string) string {
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(idx.rootPath, filepath.FromSlash(path))
+		}
+		return idx.relKey(path)
+	}
+	recovered := make(map[string]struct{}, len(successful)+len(deleted))
+	for _, path := range successful {
+		recovered[key(path)] = struct{}{}
+	}
+	for _, path := range deleted {
+		recovered[key(path)] = struct{}{}
+	}
+	for _, path := range failed {
+		delete(recovered, key(path))
+	}
+	if len(recovered) == 0 {
+		return
+	}
+	idx.parseErrorsMu.Lock()
+	defer idx.parseErrorsMu.Unlock()
+	retained := idx.parseErrors[:0]
+	for _, failure := range idx.parseErrors {
+		if _, ok := recovered[key(failure.FilePath)]; !ok {
+			retained = append(retained, failure)
+		}
+	}
+	clear(idx.parseErrors[len(retained):])
+	idx.parseErrors = retained
+}
+
 // The repository mutation lane serializes passes. The state mutex also covers
 // full-index parse workers; persistence happens once after those workers join.
 func (idx *Indexer) loadFileIndexFailuresLocked() {

--- a/internal/indexer/file_index_failures_test.go
+++ b/internal/indexer/file_index_failures_test.go
@@ -1,0 +1,157 @@
+package indexer
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer/source"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+type failingIndexSource struct {
+	source.ContentSource
+	mu    sync.Mutex
+	errs  map[string][]error
+	opens map[string]int
+}
+
+func (s *failingIndexSource) Open(path string) (io.ReadCloser, source.FileMeta, error) {
+	s.mu.Lock()
+	s.opens[path]++
+	errs := s.errs[path]
+	if len(errs) > 0 {
+		err := errs[0]
+		if len(errs) > 1 {
+			s.errs[path] = errs[1:]
+		}
+		s.mu.Unlock()
+		return nil, source.FileMeta{}, fmt.Errorf("source open failed: %w", &os.PathError{Op: "open", Path: path, Err: err})
+	}
+	s.mu.Unlock()
+	return s.ContentSource.Open(path)
+}
+
+type failureCountingStore struct {
+	*graph.Graph
+	writes int
+}
+
+func (g *failureCountingStore) ReplaceFileIndexFailures(repo string, rows []graph.FileIndexFailure) error {
+	g.writes++
+	return g.Graph.ReplaceFileIndexFailures(repo, rows)
+}
+
+func TestIncrementalPermissionFailuresRetainCauseWithoutRetry(t *testing.T) {
+	root := t.TempDir()
+	paths := []string{filepath.Join(root, "denied.go"), filepath.Join(root, "blocked.go")}
+	for _, path := range paths {
+		require.NoError(t, os.WriteFile(path, []byte("package p\nfunc Keep() {}\n"), 0o600))
+	}
+	g := &failureCountingStore{Graph: graph.New()}
+	idx := newContentSourceIndexer(t, g)
+	idx.SetRepoPrefix("repo")
+	idx.SetWorkspaceID("workspace")
+	idx.SetProjectID("project")
+	_, err := idx.Index(root)
+	require.NoError(t, err)
+	beforeNodes, beforeEdges := graphShape(g)
+	beforeMtimes := idx.FileMtimes()
+	fsSource, err := source.NewFilesystemSource(root)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = fsSource.Close() })
+	failing := &failingIndexSource{ContentSource: fsSource, opens: map[string]int{}, errs: map[string][]error{
+		"denied.go": {syscall.EACCES}, "blocked.go": {syscall.EPERM},
+	}}
+	idx.SetContentSource(failing)
+	core, logs := observer.New(zap.DebugLevel)
+	idx.logger = zap.New(core)
+	_, _, failed, raced := idx.reindexIncrementalFilesBatched(paths, nil, nil, false)
+	require.ElementsMatch(t, paths, failed)
+	require.Empty(t, raced)
+	require.Equal(t, map[string]int{"denied.go": 1, "blocked.go": 1}, failing.opens)
+	require.ErrorIs(t, idx.fileIndexFailureError(paths[0]), syscall.EACCES)
+	require.ErrorIs(t, idx.fileIndexFailureError(paths[1]), syscall.EPERM)
+	rows := LoadFileIndexFailures(g, "repo")
+	require.Len(t, rows, 2)
+	require.Equal(t, 1, g.writes, "the batch persists the ledger once, not once per file")
+	for _, row := range rows {
+		require.True(t, row.PermissionDenied)
+		require.Contains(t, row.Error, "source open failed: open")
+		require.Equal(t, "repo", row.RepoPrefix)
+		require.Equal(t, "workspace", row.WorkspaceID)
+		require.Equal(t, "project", row.ProjectID)
+	}
+	afterNodes, afterEdges := graphShape(g)
+	require.Equal(t, beforeNodes, afterNodes)
+	require.Equal(t, beforeEdges, afterEdges)
+	require.Equal(t, beforeMtimes, idx.FileMtimes())
+	warnings := logs.FilterMessage("indexer: repository indexing incomplete due to filesystem permissions")
+	require.Equal(t, 1, warnings.Len())
+	require.Equal(t, int64(2), warnings.All()[0].ContextMap()["unreadable_files"])
+	require.Contains(t, warnings.All()[0].ContextMap()["error"], "operation not permitted")
+	_, _, _, _ = idx.reindexIncrementalFilesBatched(paths, nil, nil, false)
+	require.Equal(t, 1, logs.FilterMessage("indexer: repository indexing incomplete due to filesystem permissions").Len())
+	require.Equal(t, 1, g.writes, "unchanged failures do not rewrite the ledger")
+
+	idx.SetContentSource(fsSource)
+	_, _, failed, raced = idx.reindexIncrementalFilesBatched(paths, nil, nil, false)
+	require.Empty(t, failed)
+	require.Empty(t, raced)
+	require.Empty(t, LoadFileIndexFailures(g, "repo"), "successful inert receipts clear failures too")
+}
+
+func TestIncrementalRetryLogsTerminalReadError(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "source.go")
+	require.NoError(t, os.WriteFile(path, []byte("package p\n"), 0o600))
+	g := graph.New()
+	idx := newContentSourceIndexer(t, g)
+	idx.SetRootPath(root)
+	fsSource, err := source.NewFilesystemSource(root)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = fsSource.Close() })
+	failing := &failingIndexSource{ContentSource: fsSource, opens: map[string]int{}, errs: map[string][]error{
+		"source.go": {syscall.EIO, syscall.ENOSPC},
+	}}
+	idx.SetContentSource(failing)
+	core, logs := observer.New(zap.DebugLevel)
+	idx.logger = zap.New(core)
+	_, _, failed, raced := idx.reindexIncrementalFilesBatched([]string{path}, nil, nil, false)
+	require.Equal(t, []string{path}, failed)
+	require.Empty(t, raced)
+	require.Equal(t, 2, failing.opens["source.go"])
+	require.ErrorIs(t, idx.fileIndexFailureError(path), syscall.ENOSPC)
+	warnings := logs.FilterMessage("incremental reindex: file failed after retry").All()
+	require.Len(t, warnings, 1)
+	require.Contains(t, warnings[0].ContextMap()["error"], "no space left on device")
+	var plan DerivedInvalidationPlan
+	idx.evictDeletedFilesBatched([]string{"source.go"}, &plan)
+	require.Empty(t, LoadFileIndexFailures(g, ""), "explicit deletion clears even a never-indexed failure")
+}
+
+func TestFileReadReceiptKeepsStatErrorDistinctFromVersionRace(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "source.go")
+	require.NoError(t, os.WriteFile(path, []byte("package p\n"), 0o600))
+	_, version, err := readOSFileWithVersion(path)
+	require.NoError(t, err)
+	idx := newContentSourceIndexer(t, graph.New())
+	idx.SetRootPath(root)
+	badPath := filepath.Join(path, "child.go")
+	fresh, stale := idx.recordFileReadVersionsBatched([]fileReadReceipt{{absPath: badPath, mtimeKey: "source.go/child.go", readVersion: version}})
+	require.Empty(t, fresh)
+	require.Equal(t, []string{badPath}, stale)
+	require.ErrorIs(t, idx.fileIndexFailureError(badPath), syscall.ENOTDIR)
+	require.False(t, errors.Is(idx.fileIndexFailureError(badPath), errFileVersionChanged))
+	require.False(t, idx.recordFileReadVersion("source.go/child.go", badPath, version))
+	require.ErrorIs(t, idx.fileIndexFailureError(badPath), syscall.ENOTDIR)
+}

--- a/internal/indexer/file_index_failures_test.go
+++ b/internal/indexer/file_index_failures_test.go
@@ -1,6 +1,7 @@
 package indexer
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -12,10 +13,186 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
 	"github.com/zzet/gortex/internal/indexer/source"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 )
+
+func TestFullIndexPersistsUnreadableFilesAndClearsRecovery(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{"denied.go", "blocked.go"} {
+		require.NoError(t, os.WriteFile(filepath.Join(root, name), []byte("package p\nfunc Keep() {}\n"), 0o600))
+	}
+	fsSource, err := source.NewFilesystemSource(root)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = fsSource.Close() })
+	failing := &failingIndexSource{ContentSource: fsSource, opens: map[string]int{}, errs: map[string][]error{
+		"denied.go": {syscall.EACCES}, "blocked.go": {syscall.EPERM},
+	}}
+	g := &failureCountingStore{Graph: graph.New()}
+	idx := newContentSourceIndexer(t, g)
+	idx.SetRepoPrefix("repo")
+	idx.SetContentSource(failing)
+	result, err := idx.Index(root)
+	require.NoError(t, err)
+	require.Len(t, result.FailedFiles, 2)
+	require.Len(t, result.Errors, 2)
+	require.Len(t, LoadFileIndexFailures(g, "repo"), 2)
+	require.Empty(t, LoadFileIndexFailures(g, "other"))
+	require.Equal(t, 1, g.writes, "full workers publish one failure batch")
+	metas, err := g.FileMetasForRepo("repo")
+	require.NoError(t, err)
+	require.Empty(t, metas, "failed reads must not mint successful FileMeta receipts")
+
+	idx.SetContentSource(fsSource)
+	result, err = idx.Index(root)
+	require.NoError(t, err)
+	require.Empty(t, result.FailedFiles)
+	require.Empty(t, LoadFileIndexFailures(g, "repo"))
+	metas, err = g.FileMetasForRepo("repo")
+	require.NoError(t, err)
+	require.Len(t, metas, 2)
+}
+
+type failedWalkIndexSource struct{ source.ContentSource }
+
+func (s failedWalkIndexSource) Walk(context.Context, func(source.FileMeta) error) error {
+	return &os.PathError{Op: "readdir", Path: ".", Err: syscall.EACCES}
+}
+
+func TestFullIndexPersistsWalkFailure(t *testing.T) {
+	root := t.TempDir()
+	fsSource, err := source.NewFilesystemSource(root)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = fsSource.Close() })
+	g := graph.New()
+	idx := newContentSourceIndexer(t, g)
+	idx.SetContentSource(failedWalkIndexSource{ContentSource: fsSource})
+	_, err = idx.Index(root)
+	require.ErrorIs(t, err, syscall.EACCES)
+	rows := LoadFileIndexFailures(g, "")
+	require.Len(t, rows, 1)
+	require.True(t, rows[0].PermissionDenied)
+	require.Contains(t, rows[0].Error, "readdir")
+}
+
+func TestIncrementalDiscoveryDeletesNeverIndexedFailure(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "new.go")
+	g := graph.New()
+	idx := newContentSourceIndexer(t, g)
+	idx.SetRootPath(root)
+	idx.noteFileIndexFailure(path, &os.PathError{Op: "open", Path: path, Err: syscall.EACCES})
+	idx.flushFileIndexFailures()
+	result, err := idx.IncrementalReindexPaths(root, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.DeletedFileCount)
+	require.Empty(t, LoadFileIndexFailures(g, ""))
+}
+
+func TestDirectIndexFilePreservesPermissionError(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "new.go")
+	require.NoError(t, os.WriteFile(path, []byte("package p\n"), 0o600))
+	fsSource, err := source.NewFilesystemSource(root)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = fsSource.Close() })
+	idx := newContentSourceIndexer(t, graph.New())
+	idx.SetRootPath(root)
+	idx.SetContentSource(&failingIndexSource{ContentSource: fsSource, opens: map[string]int{}, errs: map[string][]error{"new.go": {syscall.EPERM}}})
+	err = idx.IndexFile(path)
+	require.ErrorIs(t, err, syscall.EPERM)
+	require.False(t, errors.Is(err, errFileVersionChanged))
+}
+
+func TestFullIndexFailureLedgerSurvivesShadowDrainAndReopen(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "denied.go"), []byte("package p\n"), 0o600))
+	fsSource, err := source.NewFilesystemSource(root)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = fsSource.Close() })
+	failing := &failingIndexSource{ContentSource: fsSource, opens: map[string]int{}, errs: map[string][]error{"denied.go": {syscall.EPERM}}}
+	dbPath := filepath.Join(t.TempDir(), "graph.db")
+	for pass := 0; pass < 2; pass++ {
+		g, err := store_sqlite.Open(dbPath)
+		require.NoError(t, err)
+		idx := newContentSourceIndexer(t, g)
+		idx.SetRepoPrefix("repo")
+		idx.SetContentSource(failing)
+		result, err := idx.Index(root)
+		require.NoError(t, err)
+		require.Len(t, result.FailedFiles, 1)
+		rows, err := LoadFileIndexFailuresWithError(g, "repo")
+		require.NoError(t, err)
+		require.Len(t, rows, 1, "unchanged failures survive generation eviction on repeated full indexes")
+		require.True(t, rows[0].PermissionDenied)
+		require.NoError(t, g.Close())
+	}
+	g, err := store_sqlite.Open(dbPath)
+	require.NoError(t, err)
+	defer g.Close()
+	rows, err := LoadFileIndexFailuresWithError(g, "repo")
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	idx := newContentSourceIndexer(t, g)
+	idx.SetRepoPrefix("repo")
+	idx.SetContentSource(fsSource)
+	result, err := idx.Index(root)
+	require.NoError(t, err)
+	require.Empty(t, result.FailedFiles)
+	require.Empty(t, LoadFileIndexFailures(g, "repo"))
+}
+
+type unavailableFailureStore struct {
+	*graph.Graph
+	readErr       error
+	reads, writes int
+}
+
+func (g *unavailableFailureStore) FileIndexFailuresForRepo(repo string) ([]graph.FileIndexFailure, error) {
+	g.reads++
+	if g.readErr != nil {
+		return nil, g.readErr
+	}
+	return g.Graph.FileIndexFailuresForRepo(repo)
+}
+
+func (g *unavailableFailureStore) ReplaceFileIndexFailures(repo string, rows []graph.FileIndexFailure) error {
+	g.writes++
+	return g.Graph.ReplaceFileIndexFailures(repo, rows)
+}
+
+func TestFileFailureStoreReadErrorRetainsPendingUpdates(t *testing.T) {
+	root := t.TempDir()
+	readErr := errors.New("failure ledger unavailable")
+	g := &unavailableFailureStore{Graph: graph.New(), readErr: readErr}
+	require.NoError(t, g.Graph.ReplaceFileIndexFailures("", []graph.FileIndexFailure{
+		{Path: "old.go", Error: "old failure"}, {Path: "recovered.go", Error: "recovered failure"},
+	}))
+	_, err := LoadFileIndexFailuresWithError(g, "")
+	require.ErrorIs(t, err, readErr)
+	idx := newContentSourceIndexer(t, g)
+	idx.SetRootPath(root)
+	idx.loadFileIndexFailures()
+	idx.noteFileIndexFailure(filepath.Join(root, "new.go"), syscall.EACCES)
+	idx.noteFileIndexFailure(filepath.Join(root, "second.go"), syscall.EPERM)
+	idx.noteFileIndexFailure(filepath.Join(root, "recovered.go"), nil)
+	idx.flushFileIndexFailures()
+	require.Equal(t, 2, g.reads, "per-file observations do not retry or reset the failed initial read")
+	require.Zero(t, g.writes, "an unknown prior snapshot must not be overwritten")
+	g.readErr = nil
+	idx.loadFileIndexFailures()
+	idx.flushFileIndexFailures()
+	rows, err := g.Graph.FileIndexFailuresForRepo("")
+	require.NoError(t, err)
+	var paths []string
+	for _, row := range rows {
+		paths = append(paths, row.Path)
+	}
+	require.ElementsMatch(t, []string{"old.go", "new.go", "second.go"}, paths)
+	require.Equal(t, 1, g.writes)
+}
 
 type failingIndexSource struct {
 	source.ContentSource
@@ -147,6 +324,11 @@ func TestFileReadReceiptKeepsStatErrorDistinctFromVersionRace(t *testing.T) {
 	idx := newContentSourceIndexer(t, graph.New())
 	idx.SetRootPath(root)
 	badPath := filepath.Join(path, "child.go")
+	_, _, readErr := readOSFileWithVersion(badPath)
+	require.ErrorIs(t, readErr, syscall.ENOTDIR)
+	var pathErr *os.PathError
+	require.ErrorAs(t, readErr, &pathErr)
+	require.Equal(t, "stat", pathErr.Op, "the original stat error is preserved before attempting a read")
 	fresh, stale := idx.recordFileReadVersionsBatched([]fileReadReceipt{{absPath: badPath, mtimeKey: "source.go/child.go", readVersion: version}})
 	require.Empty(t, fresh)
 	require.Equal(t, []string{badPath}, stale)

--- a/internal/indexer/file_index_failures_test.go
+++ b/internal/indexer/file_index_failures_test.go
@@ -326,9 +326,9 @@ func TestFileReadReceiptKeepsStatErrorDistinctFromVersionRace(t *testing.T) {
 	badPath := filepath.Join(path, "child.go")
 	_, _, readErr := readOSFileWithVersion(badPath)
 	require.ErrorIs(t, readErr, syscall.ENOTDIR)
-	var pathErr *os.PathError
-	require.ErrorAs(t, readErr, &pathErr)
-	require.Equal(t, "stat", pathErr.Op, "the original stat error is preserved before attempting a read")
+	_, statErr := os.Stat(badPath)
+	require.Error(t, statErr)
+	require.Equal(t, statErr, readErr, "the original platform-specific stat error is preserved before attempting a read")
 	fresh, stale := idx.recordFileReadVersionsBatched([]fileReadReceipt{{absPath: badPath, mtimeKey: "source.go/child.go", readVersion: version}})
 	require.Empty(t, fresh)
 	require.Equal(t, []string{badPath}, stale)

--- a/internal/indexer/file_meta.go
+++ b/internal/indexer/file_meta.go
@@ -35,12 +35,18 @@ type fileReadVersion struct {
 // picks this or the content source.
 func readOSFileWithVersion(path string) ([]byte, fileReadVersion, error) {
 	before, beforeErr := os.Stat(path)
+	if beforeErr != nil {
+		return nil, fileReadVersion{}, beforeErr
+	}
 	src, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fileReadVersion{}, err
 	}
 	after, afterErr := os.Stat(path)
-	if beforeErr != nil || afterErr != nil || !sameFileVersion(before, after) {
+	if afterErr != nil {
+		return src, fileReadVersion{}, afterErr
+	}
+	if !sameFileVersion(before, after) {
 		return src, fileReadVersion{}, nil
 	}
 	return src, fileReadVersion{

--- a/internal/indexer/incremental_batch.go
+++ b/internal/indexer/incremental_batch.go
@@ -88,6 +88,8 @@ func (idx *Indexer) reindexIncrementalFilesBatched(
 	markerBatch *reparsePendingEnrichmentBatch,
 	surfaceFirstVersionChange bool,
 ) (DerivedInvalidationPlan, []string, []string, []string) {
+	idx.loadFileIndexFailures()
+	defer idx.flushFileIndexFailures()
 	var invalidation DerivedInvalidationPlan
 	idx.evictDeletedFilesBatched(deletedFiles, &invalidation)
 
@@ -97,7 +99,7 @@ func (idx *Indexer) reindexIncrementalFilesBatched(
 	invalidation.Merge(passPlan)
 	for _, filePath := range failed {
 		idx.logger.Debug("incremental reindex: failed to index file",
-			zap.String("file", filePath))
+			zap.String("file", filePath), zap.Error(idx.fileIndexFailureError(filePath)))
 	}
 	if len(failed) == 0 {
 		if len(reparsed) > 0 {
@@ -115,20 +117,32 @@ func (idx *Indexer) reindexIncrementalFilesBatched(
 		return invalidation, reparsed, failed, versionChanged
 	}
 
+	var retryPaths, permissionFailed []string
+	for _, path := range failed {
+		if errors.Is(idx.fileIndexFailureError(path), os.ErrPermission) {
+			permissionFailed = append(permissionFailed, path)
+		} else {
+			retryPaths = append(retryPaths, path)
+		}
+	}
 	retryPlan, retryReparsed, retryFailed, retryVersionChanged := idx.reindexIncrementalStalePass(
-		failed, markerBatch, false,
+		retryPaths, markerBatch, false,
 	)
 	invalidation.Merge(retryPlan)
 	reparsed = appendUniqueSorted(reparsed, retryReparsed...)
 	versionChanged = appendUniqueSorted(versionChanged, retryVersionChanged...)
 	for _, filePath := range retryFailed {
+		err := idx.fileIndexFailureError(filePath)
+		if errors.Is(err, os.ErrPermission) {
+			continue // One aggregate permission warning is emitted for the repo.
+		}
 		idx.logger.Warn("incremental reindex: file failed after retry",
-			zap.String("file", filePath))
+			zap.String("file", filePath), zap.Error(err))
 	}
 	if len(reparsed) > 0 {
 		idx.reparsedThisRun.Store(true)
 	}
-	return invalidation, reparsed, retryFailed, versionChanged
+	return invalidation, reparsed, appendUniqueSorted(permissionFailed, retryFailed...), versionChanged
 }
 
 func (idx *Indexer) reindexIncrementalStalePass(
@@ -188,6 +202,7 @@ func (idx *Indexer) reindexIncrementalChunk(
 	receipts := make([]fileReadReceipt, 0, len(files))
 	nodeCount, edgeCount := 0, 0
 	var retainedBytes int64
+	var readFailed []string
 	consumed := 0
 	for i, filePath := range files {
 		graphPath := graphPaths[i]
@@ -217,6 +232,11 @@ func (idx *Indexer) reindexIncrementalChunk(
 		}
 
 		if !probeOK {
+			if probe.readErr != nil {
+				idx.noteFileIndexFailure(filePath, probe.readErr)
+				readFailed = append(readFailed, filePath)
+				continue
+			}
 			fallbacks = append(fallbacks, incrementalFallback{
 				filePath: filePath, graphPath: graphPath, priorNodes: priorNodes,
 				storedGraph: storedGraph, storedDerived: storedDerived,
@@ -282,10 +302,16 @@ func (idx *Indexer) reindexIncrementalChunk(
 	}
 
 	var reparsed []string
-	failed := append([]string(nil), stalePaths...)
-	versionChanged := append([]string(nil), stalePaths...)
+	failed := append(readFailed, stalePaths...)
+	var versionChanged []string
+	for _, path := range failed {
+		if errors.Is(idx.fileIndexFailureError(path), errFileVersionChanged) {
+			versionChanged = append(versionChanged, path)
+		}
+	}
 	for _, fallback := range fallbacks {
 		if err := idx.reindexIncrementalFallback(fallback, markerBatch, &plan); err != nil {
+			idx.noteFileIndexFailure(fallback.filePath, err)
 			idx.discardPreparedExtraction(fallback.filePath)
 			failed = append(failed, fallback.filePath)
 			if errors.Is(err, errFileVersionChanged) {
@@ -293,6 +319,7 @@ func (idx *Indexer) reindexIncrementalChunk(
 			}
 			continue
 		}
+		idx.noteFileIndexFailure(fallback.filePath, nil)
 		reparsed = append(reparsed, fallback.filePath)
 	}
 	for _, stage := range stages {
@@ -1033,6 +1060,7 @@ func (idx *Indexer) recordFileReadVersionsBatched(receipts []fileReadReceipt) (f
 	mtimes := make(map[string]int64, len(receipts))
 	for _, receipt := range receipts {
 		if !receipt.readVersion.valid {
+			idx.noteFileIndexFailure(receipt.absPath, errFileVersionChanged)
 			stale = append(stale, receipt.absPath)
 			continue
 		}
@@ -1040,15 +1068,23 @@ func (idx *Indexer) recordFileReadVersionsBatched(receipts []fileReadReceipt) (f
 			// Read from an immutable content source: nothing on disk to
 			// restat, and no working-tree mtime to advance the ledger to.
 			fresh = append(fresh, receipt.absPath)
+			idx.noteFileIndexFailure(receipt.absPath, nil)
 			continue
 		}
 		current, err := os.Stat(receipt.absPath)
-		if err != nil || !sameFileVersion(receipt.readVersion.info, current) {
+		if err != nil {
+			idx.noteFileIndexFailure(receipt.absPath, err)
+			stale = append(stale, receipt.absPath)
+			continue
+		}
+		if !sameFileVersion(receipt.readVersion.info, current) {
+			idx.noteFileIndexFailure(receipt.absPath, errFileVersionChanged)
 			stale = append(stale, receipt.absPath)
 			continue
 		}
 		mtimes[receipt.mtimeKey] = receipt.readVersion.mtime
 		fresh = append(fresh, receipt.absPath)
+		idx.noteFileIndexFailure(receipt.absPath, nil)
 	}
 	if len(mtimes) == 0 {
 		return fresh, stale
@@ -1523,6 +1559,10 @@ func (idx *Indexer) removeIncrementalContractsForFile(graphPath string, plan *De
 func (idx *Indexer) evictDeletedFilesBatched(deleted []string, plan *DerivedInvalidationPlan) (nodesRemoved, edgesRemoved int) {
 	if len(deleted) == 0 {
 		return 0, 0
+	}
+	defer idx.flushFileIndexFailures()
+	for _, path := range deleted {
+		idx.noteFileIndexFailure(filepath.Join(idx.rootPath, filepath.FromSlash(path)), nil)
 	}
 	for start := 0; start < len(deleted); start += deletedBatchFiles {
 		end := min(start+deletedBatchFiles, len(deleted))

--- a/internal/indexer/incremental_batch.go
+++ b/internal/indexer/incremental_batch.go
@@ -1614,6 +1614,7 @@ func (idx *Indexer) evictDeletedFilesBatched(deleted []string, plan *DerivedInva
 		delete(idx.fileMtimes, relPath)
 	}
 	idx.mtimeMu.Unlock()
+	idx.clearRecoveredParseErrors(nil, nil, deleted)
 	return nodesRemoved, edgesRemoved
 }
 

--- a/internal/indexer/incremental_contracts.go
+++ b/internal/indexer/incremental_contracts.go
@@ -133,6 +133,10 @@ func (idx *Indexer) refreshIncrementalContractManifests(files []string) (Derived
 		graphPath := idx.prefixPath(relPath)
 		src, readVersion, err := idx.readFileWithVersion(absPath)
 		if err != nil || !readVersion.valid {
+			if err == nil {
+				err = errFileVersionChanged
+			}
+			idx.noteFileIndexFailure(absPath, err)
 			failed = append(failed, absPath)
 			continue
 		}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -150,7 +150,8 @@ type IndexError struct {
 
 // Indexer walks a repository and populates the graph.
 type Indexer struct {
-	graph graph.Store
+	graph             graph.Store
+	fileIndexFailures fileIndexFailureState
 
 	// shadowAdmission is shared by every Indexer in the process. Cold repos
 	// acquire a weighted lease before constructing an in-memory shadow; when the
@@ -4459,7 +4460,7 @@ func (idx *Indexer) indexFile(
 			evictExisting()
 			idx.graph.AddBatch([]*graph.Node{n}, nil)
 			if !idx.recordFileReadVersion(mtimeKey, absPath, readVersion) {
-				return errFileVersionChanged
+				return idx.fileIndexFailureError(absPath)
 			}
 			return nil
 		}
@@ -4475,7 +4476,7 @@ func (idx *Indexer) indexFile(
 			evictExisting()
 			idx.graph.AddBatch([]*graph.Node{n}, nil)
 			if !idx.recordFileReadVersion(mtimeKey, absPath, readVersion) {
-				return errFileVersionChanged
+				return idx.fileIndexFailureError(absPath)
 			}
 			return nil
 		}
@@ -4521,7 +4522,7 @@ func (idx *Indexer) indexFile(
 		// expensive shadow re-track path on every restart.
 		fresh := idx.recordFileReadVersion(mtimeKey, absPath, readVersion)
 		if err == nil && !fresh {
-			return errFileVersionChanged
+			return idx.fileIndexFailureError(absPath)
 		}
 		return err
 	}
@@ -4795,7 +4796,7 @@ func (idx *Indexer) indexFile(
 	// the fileMtimes map and IsStale / TrackedFileState all key on the
 	// slash form.
 	if !idx.recordFileReadVersion(mtimeKey, absPath, readVersion) {
-		return errFileVersionChanged
+		return idx.fileIndexFailureError(absPath)
 	}
 	if elapsed := time.Since(indexFileStarted); elapsed >= 2*time.Second {
 		idx.logger.Warn("indexer: slow incremental stages",
@@ -4833,19 +4834,27 @@ func (idx *Indexer) recordFileMtime(relPath, absPath string) {
 // queued event or the poller retries instead of treating newer bytes as done.
 func (idx *Indexer) recordFileReadVersion(relPath, absPath string, version fileReadVersion) bool {
 	if !version.valid {
+		idx.noteFileIndexFailure(absPath, errFileVersionChanged)
 		return false
 	}
 	if version.snapshot {
 		// An immutable snapshot has nothing to restat and no disk mtime
 		// worth stamping: the staleness ledger tracks the working tree,
 		// which this read never touched.
+		idx.noteFileIndexFailure(absPath, nil)
 		return true
 	}
 	current, err := os.Stat(absPath)
-	if err != nil || !sameFileVersion(version.info, current) {
+	if err != nil {
+		idx.noteFileIndexFailure(absPath, err)
+		return false
+	}
+	if !sameFileVersion(version.info, current) {
+		idx.noteFileIndexFailure(absPath, errFileVersionChanged)
 		return false
 	}
 	idx.recordFileMtimeValue(relPath, version.mtime)
+	idx.noteFileIndexFailure(absPath, nil)
 	return true
 }
 

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -152,6 +152,7 @@ type IndexError struct {
 type Indexer struct {
 	graph             graph.Store
 	fileIndexFailures fileIndexFailureState
+	parseErrorsMu     sync.RWMutex
 
 	// shadowAdmission is shared by every Indexer in the process. Cold repos
 	// acquire a weighted lease before constructing an in-memory shadow; when the
@@ -3948,7 +3949,9 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 	}
 
 	// Retain parse errors and record index metadata.
-	idx.parseErrors = errors
+	idx.parseErrorsMu.Lock()
+	idx.parseErrors = append([]IndexError(nil), errors...)
+	idx.parseErrorsMu.Unlock()
 	idx.totalDetected = len(files)
 	idx.lastIndexTime = time.Now()
 
@@ -5802,9 +5805,12 @@ func effectiveExcludePatterns(patterns []string) []string {
 	return patterns
 }
 
-// ParseErrors returns the parse errors from the last full index.
+// ParseErrors returns a snapshot of errors from the last full index, excluding
+// files that a later incremental pass successfully recovered or deleted.
 func (idx *Indexer) ParseErrors() []IndexError {
-	return idx.parseErrors
+	idx.parseErrorsMu.RLock()
+	defer idx.parseErrorsMu.RUnlock()
+	return append([]IndexError(nil), idx.parseErrors...)
 }
 
 // FileMtimes returns a copy of the file modification time map.
@@ -6110,6 +6116,7 @@ func (idx *Indexer) incrementalReindexPathsMode(
 	var staleFiles []string
 	var forcedDeletedFiles []string
 	var discoveryFailed []string
+	var walkedDirs []string
 
 	merkleMode := idx.merkleEnabled()
 
@@ -6171,6 +6178,7 @@ func (idx *Indexer) incrementalReindexPathsMode(
 						return filepath.SkipDir
 					}
 					idx.noteFileIndexFailure(path, nil)
+					walkedDirs = append(walkedDirs, path)
 					return nil
 				}
 				if !idx.admitScopedWalkFile(absRoot, path) {
@@ -6454,6 +6462,13 @@ func (idx *Indexer) incrementalReindexPathsMode(
 	if len(failedFiles) == 0 && !idx.hasStaleGeneratedParserProjections() {
 		idx.persistExtractorVersion("c")
 	}
+	// Accepted receipts include inert and metadata-only reparses. Directory
+	// callbacks can subsequently fail while reading entries, so exclude the
+	// final failed set before clearing their own historical walk diagnostics.
+	recoveredFiles := make([]string, 0, len(staleFiles)+len(walkedDirs))
+	recoveredFiles = append(recoveredFiles, staleFiles...)
+	recoveredFiles = append(recoveredFiles, walkedDirs...)
+	idx.clearRecoveredParseErrors(recoveredFiles, failedFiles, nil)
 	return result, nil
 }
 

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -2368,6 +2368,39 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (*IndexResult, er
 // indexCtxRaw performs full-tree indexing while the caller holds the
 // repository mutation lane.
 func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *IndexResult, retErr error) {
+	idx.loadFileIndexFailures()
+	var successfulFiles sync.Map
+	recordFileOutcome := func(path string, err error) {
+		if err != nil {
+			successfulFiles.Delete(path)
+			idx.noteFileIndexFailure(path, err)
+		} else {
+			successfulFiles.Store(path, struct{}{})
+		}
+	}
+	// Register before panic recovery and shadow restoration: failures remain
+	// durable even when a full pass fails, while recovery is acknowledged only
+	// after its replacement graph has committed to the original store.
+	defer func() {
+		if retErr == nil && result != nil {
+			successfulFiles.Range(func(path, _ any) bool {
+				idx.noteFileIndexFailure(path.(string), nil)
+				return true
+			})
+			idx.pruneMissingFileIndexFailures()
+			// A shadow drain evicts the generation's old sidecars. Rewrite even
+			// unchanged failures after restoring the destination graph.
+			idx.fileIndexFailures.mu.Lock()
+			idx.fileIndexFailures.dirty = idx.fileIndexFailures.dirty || len(idx.fileIndexFailures.rows) > 0
+			idx.fileIndexFailures.mu.Unlock()
+			for _, path := range idx.fileIndexFailurePaths() {
+				if rel, ok := idx.graphPathRelKey(path); ok {
+					result.FailedFiles = append(result.FailedFiles, filepath.Join(idx.rootPath, filepath.FromSlash(rel)))
+				}
+			}
+		}
+		idx.flushFileIndexFailures()
+	}()
 	defer recoverIndexCtxRawStoragePanic(&result, &retErr)
 
 	start := time.Now()
@@ -2419,6 +2452,7 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 	var skippedByContent []skippedFile
 	var skippedContentBytes int64
 	var parseFailedFiles []skippedFile
+	var walkFailures []IndexError
 	// admitWalkedFile applies the two gates that sit above the shared walk
 	// admission: the git-aware untracked-asset gate and the content-admission
 	// gate. Both walks below feed it, and both account for an over-cap file the
@@ -2468,12 +2502,17 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 	} else {
 		err = filepath.WalkDir(absRoot, func(path string, d os.DirEntry, err error) error {
 			if err != nil {
+				if !os.IsNotExist(err) && !idx.shouldExclude(path, absRoot, d != nil && d.IsDir()) {
+					recordFileOutcome(path, err)
+					walkFailures = append(walkFailures, IndexError{FilePath: path, Error: err.Error()})
+				}
 				return nil
 			}
 			if d.IsDir() {
 				if idx.admitWalkEntry(absRoot, path, -1, true).pruneDir {
 					return filepath.SkipDir
 				}
+				recordFileOutcome(path, nil)
 				return nil
 			}
 			// The FileInfo is taken before the admission gate rather than
@@ -2485,6 +2524,10 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 			if statErr != nil {
 				// Couldn't read FileInfo (race with deletion, broken
 				// symlink, …). Skip — the worker would fail too.
+				if !os.IsNotExist(statErr) && idx.admitWalkEntry(absRoot, path, -1, false).admit {
+					recordFileOutcome(path, statErr)
+					walkFailures = append(walkFailures, IndexError{FilePath: path, Error: statErr.Error()})
+				}
 				return nil
 			}
 			adm := idx.admitWalkEntry(absRoot, path, info.Size(), false)
@@ -2509,6 +2552,9 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 		})
 	}
 	if err != nil {
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			recordFileOutcome(absRoot, err)
+		}
 		return nil, err
 	}
 	if skippedLarge > 0 {
@@ -3179,7 +3225,7 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 	var contractMu sync.Mutex
 
 	var errMu sync.Mutex
-	var errors []IndexError
+	errors := walkFailures
 	var processed int64
 	var fileCount int64
 	var skippedByTimeout int64
@@ -3357,6 +3403,7 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 						if se, ok := walkExt.(parser.StreamingExtractor); ok {
 							result, serr := idx.extractStreaming(se, path, relPath)
 							if serr != nil {
+								recordFileOutcome(path, serr)
 								errMu.Lock()
 								errors = append(errors, IndexError{FilePath: path, Error: serr.Error()})
 								if result == nil {
@@ -3393,6 +3440,9 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 								}
 							}
 							sidecars.addConstValues(result)
+							if serr == nil {
+								recordFileOutcome(path, nil)
+							}
 							parseLease.Release()
 							continue
 						}
@@ -3402,6 +3452,7 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 					src, err := readFile(wf)
 					atomic.AddInt64(&parseReadNS, int64(time.Since(readStart)))
 					if err != nil {
+						recordFileOutcome(path, err)
 						errMu.Lock()
 						errors = append(errors, IndexError{FilePath: path, Error: err.Error()})
 						errMu.Unlock()
@@ -3454,6 +3505,7 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 						nativePressure.afterParse(lang, int64(len(src)))
 					}
 					if err != nil {
+						recordFileOutcome(path, err)
 						errMu.Lock()
 						errors = append(errors, IndexError{FilePath: path, Error: err.Error()})
 						errMu.Unlock()
@@ -3583,6 +3635,9 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 					// every tree in the chunk until the worker exits.
 					result.ReleaseTree()
 					parseLease.Release()
+					if err == nil {
+						recordFileOutcome(path, nil)
+					}
 					atomic.AddInt64(&fileCount, 1)
 				}
 				if len(localContracts) > 0 {
@@ -6018,6 +6073,8 @@ func (idx *Indexer) incrementalReindexPathsMode(
 	mode incrementalPathMode,
 	markerBatches ...*reparsePendingEnrichmentBatch,
 ) (*IndexResult, error) {
+	idx.loadFileIndexFailures()
+	defer idx.flushFileIndexFailures()
 	fullRoot := len(paths) == 0
 	if fullRoot {
 		// An empty scope means the repository root. detectDeletions decides
@@ -6052,6 +6109,7 @@ func (idx *Indexer) incrementalReindexPathsMode(
 	diskFiles := make(map[string]bool)
 	var staleFiles []string
 	var forcedDeletedFiles []string
+	var discoveryFailed []string
 
 	merkleMode := idx.merkleEnabled()
 
@@ -6095,18 +6153,24 @@ func (idx *Indexer) incrementalReindexPathsMode(
 				}
 				continue
 			}
+			idx.noteFileIndexFailure(absPath, statErr)
 			return nil, fmt.Errorf("incremental reindex: stat %q: %w", p, statErr)
 		}
 
 		if info.IsDir() {
 			walkErr := filepath.WalkDir(absPath, func(path string, d os.DirEntry, err error) error {
 				if err != nil {
+					if !os.IsNotExist(err) && !idx.shouldExclude(path, absRoot, d != nil && d.IsDir()) {
+						idx.noteFileIndexFailure(path, err)
+						discoveryFailed = append(discoveryFailed, path)
+					}
 					return nil
 				}
 				if d.IsDir() {
 					if idx.admitWalkEntry(absRoot, path, -1, true).pruneDir {
 						return filepath.SkipDir
 					}
+					idx.noteFileIndexFailure(path, nil)
 					return nil
 				}
 				if !idx.admitScopedWalkFile(absRoot, path) {
@@ -6167,6 +6231,14 @@ func (idx *Indexer) incrementalReindexPathsMode(
 			}
 		}
 	}
+	// Failure rows also inventory files that have never produced graph nodes
+	// or mtimes. A recovered read must be retried even when those ledgers say
+	// nothing changed (including Merkle mode and prior parse failures).
+	for _, graphPath := range idx.fileIndexFailurePaths() {
+		if relPath, ok := idx.graphPathRelKey(graphPath); ok && diskFiles[relPath] {
+			staleFiles = append(staleFiles, filepath.Join(absRoot, filepath.FromSlash(relPath)))
+		}
+	}
 	staleFiles = appendUniqueSorted(nil, staleFiles...)
 
 	// Restored snapshots populate fileMtimes without running IndexCtx. Preserve
@@ -6186,6 +6258,11 @@ func (idx *Indexer) incrementalReindexPathsMode(
 		candidateSet := make(map[string]struct{}, len(forcedDeletedFiles)+4)
 		for _, relPath := range forcedDeletedFiles {
 			candidateSet[relPath] = struct{}{}
+		}
+		for _, graphPath := range idx.fileIndexFailurePaths() {
+			if relPath, ok := idx.graphPathRelKey(graphPath); ok && !diskFiles[relPath] && relPathInScope(relPath, scopeRels) {
+				candidateSet[relPath] = struct{}{}
+			}
 		}
 		idx.mtimeMu.RLock()
 		for relPath := range idx.fileMtimes {
@@ -6231,8 +6308,12 @@ func (idx *Indexer) incrementalReindexPathsMode(
 				deletedFiles = append(deletedFiles, relPath)
 				continue
 			}
-			idx.logger.Warn("incremental reindex: stat failed during scoped deletion detection, preserving",
-				zap.String("rel", relPath), zap.Error(statErr))
+			idx.noteFileIndexFailure(absPath, statErr)
+			discoveryFailed = append(discoveryFailed, absPath)
+			if !errors.Is(statErr, os.ErrPermission) {
+				idx.logger.Warn("incremental reindex: stat failed during scoped deletion detection, preserving",
+					zap.String("rel", relPath), zap.Error(statErr))
+			}
 		}
 	}
 	deletedFiles = appendUniqueSorted(nil, deletedFiles...)
@@ -6270,6 +6351,7 @@ func (idx *Indexer) incrementalReindexPathsMode(
 	manifestPlan, manifestFailed := idx.refreshIncrementalContractManifests(manifestFiles)
 	invalidation.Merge(manifestPlan)
 	failedFiles = appendUniqueSorted(failedFiles, manifestFailed...)
+	failedFiles = appendUniqueSorted(failedFiles, discoveryFailed...)
 	invalidation.Files = appendUniqueSorted(invalidation.Files, idx.graphFilePaths(reparsedFiles)...)
 	invalidation.Files = appendUniqueSorted(invalidation.Files, deletedDependencyFiles...)
 	idx.pruneDeletedFileMtimes(deletedFiles)
@@ -6345,10 +6427,15 @@ func (idx *Indexer) incrementalReindexPathsMode(
 		DurationMs:          time.Since(start).Milliseconds(),
 		DerivedInvalidation: invalidation,
 	}
+	for _, path := range failedFiles {
+		result.Errors = append(result.Errors, IndexError{FilePath: path, Error: idx.fileIndexFailureError(path).Error()})
+	}
 	if mode.surfaceFirstVersionChange && len(versionChangedFiles) > 0 {
 		result.mutationErr = fmt.Errorf(
 			"%w: %s", errFileVersionChanged, strings.Join(versionChangedFiles, ", "),
 		)
+	} else if mode.surfaceFirstVersionChange && len(failedFiles) > 0 {
+		result.mutationErr = idx.fileIndexFailureError(failedFiles[0])
 	}
 	// A clean version-driven restage re-stamps the stored extractor
 	// versions; a failed file keeps the old row so the next full pass

--- a/internal/indexer/parse_error_recovery_test.go
+++ b/internal/indexer/parse_error_recovery_test.go
@@ -1,0 +1,91 @@
+package indexer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer/source"
+)
+
+func TestParseErrorsClearRecoveredOrDeletedFullIndexFailures(t *testing.T) {
+	for _, mode := range []string{"incremental", "direct", "deleted"} {
+		t.Run(mode, func(t *testing.T) {
+			root := t.TempDir()
+			deniedPath := filepath.Join(root, "denied.go")
+			for _, name := range []string{"denied.go", "blocked.go"} {
+				require.NoError(t, os.WriteFile(filepath.Join(root, name), []byte("package p\nfunc Keep() {}\n"), 0o600))
+			}
+			fsSource, err := source.NewFilesystemSource(root)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = fsSource.Close() })
+			idx := newContentSourceIndexer(t, graph.New())
+			idx.SetContentSource(&failingIndexSource{
+				ContentSource: fsSource, opens: map[string]int{},
+				errs: map[string][]error{"denied.go": {syscall.EPERM}, "blocked.go": {syscall.EACCES}},
+			})
+			_, err = idx.IndexCtx(context.Background(), root)
+			require.NoError(t, err)
+			before := idx.ParseErrors()
+			require.Len(t, before, 2)
+			var blocked IndexError
+			for _, entry := range before {
+				if filepath.Base(entry.FilePath) == "blocked.go" {
+					blocked = entry
+				}
+			}
+			require.NotEmpty(t, blocked.FilePath)
+			idx.SetContentSource(&failingIndexSource{
+				ContentSource: fsSource, opens: map[string]int{},
+				errs: map[string][]error{"blocked.go": {syscall.EACCES}},
+			})
+
+			switch mode {
+			case "direct":
+				require.NoError(t, idx.IndexFile(deniedPath))
+			case "deleted":
+				require.NoError(t, os.Remove(deniedPath))
+				result, err := idx.IncrementalReindexPaths(root, nil)
+				require.NoError(t, err)
+				require.Equal(t, 1, result.DeletedFileCount)
+			default:
+				_, err := idx.IncrementalReindexPaths(root, nil)
+				require.NoError(t, err)
+			}
+			require.Equal(t, []IndexError{blocked}, idx.ParseErrors(), "recovery must clear only the resolved error")
+		})
+	}
+}
+
+func TestParseErrorsCleanupNormalizesDirectoryAndFailedPaths(t *testing.T) {
+	root := t.TempDir()
+	idx := newContentSourceIndexer(t, graph.New())
+	idx.SetRootPath(root)
+	stillFailed := IndexError{FilePath: "blocked/still.go", Error: "permission denied"}
+	unrelated := IndexError{FilePath: "unrelated.go", Error: "parse failed"}
+	idx.parseErrors = []IndexError{
+		{FilePath: "blocked", Error: "readdir: permission denied"},
+		stillFailed,
+		{FilePath: "deleted.go", Error: "open: permission denied"},
+		unrelated,
+	}
+	idx.clearRecoveredParseErrors(
+		[]string{filepath.Join(root, "blocked"), filepath.Join(root, "blocked", "still.go")},
+		[]string{filepath.Join(root, "blocked", "still.go")},
+		[]string{filepath.Join(root, "deleted.go")},
+	)
+	require.Equal(t, []IndexError{stillFailed, unrelated}, idx.ParseErrors())
+}
+
+func TestParseErrorsReturnsIndependentSnapshot(t *testing.T) {
+	idx := newContentSourceIndexer(t, graph.New())
+	idx.parseErrors = []IndexError{{FilePath: "blocked.go", Error: "permission denied"}}
+	snapshot := idx.ParseErrors()
+	require.Len(t, snapshot, 1)
+	snapshot[0].Error = "changed by caller"
+	require.Equal(t, "permission denied", idx.ParseErrors()[0].Error)
+}

--- a/internal/mcp/index_file_failures.go
+++ b/internal/mcp/index_file_failures.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
+	"path"
 	"sort"
 	"strings"
 
@@ -86,12 +88,30 @@ func scopedIndexFileFailures(failures []indexer.FileIndexFailure, resolved Resol
 		if !opts.ScopeAllows(node) {
 			continue
 		}
-		if len(paths) > 0 && !pathMatchesAnyPrefix(failure.Path, expandPathPrefixesWithRepos(paths, []string{failure.RepoPrefix})) {
+		if len(paths) > 0 && !indexFailureOverlapsPaths(failure.Path, expandPathPrefixesWithRepos(paths, []string{failure.RepoPrefix})) {
 			continue
 		}
 		scoped = append(scoped, failure)
 	}
 	return scoped
+}
+
+func indexFailureOverlapsPaths(failurePath string, paths []string) bool {
+	failurePath = path.Clean(failurePath)
+	if failurePath == "." {
+		return true // A failed standalone repository-root walk hides every subpath.
+	}
+	if pathMatchesAnyPrefix(failurePath, paths) {
+		return true
+	}
+	// A failed directory walk can hide any descendant. Its warning applies
+	// when a request narrows further into that directory, too.
+	for _, path := range paths {
+		if pathMatchesAnyPrefix(path, []string{failurePath}) {
+			return true
+		}
+	}
+	return false
 }
 
 func indexFileFailureSummary(failures []indexer.FileIndexFailure) map[string]any {
@@ -208,4 +228,42 @@ func indexHealthParseFailureCount(value any) int {
 	default:
 		return 0
 	}
+}
+
+// The cached payload contains only baseline parse/liveness health. Failures
+// are read live, and every field changed here belongs to a new top-level map;
+// recovery therefore restores the baseline score without racing cache readers.
+func (s *Server) refreshIndexHealthFileFailures(ctx context.Context, baseline map[string]any) map[string]any {
+	result := make(map[string]any, len(baseline)+8)
+	for key, value := range baseline {
+		result[key] = value
+	}
+	failures, readErr := s.readIndexFileFailures(ctx, ResolvedScope{})
+	totalDetected, _ := baseline["total_detected"].(int)
+	fileNodes, _ := baseline["file_node_count"].(int)
+	parseErrors, _ := baseline["parse_failures"].([]indexer.IndexError)
+	totalDetected, successfullyIndexed := indexHealthFailureCounts(s.readerFor(ctx), totalDetected, fileNodes, parseErrors, failures)
+	result["total_detected"] = totalDetected
+	result["successfully_indexed"] = successfullyIndexed
+	if len(failures) > 0 && totalDetected > 0 {
+		healthScore, _ := baseline["health_score"].(float64)
+		failureScore := math.Round(float64(successfullyIndexed)/float64(totalDetected)*1000) / 10
+		result["health_score"] = min(healthScore, failureScore, 99.9)
+	}
+	for key, value := range indexFileFailureSummary(failures) {
+		result[key] = value
+	}
+	result["index_complete"] = len(failures) == 0 && readErr == nil
+	result["status"] = "ready"
+	recommendation, _ := baseline["recommendation"].(string)
+	if len(failures) > 0 {
+		result["status"] = "degraded"
+		result["recommendation"] = strings.TrimSpace("Some files could not be indexed (see failed_files). Results can omit current code or retain stale symbols. Fix the reported file access or indexing errors and reindex the affected paths. " + recommendation)
+	}
+	if readErr != nil {
+		result["status"] = "degraded"
+		result["index_state_read_error"] = readErr.Error()
+		result["recommendation"] = strings.TrimSpace("Index failure state could not be read; index completeness is unknown. " + readErr.Error() + ". " + recommendation)
+	}
+	return result
 }

--- a/internal/mcp/index_file_failures.go
+++ b/internal/mcp/index_file_failures.go
@@ -7,8 +7,11 @@ import (
 	"fmt"
 	"math"
 	"path"
+	"path/filepath"
 	"sort"
 	"strings"
+
+	"golang.org/x/text/unicode/norm"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/zzet/gortex/internal/graph"
@@ -17,6 +20,11 @@ import (
 )
 
 const indexFailureSampleLimit = 20
+
+// Internal baseline bookkeeping, removed before any response is encoded.
+const indexHealthLivenessCeilingKey = "_index_health_liveness_ceiling"
+
+const indexHealthLowScoreRecommendation = "Health score below 80%. Run index_repository with path \".\" to re-index the codebase."
 
 // Registrations include repositories with no successful file nodes. Read their
 // failures through the request reader so another checkout cannot supply them.
@@ -205,18 +213,42 @@ func indexHealthFailureCounts(reader graph.Reader, totalDetected, fileNodes int,
 		if reader.GetNode(failure.Path) == nil {
 			missing++
 		}
-		prefixedParseError := parsePaths[failure.Path]
-		relative := failure.Path
-		if failure.RepoPrefix != "" {
-			relative = strings.TrimPrefix(relative, failure.RepoPrefix+"/")
-		}
-		relativeParseError := parsePaths[relative]
-		if !prefixedParseError && !relativeParseError {
+		if !parsePaths[failure.Path] {
 			additionalFailures++
 		}
 	}
 	totalDetected = max(totalDetected, fileNodes+missing)
 	return totalDetected, max(totalDetected-len(parseErrors)-additionalFailures, 0)
+}
+
+// Full indexing reports absolute paths, while the durable ledger uses graph
+// paths. Normalize only against the originating indexer's exact root/prefix;
+// a basename or suffix match could conflate failures in different repositories.
+func indexHealthParseErrorsForCounts(parseErrors []indexer.IndexError, idx *indexer.Indexer) []indexer.IndexError {
+	if idx == nil {
+		return parseErrors
+	}
+	normalized := append([]indexer.IndexError(nil), parseErrors...)
+	for i, failure := range normalized {
+		file := failure.FilePath
+		absolute := filepath.IsAbs(file)
+		if absolute {
+			if idx.RootPath() == "" {
+				continue
+			}
+			relative, err := filepath.Rel(idx.RootPath(), file)
+			if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || filepath.IsAbs(relative) {
+				continue
+			}
+			file = filepath.ToSlash(relative)
+		}
+		file = norm.NFC.String(filepath.ToSlash(file))
+		if prefix := idx.RepoPrefix(); file != "" && prefix != "" && (absolute || !strings.HasPrefix(file, prefix+"/")) {
+			file = prefix + "/" + file
+		}
+		normalized[i].FilePath = file
+	}
+	return normalized
 }
 
 func indexHealthParseFailureCount(value any) int {
@@ -230,25 +262,40 @@ func indexHealthParseFailureCount(value any) int {
 	}
 }
 
-// The cached payload contains only baseline parse/liveness health. Failures
-// are read live, and every field changed here belongs to a new top-level map;
-// recovery therefore restores the baseline score without racing cache readers.
+// Parse and file failures are read live, and every field changed here belongs
+// to a new top-level map. Only the expensive liveness audit stays cached, so
+// recovery restores the score without racing readers or discarding orphan caps.
 func (s *Server) refreshIndexHealthFileFailures(ctx context.Context, baseline map[string]any) map[string]any {
 	result := make(map[string]any, len(baseline)+8)
 	for key, value := range baseline {
-		result[key] = value
+		if key != indexHealthLivenessCeilingKey {
+			result[key] = value
+		}
 	}
 	failures, readErr := s.readIndexFileFailures(ctx, ResolvedScope{})
 	totalDetected, _ := baseline["total_detected"].(int)
 	fileNodes, _ := baseline["file_node_count"].(int)
 	parseErrors, _ := baseline["parse_failures"].([]indexer.IndexError)
-	totalDetected, successfullyIndexed := indexHealthFailureCounts(s.readerFor(ctx), totalDetected, fileNodes, parseErrors, failures)
+	if s.indexer != nil {
+		parseErrors = s.indexer.ParseErrors()
+	}
+	if len(parseErrors) > 0 {
+		result["parse_failures"] = parseErrors
+	} else {
+		delete(result, "parse_failures")
+	}
+	totalDetected, successfullyIndexed := indexHealthFailureCounts(s.readerFor(ctx), totalDetected, fileNodes, indexHealthParseErrorsForCounts(parseErrors, s.indexer), failures)
 	result["total_detected"] = totalDetected
 	result["successfully_indexed"] = successfullyIndexed
-	if len(failures) > 0 && totalDetected > 0 {
-		healthScore, _ := baseline["health_score"].(float64)
-		failureScore := math.Round(float64(successfullyIndexed)/float64(totalDetected)*1000) / 10
-		result["health_score"] = min(healthScore, failureScore, 99.9)
+	if totalDetected > 0 {
+		healthScore := math.Round(float64(successfullyIndexed)/float64(totalDetected)*1000) / 10
+		if ceiling, ok := baseline[indexHealthLivenessCeilingKey].(float64); ok {
+			healthScore = min(healthScore, ceiling)
+		}
+		if len(failures) > 0 {
+			healthScore = min(healthScore, 99.9)
+		}
+		result["health_score"] = healthScore
 	}
 	for key, value := range indexFileFailureSummary(failures) {
 		result[key] = value
@@ -256,6 +303,18 @@ func (s *Server) refreshIndexHealthFileFailures(ctx context.Context, baseline ma
 	result["index_complete"] = len(failures) == 0 && readErr == nil
 	result["status"] = "ready"
 	recommendation, _ := baseline["recommendation"].(string)
+	if score, ok := result["health_score"].(float64); ok {
+		if score >= 80 {
+			recommendation = strings.TrimSpace(strings.ReplaceAll(recommendation, indexHealthLowScoreRecommendation, ""))
+		} else if !strings.Contains(recommendation, indexHealthLowScoreRecommendation) {
+			recommendation = strings.TrimSpace(indexHealthLowScoreRecommendation + " " + recommendation)
+		}
+	}
+	if recommendation == "" {
+		delete(result, "recommendation")
+	} else {
+		result["recommendation"] = recommendation
+	}
 	if len(failures) > 0 {
 		result["status"] = "degraded"
 		result["recommendation"] = strings.TrimSpace("Some files could not be indexed (see failed_files). Results can omit current code or retain stale symbols. Fix the reported file access or indexing errors and reindex the affected paths. " + recommendation)

--- a/internal/mcp/index_file_failures.go
+++ b/internal/mcp/index_file_failures.go
@@ -1,0 +1,211 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/query"
+)
+
+const indexFailureSampleLimit = 20
+
+// Registrations include repositories with no successful file nodes. Read their
+// failures through the request reader so another checkout cannot supply them.
+func (s *Server) readIndexFileFailures(ctx context.Context, resolved ResolvedScope) ([]indexer.FileIndexFailure, error) {
+	reader := s.readerFor(ctx)
+	if reader == nil {
+		return nil, nil
+	}
+	prefixes := map[string]bool{}
+	if s.multiIndexer != nil {
+		for _, prefix := range s.multiIndexer.RepoPrefixes() {
+			prefixes[prefix] = true
+		}
+	}
+	if s.indexer != nil {
+		prefixes[s.indexer.RepoPrefix()] = true
+	}
+	var failures []indexer.FileIndexFailure
+	var readErr error
+	scope := query.QueryOptions{WorkspaceID: resolved.WorkspaceID, ProjectID: resolved.ProjectID, RepoAllow: resolved.RepoAllow}
+	for prefix := range prefixes {
+		if len(resolved.RepoAllow) > 0 && !resolved.RepoAllow[prefix] {
+			continue
+		}
+		owner := s.indexer
+		if s.multiIndexer != nil {
+			owner = s.multiIndexer.GetIndexer(prefix)
+		}
+		node := &graph.Node{RepoPrefix: prefix}
+		if owner != nil {
+			node.WorkspaceID, node.ProjectID = owner.WorkspaceID(), owner.ProjectID()
+		}
+		project := node.ProjectID
+		if project == "" {
+			project = prefix
+		}
+		if !scope.ScopeAllows(node) || (resolved.ProjectID != "" && project != resolved.ProjectID) {
+			continue
+		}
+		rows, err := indexer.LoadFileIndexFailuresWithError(reader, prefix)
+		if err != nil {
+			readErr = errors.Join(readErr, fmt.Errorf("read index failure state for repository %q: %w", prefix, err))
+			continue
+		}
+		failures = append(failures, rows...)
+	}
+	sort.Slice(failures, func(i, j int) bool { return failures[i].Path < failures[j].Path })
+	return failures, readErr
+}
+
+// Initial read failures have no graph node. Persisted ownership attributes them
+// without requiring a successful prior index, or treating them as global nodes.
+func scopedIndexFileFailures(failures []indexer.FileIndexFailure, resolved ResolvedScope, paths []string) []indexer.FileIndexFailure {
+	opts := query.QueryOptions{WorkspaceID: resolved.WorkspaceID, ProjectID: resolved.ProjectID, RepoAllow: resolved.RepoAllow}
+	paths = normalizePathPrefixes(paths)
+	var scoped []indexer.FileIndexFailure
+	for _, failure := range failures {
+		if len(resolved.RepoAllow) > 0 && !resolved.RepoAllow[failure.RepoPrefix] {
+			continue
+		}
+		project := failure.ProjectID
+		if project == "" {
+			project = failure.RepoPrefix
+		}
+		if resolved.ProjectID != "" && project != resolved.ProjectID {
+			continue
+		}
+		node := &graph.Node{FilePath: failure.Path, RepoPrefix: failure.RepoPrefix, WorkspaceID: failure.WorkspaceID, ProjectID: failure.ProjectID}
+		if !opts.ScopeAllows(node) {
+			continue
+		}
+		if len(paths) > 0 && !pathMatchesAnyPrefix(failure.Path, expandPathPrefixesWithRepos(paths, []string{failure.RepoPrefix})) {
+			continue
+		}
+		scoped = append(scoped, failure)
+	}
+	return scoped
+}
+
+func indexFileFailureSummary(failures []indexer.FileIndexFailure) map[string]any {
+	unreadable := 0
+	byRepo, unreadableByRepo := map[string]int{}, map[string]int{}
+	for _, failure := range failures {
+		byRepo[failure.RepoPrefix]++
+		if failure.PermissionDenied {
+			unreadable++
+			unreadableByRepo[failure.RepoPrefix]++
+		}
+	}
+	result := map[string]any{
+		"failed_file_count":        len(failures),
+		"unreadable_file_count":    unreadable,
+		"failed_files_by_repo":     byRepo,
+		"unreadable_files_by_repo": unreadableByRepo,
+	}
+	if len(failures) > 0 {
+		result["failed_files"] = failures[:min(len(failures), indexFailureSampleLimit)]
+		if len(failures) > indexFailureSampleLimit {
+			result["failed_files_truncated"] = true
+		}
+	}
+	return result
+}
+
+func (s *Server) indexFileFailureWarning(ctx context.Context, resolved ResolvedScope, paths []string) map[string]any {
+	allFailures, readErr := s.readIndexFileFailures(ctx, resolved)
+	failures := scopedIndexFileFailures(allFailures, resolved, paths)
+	if len(failures) == 0 && readErr == nil {
+		return nil
+	}
+	warning := indexFileFailureSummary(failures)
+	warning["code"] = "index_incomplete"
+	warning["message"] = fmt.Sprintf("%d in-scope file(s) could not be indexed. Results may omit current code or contain stale symbols; zero matches do not prove absence. Fix the reported file access or indexing errors and reindex the affected paths.", len(failures))
+	if readErr != nil {
+		warning["index_state_read_error"] = readErr.Error()
+		warning["message"] = "Index failure state could not be read for this scope; result completeness is unknown. Results may omit current code or retain stale symbols, and zero matches do not prove absence. " + readErr.Error()
+	}
+	return warning
+}
+
+func stampIndexFileFailureWarning(resp map[string]any, warning map[string]any) {
+	if warning != nil {
+		resp["index_complete"] = false
+		resp["index_warning"] = warning
+	}
+}
+
+// Keep one text block so later freshness decoration still reaches GCX headers.
+// Compact and TOON output gain a body-visible qualification without changing
+// their result rows or pagination fields.
+func decorateIndexFileFailureResult(result *mcp.CallToolResult, warning map[string]any) *mcp.CallToolResult {
+	if result == nil || warning == nil {
+		return result
+	}
+	fields := map[string]any{"index_complete": false, "index_warning": warning}
+	result = mergeResultMeta(result, fields)
+	text, ok := singleTextContent(result)
+	if !ok {
+		return result
+	}
+	// GCX headers carry scalar fields; the full structured warning remains
+	// on the response metadata while its qualification is visible in-band.
+	gcxFields := map[string]any{
+		"index_complete":        false,
+		"index_warning":         "index_incomplete",
+		"index_warning_message": warning["message"],
+		"failed_file_count":     warning["failed_file_count"],
+		"unreadable_file_count": warning["unreadable_file_count"],
+	}
+	if body, isGCX := injectGCXHeaderMeta(text, gcxFields); isGCX {
+		return rebuildTextResult(result, body)
+	}
+	message, _ := warning["message"].(string)
+	quotedMessage, _ := json.Marshal(message)
+	return rebuildTextResult(result, strings.TrimRight(text, "\n")+"\nindex_incomplete: "+string(quotedMessage)+"\n")
+}
+
+func indexHealthFailureCounts(reader graph.Reader, totalDetected, fileNodes int, parseErrors []indexer.IndexError, failures []indexer.FileIndexFailure) (int, int) {
+	if len(failures) == 0 {
+		return totalDetected, max(totalDetected-len(parseErrors), 0)
+	}
+	parsePaths := make(map[string]bool, len(parseErrors))
+	for _, failure := range parseErrors {
+		parsePaths[failure.FilePath] = true
+	}
+	missing, additionalFailures := 0, 0
+	for _, failure := range failures {
+		if reader.GetNode(failure.Path) == nil {
+			missing++
+		}
+		prefixedParseError := parsePaths[failure.Path]
+		relative := failure.Path
+		if failure.RepoPrefix != "" {
+			relative = strings.TrimPrefix(relative, failure.RepoPrefix+"/")
+		}
+		relativeParseError := parsePaths[relative]
+		if !prefixedParseError && !relativeParseError {
+			additionalFailures++
+		}
+	}
+	totalDetected = max(totalDetected, fileNodes+missing)
+	return totalDetected, max(totalDetected-len(parseErrors)-additionalFailures, 0)
+}
+
+func indexHealthParseFailureCount(value any) int {
+	switch failures := value.(type) {
+	case []indexer.IndexError:
+		return len(failures)
+	case map[string]string:
+		return len(failures)
+	default:
+		return 0
+	}
+}

--- a/internal/mcp/index_file_failures_test.go
+++ b/internal/mcp/index_file_failures_test.go
@@ -202,3 +202,82 @@ func TestIndexFileFailures_ReadErrorDoesNotClaimCompleteness(t *testing.T) {
 	require.Nil(t, srv.indexFileFailureWarning(ctx, ResolvedScope{ProjectID: "selected-project"}, nil), "project narrowing must apply before reading failure state")
 	require.NotNil(t, srv.indexFileFailureWarning(ctx, ResolvedScope{WorkspaceID: "unrelated"}, nil), "an in-scope ledger error must remain visible")
 }
+
+func TestIndexFileFailures_DirectoryFailureQualifiesNestedSearch(t *testing.T) {
+	g := graph.New()
+	idx := indexer.New(g, testRegistry(), config.Default().Index, zap.NewNop())
+	srv := NewServer(query.NewEngine(g), g, idx, nil, zap.NewNop(), nil)
+	require.NoError(t, g.ReplaceFileIndexFailures("", []graph.FileIndexFailure{{Path: "restricted", Error: "permission denied", PermissionDenied: true}}))
+	for _, tc := range []struct {
+		path    string
+		warning bool
+	}{
+		{"restricted/nested/file.go", true},
+		{"restricted", true},
+		{"restricted-other/file.go", false},
+	} {
+		result, err := srv.handleSearchText(context.Background(), makeReq("search_text", map[string]any{"query": "MissingNeedle", "path": tc.path, "format": "json"}))
+		require.NoError(t, err)
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal([]byte(result.Content[0].(mcplib.TextContent).Text), &payload))
+		require.Equal(t, float64(0), payload["count"])
+		_, warned := payload["index_warning"]
+		require.Equal(t, tc.warning, warned, tc.path)
+	}
+	failures := []indexer.FileIndexFailure{{Path: "repo/restricted", RepoPrefix: "repo"}}
+	require.Len(t, scopedIndexFileFailures(failures, ResolvedScope{}, []string{"restricted/nested/file.go"}), 1)
+	require.Empty(t, scopedIndexFileFailures(failures, ResolvedScope{}, []string{"restricted-other/file.go"}))
+	rootFailure := []indexer.FileIndexFailure{{Path: "repo/.", RepoPrefix: "repo"}}
+	require.Len(t, scopedIndexFileFailures(rootFailure, ResolvedScope{RepoAllow: map[string]bool{"repo": true}}, []string{"pkg/file.go"}), 1)
+	require.Empty(t, scopedIndexFileFailures(rootFailure, ResolvedScope{RepoAllow: map[string]bool{"other": true}}, []string{"pkg/file.go"}))
+	require.Len(t, scopedIndexFileFailures([]indexer.FileIndexFailure{{Path: "."}}, ResolvedScope{}, []string{"pkg/file.go"}), 1)
+}
+
+func TestIndexFileFailures_HealthCacheRefreshesLiveLedger(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte("package app\n\nfunc Alpha() {}\n"), 0o644))
+	g := graph.New()
+	idx := indexer.New(g, testRegistry(), config.Default().Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	srv := NewServer(query.NewEngine(g), g, idx, nil, zap.NewNop(), nil)
+	baseline, err := srv.buildIndexHealthBasePayloadCtx(context.Background())
+	require.NoError(t, err)
+	srv.indexHealth.mu.Lock()
+	srv.indexHealth.payload = baseline
+	srv.indexHealth.updatedAt = time.Now()
+	srv.indexHealth.mu.Unlock()
+	read := func(ctx context.Context) map[string]any {
+		t.Helper()
+		result, err := srv.handleIndexHealth(ctx, makeReq("index_health", map[string]any{"format": "json"}))
+		require.NoError(t, err)
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal([]byte(result.Content[0].(mcplib.TextContent).Text), &payload))
+		return payload
+	}
+	healthy := read(context.Background())
+	require.Equal(t, true, healthy["index_complete"])
+	require.NoError(t, g.ReplaceFileIndexFailures("", []graph.FileIndexFailure{{Path: "blocked.go", Error: "permission denied", PermissionDenied: true}}))
+	failed := read(context.Background())
+	require.Equal(t, "degraded", failed["status"])
+	require.Less(t, failed["health_score"].(float64), healthy["health_score"].(float64))
+	compact, err := srv.handleIndexHealth(context.Background(), makeReq("index_health", map[string]any{"compact": true}))
+	require.NoError(t, err)
+	require.Contains(t, compact.Content[0].(mcplib.TextContent).Text, "status=degraded")
+	require.Contains(t, compact.Content[0].(mcplib.TextContent).Text, "unreadable_files=1")
+	require.NotContains(t, baseline, "failed_file_count", "response-time overlay must not mutate the shared cache")
+	selected := graph.New()
+	selectedCtx := withRequestView(context.Background(), &requestView{reader: selected})
+	require.Equal(t, true, read(selectedCtx)["index_complete"], "a healthy selected ledger must override primary failures")
+	brokenCtx := withRequestView(context.Background(), &requestView{reader: unavailableIndexFailureReader{Reader: selected, err: fmt.Errorf("selected ledger unavailable")}})
+	unknown := read(brokenCtx)
+	require.Equal(t, false, unknown["index_complete"])
+	require.Contains(t, unknown["index_state_read_error"], "selected ledger unavailable")
+	require.NoError(t, g.ReplaceFileIndexFailures("", nil))
+	recovered := read(context.Background())
+	require.Equal(t, "ready", recovered["status"])
+	require.Equal(t, healthy["health_score"], recovered["health_score"], "recovery must restore the baseline score before cache expiry")
+	require.NotContains(t, recovered, "failed_files")
+	require.NotContains(t, recovered, "index_state_read_error")
+	require.Equal(t, healthy["recommendation"], recovered["recommendation"])
+}

--- a/internal/mcp/index_file_failures_test.go
+++ b/internal/mcp/index_file_failures_test.go
@@ -1,0 +1,204 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/query"
+)
+
+func TestIndexFileFailures_SearchAndHealthRecover(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte("package app\n\nfunc Alpha() {}\n"), 0o644))
+	g := graph.New()
+	idx := indexer.New(g, testRegistry(), config.Default().Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+	srv := NewServer(query.NewEngine(g), g, idx, nil, zap.NewNop(), nil)
+	require.NoError(t, g.ReplaceFileIndexFailures("", []graph.FileIndexFailure{{Path: "blocked.go", Error: "open blocked.go: permission denied", PermissionDenied: true}}))
+	require.Nil(t, g.GetNode("blocked.go"), "an initial failure must not need an existing file node")
+
+	decode := func(result *mcplib.CallToolResult) map[string]any {
+		t.Helper()
+		require.False(t, result.IsError)
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal([]byte(result.Content[0].(mcplib.TextContent).Text), &payload))
+		return payload
+	}
+	for _, tc := range []struct {
+		term  string
+		count float64
+	}{{"Alpha", 1}, {"MissingNeedle", 0}} {
+		result, err := srv.handleSearchText(context.Background(), makeReq("search_text", map[string]any{"query": tc.term, "format": "json"}))
+		require.NoError(t, err)
+		payload := decode(result)
+		require.Equal(t, tc.count, payload["count"])
+		require.Equal(t, false, payload["index_complete"])
+		warning := payload["index_warning"].(map[string]any)
+		require.Equal(t, float64(1), warning["unreadable_file_count"])
+		require.Contains(t, warning["message"], "zero matches do not prove absence")
+	}
+	pathScoped, err := srv.handleSearchText(context.Background(), makeReq("search_text", map[string]any{"query": "Alpha", "format": "json", "path": "main.go"}))
+	require.NoError(t, err)
+	pathPayload := decode(pathScoped)
+	require.Equal(t, float64(1), pathPayload["count"])
+	require.NotContains(t, pathPayload, "index_warning", "a failure outside the requested path must not qualify its results")
+	for _, format := range []string{"json", "compact", "toon", "gcx"} {
+		args := map[string]any{"query": "Alpha", "format": format, "assist": "off"}
+		if format == "compact" {
+			args["compact"] = true
+		}
+		result, err := srv.handleSearchSymbols(context.Background(), makeReq("search_symbols", args))
+		require.NoError(t, err)
+		require.False(t, result.IsError)
+		require.Len(t, result.Content, 1, "freshness decoration requires one text block")
+		var bodies []string
+		for _, content := range result.Content {
+			if text, ok := content.(mcplib.TextContent); ok {
+				bodies = append(bodies, text.Text)
+			}
+		}
+		require.Contains(t, strings.Join(bodies, "\n"), "index_incomplete", format)
+		if format == "json" {
+			payload := decode(result)
+			require.Equal(t, false, payload["truncated"], "index failures must not rewrite pagination completeness")
+		}
+	}
+	health, err := srv.buildIndexHealthPayloadCtx(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "degraded", health["status"])
+	require.Equal(t, 1, health["failed_file_count"])
+	require.Equal(t, 1, health["unreadable_file_count"])
+	require.Less(t, health["health_score"].(float64), float64(100))
+	require.Contains(t, compactIndexHealth(health, time.Now(), true), "status=degraded")
+
+	require.NoError(t, g.ReplaceFileIndexFailures("", nil))
+	result, err := srv.handleSearchText(context.Background(), makeReq("search_text", map[string]any{"query": "MissingNeedle", "format": "json"}))
+	require.NoError(t, err)
+	require.NotContains(t, decode(result), "index_warning")
+	health, err = srv.buildIndexHealthPayloadCtx(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "ready", health["status"])
+	require.Equal(t, true, health["index_complete"])
+	require.Equal(t, 0, health["failed_file_count"])
+}
+
+func TestScopedIndexFileFailures(t *testing.T) {
+	failures := []indexer.FileIndexFailure{
+		{Path: "alpha/svc/blocked.go", RepoPrefix: "alpha", WorkspaceID: "shared", ProjectID: "backend"},
+		{Path: "beta/svc/blocked.go", RepoPrefix: "beta", WorkspaceID: "shared", ProjectID: "frontend"},
+		{Path: "gamma/svc/blocked.go", RepoPrefix: "gamma", WorkspaceID: "other", ProjectID: "backend"},
+		{Path: "svc/unowned.go"},
+	}
+	for _, tc := range []struct {
+		name  string
+		scope ResolvedScope
+		paths []string
+		want  []string
+	}{
+		{"repo", ResolvedScope{RepoAllow: map[string]bool{"alpha": true}}, nil, []string{"alpha/svc/blocked.go"}},
+		{"workspace", ResolvedScope{WorkspaceID: "shared"}, nil, []string{"alpha/svc/blocked.go", "beta/svc/blocked.go"}},
+		{"project", ResolvedScope{ProjectID: "backend"}, nil, []string{"alpha/svc/blocked.go", "gamma/svc/blocked.go"}},
+		{"combined", ResolvedScope{WorkspaceID: "shared", ProjectID: "backend"}, []string{"svc"}, []string{"alpha/svc/blocked.go"}},
+		{"prefixed path", ResolvedScope{}, []string{"beta/svc"}, []string{"beta/svc/blocked.go"}},
+		{"path boundary", ResolvedScope{}, []string{"sv"}, nil},
+		{"other path", ResolvedScope{}, []string{"tests"}, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var paths []string
+			for _, failure := range scopedIndexFileFailures(failures, tc.scope, tc.paths) {
+				paths = append(paths, failure.Path)
+			}
+			require.Equal(t, tc.want, paths)
+		})
+	}
+}
+
+func TestIndexFileFailureSummaryBoundsSamples(t *testing.T) {
+	var failures []indexer.FileIndexFailure
+	for i := 0; i < indexFailureSampleLimit+3; i++ {
+		failures = append(failures, indexer.FileIndexFailure{Path: fmt.Sprintf("alpha/file%d.go", i), RepoPrefix: "alpha", PermissionDenied: i%2 == 0})
+	}
+	summary := indexFileFailureSummary(failures)
+	require.Equal(t, len(failures), summary["failed_file_count"])
+	require.Len(t, summary["failed_files"], indexFailureSampleLimit)
+	require.Equal(t, true, summary["failed_files_truncated"])
+	require.Equal(t, map[string]int{"alpha": 23}, summary["failed_files_by_repo"])
+	require.Equal(t, map[string]int{"alpha": 12}, summary["unreadable_files_by_repo"])
+}
+
+func TestIndexHealthFailureCountsAvoidDoubleCountingParseErrors(t *testing.T) {
+	g := graph.New()
+	failures := []indexer.FileIndexFailure{{Path: "alpha/bad.go", RepoPrefix: "alpha"}}
+	for _, key := range []string{"alpha/bad.go", "bad.go"} {
+		total, successful := indexHealthFailureCounts(g, 2, 1, []indexer.IndexError{{FilePath: key, Error: "parse failure"}}, failures)
+		require.Equal(t, 2, total)
+		require.Equal(t, 1, successful)
+	}
+}
+
+func TestIndexFileFailures_SelectedReaderDoesNotInheritBase(t *testing.T) {
+	base, selected := graph.New(), graph.New()
+	require.NoError(t, base.ReplaceFileIndexFailures("", []graph.FileIndexFailure{{Path: "base.go", Error: "permission denied", PermissionDenied: true}}))
+	idx := indexer.New(base, testRegistry(), config.Default().Index, zap.NewNop())
+	srv := &Server{graph: base, indexer: idx}
+	require.NotNil(t, srv.indexFileFailureWarning(context.Background(), ResolvedScope{}, nil))
+	ctx := withRequestView(context.Background(), &requestView{reader: selected})
+	require.Nil(t, srv.indexFileFailureWarning(ctx, ResolvedScope{}, nil), "an empty selected ledger is authoritative")
+	require.NoError(t, selected.ReplaceFileIndexFailures("", []graph.FileIndexFailure{{Path: "selected.go", Error: "read failed"}}))
+	warning := srv.indexFileFailureWarning(ctx, ResolvedScope{}, nil)
+	require.Equal(t, 1, warning["failed_file_count"])
+	require.Equal(t, 0, warning["unreadable_file_count"])
+	failures := warning["failed_files"].([]indexer.FileIndexFailure)
+	require.Equal(t, "selected.go", failures[0].Path)
+}
+
+type unavailableIndexFailureReader struct {
+	graph.Reader
+	err error
+}
+
+func (r unavailableIndexFailureReader) FileIndexFailuresForRepo(string) ([]graph.FileIndexFailure, error) {
+	return nil, r.err
+}
+
+func TestIndexFileFailures_ReadErrorDoesNotClaimCompleteness(t *testing.T) {
+	g := graph.New()
+	idx := indexer.New(g, testRegistry(), config.Default().Index, zap.NewNop())
+	srv := NewServer(query.NewEngine(g), g, idx, nil, zap.NewNop(), nil)
+	reader := unavailableIndexFailureReader{Reader: g, err: fmt.Errorf("ledger unavailable\nsecond line")}
+	ctx := withRequestView(context.Background(), &requestView{reader: reader})
+	warning := srv.indexFileFailureWarning(ctx, ResolvedScope{}, nil)
+	require.NotNil(t, warning)
+	require.Equal(t, 0, warning["failed_file_count"])
+	require.Contains(t, warning["index_state_read_error"], "ledger unavailable")
+	require.Contains(t, warning["message"], "completeness is unknown")
+	result := decorateIndexFileFailureResult(mcplib.NewToolResultText("total: 0\n"), warning)
+	require.Len(t, result.Content, 1)
+	require.NotContains(t, result.Content[0].(mcplib.TextContent).Text, "\nsecond line", "multiline errors must remain a quoted TOON value")
+	health, err := srv.buildIndexHealthPayloadCtx(ctx)
+	require.NoError(t, err)
+	require.Equal(t, false, health["index_complete"])
+	require.Equal(t, "degraded", health["status"])
+	require.Contains(t, health["index_state_read_error"], "ledger unavailable")
+	require.Contains(t, compactIndexHealth(health, time.Now(), false), "status=degraded")
+	require.Nil(t, srv.indexFileFailureWarning(ctx, ResolvedScope{RepoAllow: map[string]bool{"other": true}}, nil), "unselected repository read failures must not affect scoped warnings")
+	idx.SetWorkspaceID("unrelated")
+	idx.SetProjectID("other-project")
+	require.Nil(t, srv.indexFileFailureWarning(ctx, ResolvedScope{WorkspaceID: "selected"}, nil), "another workspace's unreadable ledger must not qualify this workspace")
+	require.Nil(t, srv.indexFileFailureWarning(ctx, ResolvedScope{ProjectID: "selected-project"}, nil), "project narrowing must apply before reading failure state")
+	require.NotNil(t, srv.indexFileFailureWarning(ctx, ResolvedScope{WorkspaceID: "unrelated"}, nil), "an in-scope ledger error must remain visible")
+}

--- a/internal/mcp/index_file_failures_test.go
+++ b/internal/mcp/index_file_failures_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -17,6 +19,7 @@ import (
 	"github.com/zzet/gortex/internal/config"
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/indexer/source"
 	"github.com/zzet/gortex/internal/query"
 )
 
@@ -142,11 +145,29 @@ func TestIndexFileFailureSummaryBoundsSamples(t *testing.T) {
 
 func TestIndexHealthFailureCountsAvoidDoubleCountingParseErrors(t *testing.T) {
 	g := graph.New()
+	idx := indexer.New(g, testRegistry(), config.Default().Index, zap.NewNop())
+	idx.SetRepoPrefix("alpha")
+	idx.SetRootPath(t.TempDir())
 	failures := []indexer.FileIndexFailure{{Path: "alpha/bad.go", RepoPrefix: "alpha"}}
-	for _, key := range []string{"alpha/bad.go", "bad.go"} {
-		total, successful := indexHealthFailureCounts(g, 2, 1, []indexer.IndexError{{FilePath: key, Error: "parse failure"}}, failures)
+	for _, key := range []string{"alpha/bad.go", "bad.go", filepath.Join(idx.RootPath(), "bad.go")} {
+		errors := []indexer.IndexError{{FilePath: key, Error: "parse failure"}}
+		total, successful := indexHealthFailureCounts(g, 2, 1, indexHealthParseErrorsForCounts(errors, idx), failures)
 		require.Equal(t, 2, total)
 		require.Equal(t, 1, successful)
+		require.Equal(t, key, errors[0].FilePath, "normalization must preserve reported parse-error paths")
+	}
+	other := []indexer.IndexError{{FilePath: filepath.Join(t.TempDir(), "bad.go"), Error: "other repository"}}
+	_, successful := indexHealthFailureCounts(g, 3, 2, indexHealthParseErrorsForCounts(other, idx), failures)
+	require.Equal(t, 1, successful, "matching basenames from another root must not collapse distinct failures")
+	for _, tc := range []struct{ relative, graphPath string }{
+		{"alpha/bad.go", "alpha/alpha/bad.go"},
+		{"cafe\u0301.go", "alpha/caf\u00e9.go"},
+	} {
+		errors := []indexer.IndexError{{FilePath: filepath.Join(idx.RootPath(), tc.relative), Error: "parse failure"}}
+		normalized := indexHealthParseErrorsForCounts(errors, idx)
+		require.Equal(t, tc.graphPath, normalized[0].FilePath)
+		_, successful := indexHealthFailureCounts(g, 2, 1, normalized, []indexer.FileIndexFailure{{Path: tc.graphPath, RepoPrefix: "alpha"}})
+		require.Equal(t, 1, successful, "absolute paths must use the same prefixed NFC keys as the ledger")
 	}
 }
 
@@ -280,4 +301,75 @@ func TestIndexFileFailures_HealthCacheRefreshesLiveLedger(t *testing.T) {
 	require.NotContains(t, recovered, "failed_files")
 	require.NotContains(t, recovered, "index_state_read_error")
 	require.Equal(t, healthy["recommendation"], recovered["recommendation"])
+}
+
+type healthFailureContentSource struct {
+	source.ContentSource
+	denied bool
+}
+
+func (s *healthFailureContentSource) Open(path string) (io.ReadCloser, source.FileMeta, error) {
+	if s.denied && filepath.Base(path) == "blocked.go" {
+		return nil, source.FileMeta{}, &os.PathError{Op: "open", Path: path, Err: syscall.EPERM}
+	}
+	return s.ContentSource.Open(path)
+}
+
+func TestIndexFileFailures_HealthCacheClearsRecoveredParsePenalty(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "blocked.go"), []byte("package app\n\nfunc Blocked() {}\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "readable.go"), []byte("package app\n\nfunc Readable() {}\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "another.go"), []byte("package app\n\nfunc Another() {}\n"), 0o644))
+	g := graph.New()
+	idx := indexer.New(g, testRegistry(), config.Default().Index, zap.NewNop())
+	filesystem, err := source.NewFilesystemSource(dir)
+	require.NoError(t, err)
+	content := &healthFailureContentSource{ContentSource: filesystem, denied: true}
+	idx.SetContentSource(content)
+	_, err = idx.Index(dir)
+	require.NoError(t, err)
+	require.NotEmpty(t, idx.ParseErrors(), "full indexing must report the injected read failure")
+	srv := NewServer(query.NewEngine(g), g, idx, nil, zap.NewNop(), nil)
+	baseline, err := srv.buildIndexHealthBasePayloadCtx(context.Background())
+	require.NoError(t, err)
+	require.Less(t, baseline["health_score"].(float64), float64(100))
+	failedHealth, err := srv.buildIndexHealthPayloadCtx(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 3, failedHealth["total_detected"])
+	require.Equal(t, 2, failedHealth["successfully_indexed"], "one absolute parse error and its ledger entry identify the same failed file")
+	require.Equal(t, float64(66.7), failedHealth["health_score"])
+	content.denied = false
+	_, err = idx.IncrementalReindexPaths(dir, []string{filepath.Join(dir, "blocked.go")})
+	require.NoError(t, err)
+	require.Empty(t, idx.ParseErrors(), "successful incremental recovery must clear the historical read failure")
+	for _, ceiling := range []float64{100, 40} {
+		cached := make(map[string]any, len(baseline))
+		for key, value := range baseline {
+			cached[key] = value
+		}
+		cached[indexHealthLivenessCeilingKey] = ceiling
+		srv.indexHealth.mu.Lock()
+		srv.indexHealth.payload, srv.indexHealth.updatedAt = cached, time.Now()
+		srv.indexHealth.mu.Unlock()
+		result, err := srv.handleIndexHealth(context.Background(), makeReq("index_health", map[string]any{"format": "json"}))
+		require.NoError(t, err)
+		var payload map[string]any
+		require.NoError(t, json.Unmarshal([]byte(result.Content[0].(mcplib.TextContent).Text), &payload))
+		require.Equal(t, ceiling, payload["health_score"], "recovery must clear the cached parse penalty while retaining the liveness ceiling")
+		require.NotContains(t, payload, "parse_failures")
+		require.NotContains(t, payload, indexHealthLivenessCeilingKey, "internal cache bookkeeping must not reach callers")
+		require.Contains(t, cached, "parse_failures", "refresh must not mutate the shared cached parse error slice")
+		if ceiling == 100 {
+			require.NotContains(t, fmt.Sprint(payload["recommendation"]), "Health score below 80%")
+		}
+	}
+}
+
+func TestIndexFileFailures_EmptyHealthBaselineWithoutIndexer(t *testing.T) {
+	srv := &Server{graph: graph.New()}
+	baseline := map[string]any{"health_score": float64(0), "total_detected": 0, "file_node_count": 0, indexHealthLivenessCeilingKey: float64(100)}
+	result := srv.refreshIndexHealthFileFailures(context.Background(), baseline)
+	require.Equal(t, float64(0), result["health_score"])
+	require.NotContains(t, result, indexHealthLivenessCeilingKey)
+	require.Contains(t, baseline, indexHealthLivenessCeilingKey)
 }

--- a/internal/mcp/index_file_failures_test.go
+++ b/internal/mcp/index_file_failures_test.go
@@ -324,6 +324,9 @@ func TestIndexFileFailures_HealthCacheClearsRecoveredParsePenalty(t *testing.T) 
 	idx := indexer.New(g, testRegistry(), config.Default().Index, zap.NewNop())
 	filesystem, err := source.NewFilesystemSource(dir)
 	require.NoError(t, err)
+	// Release the os.Root handle before TempDir cleanup removes the directory;
+	// Windows does not allow removal while the source keeps that handle open.
+	t.Cleanup(func() { require.NoError(t, filesystem.Close()) })
 	content := &healthFailureContentSource{ContentSource: filesystem, denied: true}
 	idx.SetContentSource(content)
 	_, err = idx.Index(dir)

--- a/internal/mcp/index_health_cache.go
+++ b/internal/mcp/index_health_cache.go
@@ -35,7 +35,7 @@ func (s *Server) refreshIndexHealthInBackground() {
 	s.indexHealth.mu.Unlock()
 
 	go func() {
-		payload, err := s.buildIndexHealthPayloadCtx(context.Background())
+		payload, err := s.buildIndexHealthBasePayloadCtx(context.Background())
 		s.indexHealth.mu.Lock()
 		defer s.indexHealth.mu.Unlock()
 		s.indexHealth.refreshing = false

--- a/internal/mcp/index_health_cache.go
+++ b/internal/mcp/index_health_cache.go
@@ -52,11 +52,16 @@ func (s *Server) indexHealthNeedsRefresh(updatedAt time.Time) bool {
 
 func compactIndexHealth(payload map[string]any, updatedAt time.Time, refreshing bool) string {
 	stale, _ := payload["stale_files"].([]string)
-	failures, _ := payload["parse_failures"].(map[string]string)
+	parseFailureCount := indexHealthParseFailureCount(payload["parse_failures"])
+	failedFiles, _ := payload["failed_file_count"].(int)
+	unreadableFiles, _ := payload["unreadable_file_count"].(int)
 	status := "ready"
 	if refreshing {
 		status = "refreshing"
 	}
-	return fmt.Sprintf("health=%v nodes=%v stale=%d failures=%d status=%s age=%ds\n",
-		payload["health_score"], payload["node_count"], len(stale), len(failures), status, int(time.Since(updatedAt).Seconds()))
+	if failedFiles > 0 || payload["status"] == "degraded" {
+		status = "degraded"
+	}
+	return fmt.Sprintf("health=%v nodes=%v stale=%d failures=%d status=%s age=%ds failed_files=%d unreadable_files=%d\n",
+		payload["health_score"], payload["node_count"], len(stale), parseFailureCount, status, int(time.Since(updatedAt).Seconds()), failedFiles, unreadableFiles)
 }

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -2281,13 +2281,14 @@ func (s *Server) handleSearchSymbols(ctx context.Context, req mcp.CallToolReques
 		nextCursor = encodeCursor(end)
 	}
 
+	indexWarning := s.indexFileFailureWarning(ctx, resolved, pathFilter)
 	if isCompact(req) {
-		return decorateResultWithScope(mcp.NewToolResultText(compactNodes(page)), resolved), nil
+		return decorateResultWithScope(decorateIndexFileFailureResult(mcp.NewToolResultText(compactNodes(page)), indexWarning), resolved), nil
 	}
 
 	if s.isGCX(ctx, req) {
 		res, err := s.gcxResponseWithBudget(req)(encodeSearchSymbols(page, total, len(page)))
-		return withScopeResult(res, err, resolved)
+		return withScopeResult(decorateIndexFileFailureResult(res, indexWarning), err, resolved)
 	}
 
 	if s.isTOON(ctx, req) {
@@ -2298,7 +2299,7 @@ func (s *Server) handleSearchSymbols(ctx context.Context, req mcp.CallToolReques
 		}
 		data, err := toon.Marshal(result)
 		if err == nil {
-			return decorateResultWithScope(mcp.NewToolResultText(string(data)), resolved), nil
+			return decorateResultWithScope(decorateIndexFileFailureResult(mcp.NewToolResultText(string(data)), indexWarning), resolved), nil
 		}
 	}
 
@@ -2312,6 +2313,7 @@ func (s *Server) handleSearchSymbols(ctx context.Context, req mcp.CallToolReques
 		"truncated":   end < total,
 		"query_class": queryClass.String(),
 	}
+	stampIndexFileFailureWarning(resp, indexWarning)
 	if nextCursor != "" {
 		resp["next_cursor"] = nextCursor
 	}

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -3110,11 +3110,15 @@ func (s *Server) buildIndexHealthPayloadCtx(ctx context.Context) (map[string]any
 		}
 	}
 
-	successfullyIndexed := max(totalDetected-len(parseErrors), 0)
+	fileFailures, fileFailuresReadErr := s.readIndexFileFailures(ctx, ResolvedScope{})
+	totalDetected, successfullyIndexed := indexHealthFailureCounts(s.readerFor(ctx), totalDetected, stats.ByKind[string(graph.KindFile)], parseErrors, fileFailures)
 
 	var healthScore float64
 	if totalDetected > 0 {
 		healthScore = math.Round(float64(successfullyIndexed)/float64(totalDetected)*1000) / 10
+	}
+	if len(fileFailures) > 0 && healthScore == 100 {
+		healthScore = 99.9 // Do not round a known incomplete index up to 100%.
 	}
 
 	var staleFiles []string
@@ -3367,6 +3371,24 @@ func (s *Server) buildIndexHealthPayloadCtx(ctx context.Context) (map[string]any
 		// the daemon caught (and self-healed) a live-patch or boot-reload
 		// resolution regression rather than silently serving a shrunken graph.
 		"resolution_regressions": indexer.ResolutionRegressions(),
+	}
+	for key, value := range indexFileFailureSummary(fileFailures) {
+		result[key] = value
+	}
+	result["index_complete"] = len(fileFailures) == 0 && fileFailuresReadErr == nil
+	result["status"] = "ready"
+	if len(fileFailures) > 0 {
+		result["status"] = "degraded"
+		msg := "Some files could not be indexed (see failed_files). Results can omit current code or retain stale symbols. Fix the reported file access or indexing errors and reindex the affected paths."
+		if recommendation != "" {
+			msg += " " + recommendation
+		}
+		recommendation = msg
+	}
+	if fileFailuresReadErr != nil {
+		result["status"] = "degraded"
+		result["index_state_read_error"] = fileFailuresReadErr.Error()
+		recommendation = "Index failure state could not be read; index completeness is unknown. " + fileFailuresReadErr.Error() + ". " + recommendation
 	}
 	// Query-planner statistics. Read-only on purpose: this payload is served
 	// from a cached snapshot rebuilt in the background, and a health report

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -3027,6 +3027,9 @@ func (s *Server) handleIndexHealth(ctx context.Context, req mcp.CallToolRequest)
 		s.refreshIndexHealthInBackground()
 		result, updatedAt, refreshing = s.indexHealthSnapshot()
 	}
+	if result != nil {
+		result = s.refreshIndexHealthFileFailures(ctx, result)
+	}
 
 	if isCompact(req) {
 		if result == nil {
@@ -3086,6 +3089,14 @@ const healthOrphanSampleLimit = 3
 // the daemon finishing a scan for nobody, holding a transport slot the whole
 // time.
 func (s *Server) buildIndexHealthPayloadCtx(ctx context.Context) (map[string]any, error) {
+	baseline, err := s.buildIndexHealthBasePayloadCtx(ctx)
+	if err != nil || baseline == nil {
+		return baseline, err
+	}
+	return s.refreshIndexHealthFileFailures(ctx, baseline), nil
+}
+
+func (s *Server) buildIndexHealthBasePayloadCtx(ctx context.Context) (map[string]any, error) {
 	if s.indexer == nil {
 		return nil, nil
 	}
@@ -3110,15 +3121,11 @@ func (s *Server) buildIndexHealthPayloadCtx(ctx context.Context) (map[string]any
 		}
 	}
 
-	fileFailures, fileFailuresReadErr := s.readIndexFileFailures(ctx, ResolvedScope{})
-	totalDetected, successfullyIndexed := indexHealthFailureCounts(s.readerFor(ctx), totalDetected, stats.ByKind[string(graph.KindFile)], parseErrors, fileFailures)
+	successfullyIndexed := max(totalDetected-len(parseErrors), 0)
 
 	var healthScore float64
 	if totalDetected > 0 {
 		healthScore = math.Round(float64(successfullyIndexed)/float64(totalDetected)*1000) / 10
-	}
-	if len(fileFailures) > 0 && healthScore == 100 {
-		healthScore = 99.9 // Do not round a known incomplete index up to 100%.
 	}
 
 	var staleFiles []string
@@ -3367,28 +3374,11 @@ func (s *Server) buildIndexHealthPayloadCtx(ctx context.Context) (map[string]any
 		"edge_count":           stats.TotalEdges,
 		"edges_ok":             edgesOK,
 		"nodes_per_file":       nodesPerFile,
+		"file_node_count":      fileNodes,
 		// Shape-degradation guard firings since process start. Nonzero means
 		// the daemon caught (and self-healed) a live-patch or boot-reload
 		// resolution regression rather than silently serving a shrunken graph.
 		"resolution_regressions": indexer.ResolutionRegressions(),
-	}
-	for key, value := range indexFileFailureSummary(fileFailures) {
-		result[key] = value
-	}
-	result["index_complete"] = len(fileFailures) == 0 && fileFailuresReadErr == nil
-	result["status"] = "ready"
-	if len(fileFailures) > 0 {
-		result["status"] = "degraded"
-		msg := "Some files could not be indexed (see failed_files). Results can omit current code or retain stale symbols. Fix the reported file access or indexing errors and reindex the affected paths."
-		if recommendation != "" {
-			msg += " " + recommendation
-		}
-		recommendation = msg
-	}
-	if fileFailuresReadErr != nil {
-		result["status"] = "degraded"
-		result["index_state_read_error"] = fileFailuresReadErr.Error()
-		recommendation = "Index failure state could not be read; index completeness is unknown. " + fileFailuresReadErr.Error() + ". " + recommendation
 	}
 	// Query-planner statistics. Read-only on purpose: this payload is served
 	// from a cached snapshot rebuilt in the background, and a health report

--- a/internal/mcp/tools_enhancements.go
+++ b/internal/mcp/tools_enhancements.go
@@ -3235,7 +3235,7 @@ func (s *Server) buildIndexHealthBasePayloadCtx(ctx context.Context) (map[string
 
 	var recommendation string
 	if healthScore < 80 {
-		recommendation = "Health score below 80%. Run index_repository with path \".\" to re-index the codebase."
+		recommendation = indexHealthLowScoreRecommendation
 	}
 	if !orphans.Clean() {
 		msg := "Graph holds nodes for files that no longer exist on disk (" + orphans.Summary() + "). " +
@@ -3365,16 +3365,17 @@ func (s *Server) buildIndexHealthBasePayloadCtx(ctx context.Context) (map[string
 	}
 
 	result := map[string]any{
-		"health_score":         healthScore,
-		"total_detected":       totalDetected,
-		"successfully_indexed": successfullyIndexed,
-		"language_coverage":    langCoverage,
-		"last_index_time":      lastIndexStr,
-		"node_count":           stats.TotalNodes,
-		"edge_count":           stats.TotalEdges,
-		"edges_ok":             edgesOK,
-		"nodes_per_file":       nodesPerFile,
-		"file_node_count":      fileNodes,
+		"health_score":                healthScore,
+		"total_detected":              totalDetected,
+		"successfully_indexed":        successfullyIndexed,
+		"language_coverage":           langCoverage,
+		"last_index_time":             lastIndexStr,
+		"node_count":                  stats.TotalNodes,
+		"edge_count":                  stats.TotalEdges,
+		"edges_ok":                    edgesOK,
+		"nodes_per_file":              nodesPerFile,
+		"file_node_count":             fileNodes,
+		indexHealthLivenessCeilingKey: orphans.LiveScore(),
 		// Shape-degradation guard firings since process start. Nonzero means
 		// the daemon caught (and self-healed) a live-patch or boot-reload
 		// resolution regression rather than silently serving a shrunken graph.

--- a/internal/mcp/tools_search_text.go
+++ b/internal/mcp/tools_search_text.go
@@ -131,6 +131,7 @@ func (s *Server) handleSearchText(ctx context.Context, req mcp.CallToolRequest) 
 	if len(enriched) == 0 && len(resolved.RepoAllow) > 0 {
 		resp["scope_note"] = scopeZeroNote(resolved, -1)
 	}
+	stampIndexFileFailureWarning(resp, s.indexFileFailureWarning(ctx, resolved, pathFilter))
 	return s.respondScopedJSONOrTOON(ctx, req, resp, resolved)
 }
 


### PR DESCRIPTION
## Summary

Fixes #684.

The reporting defect is present on current main: incremental indexing discards fallback errors, logs terminal failures with only a filename, and retries permission denials. Queries and status have no durable record with which to qualify stale or missing results.

- Preserve underlying read/stat errors; skip futile EPERM/EACCES retries and emit one aggregate permission warning per repository outage, with a macOS Full Disk Access hint where applicable.
- Persist unresolved file failures in a generation-scoped ledger (additive SQLite schema migration), retaining them across restarts/reparses and clearing them after successful indexing or confirmed deletion.
- Qualify text and symbol results, including zero matches and compact/TOON/GCX output, with scoped incomplete-index warnings. Include failures for unreadable ancestor directories and honor the selected checkout.
- Report degraded indexing and failed/unreadable counts in index health and daemon/CLI/TUI status without conflating completeness with query readiness. Refresh failure health independently of cached aggregates, and disclose failure-ledger read errors.

## Validation

- Full indexer and graph/SQLite test suites, including migration, cleanup, persistence, and generation isolation.
- Deterministic wrapped EPERM/EACCES, terminal retry-error, recovery/deletion, full-index/shadow-drain, and restart regressions.
- Selected race tests for indexer, graphview, and CLI/status; search/health response regressions cover scope, selected-reader isolation, output formats, freshness metadata, and cached full-index-error recovery without double-counting.

The tests inject filesystem errors; they do not alter macOS permissions or claim to reproduce the original machine's precise TCC policy. Existing failures become visible when observed by the next indexing pass. Failure-ledger write errors remain logged and pending for retry; this does not add a general storage-health protocol. Existing parse/liveness health aggregates retain their configured-indexer scope; the new failure ledger and warnings honor the request-selected reader.

Changes were developed in an isolated worktree and split into atomic commits.
