### PR TITLE
fix(lsp): guard sourceCache with docMu and close openDocument check-then-act

### DIFF
--- a/internal/semantic/lsp/provider.go
+++ b/internal/semantic/lsp/provider.go
@@ -82,14 +82,18 @@ type Provider struct {
 	// interactive session — where hover / definition traffic keeps the
 	// provider's lastUsed fresh and the router never reaps it — does
 	// not retain every navigated file's bytes for the daemon's
-	// lifetime. Accessed lock-free (see getSource, which tolerates a
-	// miss by falling back to col=0): the interactive
-	// open→lookup→close sequence is serialized per file, so it needs
-	// no docMu.
+	// lifetime. Written under docMu: the interactive
+	// open→lookup→close sequence was serialized per file when this
+	// cache was introduced, but on-demand confirmation
+	// (ConfirmSymbolRefs) and the MCP tool path now reach openDocument
+	// from concurrent request goroutines, and an unsynchronised map
+	// write there is a fatal (uncatchable) concurrent map writes
+	// crash, so every access shares the docMu the open/close
+	// bookkeeping already holds.
 	sourceCache map[string][]byte
 
-	// docMu guards docVersions / openDocs / lastDiag so concurrent
-	// callers (LSP push notifications + MCP request goroutines) can
+	// docMu guards docVersions / openDocs / lastDiag / sourceCache so
+	// concurrent callers (LSP push notifications + MCP request goroutines) can
 	// share one client safely.
 	docMu       sync.RWMutex
 	docVersions map[string]int          // absPath → most-recent didOpen / didChange version
@@ -2026,13 +2030,13 @@ func (p *Provider) resetForReconnect() {
 	p.docVersions = map[string]int{}
 	p.openDocs = map[string]bool{}
 	p.lastDiag = map[string][]Diagnostic{}
-	p.docMu.Unlock()
-	// sourceCache is the unsynchronised interactive-navigation cache
-	// (written lock-free by openDocument); drop it on reconnect so a
-	// long-lived provider doesn't carry the dead session's file bytes.
-	// nil is the freed state — openDocument lazily re-creates it and
-	// getSource nil-checks before reading.
+	// sourceCache rides the same reset under docMu (every access is
+	// docMu-guarded); drop it on reconnect so a long-lived provider
+	// doesn't carry the dead session's file bytes. nil is the freed
+	// state — openDocument lazily re-creates it and getSource
+	// nil-checks under the same lock before reading.
 	p.sourceCache = nil
+	p.docMu.Unlock()
 }
 
 // dialOrSpawn builds the LSP client according to the provider's spec.
@@ -2769,7 +2773,12 @@ func uriToAbsPath(uri string) string {
 // openDocument sends textDocument/didOpen for a file. Tracks version
 // 1 in docVersions so a later didChange can monotonically bump it.
 // Idempotent — a second call to openDocument with the same path is a
-// no-op.
+// no-op. Concurrent calls on the same path are funnelled into one
+// didOpen: the first claimant marks the path open before its disk
+// read, so every later caller (including one that raced the initial
+// check-then-act) sees the open in progress and returns immediately.
+// The claim is released if the read or the didOpen fails, so a retry
+// starts clean.
 func (p *Provider) openDocument(repoRoot, relPath string) error {
 	absPath := filepath.Join(repoRoot, relPath)
 	p.docMu.Lock()
@@ -2777,16 +2786,20 @@ func (p *Provider) openDocument(repoRoot, relPath string) error {
 		p.docMu.Unlock()
 		return nil
 	}
+	p.openDocs[absPath] = true
 	p.docMu.Unlock()
 
 	content, err := os.ReadFile(absPath)
 	if err != nil {
+		p.releaseOpenClaim(absPath)
 		return err
 	}
+	p.docMu.Lock()
 	if p.sourceCache == nil {
 		p.sourceCache = map[string][]byte{}
 	}
 	p.sourceCache[absPath] = content
+	p.docMu.Unlock()
 
 	langID := p.languageIDFor(absPath)
 
@@ -2798,13 +2811,25 @@ func (p *Provider) openDocument(repoRoot, relPath string) error {
 			Text:       string(content),
 		},
 	}); err != nil {
+		p.releaseOpenClaim(absPath)
 		return err
 	}
 	p.docMu.Lock()
-	p.openDocs[absPath] = true
 	p.docVersions[absPath] = 1
 	p.docMu.Unlock()
 	return nil
+}
+
+// releaseOpenClaim reverts openDocument's optimistic openDocs claim
+// after a failed read or didOpen: the file is not open on the server
+// and must not stay marked, or a retry would silently skip its
+// didOpen. The sourceCache entry written between claim and failure is
+// dropped too — the bytes may never have reached the server.
+func (p *Provider) releaseOpenClaim(absPath string) {
+	p.docMu.Lock()
+	delete(p.openDocs, absPath)
+	delete(p.sourceCache, absPath)
+	p.docMu.Unlock()
 }
 
 // languageIDFor picks the LSP `languageId` to send in didOpen. When
@@ -2833,11 +2858,11 @@ func (p *Provider) changeDocument(absPath, newText string) error {
 	p.docMu.Lock()
 	v := p.docVersions[absPath] + 1
 	p.docVersions[absPath] = v
-	p.docMu.Unlock()
 	if p.sourceCache == nil {
 		p.sourceCache = map[string][]byte{}
 	}
 	p.sourceCache[absPath] = []byte(newText)
+	p.docMu.Unlock()
 	return p.client.Notify("textDocument/didChange", DidChangeTextDocumentParams{
 		TextDocument: VersionedTextDocumentIdentifier{
 			URI:     pathToURI(absPath),
@@ -2856,12 +2881,12 @@ func (p *Provider) closeDocument(absPath string) error {
 	}
 	delete(p.openDocs, absPath)
 	delete(p.docVersions, absPath)
-	p.docMu.Unlock()
 	// Drop this file's cached bytes too. getSource tolerates a miss
 	// (falls back to col=0) and the next openDocument repopulates, so
 	// without this an interactive session that navigates thousands of
 	// files would pin every one's contents until the daemon exits.
 	delete(p.sourceCache, absPath)
+	p.docMu.Unlock()
 	return p.client.Notify("textDocument/didClose", DidCloseTextDocumentParams{
 		TextDocument: TextDocumentIdentifier{URI: pathToURI(absPath)},
 	})
@@ -3131,6 +3156,8 @@ func (p *Provider) EnrichNode(g graph.Store, repoRoot string, n *graph.Node) (bo
 // openDocument call. Returns nil when not cached — callers fall
 // back to col=0 then.
 func (p *Provider) getSource(repoRoot, relPath string) []byte {
+	p.docMu.RLock()
+	defer p.docMu.RUnlock()
 	if p.sourceCache == nil {
 		return nil
 	}

--- a/internal/semantic/lsp/provider_cache_test.go
+++ b/internal/semantic/lsp/provider_cache_test.go
@@ -1,6 +1,16 @@
 package lsp
 
-import "testing"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
 
 // discardWriteCloser is a no-op transport write-end so closeDocument's
 // didClose notification can be "sent" without a live LSP server.
@@ -8,6 +18,92 @@ type discardWriteCloser struct{}
 
 func (discardWriteCloser) Write(p []byte) (int, error) { return len(p), nil }
 func (discardWriteCloser) Close() error                { return nil }
+
+// TestOpenDocument_ConcurrentIsRaceFree reproduces the #714 crash shape:
+// concurrent tool requests (e.g. relations.callers → ConfirmSymbolRefs →
+// EnsureFileOpen) open overlapping file sets on one provider. On the
+// unfixed code the unguarded sourceCache writes are a fatal concurrent
+// map writes error under -race; with the docMu claim, every file is
+// didOpen'd exactly once and the cache holds one entry per file.
+func TestOpenDocument_ConcurrentIsRaceFree(t *testing.T) {
+	const files = 12
+	repoRoot := t.TempDir()
+	for i := 0; i < files; i++ {
+		require.NoError(t, os.WriteFile(filepath.Join(repoRoot, fmt.Sprintf("f%d.go", i)), []byte(fmt.Sprintf("package main\n\nfunc F%d() {}\n", i)), 0o644))
+	}
+
+	server := newInstrumentedServer()
+	p, cleanup := providerWithInstrumentedServer(t, server, []string{"go"}, 4)
+	defer cleanup()
+
+	// 8 goroutines each sweep every file — same-file opens race the
+	// check-then-act, cross-file opens race the map writes.
+	const workers = 8
+	var wg sync.WaitGroup
+	errs := make(chan error, workers*files)
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < files; i++ {
+				if err := p.EnsureFileOpen(repoRoot, fmt.Sprintf("f%d.go", i)); err != nil {
+					errs <- err
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("EnsureFileOpen: %v", err)
+	}
+
+	require.Eventually(t, func() bool {
+		_, opens, _ := server.stats()
+		return opens == files
+	}, 3*time.Second, 5*time.Millisecond, "each of the %d files must be didOpen'd exactly once across %d concurrent sweepers", files, workers)
+
+	p.docMu.RLock()
+	cacheLen := len(p.sourceCache)
+	p.docMu.RUnlock()
+	assert.Equal(t, files, cacheLen, "one sourceCache entry per opened file")
+
+	// The cached bytes must be what concurrent readers see through the
+	// public getter.
+	for i := 0; i < files; i++ {
+		assert.Contains(t, string(p.getSource(repoRoot, fmt.Sprintf("f%d.go", i))), fmt.Sprintf("func F%d()", i))
+	}
+}
+
+// TestOpenDocument_FailedOpenLeavesNoClaim pins the failure half of the
+// claim: a read or didOpen error must un-claim the path, or a retry
+// after the file appears silently skips its didOpen (#714's suggested
+// fix closes the check-then-act both ways).
+func TestOpenDocument_FailedOpenLeavesNoClaim(t *testing.T) {
+	repoRoot := t.TempDir()
+
+	server := newInstrumentedServer()
+	p, cleanup := providerWithInstrumentedServer(t, server, []string{"go"}, 4)
+	defer cleanup()
+
+	missing := filepath.Join(repoRoot, "gone.go")
+	require.Error(t, p.EnsureFileOpen(repoRoot, "gone.go"))
+
+	p.docMu.RLock()
+	openClaimed := p.openDocs[missing]
+	cacheLen := len(p.sourceCache)
+	p.docMu.RUnlock()
+	assert.False(t, openClaimed, "a failed open must not leave the path claimed open")
+	assert.Zero(t, cacheLen, "a failed open must not leave cached bytes")
+
+	// The retry, once the file exists, must send its didOpen.
+	require.NoError(t, os.WriteFile(missing, []byte("package main\n"), 0o644))
+	require.NoError(t, p.EnsureFileOpen(repoRoot, "gone.go"))
+	require.Eventually(t, func() bool {
+		_, opens, _ := server.stats()
+		return opens == 1
+	}, 3*time.Second, 5*time.Millisecond, "retry after a failed open performs the didOpen")
+}
 
 // TestCloseDocument_DropsSourceCache asserts closeDocument frees the
 // file's cached bytes. Without this an interactive session that keeps


### PR DESCRIPTION
## Summary

`relations.callers` (and any other tool traffic that reaches `EnsureFileOpen`) could kill the whole daemon with `fatal error: concurrent map writes`, because `openDocument` released `docMu` after its `openDocs` check-then-act and then wrote `sourceCache` with no lock at all. That was fine while the cache was only touched from the serialized interactive-navigation path, but `confirmSymbolRefsOnDemand` now funnels concurrent tool-request goroutines into `openDocument`, so two calls on different files race the map writes directly, and two calls on the same file both pass the `openDocs` gate.

## Changes

- `sourceCache` is now guarded by the provider's existing `docMu` at every site: the writes in `openDocument` / `changeDocument`, the deletes in `closeDocument` / `releaseOpenClaim`, the read in `getSource` (RLock), and the reset in `resetForReconnect`. No new mutex — the open/close bookkeeping already held this lock around the same state.
- `openDocument` now claims the path in `openDocs` before its disk read, so concurrent opens of the same file funnel into one `didOpen`. On a read or notify failure the claim (and any bytes cached meanwhile) is released, so a retry after the failure starts clean instead of silently skipping its `didOpen`.
- The two comments that promised the opposite (`provider.go` docMu guard list, `resetForReconnect`) are updated to match.

## Testing

- [x] New regression test `TestOpenDocument_ConcurrentIsRaceFree` (8 goroutines sweeping 12 overlapping files through `EnsureFileOpen`): on unfixed main it fails with 3 `WARNING: DATA RACE` reports inside `openDocument` at the exact #714 stack, and the didOpen count never settles because same-file opens double-fire; with the fix it is race-free, exactly one `didOpen` per file, one cache entry per file, and `getSource` serves the cached bytes.
- [x] New test `TestOpenDocument_FailedOpenLeavesNoClaim`: a missing file errors without leaving an `openDocs` claim or cached bytes, and the retry after the file appears does send its `didOpen`.
- [x] `go test -race -count=1 ./internal/semantic/lsp/` — ok (full LSP package).
- [x] `go test -race -count=1 -timeout 45m ./...` — all packages ok (the four slow ones were re-run with CI's timeout: `store_sqlite` ~16m, `indexer` ~14m, `mcp` ~8m, `agents/opencode`).
- [x] `gofmt -s` clean on the changed files; `go vet ./internal/semantic/lsp/` clean.

Fixes #714
