### PR TITLE
fix(mcp): enable guarded source edits in exact worktrees

### DIFF
--- a/docs/worktree-source-mutations.md
+++ b/docs/worktree-source-mutations.md
@@ -1,0 +1,71 @@
+# Source edits in selected worktrees
+
+An exact, live automatic worktree supports `edit.file`, `edit.write`, and
+`edit.symbol` (and their legacy tool equivalents). The session may already be
+inside the worktree, or select it explicitly with `view.kind: worktree` and a
+registered checkout ID or absolute root path. No explicit tracking or dedicated
+graph is required.
+
+The old mutation guard refused every routed source tool, including dry runs,
+and suggested editing from the checkout's own working copy. That suggestion
+could not work: an automatic checkout's own session also receives a routed view.
+The replacement admits only the audited checkout-aware write paths.
+
+## Safety and freshness
+
+- Admission obtains the existing checkout coordinator's interactive build
+  admission and reconciliation lock. It verifies that the checkout and the
+  route epoch still match the view used to interpret the edit.
+- File targets must belong to that checkout, including after resolving symlinks
+  and existing parent directories. Absolute primary/sibling paths, nested Git
+  repositories, and Git metadata are refused rather than redirected.
+- Dry runs validate against the selected working copy without committing bytes,
+  withdrawing its route, or building a generation.
+- Immediately before a real write, the old dirty route becomes pending. Existing
+  leased readers remain valid; new requests cannot mistake the old generation
+  for the updated working copy.
+- The existing single-file commit ledger still distinguishes disk commit from
+  graph refresh. Refresh uses the selected checkout coordinator, never the
+  primary repository's watcher or incremental indexer. A bounded refresh failure
+  leaves a stale/failed graph outcome and schedules reconciliation; it must not
+  report that a successful disk write did not happen.
+- Coordinator shutdown joins admitted writes before checkout state can retire.
+
+All inexact fallbacks and immutable ref/commit views remain read-only. A missing
+coordinator refuses the operation before touching files. Save or discard active
+session editor buffers before editing on-disk worktree content; buffer-derived
+symbol locations are not authority to modify disk.
+
+## Deliberately unsupported write paths
+
+Batch editing/recovery, filesystem lifecycle operations, and LSP refactors have
+separate write and refresh machinery. They remain refused through routed views
+until their checkout ownership and recovery are integrated. The refusal states
+this limitation rather than recommending a CWD change that cannot solve it.
+
+Ordinary canonical-checkout editing is unchanged. This change requires no schema
+migration, daemon restart procedure, new tracking intent, or additional database.
+
+## Regression validation and benchmark scope
+
+The regression fixtures create real temporary Git families, automatically
+register/activate a linked checkout through the lifecycle, and invoke MCP
+handlers and the registered facade. They cover own-CWD and explicit path/ID
+selection, explicit and inferred operations, dry runs, disk isolation, and
+subsequent exact graph/source reads. Separate tests cover stale epochs, dirty
+state, cancellation, shutdown, panic cleanup, root replacement, and failed
+publication after a successful disk commit.
+
+On an Apple M1 Pro, three 10-iteration runs against a tiny fixture measured:
+
+| Operation | Time per operation |
+| --- | --- |
+| Checkout admission and release (no build) | 10.06–10.21 ms |
+| Complete MCP worktree dry run | 12.35–19.55 ms |
+
+These figures measure the new admission path, not cold indexing or large-repo
+scaling. Tests additionally assert that a dry run leaves the route epoch and
+generation IDs unchanged. Reproduce with
+`go test ./internal/indexer -run '^$' -bench '^BenchmarkCheckoutMutation' -benchmem`
+and
+`go test ./internal/mcp -run '^$' -bench '^BenchmarkWorktreeMutationDryRun$' -benchmem`.

--- a/internal/graph/store_sqlite/store_repo_estimates_test.go
+++ b/internal/graph/store_sqlite/store_repo_estimates_test.go
@@ -104,13 +104,43 @@ func TestScanRepoMemoryEstimatesReportsTheCorpusAndExposesDrift(t *testing.T) {
 // because the caller owns the deadline and gets an error instead of numbers.
 func TestScanRepoMemoryEstimatesFailsRatherThanTruncating(t *testing.T) {
 	s := openEstimateStore(t)
-	addRepoNodes(t, s, "r1", 20000)
+	addRepoNodes(t, s, "r1", 2)
+	addRepoNodes(t, s, "r2", 3)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
-	defer cancel()
-	got, err := s.ScanRepoMemoryEstimates(ctx)
-	require.Error(t, err, "an unfinished scan must not be reported as a result")
-	require.Nil(t, got)
+	// A 1 ns timer can fire after a fast scan completes, especially on
+	// platforms with coarse clock/timer resolution. Inject the failure before
+	// querying so this checks the error contract, not a scheduling race.
+	for _, tc := range []struct {
+		name       string
+		newContext func() (context.Context, context.CancelFunc)
+		wantErr    error
+	}{
+		{
+			name: "canceled",
+			newContext: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx, cancel
+			},
+			wantErr: context.Canceled,
+		},
+		{
+			name: "expired_deadline",
+			newContext: func() (context.Context, context.CancelFunc) {
+				return context.WithDeadline(context.Background(), time.Unix(0, 0))
+			},
+			wantErr: context.DeadlineExceeded,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := tc.newContext()
+			defer cancel()
+			require.ErrorIs(t, ctx.Err(), tc.wantErr, "the scan must start with the failure already observable")
+			got, err := s.ScanRepoMemoryEstimates(ctx)
+			require.ErrorIs(t, err, tc.wantErr, "an unfinished scan must not be reported as a result")
+			require.Nil(t, got, "failed scans must not expose partial estimates")
+		})
+	}
 }
 
 // Whatever the scan reports can be written straight back, which is how

--- a/internal/graphview/materialize.go
+++ b/internal/graphview/materialize.go
@@ -70,6 +70,11 @@ type GenerationSource struct {
 type RepoView struct {
 	// ID names the exact content this view reads.
 	ID RepoViewID
+	// CheckoutRouteEpoch is the catalog route snapshot pinned by this view.
+	// A checkout mutation must revalidate it after taking the coordinator lock;
+	// generation identity alone cannot detect a route that moved away and back.
+	// It is zero for immutable ref views.
+	CheckoutRouteEpoch int64
 	// Reader is the composed graph: the indexed corpus with the
 	// checkout's routed generations stacked on it.
 	Reader graph.Reader
@@ -203,6 +208,7 @@ func (m *Materializer) MaterializeCheckout(ctx context.Context, checkoutID strin
 			lease.Release()
 			return nil, err
 		}
+		view.CheckoutRouteEpoch = route.RouteEpoch
 		return view, nil
 	}
 	return nil, NewViewError(CodeViewBuilding,

--- a/internal/indexer/checkout_coordinator.go
+++ b/internal/indexer/checkout_coordinator.go
@@ -253,6 +253,11 @@ type CheckoutCoordinator struct {
 	cycleMu sync.Mutex
 
 	mu sync.Mutex
+	// Source mutations are admitted under mu and joined by CloseContext before
+	// lifecycle teardown can retire the checkout while its disk writer runs.
+	sourceMutationsClosing bool
+	sourceMutations        int
+	sourceMutationsDrained chan struct{}
 	// retained is the commit-layer reuse cache, most recently routed first.
 	retained []retainedCommitLayer
 	// backlog holds generations a retire refused. The janitor retries them.
@@ -405,6 +410,9 @@ func (c *CheckoutCoordinator) CloseContext(ctx context.Context) error {
 		ctx = context.Background()
 	}
 	c.once.Do(func() {
+		c.mu.Lock()
+		c.sourceMutationsClosing = true
+		c.mu.Unlock()
 		if c.cancelLifetime != nil {
 			c.cancelLifetime()
 		}
@@ -414,7 +422,7 @@ func (c *CheckoutCoordinator) CloseContext(ctx context.Context) error {
 	})
 	select {
 	case <-c.done:
-		return nil
+		return c.waitSourceMutations(ctx)
 	case <-ctx.Done():
 		return ctx.Err()
 	}

--- a/internal/indexer/checkout_mutation.go
+++ b/internal/indexer/checkout_mutation.go
@@ -1,0 +1,330 @@
+package indexer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/pathkey"
+)
+
+// ErrCheckoutMutationStale means the view used to prepare an edit is no longer
+// the current writable checkout. No disk write has been admitted by Prepare.
+var ErrCheckoutMutationStale = errors.New("indexer: checkout mutation view is stale")
+
+// ErrCheckoutMutationPending means a disk mutation has not yet reached a fresh
+// routed generation. It does not mean the disk mutation was rolled back.
+var ErrCheckoutMutationPending = errors.New("indexer: checkout mutation refresh is pending")
+
+// CheckoutMutation owns one checkout's physical build lane and route lock for
+// a source edit. Callers must Close it on every exit, including dry runs. It
+// never writes source itself and must not be used to update the primary corpus.
+type CheckoutMutation struct {
+	mu          sync.Mutex
+	coordinator *CheckoutCoordinator
+	checkout    store_sqlite.Checkout
+	rootInfo    os.FileInfo
+	route       store_sqlite.CheckoutRoute
+	release     func()
+	prepared    bool
+	fresh       bool
+	closed      bool
+}
+
+// BeginCheckoutMutation admits a source edit against the exact checkout route
+// the caller materialized. It changes neither disk nor catalog: a dry run may
+// simply close the lease. Gate-before-cycleMu matches background reconciliation
+// so an edit can never hold the route lock while waiting on a build that needs it.
+func (l *CheckoutLifecycle) BeginCheckoutMutation(ctx context.Context, checkoutID, expectedRoot string, expectedRouteEpoch int64) (*CheckoutMutation, error) {
+	if l == nil || l.catalog == nil || checkoutID == "" || expectedRoot == "" || expectedRouteEpoch <= 0 {
+		return nil, fmt.Errorf("%w: exact checkout identity and route epoch are required", ErrCheckoutMutationStale)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	checkout, found, err := l.catalog.GetCheckout(ctx, checkoutID)
+	if err != nil {
+		return nil, err
+	}
+	if !found || !sameMutationRoot(checkout.RootPath, expectedRoot) {
+		return nil, fmt.Errorf("%w: checkout root changed", ErrCheckoutMutationStale)
+	}
+	rootInfo, err := os.Stat(checkout.RootPath)
+	if err != nil || !rootInfo.IsDir() {
+		return nil, fmt.Errorf("%w: checkout root is unavailable", ErrCheckoutMutationStale)
+	}
+	l.coordMu.Lock()
+	c := l.coordinators[checkoutID]
+	closing := l.coordinatorClosing
+	l.coordMu.Unlock()
+	if c == nil || closing || !sameMutationRoot(c.root, expectedRoot) {
+		return nil, fmt.Errorf("%w: checkout coordinator is not available; retry after activation", ErrCheckoutMutationStale)
+	}
+	if !c.admitSourceMutation() {
+		return nil, fmt.Errorf("%w: checkout coordinator is closing", ErrCheckoutMutationStale)
+	}
+	admitted := true
+	defer func() {
+		if admitted {
+			c.releaseSourceMutation()
+		}
+	}()
+
+	waitCtx, cancel := checkoutMutationContext(ctx, c.lifetimeContext())
+	defer cancel()
+	releaseGate, err := c.gate.Acquire(waitCtx, ViewBuildInteractive)
+	if err != nil {
+		return nil, err
+	}
+	gateOwned := true
+	defer func() {
+		if gateOwned {
+			releaseGate()
+		}
+	}()
+	if err := lockCheckoutMutationCycle(waitCtx, c); err != nil {
+		return nil, err
+	}
+	cycleOwned := true
+	defer func() {
+		if cycleOwned {
+			c.cycleMu.Unlock()
+		}
+	}()
+	m := &CheckoutMutation{coordinator: c, checkout: checkout, rootInfo: rootInfo, release: releaseGate}
+	if err := m.validateCheckout(waitCtx); err != nil {
+		return nil, err
+	}
+	route, found, err := c.catalog.GetCheckoutRoute(waitCtx, checkoutID)
+	if err == nil && (!found || route.State != store_sqlite.RouteActive || route.RouteEpoch != expectedRouteEpoch || route.CommitGenerationID <= 0 || route.DirtyGenerationID <= 0) {
+		err = fmt.Errorf("%w: checkout route changed; read the current exact view and retry", ErrCheckoutMutationStale)
+	}
+	if err != nil {
+		return nil, err
+	}
+	m.route = route
+	if err := m.validateSnapshot(waitCtx); err != nil {
+		return nil, err
+	}
+	admitted, gateOwned, cycleOwned = false, false, false // Close now owns every acquired resource.
+	return m, nil
+}
+
+// Prepare withdraws the old dirty generation immediately before the disk
+// commit. It is idempotent until Refresh; validation/preview failures and dry
+// runs must not call it. Already-pinned readers retain their immutable view.
+func (m *CheckoutMutation) Prepare(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed || m.fresh {
+		return fmt.Errorf("%w: mutation lease is no longer writable", ErrCheckoutMutationStale)
+	}
+	if m.prepared {
+		return nil
+	}
+	ctx, cancel := checkoutMutationContext(ctx, m.coordinator.lifetimeContext())
+	defer cancel()
+	if err := m.validateCheckout(ctx); err != nil {
+		return err
+	}
+	if err := m.validateSnapshot(ctx); err != nil {
+		return err
+	}
+	if err := m.coordinator.clearDirtySlot(ctx, &m.route); err != nil {
+		return fmt.Errorf("%w: withdraw dirty route: %w", ErrCheckoutMutationStale, err)
+	}
+	m.prepared = true
+	return nil
+}
+
+// Refresh publishes the edited checkout through its sparse coordinator, never
+// through the primary's incremental indexer. Nil error promises an active route
+// containing both resulting generations. A failure leaves a retry to Close.
+func (m *CheckoutMutation) Refresh(ctx context.Context) (CheckoutCycle, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed || !m.prepared {
+		return CheckoutCycle{}, fmt.Errorf("%w: no prepared checkout mutation", ErrCheckoutMutationStale)
+	}
+	ctx, cancel := checkoutMutationContext(ctx, m.coordinator.lifetimeContext())
+	defer cancel()
+	if err := m.validateCheckout(ctx); err != nil {
+		return CheckoutCycle{}, err
+	}
+	out := m.coordinator.reconcile(ctx)
+	recordCoordinatorCycle(out)
+	if out.Err != nil {
+		return out, out.Err
+	}
+	if out.Rescheduled || out.Deferred || out.CommitGenerationID <= 0 || out.DirtyGenerationID <= 0 {
+		return out, ErrCheckoutMutationPending
+	}
+	route, found, err := m.coordinator.catalog.GetCheckoutRoute(ctx, m.checkout.CheckoutID)
+	if err != nil {
+		return out, err
+	}
+	if !found || route.State != store_sqlite.RouteActive || route.CommitGenerationID != out.CommitGenerationID || route.DirtyGenerationID != out.DirtyGenerationID {
+		return out, ErrCheckoutMutationPending
+	}
+	m.route, m.fresh = route, true
+	return out, nil
+}
+
+// Close releases a lease once. Any prepared edit that did not reach a fresh
+// route is rescheduled, including a callback error or a partially applied write.
+func (m *CheckoutMutation) Close() {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return
+	}
+	m.closed = true
+	if m.prepared && !m.fresh {
+		m.coordinator.Signal("source mutation needs a dirty generation refresh")
+	}
+	m.coordinator.cycleMu.Unlock()
+	m.release()
+	m.coordinator.releaseSourceMutation()
+}
+
+func (m *CheckoutMutation) validateCheckout(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	checkout, found, err := m.coordinator.catalog.GetCheckout(ctx, m.checkout.CheckoutID)
+	if err != nil {
+		return err
+	}
+	if !found || checkout.Incarnation != m.checkout.Incarnation || checkout.State != store_sqlite.CheckoutStateReady || checkout.EffectiveMode != store_sqlite.CheckoutModeAutomatic || checkout.DesiredMode != store_sqlite.CheckoutModeAutomatic || checkout.ActiveIntentTransitionID != "" || checkout.UnavailableSince != 0 || checkout.RemovalDetectedAt != 0 || !sameMutationRoot(checkout.RootPath, m.checkout.RootPath) {
+		return fmt.Errorf("%w: checkout identity or availability changed", ErrCheckoutMutationStale)
+	}
+	info, err := os.Stat(checkout.RootPath)
+	if err != nil || !info.IsDir() {
+		return fmt.Errorf("%w: checkout root is unavailable", ErrCheckoutMutationStale)
+	}
+	if !os.SameFile(m.rootInfo, info) {
+		return fmt.Errorf("%w: checkout root was replaced", ErrCheckoutMutationStale)
+	}
+	return nil
+}
+
+func sameMutationRoot(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	if resolved, err := filepath.EvalSymlinks(a); err == nil {
+		a = resolved
+	}
+	if resolved, err := filepath.EvalSymlinks(b); err == nil {
+		b = resolved
+	}
+	return pathkey.EqualPaths(a, b)
+}
+
+// An unchanged route epoch does not imply unchanged disk: external editors and
+// git can run before the watcher reconciles. Refuse their newer state instead
+// of applying symbol offsets from the previously materialized generation.
+func (m *CheckoutMutation) validateSnapshot(ctx context.Context) error {
+	c := m.coordinator
+	sample, err := c.sampler.Sample(ctx)
+	if err != nil {
+		return fmt.Errorf("%w: sample checkout: %w", ErrCheckoutMutationStale, err)
+	}
+	base, err := c.primaryBase(ctx)
+	if err != nil {
+		return err
+	}
+	commit, found, err := c.catalog.GetViewGeneration(ctx, m.route.CommitGenerationID)
+	if err != nil {
+		return err
+	}
+	if !found || !servableGeneration(commit.State) || m.route.GraphID != base.graphID || generationRowKey(commit) != generationIdentityKey(c.commitIdentity(base, sample.HeadTree)) {
+		return fmt.Errorf("%w: checkout HEAD or primary base changed", ErrCheckoutMutationStale)
+	}
+	dirty, found, err := c.catalog.GetViewGeneration(ctx, m.route.DirtyGenerationID)
+	if err != nil {
+		return err
+	}
+	if !found || !servableGeneration(dirty.State) || dirty.BaseGenerationID != m.route.CommitGenerationID || dirty.LowerViewFingerprint != sample.Fingerprint {
+		return fmt.Errorf("%w: checkout disk changed; wait for a fresh view and retry", ErrCheckoutMutationStale)
+	}
+	return nil
+}
+
+func checkoutMutationContext(ctx, lifetime context.Context) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	merged, cancel := context.WithCancel(ctx)
+	stop := context.AfterFunc(lifetime, cancel)
+	if lifetime.Err() != nil {
+		cancel()
+	}
+	return merged, func() { stop(); cancel() }
+}
+
+// TryLock polling avoids leaving an unbounded goroutine behind when a caller
+// cancels while another checkout transition owns cycleMu.
+func lockCheckoutMutationCycle(ctx context.Context, c *CheckoutCoordinator) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if c.cycleMu.TryLock() {
+			return nil
+		}
+		timer := time.NewTimer(10 * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (c *CheckoutCoordinator) admitSourceMutation() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.sourceMutationsClosing || c.lifetimeContext().Err() != nil {
+		return false
+	}
+	if c.sourceMutations == 0 {
+		c.sourceMutationsDrained = make(chan struct{})
+	}
+	c.sourceMutations++
+	return true
+}
+
+func (c *CheckoutCoordinator) releaseSourceMutation() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.sourceMutations--
+	if c.sourceMutations == 0 {
+		close(c.sourceMutationsDrained)
+		c.sourceMutationsDrained = nil
+	}
+}
+
+func (c *CheckoutCoordinator) waitSourceMutations(ctx context.Context) error {
+	c.mu.Lock()
+	drained := c.sourceMutationsDrained
+	c.mu.Unlock()
+	if drained == nil {
+		return nil
+	}
+	select {
+	case <-drained:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/internal/indexer/checkout_mutation_test.go
+++ b/internal/indexer/checkout_mutation_test.go
@@ -1,0 +1,295 @@
+package indexer
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/graphview"
+)
+
+func newCheckoutMutationFixture(t testing.TB) (*coordinatorFixture, *CheckoutCoordinator, *CheckoutLifecycle) {
+	t.Helper()
+	f := newCoordinatorFixture(t)
+	gate := NewViewBuildGate()
+	gate.Open()
+	c := f.coordinator(t, CheckoutCoordinatorConfig{Gate: gate, Debounce: time.Hour})
+	if out := c.reconcile(context.Background()); out.Err != nil || out.DirtyGenerationID == 0 {
+		t.Fatalf("initial reconcile: %+v", out)
+	}
+	l := &CheckoutLifecycle{
+		catalog:      f.catalog,
+		store:        f.store,
+		coordinators: map[string]*CheckoutCoordinator{f.checkoutID: c},
+	}
+	return f, c, l
+}
+
+func TestCheckoutMutationDryRunLeavesRouteUntouched(t *testing.T) {
+	f, _, l := newCheckoutMutationFixture(t)
+	before := f.route()
+	m, err := l.BeginCheckoutMutation(t.Context(), f.checkoutID, f.worktree, before.RouteEpoch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.Close()
+	m.Close()
+	if after := f.route(); after != before {
+		t.Fatalf("dry run changed route: before=%+v after=%+v", before, after)
+	}
+}
+
+func TestCheckoutMutationPublishesOnlyDirtyLayerAndPreservesPinnedView(t *testing.T) {
+	f, _, l := newCheckoutMutationFixture(t)
+	before := f.route()
+	primaryBefore, err := os.ReadFile(filepath.Join(f.primary, "helper.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	materializer := &graphview.Materializer{Store: f.store, Catalog: f.catalog, Leases: f.leases}
+	pinned, err := materializer.MaterializeCheckout(t.Context(), f.checkoutID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pinned.Close()
+	m, err := l.BeginCheckoutMutation(t.Context(), f.checkoutID, f.worktree, before.RouteEpoch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	if err := m.Prepare(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Prepare(t.Context()); err != nil {
+		t.Fatalf("prepare must be idempotent before refresh: %v", err)
+	}
+	if route := f.route(); route.State != store_sqlite.RoutePending || route.DirtyGenerationID != 0 || route.CommitGenerationID != before.CommitGenerationID {
+		t.Fatalf("old exact route remained visible while source is changing: %+v", route)
+	}
+	if _, found := f.generation(before.DirtyGenerationID); !found {
+		t.Fatal("prepare collected an old reader's pinned dirty generation")
+	}
+	builderWriteFile(t, f.worktree, "helper.go", "package fixture\n\nfunc EditedHelper() {}\n")
+	out, err := m.Refresh(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.CommitGenerationID != before.CommitGenerationID || out.DirtyGenerationID == before.DirtyGenerationID || !out.DirtyBuilt {
+		t.Fatalf("unexpected mutation rebuild: %+v", out)
+	}
+	if route := f.route(); route.State != store_sqlite.RouteActive || route.DirtyGenerationID != out.DirtyGenerationID {
+		t.Fatalf("successful refresh did not leave exact route: %+v", route)
+	}
+	primaryAfter, err := os.ReadFile(filepath.Join(f.primary, "helper.go"))
+	if err != nil || string(primaryAfter) != string(primaryBefore) {
+		t.Fatalf("source mutation changed primary: %v", err)
+	}
+	if err := m.Prepare(t.Context()); !errors.Is(err, ErrCheckoutMutationStale) {
+		t.Fatalf("fresh lease admitted a second unguarded disk commit: %v", err)
+	}
+}
+
+func TestCheckoutMutationRejectsWrongRootEpochAndExternalChanges(t *testing.T) {
+	f, _, l := newCheckoutMutationFixture(t)
+	before := f.route()
+	for _, tc := range []struct {
+		root  string
+		epoch int64
+	}{
+		{f.primary, before.RouteEpoch},
+		{f.worktree, before.RouteEpoch + 1},
+		{f.worktree, 0},
+	} {
+		if m, err := l.BeginCheckoutMutation(t.Context(), f.checkoutID, tc.root, tc.epoch); !errors.Is(err, ErrCheckoutMutationStale) {
+			if m != nil {
+				m.Close()
+			}
+			t.Fatalf("root=%s epoch=%d: %v", tc.root, tc.epoch, err)
+		}
+	}
+	m, err := l.BeginCheckoutMutation(t.Context(), f.checkoutID, f.worktree, before.RouteEpoch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	builderWriteFile(t, f.worktree, "helper.go", "package fixture\n\nfunc ExternalEdit() {}\n")
+	if err := m.Prepare(t.Context()); !errors.Is(err, ErrCheckoutMutationStale) {
+		t.Fatalf("external edit between begin and prepare was not refused: %v", err)
+	}
+	m.Close()
+	if m, err := l.BeginCheckoutMutation(t.Context(), f.checkoutID, f.worktree, before.RouteEpoch); !errors.Is(err, ErrCheckoutMutationStale) {
+		if m != nil {
+			m.Close()
+		}
+		t.Fatalf("stale disk at admission was not refused: %v", err)
+	}
+	if f.route() != before {
+		t.Fatal("rejected mutations changed the catalog route")
+	}
+}
+
+func TestCheckoutMutationCanceledRefreshLeavesPendingAndSignalsRetry(t *testing.T) {
+	f, c, l := newCheckoutMutationFixture(t)
+	m, err := l.BeginCheckoutMutation(t.Context(), f.checkoutID, f.worktree, f.route().RouteEpoch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Prepare(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	builderWriteFile(t, f.worktree, "helper.go", "package fixture\n\nfunc PendingEdit() {}\n")
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if _, err := m.Refresh(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("refresh: %v", err)
+	}
+	m.Close()
+	if route := f.route(); route.State != store_sqlite.RoutePending {
+		t.Fatalf("failed refresh became active: %+v", route)
+	}
+	c.mu.Lock()
+	reason := c.reason
+	c.mu.Unlock()
+	if reason != "source mutation needs a dirty generation refresh" {
+		t.Fatalf("missing retry signal: %q", reason)
+	}
+}
+
+func TestCheckoutMutationRejectsReplacedRoot(t *testing.T) {
+	f, _, l := newCheckoutMutationFixture(t)
+	before := f.route()
+	m, err := l.BeginCheckoutMutation(t.Context(), f.checkoutID, f.worktree, before.RouteEpoch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	oldRoot := f.worktree + "-original"
+	if err := os.Rename(f.worktree, oldRoot); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		// Keep the replacement under this fixture's temporary directory so
+		// standard test cleanup owns its removal.
+		_ = os.Rename(f.worktree, f.worktree+"-replacement")
+		if err := os.Rename(oldRoot, f.worktree); err != nil {
+			t.Errorf("restore fixture root: %v", err)
+		}
+	}()
+	if err := os.CopyFS(f.worktree, os.DirFS(oldRoot)); err != nil {
+		t.Fatal(err)
+	}
+	// This replacement precedes lifecycle discovery: catalog id/incarnation
+	// and route epoch are unchanged, as are Git and source contents. The pinned
+	// filesystem identity must refuse before a content comparison can accept it.
+	if err := m.Prepare(t.Context()); !errors.Is(err, ErrCheckoutMutationStale) || !strings.Contains(err.Error(), "root was replaced") {
+		t.Fatalf("replaced root admitted a source write: %v", err)
+	}
+	if f.route() != before {
+		t.Fatal("root replacement refusal invalidated the original route")
+	}
+}
+
+func TestCheckoutMutationCloseJoinsLeaseAndCancelsWaitingAdmission(t *testing.T) {
+	f, c, l := newCheckoutMutationFixture(t)
+	m, err := l.BeginCheckoutMutation(t.Context(), f.checkoutID, f.worktree, f.route().RouteEpoch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	ctx, cancel := context.WithTimeout(t.Context(), 25*time.Millisecond)
+	defer cancel()
+	if err := c.CloseContext(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("shutdown did not wait for active writer: %v", err)
+	}
+	if err := m.Prepare(t.Context()); !errors.Is(err, context.Canceled) {
+		t.Fatalf("closing coordinator admitted a write: %v", err)
+	}
+	m.Close()
+	if err := c.CloseContext(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if lease, err := l.BeginCheckoutMutation(t.Context(), f.checkoutID, f.worktree, f.route().RouteEpoch); err == nil {
+		lease.Close()
+		t.Fatal("closed coordinator admitted new source mutation")
+	}
+}
+
+func TestCheckoutMutationAdmissionCancellationReleasesResources(t *testing.T) {
+	f, c, l := newCheckoutMutationFixture(t)
+	block, err := c.gate.Acquire(t.Context(), ViewBuildBackground)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 25*time.Millisecond)
+	defer cancel()
+	if m, err := l.BeginCheckoutMutation(ctx, f.checkoutID, f.worktree, f.route().RouteEpoch); !errors.Is(err, context.DeadlineExceeded) {
+		if m != nil {
+			m.Close()
+		}
+		t.Fatalf("admission was not canceled: %v", err)
+	}
+	block()
+	c.mu.Lock()
+	active := c.sourceMutations
+	c.mu.Unlock()
+	if active != 0 {
+		t.Fatalf("canceled admission leaked %d leases", active)
+	}
+	m, err := l.BeginCheckoutMutation(t.Context(), f.checkoutID, f.worktree, f.route().RouteEpoch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.Close()
+}
+
+func TestCheckoutMutationAdmissionPanicReleasesResources(t *testing.T) {
+	f, c, l := newCheckoutMutationFixture(t)
+	// A backend panic recovered by MCP must not strand the shared build gate
+	// or the checkout route lock. A missing coordinator catalog injects failure after
+	// both locks have been acquired, without changing the production path.
+	catalog := c.catalog
+	c.catalog = nil
+	var panicValue any
+	func() {
+		defer func() { panicValue = recover() }()
+		m, _ := l.BeginCheckoutMutation(t.Context(), f.checkoutID, f.worktree, f.route().RouteEpoch)
+		if m != nil {
+			m.Close()
+		}
+	}()
+	c.catalog = catalog
+	if panicValue == nil {
+		t.Fatal("fault injection did not panic")
+	}
+	if !c.cycleMu.TryLock() {
+		t.Fatal("panic stranded the checkout route lock")
+	}
+	c.cycleMu.Unlock()
+	if stats := c.gate.Stats(); stats.Active {
+		t.Fatal("panic stranded the shared build gate")
+	}
+	c.mu.Lock()
+	active := c.sourceMutations
+	c.mu.Unlock()
+	if active != 0 {
+		t.Fatalf("panic leaked %d admissions", active)
+	}
+}
+
+func BenchmarkCheckoutMutationDryRunAdmission(b *testing.B) {
+	f, _, l := newCheckoutMutationFixture(b)
+	epoch := f.route().RouteEpoch
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		m, err := l.BeginCheckoutMutation(b.Context(), f.checkoutID, f.worktree, epoch)
+		if err != nil {
+			b.Fatal(err)
+		}
+		m.Close()
+	}
+}

--- a/internal/mcp/edit_serialization.go
+++ b/internal/mcp/edit_serialization.go
@@ -45,6 +45,9 @@ type mutationReindexOutcome struct {
 	Generation        uint64
 	AppliedGeneration uint64
 	Err               error
+	// A checkout generation is not reflected in the canonical syntax-health
+	// reader. Do not attach another checkout's parse errors to this result.
+	checkoutScoped bool
 }
 
 type mutationReceipt struct {
@@ -66,6 +69,9 @@ type mutationScheduler interface {
 // context-aware: a cancelled MCP request leaves the queue immediately, which
 // lets its dispatcher goroutine finish and release admission capacity.
 func acquireMutationPath(ctx context.Context, path string) (func(), error) {
+	if err := guardCheckoutMutationPath(ctx, path); err != nil {
+		return nil, err
+	}
 	path = filepath.Clean(path)
 
 	mutationPathLocks.Lock()
@@ -321,6 +327,9 @@ func (s *Server) mutationSafetyWaitDuration() time.Duration {
 // the request path both blocks the response and races the watcher. Embedded
 // servers have no watcher and retain the synchronous freshness contract.
 func (s *Server) mutationReindexState(ctx context.Context, absPath string) mutationReindexOutcome {
+	if state := checkoutMutationFromContext(ctx); state != nil {
+		return s.refreshCheckoutMutation(ctx, absPath, state)
+	}
 	if watcher := s.currentWatcher(); watcher != nil {
 		// Admission is path-scoped and authoritative. Scheduling uses a detached
 		// context because the disk commit already happened; client cancellation
@@ -528,7 +537,7 @@ func (s *Server) attachMutationFreshness(resp map[string]any, relPath, absPath s
 		resp["reindex_pending"] = true
 		return
 	}
-	if outcome.Reindexed {
+	if outcome.Reindexed && !outcome.checkoutScoped {
 		if health := s.fileSyntaxHealth(relPath, absPath); health != nil {
 			resp["syntax_health"] = health
 		}

--- a/internal/mcp/mutation_commit.go
+++ b/internal/mcp/mutation_commit.go
@@ -484,6 +484,16 @@ func (s *Server) commitFileMutation(
 		record.markNotApplied(err)
 		return record, fmt.Errorf("%w: %w", errMutationNotApplied, err)
 	}
+	if err := prepareCheckoutMutation(ctx, absPath); err != nil {
+		record.markNotApplied(err)
+		return record, fmt.Errorf("%w: %w", errMutationNotApplied, err)
+	}
+	// Preparing may wait for durable route invalidation. Cancellation during
+	// that wait still guarantees that this handler has not written any bytes.
+	if err := ctx.Err(); err != nil {
+		record.markNotApplied(err)
+		return record, fmt.Errorf("%w: %w", errMutationNotApplied, err)
+	}
 	if err := agents.AtomicWriteFile(absPath, data, perm); err != nil {
 		record.markFailed(err)
 		return record, err

--- a/internal/mcp/overlay.go
+++ b/internal/mcp/overlay.go
@@ -168,8 +168,15 @@ func (s *Server) wrapToolHandlerMode(h mcpserver.ToolHandlerFunc, injectOverlay 
 			ctx = withRequestView(ctx, view)
 			defer view.close()
 		}
-		// A write issued while reading a routed view would land in the
-		// canonical checkout, not the one the answer came from.
+		// Approved source tools serialize with the selected checkout's index
+		// coordinator. The lease does not invalidate or rebuild for dry runs;
+		// the shared disk-commit and reindex helpers perform those steps.
+		mutationCtx, releaseMutation, mutationErr := s.prepareRoutedViewMutation(ctx, &req)
+		if mutationErr != nil {
+			return mutationErr, nil
+		}
+		ctx = mutationCtx
+		defer releaseMutation()
 		if refused := s.refuseRoutedViewMutation(ctx, req.Params.Name); refused != nil {
 			return refused, nil
 		}

--- a/internal/mcp/view_mutation.go
+++ b/internal/mcp/view_mutation.go
@@ -1,0 +1,66 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/zzet/gortex/internal/graphview"
+)
+
+// prepareRoutedViewMutation establishes authority for the small set of tools
+// whose disk commits and graph refreshes use the checkout-aware primitives.
+// All other source operations continue to fail closed in the mutation guard.
+func (s *Server) prepareRoutedViewMutation(ctx context.Context, req *mcp.CallToolRequest) (context.Context, func(), *mcp.CallToolResult) {
+	noop := func() {}
+	view := requestViewFromContext(ctx)
+	if !s.facades.mutatesSource(req.Params.Name) || !view.routed() ||
+		view.rider == nil || !view.rider.Exact || view.viewRoot == "" ||
+		view.files != nil || view.materialized == nil || s.lifecycle == nil {
+		return ctx, noop, nil
+	}
+	// Use the same inference/defaults as facade dispatch. Looking only at an
+	// explicit operation would refuse valid edit calls that infer it from target.
+	legacy := req.Params.Name
+	if isFacadeToolName(legacy) {
+		spec, ok := s.viewFacadeOperation(req)
+		if !ok {
+			return ctx, noop, nil
+		}
+		legacy = spec.Legacy
+	}
+	switch legacy {
+	case "edit_file", "write_file", "edit_symbol":
+	default:
+		return ctx, noop, nil
+	}
+
+	// Symbol ranges must come from the persisted checkout view, not unsaved
+	// editor buffers. Pin even an empty cohort so a later facade preparation
+	// cannot pick up buffers pushed while this request waits for admission.
+	snapshot, present := overlayRequestSnapshotFromContext(ctx)
+	if !present {
+		var err error
+		snapshot, err = s.snapshotOverlayRequestForCtx(ctx)
+		if err != nil {
+			return ctx, noop, mcp.NewToolResultError(fmt.Sprintf("%s: inspect editor buffers: %v", graphview.CodeViewReadOnly, err))
+		}
+	}
+	if OverlayViewFromContext(ctx) != nil || (snapshot != nil && len(snapshot.files) != 0) {
+		return ctx, noop, mcp.NewToolResultError(fmt.Sprintf(
+			"%s: save or discard the session's editor buffers before editing the on-disk worktree.", graphview.CodeViewReadOnly))
+	}
+	if snapshot != nil {
+		ctx = withOverlayRequestSnapshot(ctx, snapshot)
+	}
+
+	mutation, err := s.lifecycle.BeginCheckoutMutation(ctx, view.rider.CheckoutID,
+		view.viewRoot, view.materialized.CheckoutRouteEpoch)
+	if err != nil {
+		s.activateSelectedCheckout(view.rider.CheckoutID, "source mutation needs a fresh checkout view")
+		return ctx, noop, mcp.NewToolResultError(fmt.Sprintf(
+			"%s: checkout mutation was not admitted; no files were changed: %v", graphview.CodeViewReadOnly, err))
+	}
+	return withCheckoutMutation(ctx, mutation, view.viewRoot), mutation.Close, nil
+}

--- a/internal/mcp/view_mutation_state.go
+++ b/internal/mcp/view_mutation_state.go
@@ -1,0 +1,130 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/zzet/gortex/internal/indexer"
+)
+
+// checkoutMutationLifecycle is the request's already-acquired checkout lease.
+// Keeping this narrow also lets handler tests prove that neither a primary
+// watcher nor a canonical indexer is used for a selected-worktree mutation.
+type checkoutMutationLifecycle interface {
+	Prepare(context.Context) error
+	Refresh(context.Context) (indexer.CheckoutCycle, error)
+}
+
+type checkoutMutationContextKey struct{}
+
+type checkoutMutationState struct {
+	mutation checkoutMutationLifecycle
+	root     string
+}
+
+func withCheckoutMutation(ctx context.Context, mutation checkoutMutationLifecycle, root string) context.Context {
+	return context.WithValue(ctx, checkoutMutationContextKey{}, &checkoutMutationState{
+		mutation: mutation,
+		root:     resolveNearestExistingAncestor(root),
+	})
+}
+
+func checkoutMutationFromContext(ctx context.Context) *checkoutMutationState {
+	if ctx == nil {
+		return nil
+	}
+	state, _ := ctx.Value(checkoutMutationContextKey{}).(*checkoutMutationState)
+	return state
+}
+
+// guardCheckoutMutationPath is stricter than read confinement: an absolute
+// path naming another indexed checkout is not a valid target for this lease.
+// Resolve the nearest existing ancestor too, so a newly created file cannot
+// escape through a symlinked parent. The selected root itself may be an alias.
+func guardCheckoutMutationPath(ctx context.Context, path string) error {
+	state := checkoutMutationFromContext(ctx)
+	if state == nil {
+		return nil
+	}
+	if state.mutation == nil || !filepath.IsAbs(state.root) || !filepath.IsAbs(path) {
+		return fmt.Errorf("checkout mutation requires an absolute path in its selected working copy")
+	}
+	// AtomicWriteFile replaces the named directory entry, not a symlink's
+	// target. A link in the primary pointing into this worktree must therefore
+	// fail even though the bytes read through it belong to the selected root.
+	entry := filepath.Join(resolveNearestExistingAncestor(filepath.Dir(path)), filepath.Base(path))
+	if err := guardCheckoutMutationResolvedPath(state.root, entry, path); err != nil {
+		return err
+	}
+	resolved := resolveNearestExistingAncestor(path)
+	if resolved == entry {
+		return nil
+	}
+	return guardCheckoutMutationResolvedPath(state.root, resolved, path)
+}
+
+func guardCheckoutMutationResolvedPath(root, resolved, path string) error {
+	if !pathContainedIn(resolved, root) || resolved == root {
+		return fmt.Errorf("checkout mutation target %q is outside selected working copy %q", path, root)
+	}
+	relative, err := filepath.Rel(root, resolved)
+	if err != nil {
+		return fmt.Errorf("could not verify checkout mutation target %q: %w", path, err)
+	}
+	for _, component := range strings.Split(relative, string(filepath.Separator)) {
+		if strings.EqualFold(component, ".git") {
+			return fmt.Errorf("checkout source mutation cannot modify Git metadata: %q", path)
+		}
+	}
+	// A repository nested below the selected checkout has independent dirty
+	// state and a different coordinator, even though lexical confinement passes.
+	for dir := filepath.Dir(resolved); dir != root; dir = filepath.Dir(dir) {
+		if dir == filepath.Dir(dir) {
+			return fmt.Errorf("could not verify selected checkout root for mutation target %q", path)
+		}
+		if _, err := os.Lstat(filepath.Join(dir, ".git")); err == nil {
+			return fmt.Errorf("checkout mutation target %q belongs to nested checkout %q; select that checkout instead", path, dir)
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("could not verify checkout mutation target %q: %w", path, err)
+		}
+	}
+	return nil
+}
+
+func prepareCheckoutMutation(ctx context.Context, path string) error {
+	state := checkoutMutationFromContext(ctx)
+	if state == nil {
+		return nil
+	}
+	if err := guardCheckoutMutationPath(ctx, path); err != nil {
+		return err
+	}
+	return state.mutation.Prepare(ctx)
+}
+
+func (s *Server) refreshCheckoutMutation(ctx context.Context, path string, state *checkoutMutationState) mutationReindexOutcome {
+	outcome := mutationReindexOutcome{checkoutScoped: true}
+	if err := guardCheckoutMutationPath(ctx, path); err != nil {
+		outcome.Err = err
+		return outcome
+	}
+	// Disk has committed. Give its selected checkout a bounded refresh even
+	// when the caller has disconnected, then let Close signal a retry on failure.
+	refreshCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), s.mutationWaitDuration())
+	defer cancel()
+	cycle, err := state.mutation.Refresh(refreshCtx)
+	if err != nil {
+		outcome.Err = fmt.Errorf("checkout graph refresh failed after disk commit: %w", err)
+		return outcome
+	}
+	if cycle.Err != nil || cycle.Rescheduled || cycle.Deferred || cycle.DirtyGenerationID <= 0 || cycle.CommitGenerationID <= 0 {
+		outcome.Err = fmt.Errorf("checkout graph refresh did not publish an exact view")
+		return outcome
+	}
+	outcome.Reindexed = true
+	outcome.AppliedGeneration = uint64(cycle.DirtyGenerationID)
+	return outcome
+}

--- a/internal/mcp/view_mutation_state.go
+++ b/internal/mcp/view_mutation_state.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/pathkey"
 )
 
 // checkoutMutationLifecycle is the request's already-acquired checkout lease.
@@ -67,28 +68,38 @@ func guardCheckoutMutationPath(ctx context.Context, path string) error {
 }
 
 func guardCheckoutMutationResolvedPath(root, resolved, path string) error {
-	if !pathContainedIn(resolved, root) || resolved == root {
+	if !pathkey.HasPathPrefix(resolved, root) || pathkey.EqualPaths(resolved, root) {
 		return fmt.Errorf("checkout mutation target %q is outside selected working copy %q", path, root)
-	}
-	relative, err := filepath.Rel(root, resolved)
-	if err != nil {
-		return fmt.Errorf("could not verify checkout mutation target %q: %w", path, err)
-	}
-	for _, component := range strings.Split(relative, string(filepath.Separator)) {
-		if strings.EqualFold(component, ".git") {
-			return fmt.Errorf("checkout source mutation cannot modify Git metadata: %q", path)
-		}
 	}
 	// A repository nested below the selected checkout has independent dirty
 	// state and a different coordinator, even though lexical confinement passes.
-	for dir := filepath.Dir(resolved); dir != root; dir = filepath.Dir(dir) {
-		if dir == filepath.Dir(dir) {
+	// Use the same path identity for confinement and termination: a case or
+	// separator alias must not make the selected root's own .git look nested.
+	dir := resolved
+	for ; !pathkey.EqualPaths(dir, root); dir = filepath.Dir(dir) {
+		if strings.EqualFold(filepath.Base(dir), ".git") {
+			return fmt.Errorf("checkout source mutation cannot modify Git metadata: %q", path)
+		}
+		if pathkey.EqualPaths(dir, filepath.Dir(dir)) {
 			return fmt.Errorf("could not verify selected checkout root for mutation target %q", path)
+		}
+		if dir == resolved {
+			continue // Only ancestors, not the source file, can contain a nested .git.
 		}
 		if _, err := os.Lstat(filepath.Join(dir, ".git")); err == nil {
 			return fmt.Errorf("checkout mutation target %q belongs to nested checkout %q; select that checkout instead", path, dir)
 		} else if !os.IsNotExist(err) {
 			return fmt.Errorf("could not verify checkout mutation target %q: %w", path, err)
+		}
+	}
+	if dir != root {
+		// Identity folding follows the host default, but a particular volume
+		// may be case-sensitive. Never grant a lease for /repo access to a
+		// physically distinct /REPO merely because their names fold equally.
+		selected, selectedErr := os.Stat(root)
+		matched, matchedErr := os.Stat(dir)
+		if selectedErr != nil || matchedErr != nil || !os.SameFile(selected, matched) {
+			return fmt.Errorf("could not verify selected checkout root identity for mutation target %q", path)
 		}
 	}
 	return nil

--- a/internal/mcp/view_mutation_state_test.go
+++ b/internal/mcp/view_mutation_state_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/pathkey"
 )
 
 type fakeCheckoutMutationLifecycle struct {
@@ -96,6 +97,91 @@ func TestCheckoutMutationPathConfinement(t *testing.T) {
 
 	if err := guardCheckoutMutationPath(context.Background(), filepath.Join(other, "file.go")); err != nil {
 		t.Fatalf("ordinary mutation was changed: %v", err)
+	}
+}
+
+func TestCheckoutMutationResolvedRootIdentity(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".git"), []byte("gitdir: elsewhere\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	nested := filepath.Join(root, "nested")
+	if err := os.Mkdir(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, ".git"), []byte("gitdir: independent\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	roots := map[string]string{
+		"canonical":          root,
+		"trailing_separator": root + string(filepath.Separator),
+		"dot_component":      root + string(filepath.Separator) + ".",
+	}
+	if pathkey.CaseInsensitivePaths {
+		roots["case_alias"] = strings.ToUpper(root)
+	}
+	for name, selected := range roots {
+		t.Run(name, func(t *testing.T) {
+			if name == "case_alias" {
+				actual, actualErr := os.Stat(root)
+				alias, aliasErr := os.Stat(selected)
+				if actualErr != nil || aliasErr != nil || !os.SameFile(actual, alias) {
+					t.Skip("filesystem does not resolve this case alias to the selected root")
+				}
+			}
+			// The selected checkout's own .git must not look like a nested repo
+			// merely because Git and the filesystem spell its root differently.
+			path := filepath.Join(root, "new", "file.go")
+			if err := guardCheckoutMutationResolvedPath(selected, path, path); err != nil {
+				t.Fatalf("selected checkout source rejected: %v", err)
+			}
+			if err := guardCheckoutMutationResolvedPath(selected, root, root); err == nil {
+				t.Fatal("accepted checkout root as a source file")
+			}
+			for _, path := range []string{filepath.Join(root+"-sibling", "file.go"), filepath.Join(root, "..", "other", "file.go")} {
+				if err := guardCheckoutMutationResolvedPath(selected, path, path); err == nil {
+					t.Fatalf("accepted path outside selected working copy: %q", path)
+				}
+			}
+			path = filepath.Join(root, ".git", "HEAD")
+			if err := guardCheckoutMutationResolvedPath(selected, path, path); err == nil || !strings.Contains(err.Error(), "Git metadata") {
+				t.Fatalf("Git metadata refusal = %v", err)
+			}
+			path = filepath.Join(nested, "new", "file.go")
+			if err := guardCheckoutMutationResolvedPath(selected, path, path); err == nil || !strings.Contains(err.Error(), "nested checkout") {
+				t.Fatalf("nested checkout refusal = %v", err)
+			}
+		})
+	}
+}
+
+func TestCheckoutMutationResolvedRootRejectsFoldedDistinctDirectory(t *testing.T) {
+	base := t.TempDir()
+	root, other := filepath.Join(base, "repo"), filepath.Join(base, "REPO")
+	for _, dir := range []string{root, other} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	selected, err := os.Stat(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	distinct, err := os.Stat(other)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if os.SameFile(selected, distinct) {
+		t.Skip("filesystem cannot represent case-distinct directories")
+	}
+	// Model a case-sensitive volume mounted on a normally case-insensitive
+	// host. This test is deliberately not parallel: the policy is global.
+	original := pathkey.CaseInsensitivePaths
+	pathkey.CaseInsensitivePaths = true
+	t.Cleanup(func() { pathkey.CaseInsensitivePaths = original })
+	path := filepath.Join(other, "file.go")
+	if err := guardCheckoutMutationResolvedPath(root, path, path); err == nil || !strings.Contains(err.Error(), "root identity") {
+		t.Fatalf("physically distinct checkout refusal = %v", err)
 	}
 }
 

--- a/internal/mcp/view_mutation_state_test.go
+++ b/internal/mcp/view_mutation_state_test.go
@@ -1,0 +1,295 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/zzet/gortex/internal/indexer"
+)
+
+type fakeCheckoutMutationLifecycle struct {
+	prepare func(context.Context) error
+	refresh func(context.Context) (indexer.CheckoutCycle, error)
+}
+
+func (f *fakeCheckoutMutationLifecycle) Prepare(ctx context.Context) error {
+	if f.prepare != nil {
+		return f.prepare(ctx)
+	}
+	return nil
+}
+
+func (f *fakeCheckoutMutationLifecycle) Refresh(ctx context.Context) (indexer.CheckoutCycle, error) {
+	if f.refresh != nil {
+		return f.refresh(ctx)
+	}
+	return indexer.CheckoutCycle{CommitGenerationID: 4, DirtyGenerationID: 5}, nil
+}
+
+func TestCheckoutMutationPathConfinement(t *testing.T) {
+	root := t.TempDir()
+	other := t.TempDir()
+	ctx := withCheckoutMutation(context.Background(), &fakeCheckoutMutationLifecycle{}, root)
+	for _, path := range []string{filepath.Join(root, "file.go"), filepath.Join(root, "new", "nested", "file.go")} {
+		if err := guardCheckoutMutationPath(ctx, path); err != nil {
+			t.Fatalf("selected path %q: %v", path, err)
+		}
+	}
+	for _, path := range []string{root, "file.go", filepath.Join(other, "file.go"), root + "-sibling/file.go"} {
+		if err := guardCheckoutMutationPath(ctx, path); err == nil {
+			t.Fatalf("accepted path outside selected working copy: %q", path)
+		}
+	}
+	for _, path := range []string{filepath.Join(root, ".git"), filepath.Join(root, ".git", "HEAD"), filepath.Join(root, ".GIT", "config"), filepath.Join(root, "nested", ".git", "HEAD")} {
+		if err := guardCheckoutMutationPath(ctx, path); err == nil || !strings.Contains(err.Error(), "Git metadata") {
+			t.Fatalf("Git metadata refusal for %q = %v", path, err)
+		}
+	}
+
+	outsideLink := filepath.Join(root, "outside")
+	if err := os.Symlink(other, outsideLink); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{filepath.Join(outsideLink, "new.go"), filepath.Join(outsideLink, "new", "file.go")} {
+		if err := guardCheckoutMutationPath(ctx, path); err == nil {
+			t.Fatalf("accepted symlink escape: %q", path)
+		}
+	}
+	outsideFile := filepath.Join(other, "file.go")
+	if err := os.WriteFile(outsideFile, []byte("package other\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	insideLink := filepath.Join(root, "linked.go")
+	if err := os.Symlink(outsideFile, insideLink); err != nil {
+		t.Fatal(err)
+	}
+	if err := guardCheckoutMutationPath(ctx, insideLink); err == nil {
+		t.Fatal("accepted final symlink reading another checkout's source")
+	}
+
+	alias := filepath.Join(t.TempDir(), "alias")
+	if err := os.Symlink(root, alias); err != nil {
+		t.Fatal(err)
+	}
+	aliasCtx := withCheckoutMutation(context.Background(), &fakeCheckoutMutationLifecycle{}, alias)
+	for _, path := range []string{filepath.Join(alias, "new.go"), filepath.Join(root, "new.go")} {
+		if err := guardCheckoutMutationPath(aliasCtx, path); err != nil {
+			t.Fatalf("root alias %q: %v", path, err)
+		}
+	}
+
+	nested := filepath.Join(root, "nested")
+	if err := os.Mkdir(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nested, ".git"), []byte("gitdir: elsewhere\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := guardCheckoutMutationPath(ctx, filepath.Join(nested, "new", "file.go")); err == nil || !strings.Contains(err.Error(), "nested checkout") {
+		t.Fatalf("nested checkout refusal = %v", err)
+	}
+
+	if err := guardCheckoutMutationPath(context.Background(), filepath.Join(other, "file.go")); err != nil {
+		t.Fatalf("ordinary mutation was changed: %v", err)
+	}
+}
+
+func TestCheckoutMutationPathLockRefusesOtherCheckout(t *testing.T) {
+	root := t.TempDir()
+	ctx := withCheckoutMutation(context.Background(), &fakeCheckoutMutationLifecycle{}, root)
+	release, err := acquireMutationPath(ctx, filepath.Join(t.TempDir(), "file.go"))
+	if err == nil || release != nil {
+		t.Fatalf("lock acquired outside selected checkout: release=%v err=%v", release != nil, err)
+	}
+	release, err = acquireMutationPath(ctx, filepath.Join(root, "file.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	release()
+}
+
+func TestCheckoutMutationOutsideFinalSymlinkPreserved(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "file.go")
+	before := []byte("package example\n")
+	if err := os.WriteFile(target, before, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outsideLink := filepath.Join(t.TempDir(), "link.go")
+	if err := os.Symlink(target, outsideLink); err != nil {
+		t.Fatal(err)
+	}
+	prepared := false
+	lease := &fakeCheckoutMutationLifecycle{prepare: func(context.Context) error {
+		prepared = true
+		return nil
+	}}
+	ctx := withCheckoutMutation(context.Background(), lease, root)
+	s := &Server{}
+	record, err := s.commitFileMutation(ctx, "write_file", "", "test", "link.go", outsideLink, []byte("package changed\n"), 0o644)
+	if !errors.Is(err, errMutationNotApplied) || prepared || record.diskStatus() != mutationDiskNotApplied {
+		t.Fatalf("outside link was admitted: prepared=%v receipt=%+v err=%v", prepared, record.snapshot(), err)
+	}
+	link, err := os.Lstat(outsideLink)
+	if err != nil || link.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("outside symlink was replaced: stat=%v err=%v", link, err)
+	}
+	actual, err := os.ReadFile(target)
+	if err != nil || string(actual) != string(before) {
+		t.Fatalf("selected file was changed: %q err=%v", actual, err)
+	}
+}
+
+func TestCheckoutMutationGitSymlinkEntryRefused(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "file.go")
+	if err := os.WriteFile(target, []byte("package example\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitLink := filepath.Join(root, ".git")
+	if err := os.Symlink(target, gitLink); err != nil {
+		t.Fatal(err)
+	}
+	ctx := withCheckoutMutation(context.Background(), &fakeCheckoutMutationLifecycle{}, root)
+	if err := guardCheckoutMutationPath(ctx, gitLink); err == nil || !strings.Contains(err.Error(), "Git metadata") {
+		t.Fatalf("Git symlink entry accepted because target was ordinary source: %v", err)
+	}
+}
+
+func TestCheckoutMutationCommitPreparesBeforeDisk(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "file.go")
+	before := []byte("package example\n")
+	if err := os.WriteFile(path, before, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	prepared := false
+	lease := &fakeCheckoutMutationLifecycle{prepare: func(context.Context) error {
+		actual, err := os.ReadFile(path)
+		if err != nil || string(actual) != string(before) {
+			t.Fatalf("disk changed before Prepare: %q, %v", actual, err)
+		}
+		prepared = true
+		return nil
+	}}
+	ctx := withCheckoutMutation(context.Background(), lease, root)
+	s := &Server{}
+	record, err := s.commitFileMutation(ctx, "write_file", "", "test", "file.go", path, []byte("package changed\n"), 0o644)
+	if err != nil || !prepared || record.diskStatus() != mutationDiskCommitted {
+		t.Fatalf("commit prepared=%v record=%+v err=%v", prepared, record.snapshot(), err)
+	}
+	actual, err := os.ReadFile(path)
+	if err != nil || string(actual) != "package changed\n" {
+		t.Fatalf("disk commit = %q, %v", actual, err)
+	}
+}
+
+func TestCheckoutMutationPrepareFailureLeavesDiskUntouched(t *testing.T) {
+	for _, cancelDuringPrepare := range []bool{false, true} {
+		t.Run(map[bool]string{false: "prepare_error", true: "cancel_during_prepare"}[cancelDuringPrepare], func(t *testing.T) {
+			root := t.TempDir()
+			path := filepath.Join(root, "file.go")
+			before := []byte("package example\n")
+			if err := os.WriteFile(path, before, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			lease := &fakeCheckoutMutationLifecycle{prepare: func(context.Context) error {
+				if cancelDuringPrepare {
+					cancel()
+					return nil
+				}
+				return errors.New("route invalidation failed")
+			}}
+			ctx = withCheckoutMutation(ctx, lease, root)
+			s := &Server{}
+			record, err := s.commitFileMutation(ctx, "write_file", "", "test", "file.go", path, []byte("package changed\n"), 0o644)
+			if !errors.Is(err, errMutationNotApplied) || record.diskStatus() != mutationDiskNotApplied {
+				t.Fatalf("expected not-applied receipt: %+v, %v", record.snapshot(), err)
+			}
+			actual, err := os.ReadFile(path)
+			if err != nil || string(actual) != string(before) {
+				t.Fatalf("disk changed on prepare failure: %q, %v", actual, err)
+			}
+		})
+	}
+}
+
+func TestCheckoutMutationReindexUsesLease(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "file.go")
+	refreshed := false
+	lease := &fakeCheckoutMutationLifecycle{refresh: func(ctx context.Context) (indexer.CheckoutCycle, error) {
+		if err := ctx.Err(); err != nil {
+			t.Fatalf("committed mutation inherited client cancellation: %v", err)
+		}
+		deadline, ok := ctx.Deadline()
+		if !ok || time.Until(deadline) > defaultMutationReindexWait {
+			t.Fatalf("refresh has no bounded deadline: %v, %v", deadline, ok)
+		}
+		refreshed = true
+		return indexer.CheckoutCycle{CommitGenerationID: 4, DirtyGenerationID: 9}, nil
+	}}
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = withCheckoutMutation(ctx, lease, root)
+	cancel()
+	// No watcher or canonical indexer is attached: success must come from the
+	// selected lease, even for a caller that disconnected after disk commit.
+	s := &Server{}
+	outcome := s.mutationReindexState(ctx, path)
+	if !refreshed || !outcome.Reindexed || outcome.Err != nil || outcome.AppliedGeneration != 9 {
+		t.Fatalf("selected refresh = %+v, called=%v", outcome, refreshed)
+	}
+	resp := map[string]any{}
+	s.attachMutationFreshness(resp, "file.go", path, outcome)
+	if resp["graph_status"] != mutationGraphFresh {
+		t.Fatalf("freshness = %v", resp)
+	}
+	if _, ok := resp["syntax_health"]; ok {
+		t.Fatalf("canonical syntax health leaked into checkout response: %v", resp)
+	}
+}
+
+func TestCheckoutMutationReindexNeverClaimsPendingCycleFresh(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		cycle indexer.CheckoutCycle
+		err   error
+	}{
+		{name: "refresh_error", err: errors.New("publish failed")},
+		{name: "deferred", cycle: indexer.CheckoutCycle{Deferred: true, CommitGenerationID: 4, DirtyGenerationID: 5}},
+		{name: "rescheduled", cycle: indexer.CheckoutCycle{Rescheduled: true, CommitGenerationID: 4, DirtyGenerationID: 5}},
+		{name: "missing_generation", cycle: indexer.CheckoutCycle{CommitGenerationID: 4}},
+		{name: "cycle_error", cycle: indexer.CheckoutCycle{Err: errors.New("build failed"), CommitGenerationID: 4, DirtyGenerationID: 5}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			lease := &fakeCheckoutMutationLifecycle{refresh: func(context.Context) (indexer.CheckoutCycle, error) { return tc.cycle, tc.err }}
+			ctx := withCheckoutMutation(context.Background(), lease, root)
+			s := &Server{}
+			outcome := s.mutationReindexState(ctx, filepath.Join(root, "file.go"))
+			if outcome.Reindexed || outcome.Err == nil || outcome.AppliedGeneration != 0 {
+				t.Fatalf("unpublished cycle claimed fresh: %+v", outcome)
+			}
+		})
+	}
+}
+
+func BenchmarkCheckoutMutationPathConfinement(b *testing.B) {
+	root := b.TempDir()
+	ctx := withCheckoutMutation(context.Background(), &fakeCheckoutMutationLifecycle{}, root)
+	path := filepath.Join(root, "new", "file.go")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if err := guardCheckoutMutationPath(ctx, path); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/mcp/view_request.go
+++ b/internal/mcp/view_request.go
@@ -916,23 +916,27 @@ func (s *Server) repoPrefixForCheckout(ctx context.Context, checkout store_sqlit
 	return primary
 }
 
-// refuseRoutedViewMutation blocks a source-mutating tool whose request reads
-// through a routed view.
-//
-// Path resolution follows the view, but nothing else on the write path does:
-// the view is a leased snapshot of generations, and a write beneath it leaves
-// the stack this request read describing content that is no longer there.
-// Refusing is the honest answer until the write path can invalidate the route
-// it wrote through; editing an automatic worktree comes with that.
+// refuseRoutedViewMutation admits only mutations that obtained checkout-local
+// coordination. An inexact fallback is read-only even when it has no routed
+// reader: allowing that case would silently write the primary checkout.
 func (s *Server) refuseRoutedViewMutation(ctx context.Context, tool string) *mcp.CallToolResult {
 	view := requestViewFromContext(ctx)
-	if !view.routed() || !s.facades.mutatesSource(tool) {
+	if !s.facades.mutatesSource(tool) || view == nil {
+		return nil
+	}
+	if view.rider != nil && !view.rider.Exact {
+		return mcp.NewToolResultError(fmt.Sprintf(
+			"%s: source edits require an exact live checkout; this request received a read-only fallback. Retry when the selected checkout is ready.",
+			graphview.CodeViewReadOnly))
+	}
+	if !view.routed() || checkoutMutationFromContext(ctx) != nil {
 		return nil
 	}
 	return mcp.NewToolResultError(fmt.Sprintf(
-		"%s: this request reads through %s, and %s would write the canonical checkout instead of that one. "+
-			"Read through the view; edit from the checkout's own working copy.",
-		graphview.CodeViewReadOnly, view.rider.ActualView, tool))
+		"%s: %s has no approved write path for this view. "+
+			"Only file edits, file writes, and symbol edits are supported on an exact live worktree with an active checkout coordinator. "+
+			"Batch operations, refactors, and immutable ref views remain read-only through routed views.",
+		graphview.CodeViewReadOnly, tool))
 }
 
 // attachViewRider puts the view fields on the response, inside the freshness

--- a/internal/mcp/worktree_source_mutation_test.go
+++ b/internal/mcp/worktree_source_mutation_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/zzet/gortex/internal/indexer"
 	"github.com/zzet/gortex/internal/parser"
 	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/pathkey"
 	"github.com/zzet/gortex/internal/query"
 	"github.com/zzet/gortex/internal/search"
 )
@@ -347,12 +348,14 @@ func newRealCheckoutMutationFixture(t testing.TB) *realCheckoutMutationFixture {
 	checkoutID := ""
 	for _, family := range overview.Families {
 		for _, checkout := range family.Checkouts {
-			if checkout.RootPath == worktree {
+			// Git emits slash-separated worktree roots on Windows, while
+			// filepath.Join uses native separators. Compare path identities.
+			if pathkey.EqualPaths(checkout.RootPath, worktree) {
 				checkoutID = checkout.CheckoutID
 			}
 		}
 	}
-	require.NotEmpty(t, checkoutID, "linked worktree must be discovered through registration")
+	require.NotEmpty(t, checkoutID, "linked worktree %q must be discovered through registration: %+v", worktree, overview.Families)
 	require.True(t, lifecycle.ActivateCheckout(checkoutID, "mutation-test"))
 	require.Eventually(t, func() bool {
 		route, found, routeErr := store.Catalog().GetCheckoutRoute(ctx, checkoutID)

--- a/internal/mcp/worktree_source_mutation_test.go
+++ b/internal/mcp/worktree_source_mutation_test.go
@@ -1,0 +1,567 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/graphview"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/query"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// Handler tests use the published view fixture and an observable mutation
+// lease. The coordinator integration below exercises the actual publication
+// path; these cases pin that every primitive honors its lease at the disk seam.
+type primitiveCheckoutMutation struct {
+	prepared   int
+	refreshed  int
+	prepareErr error
+	refreshErr error
+	cycle      indexer.CheckoutCycle
+}
+
+func (m *primitiveCheckoutMutation) Prepare(context.Context) error {
+	m.prepared++
+	return m.prepareErr
+}
+
+func (m *primitiveCheckoutMutation) Refresh(context.Context) (indexer.CheckoutCycle, error) {
+	m.refreshed++
+	return m.cycle, m.refreshErr
+}
+
+const primitiveWorktreeSource = "package repo\n\nfunc New() {}\n"
+
+func callCheckoutPrimitive(
+	t *testing.T,
+	stack *viewStack,
+	cwd string,
+	viewArgs map[string]any,
+	tool string,
+	args map[string]any,
+	mutation *primitiveCheckoutMutation,
+) *mcplib.CallToolResult {
+	t.Helper()
+	req := mcplib.CallToolRequest{}
+	req.Params.Name = tool
+	req.Params.Arguments = args
+	// Acquire the fixture's genuine routed reader, then supply the mutation
+	// authority at the handler boundary. This deliberately separates primitive
+	// behavior from middleware admission, which the real lifecycle tests cover.
+	res, err := stack.callWithView(t, cwd, "get_symbol", viewArgs,
+		func(ctx context.Context) (*mcplib.CallToolResult, error) {
+			ctx = withCheckoutMutation(ctx, mutation, stack.worktreeRoot)
+			switch tool {
+			case "edit_file":
+				return stack.srv.handleEditFile(ctx, req)
+			case "write_file":
+				return stack.srv.handleWriteFile(ctx, req)
+			case "edit_symbol":
+				return stack.srv.handleEditSymbol(ctx, req)
+			default:
+				t.Fatalf("unsupported primitive test tool %q", tool)
+				return nil, nil
+			}
+		})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	return res
+}
+
+func TestCheckoutSourcePrimitivesHonorDryRunAndIsolateDiskWrites(t *testing.T) {
+	for _, tool := range []string{"edit_file", "write_file"} {
+		for _, selection := range []string{"cwd", "explicit"} {
+			for _, dryRun := range []bool{true, false} {
+				name := tool + "/" + selection + "/write"
+				if dryRun {
+					name = tool + "/" + selection + "/dry_run"
+				}
+				t.Run(name, func(t *testing.T) {
+					stack := newViewStack(t)
+					primaryFile := filepath.Join(stack.repoRoot, "edit.go")
+					primaryBefore, err := os.ReadFile(primaryFile)
+					require.NoError(t, err)
+					worktreeFile := filepath.Join(stack.worktreeRoot, "edit.go")
+					require.NoError(t, os.WriteFile(worktreeFile, []byte(primitiveWorktreeSource), 0o644))
+					mutation := &primitiveCheckoutMutation{cycle: indexer.CheckoutCycle{
+						CommitGenerationID: stack.commit,
+						DirtyGenerationID:  stack.dirty,
+					}}
+					cwd := stack.worktreeRoot
+					var viewArgs map[string]any
+					if selection == "explicit" {
+						cwd = stack.repoRoot
+						viewArgs = worktreeViewArgs()
+					}
+					const changed = "package repo\n\nfunc AfterCheckoutEdit() {}\n"
+					args := map[string]any{"path": "repo/edit.go", "dry_run": dryRun}
+					if tool == "edit_file" {
+						args["old_string"] = "func New() {}"
+						args["new_string"] = "func AfterCheckoutEdit() {}"
+					} else {
+						args["content"] = changed
+					}
+					res := callCheckoutPrimitive(t, stack, cwd, viewArgs, tool, args, mutation)
+					require.False(t, res.IsError, viewResultText(t, res))
+					payload := decodeFileOpsResult(t, res)
+					gotPrimary, err := os.ReadFile(primaryFile)
+					require.NoError(t, err)
+					require.Equal(t, primaryBefore, gotPrimary, "the canonical checkout must not be edited")
+					gotWorktree, err := os.ReadFile(worktreeFile)
+					require.NoError(t, err)
+					if dryRun {
+						require.Equal(t, primitiveWorktreeSource, string(gotWorktree))
+						require.Zero(t, mutation.prepared, "preview must not invalidate the checkout route")
+						require.Zero(t, mutation.refreshed, "preview must not rebuild the checkout")
+						require.Equal(t, true, payload["dry_run"])
+						require.Equal(t, false, payload["reindexed"])
+					} else {
+						require.Equal(t, changed, string(gotWorktree))
+						require.Equal(t, 1, mutation.prepared)
+						require.Equal(t, 1, mutation.refreshed)
+						require.Equal(t, true, payload["reindexed"])
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestCheckoutSourcePrimitiveRejectsForeignCheckoutBeforePrepare(t *testing.T) {
+	for _, target := range []string{"primary", "sibling"} {
+		t.Run(target, func(t *testing.T) {
+			stack := newViewStack(t)
+			path := filepath.Join(stack.repoRoot, "edit.go")
+			if target == "sibling" {
+				path = filepath.Join(stack.otherRoot, "other.go")
+			}
+			before, err := os.ReadFile(path)
+			require.NoError(t, err)
+			mutation := &primitiveCheckoutMutation{}
+			res := callCheckoutPrimitive(t, stack, stack.worktreeRoot, nil, "write_file",
+				map[string]any{"path": path, "content": "must not land"}, mutation)
+			require.True(t, res.IsError)
+			require.Zero(t, mutation.prepared)
+			require.Zero(t, mutation.refreshed)
+			after, err := os.ReadFile(path)
+			require.NoError(t, err)
+			require.Equal(t, before, after)
+		})
+	}
+}
+
+func TestCheckoutSourceSymbolPrimitiveUsesSelectedPhysicalSpan(t *testing.T) {
+	for _, dryRun := range []bool{true, false} {
+		name := "write"
+		if dryRun {
+			name = "dry_run"
+		}
+		t.Run(name, func(t *testing.T) {
+			stack := newViewStack(t)
+			const before = "package repo\n\nfunc New() {\n}\n"
+			path := filepath.Join(stack.worktreeRoot, "edit.go")
+			require.NoError(t, os.WriteFile(path, []byte(before), 0o644))
+			primaryBefore, err := os.ReadFile(filepath.Join(stack.repoRoot, "edit.go"))
+			require.NoError(t, err)
+			mutation := &primitiveCheckoutMutation{cycle: indexer.CheckoutCycle{
+				CommitGenerationID: stack.commit, DirtyGenerationID: stack.dirty,
+			}}
+			res := callCheckoutPrimitive(t, stack, stack.repoRoot, worktreeViewArgs(), "edit_symbol",
+				map[string]any{
+					"id": "repo/edit.go::New", "old_source": "func New() {\n}",
+					"new_source": "func ChangedBySymbol() {\n}", "dry_run": dryRun,
+				}, mutation)
+			require.False(t, res.IsError, viewResultText(t, res))
+			after, err := os.ReadFile(path)
+			require.NoError(t, err)
+			if dryRun {
+				require.Equal(t, before, string(after))
+				require.Zero(t, mutation.prepared)
+				require.Zero(t, mutation.refreshed)
+			} else {
+				require.Equal(t, "package repo\n\nfunc ChangedBySymbol() {\n}\n", string(after))
+				require.Equal(t, 1, mutation.prepared)
+				require.Equal(t, 1, mutation.refreshed)
+				require.Equal(t, true, decodeFileOpsResult(t, res)["reindexed"])
+			}
+			primaryAfter, err := os.ReadFile(filepath.Join(stack.repoRoot, "edit.go"))
+			require.NoError(t, err)
+			require.Equal(t, primaryBefore, primaryAfter)
+		})
+	}
+}
+
+func TestCheckoutSourcePrimitivePrepareFailurePreservesFile(t *testing.T) {
+	stack := newViewStack(t)
+	path := filepath.Join(stack.worktreeRoot, "edit.go")
+	require.NoError(t, os.WriteFile(path, []byte(primitiveWorktreeSource), 0o644))
+	mutation := &primitiveCheckoutMutation{prepareErr: errors.New("checkout route changed")}
+	res := callCheckoutPrimitive(t, stack, stack.worktreeRoot, nil, "edit_file",
+		map[string]any{"path": path, "old_string": "New", "new_string": "Changed"}, mutation)
+	require.True(t, res.IsError)
+	require.Equal(t, 1, mutation.prepared)
+	require.Zero(t, mutation.refreshed)
+	after, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, primitiveWorktreeSource, string(after))
+}
+
+func TestCheckoutSourcePrimitiveReportsPublicationFailureAfterDiskCommit(t *testing.T) {
+	stack := newViewStack(t)
+	path := filepath.Join(stack.worktreeRoot, "edit.go")
+	require.NoError(t, os.WriteFile(path, []byte(primitiveWorktreeSource), 0o644))
+	mutation := &primitiveCheckoutMutation{refreshErr: errors.New("injected checkout publication failure")}
+	res := callCheckoutPrimitive(t, stack, stack.worktreeRoot, nil, "edit_file",
+		map[string]any{"path": path, "old_string": "New", "new_string": "CommittedButUnpublished"}, mutation)
+	require.Equal(t, 1, mutation.prepared)
+	require.Equal(t, 1, mutation.refreshed)
+	after, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Contains(t, string(after), "CommittedButUnpublished", "failed publication must not pretend to roll disk back")
+	require.Contains(t, viewResultText(t, res), "injected checkout publication failure")
+	if !res.IsError {
+		require.Equal(t, false, decodeFileOpsResult(t, res)["reindexed"], "disk commit is not a successful graph publication")
+	}
+}
+
+func TestCheckoutSourcePrimitivesStillRequireCoordinatorForPreview(t *testing.T) {
+	stack := newViewStack(t)
+	for _, tool := range []string{"edit_file", "write_file", "edit_symbol"} {
+		t.Run(tool, func(t *testing.T) {
+			ran := false
+			res, err := stack.callWithView(t, stack.worktreeRoot, tool,
+				map[string]any{"dry_run": true}, func(context.Context) (*mcplib.CallToolResult, error) {
+					ran = true
+					return mcplib.NewToolResultText(`{"ok":true}`), nil
+				})
+			require.NoError(t, err)
+			assertToolError(t, res, graphview.CodeViewReadOnly)
+			require.False(t, ran)
+		})
+	}
+	var reader graph.Reader
+	res, err := stack.callWithView(t, stack.worktreeRoot, "get_symbol", nil, captureReader(stack.srv, &reader))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	require.True(t, hasNode(reader, "repo/added.go::Fresh"))
+}
+
+func TestCheckoutSourceFallbackRemainsReadOnly(t *testing.T) {
+	stack := newViewStack(t)
+	routeViewCheckout(t, stack.store, stack.graphID, stack.commit, 0, store_sqlite.RouteActive)
+	for _, dryRun := range []bool{true, false} {
+		ran := false
+		res, err := stack.callWithView(t, stack.worktreeRoot, "edit_file",
+			map[string]any{"dry_run": dryRun}, func(context.Context) (*mcplib.CallToolResult, error) {
+				ran = true
+				return mcplib.NewToolResultText(`{"ok":true}`), nil
+			})
+		require.NoError(t, err)
+		assertToolError(t, res, graphview.CodeViewReadOnly)
+		require.False(t, ran, "base fallback must not grant permission to edit the primary checkout")
+	}
+}
+
+// realCheckoutMutationFixture uses production registration, activation,
+// publication, middleware and handlers. Only its Git family and store are
+// temporary: it never connects to the installed daemon.
+type realCheckoutMutationFixture struct {
+	srv        *Server
+	store      *store_sqlite.Store
+	primary    string
+	worktree   string
+	checkoutID string
+}
+
+func checkoutMutationGit(t testing.TB, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd.Env = append(os.Environ(),
+		"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL="+os.DevNull,
+		"GIT_AUTHOR_NAME=Gortex Test", "GIT_AUTHOR_EMAIL=test@example.invalid",
+		"GIT_COMMITTER_NAME=Gortex Test", "GIT_COMMITTER_EMAIL=test@example.invalid",
+		"GIT_TERMINAL_PROMPT=0")
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, output)
+	return strings.TrimSpace(string(output))
+}
+
+func newRealCheckoutMutationFixture(t testing.TB) *realCheckoutMutationFixture {
+	t.Helper()
+	base, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+	primary := filepath.Join(base, "repo")
+	worktree := filepath.Join(base, "wt")
+	require.NoError(t, os.Mkdir(primary, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(primary, "edit.go"), []byte("package repo\n\nfunc Old() {}\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(primary, ".gortex.yaml"), []byte("workspace: checkout-mutations\n"), 0o644))
+	checkoutMutationGit(t, primary, "init", "--initial-branch=main")
+	checkoutMutationGit(t, primary, "add", "-A")
+	checkoutMutationGit(t, primary, "commit", "-m", "base")
+	checkoutMutationGit(t, primary, "worktree", "add", "-b", "feature", worktree)
+	require.NoError(t, os.WriteFile(filepath.Join(worktree, "edit.go"), []byte(primitiveWorktreeSource), 0o644))
+
+	store, err := store_sqlite.Open(filepath.Join(base, "store.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	cfgPath := filepath.Join(base, "config.yaml")
+	global := &config.GlobalConfig{}
+	global.SetConfigPath(cfgPath)
+	require.NoError(t, global.Save())
+	cm, err := config.NewConfigManager(cfgPath)
+	require.NoError(t, err)
+	registry := parser.NewRegistry()
+	languages.RegisterAll(registry)
+	bm := search.NewNull()
+	mi := indexer.NewMultiIndexer(store, registry, bm, cm, zap.NewNop())
+	leases := graphview.NewLeaseManager()
+	lifecycle, err := indexer.NewCheckoutLifecycle(indexer.CheckoutLifecycleConfig{
+		MultiIndexer: mi, ConfigManager: cm, Graph: store,
+		Logger: zap.NewNop(), ViewLeases: leases,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lifecycle.Close() })
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	registered, err := lifecycle.Register(ctx, config.RepoEntry{Path: primary, Name: "repo"}, indexer.TrackSourceCLI)
+	require.NoError(t, err)
+	require.NoError(t, registered.CatalogErr)
+	overview, err := lifecycle.FamiliesOverview(ctx, registered.FamilyID)
+	require.NoError(t, err)
+	checkoutID := ""
+	for _, family := range overview.Families {
+		for _, checkout := range family.Checkouts {
+			if checkout.RootPath == worktree {
+				checkoutID = checkout.CheckoutID
+			}
+		}
+	}
+	require.NotEmpty(t, checkoutID, "linked worktree must be discovered through registration")
+	require.True(t, lifecycle.ActivateCheckout(checkoutID, "mutation-test"))
+	require.Eventually(t, func() bool {
+		route, found, routeErr := store.Catalog().GetCheckoutRoute(ctx, checkoutID)
+		return routeErr == nil && found && route.State == store_sqlite.RouteActive &&
+			route.CommitGenerationID > 0 && route.DirtyGenerationID > 0
+	}, 20*time.Second, 20*time.Millisecond, "automatic worktree did not publish its initial route")
+
+	engine := query.NewEngine(store)
+	engine.SetSearch(bm)
+	srv := NewServer(engine, store, nil, nil, zap.NewNop(), nil, MultiRepoOptions{
+		MultiIndexer: mi, ConfigManager: cm,
+	})
+	srv.SetMaterializer(&graphview.Materializer{Store: store, Catalog: store.Catalog(), Leases: leases})
+	srv.lifecycle = lifecycle
+	return &realCheckoutMutationFixture{
+		srv: srv, store: store,
+		primary: primary, worktree: worktree, checkoutID: checkoutID,
+	}
+}
+
+func (f *realCheckoutMutationFixture) edit(t testing.TB, cwd string, args map[string]any) *mcplib.CallToolResult {
+	t.Helper()
+	req := mcplib.CallToolRequest{}
+	req.Params.Name = "edit_file"
+	req.Params.Arguments = args
+	ctx := WithSessionCWD(WithSessionID(context.Background(), "real-checkout-mutation"), cwd)
+	result, err := f.srv.wrapToolHandler(f.srv.handleEditFile)(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	return result
+}
+
+func TestWorktreeMutationCoordinatorEndToEnd(t *testing.T) {
+	for _, selection := range []string{"cwd", "checkout_id", "path"} {
+		t.Run(selection, func(t *testing.T) {
+			fixture := newRealCheckoutMutationFixture(t)
+			primaryFile := filepath.Join(fixture.primary, "edit.go")
+			primaryBefore, err := os.ReadFile(primaryFile)
+			require.NoError(t, err)
+			ctx := context.Background()
+			before, found, err := fixture.store.Catalog().GetCheckoutRoute(ctx, fixture.checkoutID)
+			require.NoError(t, err)
+			require.True(t, found)
+			cwd := fixture.worktree
+			args := func(dryRun bool) map[string]any {
+				out := map[string]any{
+					"path": "repo/edit.go", "old_string": "func New() {}",
+					"new_string": "func ChangedInWorktree() {}", "dry_run": dryRun,
+				}
+				if selection != "cwd" {
+					cwd = fixture.primary
+					selector := map[string]any{"kind": "worktree"}
+					if selection == "path" {
+						selector["path"] = fixture.worktree
+					} else {
+						selector["checkout_id"] = fixture.checkoutID
+					}
+					out["view"] = selector
+				}
+				return out
+			}
+			previewArgs := args(true)
+			preview := fixture.edit(t, cwd, previewArgs)
+			require.False(t, preview.IsError, viewResultText(t, preview))
+			require.Equal(t, "would_apply", decodeFileOpsResult(t, preview)["status"])
+			afterPreview, found, err := fixture.store.Catalog().GetCheckoutRoute(ctx, fixture.checkoutID)
+			require.NoError(t, err)
+			require.True(t, found)
+			require.Equal(t, before, afterPreview, "preview must leave the published route untouched")
+			worktreeBefore, err := os.ReadFile(filepath.Join(fixture.worktree, "edit.go"))
+			require.NoError(t, err)
+			require.Equal(t, primitiveWorktreeSource, string(worktreeBefore))
+
+			writeArgs := args(false)
+			written := fixture.edit(t, cwd, writeArgs)
+			require.False(t, written.IsError, viewResultText(t, written))
+			require.Equal(t, true, decodeFileOpsResult(t, written)["reindexed"])
+			afterWrite, found, err := fixture.store.Catalog().GetCheckoutRoute(ctx, fixture.checkoutID)
+			require.NoError(t, err)
+			require.True(t, found)
+			require.Greater(t, afterWrite.RouteEpoch, before.RouteEpoch)
+			require.NotEqual(t, before.DirtyGenerationID, afterWrite.DirtyGenerationID)
+			primaryAfter, err := os.ReadFile(primaryFile)
+			require.NoError(t, err)
+			require.Equal(t, primaryBefore, primaryAfter)
+			worktreeAfter, err := os.ReadFile(filepath.Join(fixture.worktree, "edit.go"))
+			require.NoError(t, err)
+			require.Contains(t, string(worktreeAfter), "func ChangedInWorktree() {}")
+
+			var reader graph.Reader
+			readReq := mcplib.CallToolRequest{}
+			readReq.Params.Name = "get_symbol"
+			readReq.Params.Arguments = map[string]any{"require_exact": true}
+			readCtx := WithSessionCWD(WithSessionID(ctx, "real-checkout-read-after-write"), fixture.worktree)
+			readResult, err := fixture.srv.wrapToolHandler(func(ctx context.Context, _ mcplib.CallToolRequest) (*mcplib.CallToolResult, error) {
+				reader = fixture.srv.readerFor(ctx)
+				return mcplib.NewToolResultText(`{"ok":true}`), nil
+			})(readCtx, readReq)
+			require.NoError(t, err)
+			require.False(t, readResult.IsError, viewResultText(t, readResult))
+			require.Equal(t, true, resultFreshness(t, readResult)["exact"])
+			require.True(t, hasNode(reader, "repo/edit.go::ChangedInWorktree"))
+			require.False(t, hasNode(reader, "repo/edit.go::New"))
+		})
+	}
+}
+
+func TestWorktreeMutationFacadeEndToEnd(t *testing.T) {
+	t.Setenv("GORTEX_TOOLS", "facade-v1")
+	for _, operation := range []string{"file", "write", "symbol"} {
+		for _, inferred := range []bool{false, true} {
+			name := operation + "/explicit_operation"
+			if inferred {
+				name = operation + "/inferred_operation"
+			}
+			t.Run(name, func(t *testing.T) {
+				fixture := newRealCheckoutMutationFixture(t)
+				primaryBefore, err := os.ReadFile(filepath.Join(fixture.primary, "edit.go"))
+				require.NoError(t, err)
+				tool := fixture.srv.mcpServer.GetTool("edit")
+				require.NotNil(t, tool, "exercise the registered facade, including its middleware")
+				ctx := WithSessionCWD(WithSessionID(context.Background(), "real-checkout-facade"), fixture.primary)
+				const after = "package repo\n\nfunc EditedThroughFacade() {}\n"
+				for _, dryRun := range []bool{true, false} {
+					args := map[string]any{
+						"dry_run": dryRun,
+						"view":    map[string]any{"kind": "worktree", "path": fixture.worktree},
+					}
+					if !inferred {
+						args["operation"] = operation
+					}
+					if operation == "symbol" {
+						args["target"] = map[string]any{"symbol": "repo/edit.go::New"}
+					} else {
+						args["target"] = map[string]any{"file": "repo/edit.go"}
+					}
+					if operation == "write" {
+						args["content"] = after
+					} else {
+						args["match"] = "func New() {}"
+						args["replacement"] = "func EditedThroughFacade() {}"
+					}
+					req := mcplib.CallToolRequest{}
+					req.Params.Name = "edit"
+					req.Params.Arguments = args
+					result, err := tool.Handler(ctx, req)
+					require.NoError(t, err)
+					require.False(t, result.IsError, viewResultText(t, result))
+					body, err := os.ReadFile(filepath.Join(fixture.worktree, "edit.go"))
+					require.NoError(t, err)
+					if dryRun {
+						require.Equal(t, primitiveWorktreeSource, string(body))
+					} else {
+						require.Equal(t, after, string(body))
+						require.Equal(t, true, decodeFileOpsResult(t, result)["reindexed"])
+					}
+				}
+				primaryAfter, err := os.ReadFile(filepath.Join(fixture.primary, "edit.go"))
+				require.NoError(t, err)
+				require.Equal(t, primaryBefore, primaryAfter)
+
+				read := fixture.srv.mcpServer.GetTool("read")
+				require.NotNil(t, read)
+				req := mcplib.CallToolRequest{}
+				req.Params.Name = "read"
+				req.Params.Arguments = map[string]any{
+					"operation": "file", "target": map[string]any{"file": "repo/edit.go"},
+					"view":          map[string]any{"kind": "worktree", "path": fixture.worktree},
+					"require_exact": true,
+				}
+				result, err := read.Handler(ctx, req)
+				require.NoError(t, err)
+				require.False(t, result.IsError, viewResultText(t, result))
+				require.Contains(t, viewResultText(t, result), "EditedThroughFacade")
+				require.NotContains(t, viewResultText(t, result), "func Old()")
+				require.Equal(t, true, resultFreshness(t, result)["exact"])
+			})
+		}
+	}
+}
+
+func TestWorktreeMutationInactiveRefRemainsReadOnly(t *testing.T) {
+	fixture := newRealCheckoutMutationFixture(t)
+	before, err := os.ReadFile(filepath.Join(fixture.primary, "edit.go"))
+	require.NoError(t, err)
+	for _, dryRun := range []bool{true, false} {
+		result := fixture.edit(t, fixture.primary, map[string]any{
+			"path": "repo/edit.go", "old_string": "func Old() {}", "new_string": "func MustNotLand() {}",
+			"dry_run": dryRun,
+			"view":    map[string]any{"kind": "git_ref", "graph_id": indexer.GraphIDFor("repo"), "value": "refs/heads/main"},
+		})
+		assertToolError(t, result, graphview.CodeViewReadOnly)
+	}
+	after, err := os.ReadFile(filepath.Join(fixture.primary, "edit.go"))
+	require.NoError(t, err)
+	require.Equal(t, before, after)
+}
+
+func BenchmarkWorktreeMutationDryRun(b *testing.B) {
+	fixture := newRealCheckoutMutationFixture(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result := fixture.edit(b, fixture.worktree, map[string]any{
+			"path": "repo/edit.go", "old_string": "func New() {}",
+			"new_string": "func PreviewOnly() {}", "dry_run": true,
+		})
+		if result.IsError {
+			b.Fatalf("dry-run refused: %+v", result.Content)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The routed-view mutation guard rejected all source edits, even dry runs from a session already inside the selected worktree. Its advice to edit from that checkout's own working copy could not resolve the refusal.

## Fix

Enable the audited single-file paths: `edit.file`, `edit.write`, and `edit.symbol`, including legacy equivalents and inferred facade operations. Own-CWD and explicit path/checkout-ID selectors use the same admission path.

- Acquire a checkout-specific mutation lease using the existing interactive build admission and reconciliation lock. Revalidate route epoch, incarnation, filesystem root identity, HEAD/base identity, and dirty fingerprint.
- Dry runs perform no disk commit, route invalidation, or generation build.
- Withdraw the old dirty route before a real write, preserve already-pinned readers, then refresh through the selected checkout's sparse coordinator. Never enqueue the primary watcher or index the worktree into the canonical corpus.
- Preserve the existing disk-commit receipt if graph refresh fails. Shutdown joins admitted mutations; cancellation and panic paths release admission safely.
- Confine both the physical read target and the atomic-write directory entry to the selected checkout. Refuse primary/sibling paths, symlink escapes in either direction, nested repositories, and Git metadata.
- Keep all inexact fallbacks and immutable ref/commit views read-only. Unsaved editor-buffer cohorts require saving/discarding before an on-disk edit.

Batch editing/recovery, lifecycle operations, and LSP refactors have separate write paths and remain explicitly refused through routed views. This PR does not enable unaudited writes by removing the guard. Ordinary canonical-checkout editing is unchanged.

Implementation notes and reproducible benchmarks are in `docs/worktree-source-mutations.md`. No schema migration or extra store is required.

## Validation

- Full `internal/indexer`, `internal/mcp`, `internal/graphview`, and `cmd/gortex` package suites.
- Full graphview race suite; focused MCP mutation/routing and indexer coordinator/mutation race suites.
- Real temporary Git-worktree E2E through the registered MCP facade: file/write/symbol, explicit/inferred operations, previews and writes, own-CWD/path/ID selection, unchanged primary files, and subsequent exact graph/source reads.
- Failure regressions for stale views, cancellation, shutdown, root replacement, panic cleanup, publication failure, and symlink directory-entry confinement.
- Scoped golangci-lint and CLI build.
- Apple M1 Pro tiny-fixture benchmarks: checkout admission 10.06–10.21 ms/op; complete MCP dry run 12.35–19.55 ms/op. These are admission-path measurements, not large-repository indexing claims.

The CLI suite initially reported its documented false positive when our MCP calls changed the running daemon's query log during its real-home audit. It passed when rerun without concurrent Gortex queries. The live daemon was never restarted or stopped. Validation used temporary fixtures; no explicit tracking, store deletion, or administrative reindex was performed.
