### PR TITLE
feat: add detailed warm-restart phase timing diagnostics

### DIFF
--- a/cmd/gortex/daemon_state.go
+++ b/cmd/gortex/daemon_state.go
@@ -929,6 +929,10 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 		// and cross-repo passes starved cross-repo to a standstill
 		// (measured: 1,049s for a pass that runs in ~38s uncontended). The
 		// gate opens right after this call returns.
+		var lspBefore lsp.RouterTimingStats
+		if state.lspRouter != nil {
+			lspBefore = state.lspRouter.TimingStats()
+		}
 		resolveTimer := newWarmupResolveTimer(logger)
 		timedReady := resolveTimer.ready(markReady)
 		var resolveErr error
@@ -938,6 +942,14 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 			resolveErr = state.multiIndexer.RunPreEnrichResolve(ctx, resolveScope, timedReady)
 		}
 		timings.resolveCompute, timings.resolveTail = resolveTimer.finish(resolveErr)
+		if state.lspRouter != nil {
+			// Router counters are global: concurrent queries or opt-in enrichment
+			// overlap may contribute. Summed operation durations are not wall time.
+			logger.Info("daemon: resolver LSP timing",
+				zap.String("phase", "pre_enrich_resolve"),
+				zap.String("scope", "router_global_delta"),
+				zap.Any("timing", state.lspRouter.TimingStats().Sub(lspBefore)))
+		}
 		if resolveErr != nil {
 			resolveOK = false
 			exactWarmDelta = false

--- a/cmd/gortex/daemon_state.go
+++ b/cmd/gortex/daemon_state.go
@@ -264,12 +264,19 @@ func boundedStartupError(err error) string {
 // already compute — those logs stay untouched; this just also keeps the
 // values around instead of discarding them.
 type warmupTimings struct {
-	parse         time.Duration
-	resolve       time.Duration
-	enrich        time.Duration
-	globalResolve time.Duration
-	endBatch      time.Duration
-	analysis      time.Duration
+	prelude           time.Duration
+	prepareResolve    time.Duration
+	contractRehydrate time.Duration
+	workspaceBackfill time.Duration
+	watchers          time.Duration
+	resolveCompute    time.Duration
+	resolveTail       time.Duration
+	parse             time.Duration
+	resolve           time.Duration
+	enrich            time.Duration
+	globalResolve     time.Duration
+	endBatch          time.Duration
+	analysis          time.Duration
 	// reposChanged is the number of tracked repos whose reindex actually did
 	// work this warmup (cold track, or a reconcile with stale/deleted files).
 	reposChanged int
@@ -425,6 +432,7 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 		return nil, timings
 	}
 
+	finishPrelude := startWarmupStep(logger, "prelude")
 	ctx := progress.WithReporter(context.Background(), progress.Nop{})
 	// BeginParallelBatch / EndBatch tells every per-repo Indexer
 	// constructed inside the loop to skip both the graph-wide
@@ -436,14 +444,18 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 	// loop below just parses; RunDeferredPassesAll drains the deferred
 	// per-repo passes serially before the global resolve. Without this
 	// batch wrapper, a 100+ repo warmup is O(R · global_size).
+	finishBatch := startWarmupStep(logger, "begin_parallel_batch")
 	state.multiIndexer.BeginParallelBatch()
+	finishBatch()
 
 	// Heal any duplicate tracked-repo entries that name the same directory
 	// under a different path spelling (case, or Unicode normalisation)
 	// BEFORE the warmup loop registers them. Two spellings of one directory
 	// would otherwise both reach the indexer and flip the daemon into
 	// multi-repo mode, desyncing the unprefixed graph (#270).
-	healDuplicateRepos(state.configManager.Global(), logger)
+	finishHeal := startWarmupStep(logger, "heal_duplicate_repos")
+	removedDuplicates := healDuplicateRepos(state.configManager.Global(), logger)
+	finishHeal(zap.Int("removed", removedDuplicates))
 
 	repos := state.configManager.Global().Repos
 
@@ -459,10 +471,15 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 	// prefix outside that set, and PurgeRepo each. '' is never an orphan
 	// (shared global externals / solo data). Capability-probed, so only the
 	// sidecar-bearing on-disk store participates; the in-memory store skips it.
+	finishOrphans := startWarmupStep(logger, "orphan_maintenance")
+	orphanSupported := false
+	orphanCount, purgedCount, purgeFailures := 0, 0, 0
 	if orphaner, ok := state.graph.(interface {
 		OrphanRepoPrefixes(known []string) []string
 	}); ok {
 		if purger, ok := state.graph.(interface{ PurgeRepo(string) error }); ok {
+			orphanSupported = true
+			finishScan := startWarmupStep(logger, "orphan_prefix_scan", zap.Int("repos", len(repos)))
 			known := make([]string, 0, len(repos))
 			for _, entry := range repos {
 				p := strings.TrimPrefix(indexer.EffectiveRepoPrefix(state.configManager, entry), "/")
@@ -470,17 +487,28 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 					known = append(known, p)
 				}
 			}
-			for _, prefix := range orphaner.OrphanRepoPrefixes(known) {
+			orphans := orphaner.OrphanRepoPrefixes(known)
+			orphanCount = len(orphans)
+			finishScan(zap.Int("orphans", orphanCount))
+			for _, prefix := range orphans {
+				finishPurge := startWarmupStep(logger, "orphan_prefix_purge", zap.String("repo", prefix))
 				if err := purger.PurgeRepo(prefix); err != nil {
+					purgeFailures++
+					finishPurge(zap.String("outcome", "error"), zap.Error(err))
 					logger.Warn("daemon: purging orphaned repo prefix failed",
 						zap.String("prefix", prefix), zap.Error(err))
 					continue
 				}
+				purgedCount++
+				finishPurge(zap.String("outcome", "purged"))
 				logger.Info("daemon: purged orphaned repo prefix (no tracked repo in config keys under it)",
 					zap.String("prefix", prefix))
 			}
 		}
 	}
+
+	finishOrphans(zap.Bool("supported", orphanSupported), zap.Int("orphans", orphanCount),
+		zap.Int("purged", purgedCount), zap.Int("failed", purgeFailures))
 
 	// One-time store compaction, guarded (see daemon_compact.go). Placed HERE
 	// on purpose: after the orphan purge, so the pages it just freed are
@@ -494,28 +522,36 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 	// Running before the socket opened instead would hold the daemon
 	// unreachable for the whole VACUUM, turning a compacting boot into an
 	// apparent hang.
+	finishCompact := startWarmupStep(logger, "store_compaction_check")
 	maybeCompactStore(state.graph, logger)
+	finishCompact()
 
 	// Register a per-repo resolver-time LSP helper for every
 	// tracked repo BEFORE the parallel warmup loop fires. The
 	// helpers are lazy: language servers are not spawned until the
-	// resolver asks for a supported edge resolution, so there's no
-	// startup cost for repos with no matching code.
+	// resolver asks for a supported edge resolution. Time helper construction
+	// separately so repository discovery is visible even when no server starts.
+	finishHelpers := startWarmupStep(logger, "resolver_helper_registration", zap.Int("repos", len(repos)))
 	if state.resolverLSPRegistry != nil && state.lspRouter != nil {
 		poolSize := lsp.ResolverPoolSizeFromEnv(1)
 		registered, skipped, tsRepos, pythonRepos := 0, 0, 0, 0
 		for _, entry := range repos {
+			finishHelper := startWarmupStep(logger, "resolver_helper", zap.String("path", entry.Path))
 			absRoot, err := filepath.Abs(entry.Path)
 			if err != nil {
+				skipped++
+				finishHelper(zap.String("outcome", "invalid_path"), zap.Error(err))
 				continue
 			}
 			helper, specs := serverstack.BuildResolverLSPHelperForRepo(state.lspRouter, absRoot, poolSize, logger)
 			if helper == nil {
 				skipped++
+				finishHelper(zap.String("outcome", "skipped"))
 				continue
 			}
 			prefix := strings.TrimPrefix(indexer.EffectiveRepoPrefix(state.configManager, entry), "/")
 			state.resolverLSPRegistry.Register(prefix, helper)
+			finishHelper(zap.String("outcome", "registered"), zap.String("repo", prefix), zap.Strings("providers", specs))
 			registered++
 			for _, spec := range specs {
 				switch spec {
@@ -532,6 +568,9 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 			zap.Int("ts_repos", tsRepos),
 			zap.Int("python_repos", pythonRepos),
 			zap.Int("pool_size", poolSize))
+		finishHelpers(zap.Int("registered", registered), zap.Int("skipped", skipped), zap.Bool("enabled", true))
+	} else {
+		finishHelpers(zap.Bool("enabled", false), zap.Int("skipped", len(repos)))
 	}
 	// Bounded worker pool — disk I/O dominates parsing for most repos,
 	// but a few CPU-heavy ones overlap with disk waits on others. NumCPU
@@ -556,6 +595,7 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 			zap.String("value", os.Getenv(warmupMemoryBudgetEnv)),
 			zap.Error(budgetErr))
 	}
+	timings.prelude = finishPrelude(zap.Int("repos", len(repos)))
 	logger.Info("daemon: warmup phase start",
 		zap.String("phase", "parallel_parse"),
 		zap.Int("repos", len(repos)),
@@ -770,6 +810,8 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 		"repos_per_sec": parseStats.ItemsPerSec,
 	})
 
+	prepareStart := time.Now()
+	logger.Info("daemon: warmup step start", zap.String("step", "prepare_resolve"))
 	// Warm-restart fast path. When the reconcile loop above re-indexed
 	// nothing, the persistent backend already carries every resolved and
 	// derived edge from the prior run; the deferred per-repo passes, the
@@ -827,7 +869,9 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 	// covers those repos too. Cheap for a fully-enriched workspace: each
 	// already-complete repo pays a git rev-parse, one marker lookup, and one
 	// repo-scoped file-node projection — bounded by file count, not symbols.
+	finishSeed := startWarmupStep(logger, "seed_pending_enrichment", zap.Int("repos", len(repos)))
 	enrichPending := state.multiIndexer.SeedPendingEnrichAll()
+	finishSeed(zap.Int("pending_repos", enrichPending))
 	if enrichPending > 0 && !anyChanged {
 		logger.Info("daemon: warmup resuming incomplete enrichment on an otherwise-unchanged restart",
 			zap.Int("repos_pending_enrich", enrichPending))
@@ -866,6 +910,8 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 	// cross-repo resolver. On the warm-restart fast path nothing changed, so
 	// the persisted graph already carries resolved edges and we skip straight
 	// to marking ready.
+	timings.prepareResolve = time.Since(prepareStart)
+	logger.Info("daemon: warmup step complete", zap.String("step", "prepare_resolve"), zap.Duration("elapsed", timings.prepareResolve))
 	resolveOK := true
 	if anyChanged {
 		phaseStart = time.Now()
@@ -883,12 +929,15 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 		// and cross-repo passes starved cross-repo to a standstill
 		// (measured: 1,049s for a pass that runs in ~38s uncontended). The
 		// gate opens right after this call returns.
+		resolveTimer := newWarmupResolveTimer(logger)
+		timedReady := resolveTimer.ready(markReady)
 		var resolveErr error
 		if exactWarmDelta {
-			resolveErr = state.multiIndexer.RunPreEnrichResolveFiles(ctx, deltaFiles, markReady)
+			resolveErr = state.multiIndexer.RunPreEnrichResolveFiles(ctx, deltaFiles, timedReady)
 		} else {
-			resolveErr = state.multiIndexer.RunPreEnrichResolve(ctx, resolveScope, markReady)
+			resolveErr = state.multiIndexer.RunPreEnrichResolve(ctx, resolveScope, timedReady)
 		}
+		timings.resolveCompute, timings.resolveTail = resolveTimer.finish(resolveErr)
 		if resolveErr != nil {
 			resolveOK = false
 			exactWarmDelta = false
@@ -925,6 +974,7 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 	var deferredResult indexer.DeferredPassesResult
 	if anyChanged || enrichPending > 0 {
 		phaseStart = time.Now()
+		logger.Info("daemon: warmup phase start", zap.String("phase", "deferred_passes_all"), zap.Int("pending_repos", enrichPending))
 		publishReadinessPhase(state, "deferred_passes_all", true, nil)
 		if deferredRun != nil {
 			deferredResult = deferredRun.FinishTailResult()
@@ -955,6 +1005,7 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 	// last shutdown.
 	{
 		phaseStart = time.Now()
+		finishContracts := startWarmupStep(logger, "contract_registry_rehydrate")
 		injectedRepos, injectedCount := 0, 0
 		for prefix := range state.multiIndexer.AllMetadata() {
 			idx := state.multiIndexer.GetIndexer(prefix)
@@ -972,6 +1023,7 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 			injectedRepos++
 			injectedCount += len(reg.All())
 		}
+		timings.contractRehydrate = finishContracts(zap.Int("repos", injectedRepos), zap.Int("contracts", injectedCount))
 		if injectedRepos > 0 {
 			logger.Info("daemon: rehydrated contract registries from graph",
 				zap.Int("repos", injectedRepos),
@@ -985,9 +1037,11 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 	// shared-workspace declarations stop working until every file is
 	// touched. Idempotent — re-running on a stamped graph is a no-op.
 	phaseStart = time.Now()
+	finishBackfill := startWarmupStep(logger, "workspace_backfill_before_derived")
 	backfillRevisionBefore, backfillRevisionBeforeKnown := state.multiIndexer.GraphMutationRevision()
 	backfilledNodes, backfilledContracts, backfillResolutionAffected := state.multiIndexer.BackfillWorkspaceSlugsWithImpact()
 	backfillRevisionAfter, backfillRevisionAfterKnown := state.multiIndexer.GraphMutationRevision()
+	timings.workspaceBackfill = finishBackfill(zap.Int("nodes", backfilledNodes), zap.Int("contracts", backfilledContracts), zap.Int("resolution_affected", backfillResolutionAffected))
 	if backfilledNodes+backfilledContracts > 0 {
 		logger.Info("daemon: backfilled workspace/project slugs from .gortex.yaml",
 			zap.Int("nodes", backfilledNodes),
@@ -1021,6 +1075,7 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 	}, backfilledContracts)
 	if globalResolveAction != warmGlobalResolveNone {
 		phaseStart = time.Now()
+		logger.Info("daemon: warmup phase start", zap.String("phase", "global_resolve"), zap.Bool("full_cross_repo", globalResolveAction == warmGlobalResolveFull))
 		publishReadinessPhase(state, "global_resolve", true, nil)
 		switch globalResolveAction {
 		case warmGlobalResolveContracts:
@@ -1071,6 +1126,7 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 	}
 
 	phaseStart = time.Now()
+	logger.Info("daemon: warmup phase start", zap.String("phase", "end_batch"), zap.Bool("changed", anyChanged), zap.Bool("exact", exactWarmDelta))
 	publishReadinessPhase(state, "end_batch", true, nil)
 	switch {
 	case !anyChanged:
@@ -1084,7 +1140,9 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 	default:
 		state.multiIndexer.EndBatch()
 	}
+	finishPostBackfill := startWarmupStep(logger, "workspace_backfill_after_derived")
 	postBatchNodes, postBatchContracts, postBatchResolutionAffected := state.multiIndexer.BackfillWorkspaceSlugsWithImpact()
+	finishPostBackfill(zap.Int("nodes", postBatchNodes), zap.Int("contracts", postBatchContracts), zap.Int("resolution_affected", postBatchResolutionAffected))
 	if postBatchNodes+postBatchContracts > 0 {
 		logger.Info("daemon: backfilled workspace/project slugs after derived passes",
 			zap.Int("nodes", postBatchNodes),
@@ -1110,6 +1168,7 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 		"elapsed_ms": time.Since(phaseStart).Milliseconds(),
 	})
 
+	finishWatchers := startWarmupStep(logger, "watcher_start")
 	watchCfgs := make(map[string]config.WatchConfig)
 	for prefix := range state.multiIndexer.AllMetadata() {
 		watchCfgs[prefix] = state.configManager.GetRepoConfig(prefix).Watch
@@ -1117,10 +1176,12 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 	mw, err := indexer.NewMultiWatcher(state.multiIndexer, watchCfgs, logger)
 	if err != nil {
 		logger.Warn("daemon: multi-watcher init failed", zap.Error(err))
+		timings.watchers = finishWatchers(zap.String("outcome", "init_failed"), zap.Error(err))
 		return nil, timings
 	}
 	if err := mw.Start(); err != nil {
 		logger.Warn("daemon: multi-watcher start failed", zap.Error(err))
+		timings.watchers = finishWatchers(zap.String("outcome", "start_failed"), zap.Error(err))
 		return nil, timings
 	}
 	// Attach the live watcher before publishing watcher_started. This makes
@@ -1145,6 +1206,7 @@ func warmupDaemonState(state *daemonState, logger *zap.Logger, markReady func())
 			zap.String("first_reason", mw.DegradedReason()),
 		)
 	}
+	timings.watchers = finishWatchers(zap.String("outcome", "started"), zap.Int("repos", live), zap.Int("configured", configured))
 	logger.Info("daemon: watching", zap.Int("repos", live), zap.Int("configured", configured))
 	publishReadinessPhase(state, "watcher_started", true, map[string]any{
 		"watched_repos":    live,
@@ -1164,7 +1226,20 @@ func logWarmupSummary(logger *zap.Logger, warmup *warmupTimings, queryable, tota
 	if logger == nil || warmup == nil {
 		return
 	}
+	// Resolve compute/tail and post-derived backfill are nested measurements.
+	// Only disjoint top-level intervals belong in the accounting total.
+	accounted := warmup.prelude + warmup.prepareResolve + warmup.parse + warmup.resolve + warmup.enrich + warmup.contractRehydrate + warmup.workspaceBackfill + warmup.globalResolve + warmup.endBatch + warmup.watchers + warmup.analysis
+	other := max(total-accounted, 0)
 	logger.Info("daemon: warmup summary",
+		zap.Float64("prepare_resolve_s", warmup.prepareResolve.Seconds()),
+		zap.Float64("contract_rehydrate_s", warmup.contractRehydrate.Seconds()),
+		zap.Float64("workspace_backfill_s", warmup.workspaceBackfill.Seconds()),
+		zap.Float64("watchers_s", warmup.watchers.Seconds()),
+		zap.Float64("resolve_compute_s", warmup.resolveCompute.Seconds()),
+		zap.Float64("resolve_tail_s", warmup.resolveTail.Seconds()),
+		zap.Float64("accounted_s", accounted.Seconds()),
+		zap.Float64("other_s", other.Seconds()),
+		zap.Float64("prelude_s", warmup.prelude.Seconds()),
 		zap.Float64("parse_s", warmup.parse.Seconds()),
 		zap.Float64("resolve_s", warmup.resolve.Seconds()),
 		zap.Float64("enrich_s", warmup.enrich.Seconds()),

--- a/cmd/gortex/daemon_state_test.go
+++ b/cmd/gortex/daemon_state_test.go
@@ -1,15 +1,108 @@
 package main
 
 import (
+	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/zzet/gortex/internal/config"
 	"github.com/zzet/gortex/internal/intern"
 	"github.com/zzet/gortex/internal/serverstack"
 )
+
+func TestWarmupStepLogsStartBeforeCompletion(t *testing.T) {
+	core, observed := observer.New(zap.InfoLevel)
+	finish := startWarmupStep(zap.New(core), "resolver_helper", zap.String("repo", "example"))
+	if observed.Len() != 1 {
+		t.Fatalf("expected a start event before work completes, got %d", observed.Len())
+	}
+	if got := observed.All()[0]; got.Message != "daemon: warmup step start" || got.ContextMap()["step"] != "resolver_helper" {
+		t.Fatalf("unexpected start event: %+v", got)
+	}
+	elapsed := finish(zap.String("outcome", "skipped"), zap.Int("files", 0))
+	if elapsed < 0 || observed.Len() != 2 {
+		t.Fatalf("expected completion with nonnegative elapsed, elapsed=%v events=%d", elapsed, observed.Len())
+	}
+	event := observed.All()[1]
+	fields := event.ContextMap()
+	if event.Message != "daemon: warmup step complete" || fields["repo"] != "example" ||
+		fields["outcome"] != "skipped" || fields["files"] != int64(0) {
+		t.Fatalf("missing no-op result or correlation fields: %+v", event)
+	}
+	if _, ok := fields["elapsed"]; !ok {
+		t.Fatal("completion has no elapsed field")
+	}
+}
+
+func TestWarmupStepAllowsNilLogger(t *testing.T) {
+	if elapsed := startWarmupStep(nil, "no_logger")(); elapsed < 0 {
+		t.Fatalf("negative elapsed: %v", elapsed)
+	}
+}
+
+func TestWarmupSummaryIncludesPrelude(t *testing.T) {
+	core, observed := observer.New(zap.InfoLevel)
+	logWarmupSummary(zap.New(core), &warmupTimings{}, 0, 0)
+	if observed.Len() != 1 {
+		t.Fatalf("expected one summary, got %d", observed.Len())
+	}
+	if _, ok := observed.All()[0].ContextMap()["prelude_s"]; !ok {
+		t.Fatal("summary omits prelude")
+	}
+}
+
+func TestWarmupSummaryAccountsOnlyTopLevelPhases(t *testing.T) {
+	core, observed := observer.New(zap.InfoLevel)
+	timings := &warmupTimings{
+		prelude: time.Second, prepareResolve: time.Second, parse: time.Second,
+		resolve: 3 * time.Second, resolveCompute: time.Second, resolveTail: 2 * time.Second,
+		enrich: time.Second, contractRehydrate: time.Second, workspaceBackfill: time.Second,
+		globalResolve: time.Second, endBatch: time.Second, watchers: time.Second, analysis: time.Second,
+	}
+	logWarmupSummary(zap.New(core), timings, 5*time.Second, 15*time.Second)
+	fields := observed.All()[0].ContextMap()
+	if fields["accounted_s"] != float64(13) || fields["other_s"] != float64(2) {
+		t.Fatalf("nested measurements counted twice or phases omitted: %+v", fields)
+	}
+	if fields["resolve_compute_s"] != float64(1) || fields["resolve_tail_s"] != float64(2) {
+		t.Fatalf("missing resolver split: %+v", fields)
+	}
+}
+
+func TestWarmupResolveTimerPreservesCallbacks(t *testing.T) {
+	core, observed := observer.New(zap.InfoLevel)
+	timer := newWarmupResolveTimer(zap.New(core))
+	calls := 0
+	ready := timer.ready(func() { calls++ })
+	ready()
+	ready()
+	compute, tail := timer.finish(nil)
+	if calls != 2 || compute <= 0 || tail < 0 {
+		t.Fatalf("callbacks=%d compute=%v tail=%v", calls, compute, tail)
+	}
+	entries := observed.All()
+	if len(entries) != 4 || entries[1].ContextMap()["step"] != "resolve_compute" ||
+		entries[2].ContextMap()["step"] != "resolve_tail" || entries[3].Message != "daemon: warmup step complete" {
+		t.Fatalf("expected exactly one compute and tail pair, got %+v", entries)
+	}
+}
+
+func TestWarmupResolveTimerWithoutReadyReportsFailure(t *testing.T) {
+	core, observed := observer.New(zap.InfoLevel)
+	timer := newWarmupResolveTimer(zap.New(core))
+	compute, tail := timer.finish(errors.New("resolve failed"))
+	if compute < 0 || tail != 0 || observed.Len() != 2 {
+		t.Fatalf("compute=%v tail=%v events=%d", compute, tail, observed.Len())
+	}
+	fields := observed.All()[1].ContextMap()
+	if fields["queryable_callback"] != false || fields["error"] != "resolve failed" {
+		t.Fatalf("missing failure without readiness: %+v", fields)
+	}
+}
 
 // TestLSPDisabledSet_ConfigOnly — a `semantic.providers` entry with
 // `enabled: false` whose name matches a known LSP spec lands in the

--- a/cmd/gortex/warmup_step.go
+++ b/cmd/gortex/warmup_step.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// startWarmupStep logs before work begins, including on no-op paths. The returned
+// function records elapsed wall time and result counts without retaining graph
+// objects or starting a timer goroutine. Nested steps must not be added to their
+// parent's duration when accounting for total warmup time.
+func startWarmupStep(logger *zap.Logger, step string, fields ...zap.Field) func(...zap.Field) time.Duration {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	started := time.Now()
+	base := append([]zap.Field{zap.String("step", step)}, fields...)
+	logger.Info("daemon: warmup step start", base...)
+	return func(result ...zap.Field) time.Duration {
+		elapsed := time.Since(started)
+		done := make([]zap.Field, 0, len(base)+len(result)+1)
+		done = append(done, base...)
+		done = append(done, zap.Duration("elapsed", elapsed))
+		done = append(done, result...)
+		logger.Info("daemon: warmup step complete", done...)
+		return elapsed
+	}
+}
+
+// warmupResolveTimer splits synchronous resolution at its readiness callback.
+// Atomics protect the observation even if a resolver calls back on another
+// goroutine. Callback delivery itself is preserved, including repeated calls.
+type warmupResolveTimer struct {
+	started      time.Time
+	computeNanos atomic.Int64
+	logger       *zap.Logger
+}
+
+func newWarmupResolveTimer(logger *zap.Logger) *warmupResolveTimer {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	r := &warmupResolveTimer{started: time.Now(), logger: logger}
+	logger.Info("daemon: warmup step start", zap.String("step", "resolve_compute"))
+	return r
+}
+
+func (r *warmupResolveTimer) ready(markReady func()) func() {
+	return func() {
+		compute := max(time.Since(r.started), time.Nanosecond)
+		if r.computeNanos.CompareAndSwap(0, int64(compute)) {
+			r.logger.Info("daemon: warmup step complete", zap.String("step", "resolve_compute"), zap.Duration("elapsed", compute), zap.Bool("queryable_callback", true))
+			r.logger.Info("daemon: warmup step start", zap.String("step", "resolve_tail"))
+		}
+		if markReady != nil {
+			markReady()
+		}
+	}
+}
+
+func (r *warmupResolveTimer) finish(err error) (time.Duration, time.Duration) {
+	total := time.Since(r.started)
+	compute := time.Duration(r.computeNanos.Load())
+	if compute == 0 {
+		r.logger.Info("daemon: warmup step complete", zap.String("step", "resolve_compute"), zap.Duration("elapsed", total), zap.Bool("queryable_callback", false), zap.Error(err))
+		return total, 0
+	}
+	tail := max(total-compute, 0)
+	r.logger.Info("daemon: warmup step complete", zap.String("step", "resolve_tail"), zap.Duration("elapsed", tail), zap.Error(err))
+	return compute, tail
+}

--- a/internal/indexer/incremental_batch.go
+++ b/internal/indexer/incremental_batch.go
@@ -335,6 +335,7 @@ func (idx *Indexer) reindexIncrementalChunk(
 			zap.Int("files", len(fallbacks)))
 		defer fallbackTiming.abort()
 	}
+	failedBeforeFallback := len(failed)
 	for _, fallback := range fallbacks {
 		if err := idx.reindexIncrementalFallback(fallback, markerBatch, &plan); err != nil {
 			idx.noteFileIndexFailure(fallback.filePath, err)
@@ -349,7 +350,8 @@ func (idx *Indexer) reindexIncrementalChunk(
 		reparsed = append(reparsed, fallback.filePath)
 	}
 	if fallbackTiming != nil {
-		fallbackTiming.complete(nil, zap.Int("failed_files", len(failed)))
+		// Prior read/receipt failures belong to earlier phases, not fallback.
+		fallbackTiming.complete(nil, zap.Int("failed_files", len(failed)-failedBeforeFallback))
 	}
 	for _, stage := range stages {
 		if _, fresh := freshSet[stage.absPath]; fresh && !stage.metadataOnly {

--- a/internal/indexer/incremental_batch.go
+++ b/internal/indexer/incremental_batch.go
@@ -91,7 +91,11 @@ func (idx *Indexer) reindexIncrementalFilesBatched(
 	idx.loadFileIndexFailures()
 	defer idx.flushFileIndexFailures()
 	var invalidation DerivedInvalidationPlan
+	deleteTiming := startReconcilePhase(idx.logger, idx.repoPrefix, "graph_delete",
+		zap.Int("deleted_files", len(deletedFiles)))
+	defer deleteTiming.abort()
 	idx.evictDeletedFilesBatched(deletedFiles, &invalidation)
+	deleteTiming.complete(nil)
 
 	passPlan, reparsed, failed, versionChanged := idx.reindexIncrementalStalePass(
 		staleFiles, markerBatch, surfaceFirstVersionChange,
@@ -183,10 +187,17 @@ func (idx *Indexer) reindexIncrementalChunk(
 	}
 
 	graphPaths := make([]string, len(files))
+	priorTiming := startReconcilePhase(idx.logger, idx.repoPrefix, "chunk_prior_graph",
+		zap.Int("candidate_files", len(files)))
+	defer priorTiming.abort()
 	for i, filePath := range files {
 		graphPaths[i] = idx.prefixPath(idx.relKey(filePath))
 	}
 	priorByFile := idx.graph.GetFileNodesByPaths(graphPaths)
+	priorTiming.complete(nil)
+	parseTiming := startReconcilePhase(idx.logger, idx.repoPrefix, "chunk_parse",
+		zap.Int("candidate_files", len(files)), zap.Bool("includes_admission_wait", true))
+	defer parseTiming.abort()
 
 	stages := make([]*incrementalBatchStage, 0, len(files))
 	// Each staged result carries the tree-sitter tree its extraction
@@ -281,6 +292,9 @@ func (idx *Indexer) reindexIncrementalChunk(
 		}
 	}
 
+	parseTiming.complete(nil, zap.Int("consumed_files", consumed), zap.Int("staged_files", len(stages)),
+		zap.Int("inert_files", plan.InertFiles), zap.Int("read_failed_files", len(readFailed)),
+		zap.Int("fallback_files", len(fallbacks)), zap.Int("nodes", nodeCount), zap.Int("edges", edgeCount))
 	if len(stages) > 0 {
 		plan.Merge(idx.commitIncrementalStages(stages, markerBatch))
 		for _, stage := range stages {
@@ -295,7 +309,11 @@ func (idx *Indexer) reindexIncrementalChunk(
 			stage.releasePrepared()
 		}
 	}
+	receiptTiming := startReconcilePhase(idx.logger, idx.repoPrefix, "chunk_receipts",
+		zap.Int("receipts", len(receipts)))
+	defer receiptTiming.abort()
 	freshPaths, stalePaths := idx.recordFileReadVersionsBatched(receipts)
+	receiptTiming.complete(nil, zap.Int("fresh_files", len(freshPaths)), zap.Int("stale_files", len(stalePaths)))
 	freshSet := make(map[string]struct{}, len(freshPaths))
 	for _, filePath := range freshPaths {
 		freshSet[filePath] = struct{}{}
@@ -309,6 +327,14 @@ func (idx *Indexer) reindexIncrementalChunk(
 			versionChanged = append(versionChanged, path)
 		}
 	}
+	var fallbackTiming *reconcilePhaseTiming
+	if len(fallbacks) > 0 {
+		// Legacy fallback combines extraction and graph mutation; do not label
+		// this interval as parse-only or silently charge it to graph apply.
+		fallbackTiming = startReconcilePhase(idx.logger, idx.repoPrefix, "chunk_fallback_parse_apply",
+			zap.Int("files", len(fallbacks)))
+		defer fallbackTiming.abort()
+	}
 	for _, fallback := range fallbacks {
 		if err := idx.reindexIncrementalFallback(fallback, markerBatch, &plan); err != nil {
 			idx.noteFileIndexFailure(fallback.filePath, err)
@@ -321,6 +347,9 @@ func (idx *Indexer) reindexIncrementalChunk(
 		}
 		idx.noteFileIndexFailure(fallback.filePath, nil)
 		reparsed = append(reparsed, fallback.filePath)
+	}
+	if fallbackTiming != nil {
+		fallbackTiming.complete(nil, zap.Int("failed_files", len(failed)))
 	}
 	for _, stage := range stages {
 		if _, fresh := freshSet[stage.absPath]; fresh && !stage.metadataOnly {
@@ -449,6 +478,9 @@ func (idx *Indexer) commitIncrementalStages(
 	stages []*incrementalBatchStage,
 	markerBatch *reparsePendingEnrichmentBatch,
 ) DerivedInvalidationPlan {
+	timing := startReconcilePhase(idx.logger, idx.repoPrefix, "chunk_graph_apply",
+		zap.Int("staged_files", len(stages)))
+	defer timing.abort()
 	var plan DerivedInvalidationPlan
 	view := loadIncrementalPriorView(idx.graph, stages)
 
@@ -584,6 +616,7 @@ func (idx *Indexer) commitIncrementalStages(
 			stage.graphPath, stage.priorNodes, stage.result.Nodes,
 		))
 	}
+	timing.complete(nil, zap.Int("structural_files", len(structural)), zap.Int("metadata_files", len(metadata)))
 	return plan
 }
 

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -9117,13 +9117,19 @@ func (idx *Indexer) changedSinceMtimesCensus(root string) (
 	err error,
 ) {
 	timing := startReconcilePhase(idx.logger, idx.repoPrefix, "census")
+	returned := false
 	defer func() {
+		if !returned {
+			timing.abort()
+			return
+		}
 		timing.complete(err, zap.Int("detected_files", detected),
 			zap.Int("changed_files", len(changed)), zap.Int("deleted_files", len(deleted)),
 			zap.Bool("no_changes", err == nil && len(changed) == 0 && len(deleted) == 0))
 	}()
 	absRoot, absErr := filepath.Abs(root)
 	if absErr != nil {
+		returned = true
 		return nil, nil, 0, absErr
 	}
 	idx.storeRootPath(absRoot)
@@ -9157,6 +9163,7 @@ func (idx *Indexer) changedSinceMtimesCensus(root string) (
 		return nil
 	})
 	if walkErr != nil {
+		returned = true
 		return nil, nil, 0, walkErr
 	}
 
@@ -9187,6 +9194,7 @@ func (idx *Indexer) changedSinceMtimesCensus(root string) (
 			deleted = append(deleted, rel)
 		}
 	}
+	returned = true
 	return changed, deleted, len(diskFiles), nil
 }
 

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -6101,9 +6101,16 @@ func (idx *Indexer) incrementalReindexPathsMode(
 	// Reconcile the complete durable corpus before any scoped mutation writes
 	// rows with this process's normalization mode. Doing this after a partial
 	// update would leave unchanged symbols in the previous mode.
+	normalizationTiming := startReconcilePhase(idx.logger, idx.repoPrefix, "fts_normalization")
+	defer normalizationTiming.abort()
 	if _, err := idx.reconcileSymbolFTSNormalization(nil); err != nil {
+		normalizationTiming.complete(err)
 		return nil, err
 	}
+	normalizationTiming.complete(nil)
+	discoveryTiming := startReconcilePhase(idx.logger, idx.repoPrefix, "scoped_discovery",
+		zap.Int("requested_paths", len(paths)), zap.Bool("full_root", fullRoot))
+	defer discoveryTiming.abort()
 
 	// scopeRels holds the repo-relative slash-paths the caller asked to
 	// reindex — used both to drive the discovery walk and to bound
@@ -6325,6 +6332,12 @@ func (idx *Indexer) incrementalReindexPathsMode(
 		}
 	}
 	deletedFiles = appendUniqueSorted(nil, deletedFiles...)
+	discoveryTiming.complete(nil, zap.Int("detected_files", len(diskFiles)),
+		zap.Int("changed_files", len(staleFiles)), zap.Int("deleted_files", len(deletedFiles)),
+		zap.Int("failed_paths", len(discoveryFailed)))
+	dependencyTiming := startReconcilePhase(idx.logger, idx.repoPrefix, "deletion_frontier",
+		zap.Int("deleted_files", len(deletedFiles)))
+	defer dependencyTiming.abort()
 
 	// Capture surviving dependents before deletion evicts the target symbols and
 	// their incoming adjacency. The helper performs one batched node/edge
@@ -6349,6 +6362,7 @@ func (idx *Indexer) incrementalReindexPathsMode(
 		}
 	}
 	sourceStaleFiles, manifestFiles := splitIncrementalContractManifests(idx, staleFiles)
+	dependencyTiming.complete(nil, zap.Int("dependent_files", len(deletedDependencyFiles)))
 	markerBatch := &reparsePendingEnrichmentBatch{}
 	if len(markerBatches) > 0 && markerBatches[0] != nil {
 		markerBatch = markerBatches[0]
@@ -6356,6 +6370,9 @@ func (idx *Indexer) incrementalReindexPathsMode(
 	invalidation, reparsedFiles, failedFiles, versionChangedFiles := idx.reindexIncrementalFilesBatched(
 		sourceStaleFiles, deletedFiles, markerBatch, mode.surfaceFirstVersionChange,
 	)
+	finalizeTiming := startReconcilePhase(idx.logger, idx.repoPrefix, "contracts_and_metadata",
+		zap.Int("manifest_files", len(manifestFiles)), zap.Int("reparsed_files", len(reparsedFiles)))
+	defer finalizeTiming.abort()
 	manifestPlan, manifestFailed := idx.refreshIncrementalContractManifests(manifestFiles)
 	invalidation.Merge(manifestPlan)
 	failedFiles = appendUniqueSorted(failedFiles, manifestFailed...)
@@ -6469,6 +6486,8 @@ func (idx *Indexer) incrementalReindexPathsMode(
 	recoveredFiles = append(recoveredFiles, staleFiles...)
 	recoveredFiles = append(recoveredFiles, walkedDirs...)
 	idx.clearRecoveredParseErrors(recoveredFiles, failedFiles, nil)
+	finalizeTiming.complete(nil, zap.Int("failed_files", len(failedFiles)),
+		zap.Int("nodes", result.NodeCount), zap.Int("edges", result.EdgeCount))
 	return result, nil
 }
 
@@ -9040,6 +9059,54 @@ func (idx *Indexer) ChangedSinceMtimes(root string) (changed []string, deleted [
 	return changed, deleted, err
 }
 
+// reconcilePhaseTiming measures wall time for one serial phase. Chunk timings
+// are bounded summaries, never per-file logs. Abort distinguishes an early
+// return or panic from a successful completion. Do not share timers between
+// goroutines.
+type reconcilePhaseTiming struct {
+	logger   *zap.Logger
+	fields   []zap.Field
+	started  time.Time
+	finished bool
+}
+
+func startReconcilePhase(logger *zap.Logger, repo, phase string, fields ...zap.Field) *reconcilePhaseTiming {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	timer := &reconcilePhaseTiming{
+		logger:  logger,
+		fields:  append([]zap.Field{zap.String("repo", repo), zap.String("phase", phase)}, fields...),
+		started: time.Now(),
+	}
+	logger.Info("indexer: reconcile phase started", timer.fields...)
+	return timer
+}
+
+func (timer *reconcilePhaseTiming) complete(err error, fields ...zap.Field) {
+	outcome := "complete"
+	if err != nil {
+		outcome = "error"
+		fields = append(fields, zap.Error(err))
+	}
+	timer.finish(outcome, fields...)
+}
+
+func (timer *reconcilePhaseTiming) abort() {
+	timer.finish("aborted")
+}
+
+func (timer *reconcilePhaseTiming) finish(outcome string, fields ...zap.Field) {
+	if timer.finished {
+		return
+	}
+	timer.finished = true
+	all := append([]zap.Field(nil), timer.fields...)
+	all = append(all, zap.Duration("elapsed", time.Since(timer.started)), zap.String("outcome", outcome))
+	all = append(all, fields...)
+	timer.logger.Info("indexer: reconcile phase complete", all...)
+}
+
 // changedSinceMtimesCensus also returns the complete tracked-source count from
 // the same walk. ReconcileRepoCtx uses that count to publish an honest clean
 // result without repeating the full-tree discovery in the incremental path.
@@ -9049,6 +9116,12 @@ func (idx *Indexer) changedSinceMtimesCensus(root string) (
 	detected int,
 	err error,
 ) {
+	timing := startReconcilePhase(idx.logger, idx.repoPrefix, "census")
+	defer func() {
+		timing.complete(err, zap.Int("detected_files", detected),
+			zap.Int("changed_files", len(changed)), zap.Int("deleted_files", len(deleted)),
+			zap.Bool("no_changes", err == nil && len(changed) == 0 && len(deleted) == 0))
+	}()
 	absRoot, absErr := filepath.Abs(root)
 	if absErr != nil {
 		return nil, nil, 0, absErr

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -2926,6 +2926,9 @@ func (mi *MultiIndexer) trackRepoSourceCtx(
 // reconcile against and a full index is the correct path.
 func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoEntry, priorMtimes map[string]int64) (*IndexResult, error) {
 	start := time.Now()
+	setupTiming := startReconcilePhase(mi.logger, entry.Name, "repository_setup",
+		zap.Int("prior_files", len(priorMtimes)))
+	defer setupTiming.abort()
 
 	absPath, err := filepath.Abs(entry.Path)
 	if err != nil {
@@ -2952,6 +2955,7 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 	// reconcile path too; config can change between sessions and warmup-
 	// time reconcile runs after a daemon restart.
 	prefix, cfg := mi.resolveTrackPrefix(&entry, absPath, identity)
+	setupTiming.complete(nil, zap.String("prefix", prefix))
 
 	// Already tracked — nothing to do.
 	mi.mu.RLock()
@@ -2973,6 +2977,8 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 	}
 
 	// Prefix unconditionally, as TrackRepoCtx does — see the note there.
+	restoreTiming := startReconcilePhase(mi.logger, prefix, "indexer_restore")
+	defer restoreTiming.abort()
 	idx := mi.newPerRepoIndexerForMutation(ctx, cfg.Index)
 	idx.SetRepoPrefix(prefix)
 	entryCopy := entry
@@ -2980,10 +2986,16 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 	idx.SetProjectID(resolveProjectID(&entryCopy, cfg, prefix))
 	idx.SetRootPath(absPath)
 	idx.SetFileMtimes(priorMtimes)
+	restoreTiming.complete(nil)
 
 	var result *IndexResult
 	installed := false
+	admissionTiming := startReconcilePhase(mi.logger, prefix, "topology_admission")
+	defer admissionTiming.abort()
 	err = mi.coordinateRepositoryTopologyMutation(ctx, idx, func() error {
+		admissionTiming.complete(nil)
+		admittedSetupTiming := startReconcilePhase(mi.logger, prefix, "admitted_setup")
+		defer admittedSetupTiming.abort()
 		// Construction can precede a queued batch transition. Once the stable
 		// lane and transition generation are held, reapply the authoritative mode.
 		batchMode := mi.reapplyBatchModeForMutation(idx)
@@ -3037,6 +3049,7 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 			}
 			return r, e
 		}
+		admittedSetupTiming.complete(nil)
 		changed, deleted, detected, censusErr := idx.changedSinceMtimesCensus(absPath)
 		churn := len(changed) + len(deleted)
 		priorCount := len(priorMtimes)
@@ -3049,6 +3062,10 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 				break
 			}
 		}
+		applyTiming := startReconcilePhase(mi.logger, prefix, "apply",
+			zap.Int("changed_files", len(changed)), zap.Int("deleted_files", len(deleted)),
+			zap.Bool("force_full", forceFull), zap.Bool("census_failed", censusErr != nil))
+		defer applyTiming.abort()
 		switch {
 		case censusErr != nil:
 			// A partial filesystem census cannot safely authorize replacement:
@@ -3086,12 +3103,15 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 			route = "scoped"
 			result, receipt, batch, err = idx.incrementalReindexPathsWithReceipt(absPath, append(changed, deleted...), true)
 		}
+		applyTiming.complete(err, zap.String("route", route))
 		if err != nil {
 			return fmt.Errorf("reconciling %s: %w", absPath, err)
 		}
 		if result == nil {
 			return fmt.Errorf("reconciling %s returned a nil result", absPath)
 		}
+		publishTiming := startReconcilePhase(mi.logger, prefix, "publish_and_catchup", zap.String("route", route))
+		defer publishTiming.abort()
 		// A scoped snapshot reconcile cannot derive its total from the walked
 		// scope. Its post-mutation tracked count is the repository-wide baseline.
 		if idx.totalDetected == 0 {
@@ -3141,6 +3161,8 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 			mi.ReconcileContractEdges()
 		}
 
+		publishTiming.complete(nil)
+		// Total includes nested phase timings: do not sum it with them.
 		mi.logger.Info("daemon: reconciled repo from snapshot",
 			zap.String("prefix", prefix),
 			zap.String("route", route),

--- a/internal/indexer/multi_test.go
+++ b/internal/indexer/multi_test.go
@@ -1,15 +1,18 @@
 package indexer
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 	"pgregory.net/rapid"
 
 	"github.com/zzet/gortex/internal/config"
@@ -34,6 +37,140 @@ func newTestRegistry() *parser.Registry {
 	reg := parser.NewRegistry()
 	reg.Register(languages.NewGoExtractor())
 	return reg
+}
+
+func TestReconcilePhaseTimingOutcomes(t *testing.T) {
+	for _, outcome := range []string{"complete", "error", "aborted"} {
+		t.Run(outcome, func(t *testing.T) {
+			core, logs := observer.New(zap.InfoLevel)
+			timing := startReconcilePhase(zap.New(core), "repo", "test", zap.Int("files", 3))
+			switch outcome {
+			case "complete":
+				timing.complete(nil)
+			case "error":
+				timing.complete(errors.New("census failed"))
+			case "aborted":
+				timing.abort()
+			}
+			// Deferred abort and duplicate completion cannot turn an error into
+			// success or emit multiple terminal records.
+			timing.abort()
+			timing.complete(nil)
+			entries := logs.All()
+			require.Len(t, entries, 2)
+			require.Equal(t, "indexer: reconcile phase started", entries[0].Message)
+			require.Equal(t, "indexer: reconcile phase complete", entries[1].Message)
+			for _, entry := range entries {
+				require.Equal(t, "repo", entry.ContextMap()["repo"])
+				require.Equal(t, "test", entry.ContextMap()["phase"])
+				require.EqualValues(t, 3, entry.ContextMap()["files"])
+			}
+			fields := entries[1].ContextMap()
+			require.Equal(t, outcome, fields["outcome"])
+			elapsed, ok := fields["elapsed"].(time.Duration)
+			require.True(t, ok, "elapsed is a structured duration")
+			require.GreaterOrEqual(t, elapsed, time.Duration(0))
+			if outcome == "error" {
+				require.Equal(t, "census failed", fields["error"])
+			}
+		})
+	}
+}
+
+func TestReconcileCensusTiming(t *testing.T) {
+	for _, mode := range []string{"clean", "changed", "missing"} {
+		t.Run(mode, func(t *testing.T) {
+			dir := setupRepoDir(t, "census")
+			core, logs := observer.New(zap.InfoLevel)
+			idx := New(graph.New(), newTestRegistry(), config.IndexConfig{}, zap.New(core))
+			t.Cleanup(func() { idx.Close() })
+			idx.SetRepoPrefix("repo")
+			info, err := os.Stat(filepath.Join(dir, "main.go"))
+			require.NoError(t, err)
+			mtime := info.ModTime().UnixNano()
+			if mode == "changed" {
+				mtime = 0
+			}
+			idx.SetFileMtimes(map[string]int64{"main.go": mtime})
+			if mode == "missing" {
+				dir = filepath.Join(dir, "missing")
+			}
+			changed, deleted, detected, err := idx.changedSinceMtimesCensus(dir)
+			if mode == "missing" {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, 1, detected)
+				require.Empty(t, deleted)
+				require.Len(t, changed, map[string]int{"clean": 0, "changed": 1}[mode])
+			}
+			entries := logs.FilterMessage("indexer: reconcile phase complete").All()
+			require.Len(t, entries, 1)
+			fields := entries[0].ContextMap()
+			require.Equal(t, "census", fields["phase"])
+			require.EqualValues(t, len(changed), fields["changed_files"])
+			require.EqualValues(t, detected, fields["detected_files"])
+			require.Equal(t, mode == "clean", fields["no_changes"])
+			if mode == "missing" {
+				require.Equal(t, "error", fields["outcome"])
+				require.NotEmpty(t, fields["error"])
+			} else {
+				require.Equal(t, "complete", fields["outcome"])
+			}
+		})
+	}
+}
+
+func TestIncrementalReconcilePhaseTimings(t *testing.T) {
+	dir := setupRepoDir(t, "incremental")
+	core, logs := observer.New(zap.InfoLevel)
+	g := graph.New()
+	idx := New(g, newTestRegistry(), config.IndexConfig{}, zap.New(core))
+	t.Cleanup(func() { idx.Close() })
+	idx.SetRepoPrefix("repo")
+	idx.SetDeferResolve(true)
+	idx.SetDeferGlobalPasses(true)
+
+	result, err := idx.incrementalReindexPathsMode(dir, []string{"main.go"}, incrementalPathMode{})
+	require.NoError(t, err)
+	require.Equal(t, 1, result.StaleFileCount)
+	require.NotEmpty(t, g.AllNodes())
+	phases := make(map[string]map[string]any)
+	for _, entry := range logs.FilterMessage("indexer: reconcile phase complete").All() {
+		fields := entry.ContextMap()
+		require.Equal(t, "repo", fields["repo"])
+		require.Equal(t, "complete", fields["outcome"])
+		phases[fields["phase"].(string)] = fields
+	}
+	for _, phase := range []string{"fts_normalization", "scoped_discovery", "deletion_frontier",
+		"graph_delete", "chunk_prior_graph", "chunk_parse", "chunk_graph_apply", "chunk_receipts",
+		"contracts_and_metadata"} {
+		require.Contains(t, phases, phase)
+	}
+	require.EqualValues(t, 1, phases["chunk_parse"]["consumed_files"])
+	require.Equal(t, true, phases["chunk_parse"]["includes_admission_wait"])
+	require.EqualValues(t, 1, phases["chunk_graph_apply"]["staged_files"])
+
+	logs.TakeAll()
+	result, err = idx.incrementalReindexPathsMode(dir, []string{"main.go"}, incrementalPathMode{})
+	require.NoError(t, err)
+	require.Zero(t, result.StaleFileCount)
+	for _, entry := range logs.FilterMessage("indexer: reconcile phase started").All() {
+		require.NotEqual(t, "chunk_parse", entry.ContextMap()["phase"], "no-op reconciliation must not invent parse work")
+	}
+
+	logs.TakeAll()
+	_, err = idx.incrementalReindexPathsMode(dir, []string{"../outside.go"}, incrementalPathMode{})
+	require.Error(t, err)
+	aborted := false
+	for _, entry := range logs.FilterMessage("indexer: reconcile phase complete").All() {
+		fields := entry.ContextMap()
+		if fields["phase"] == "scoped_discovery" {
+			require.Equal(t, "aborted", fields["outcome"])
+			aborted = true
+		}
+	}
+	require.True(t, aborted, "early discovery failure must have a terminal phase record")
 }
 
 // setupRepoDir creates a temp directory with a Go file for testing.

--- a/internal/indexer/multi_test.go
+++ b/internal/indexer/multi_test.go
@@ -78,7 +78,7 @@ func TestReconcilePhaseTimingOutcomes(t *testing.T) {
 }
 
 func TestReconcileCensusTiming(t *testing.T) {
-	for _, mode := range []string{"clean", "changed", "missing"} {
+	for _, mode := range []string{"clean", "changed", "missing", "panic"} {
 		t.Run(mode, func(t *testing.T) {
 			dir := setupRepoDir(t, "census")
 			core, logs := observer.New(zap.InfoLevel)
@@ -94,6 +94,20 @@ func TestReconcileCensusTiming(t *testing.T) {
 			idx.SetFileMtimes(map[string]int64{"main.go": mtime})
 			if mode == "missing" {
 				dir = filepath.Join(dir, "missing")
+			}
+			if mode == "panic" {
+				// Inject a parser lookup panic; the telemetry must not claim a
+				// successful no-op merely because the named error is still nil.
+				registry := idx.registry
+				idx.registry = nil
+				defer func() { idx.registry = registry }()
+				require.Panics(t, func() { _, _, _, _ = idx.changedSinceMtimesCensus(dir) })
+				entries := logs.FilterMessage("indexer: reconcile phase complete").All()
+				require.Len(t, entries, 1)
+				fields := entries[0].ContextMap()
+				require.Equal(t, "aborted", fields["outcome"])
+				require.NotContains(t, fields, "no_changes")
+				return
 			}
 			changed, deleted, detected, err := idx.changedSinceMtimesCensus(dir)
 			if mode == "missing" {

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -2502,6 +2502,10 @@ type incrementalFileFrontier struct {
 	outByNode   map[string][]*graph.Edge
 	stubKeys    []string
 	pending     []*graph.Edge
+	// Admissions may overlap between outgoing and incoming frontiers.
+	outgoingPending int
+	outgoingCollect time.Duration
+	incomingCollect time.Duration
 }
 
 func (r *Resolver) pendingEdgesForFileAndIncoming(filePath string) []*graph.Edge {
@@ -2557,6 +2561,7 @@ func collectIncrementalFileFrontierMode(
 		return frontier
 	}
 
+	outgoingStarted := time.Now()
 	frontier.nodesByFile = g.GetFileNodesByPaths(frontier.paths)
 	var nodeIDs []string
 	for _, path := range frontier.paths {
@@ -2602,6 +2607,9 @@ func collectIncrementalFileFrontierMode(
 			}
 		}
 	}
+	frontier.outgoingPending = len(frontier.pending)
+	frontier.outgoingCollect = time.Since(outgoingStarted)
+	incomingStarted := time.Now()
 	// The unresolved target string is the incoming-edge bucket key even when
 	// no node with that ID exists.
 	if lightweightIncoming {
@@ -2629,6 +2637,7 @@ func collectIncrementalFileFrontierMode(
 			}
 		}
 	}
+	frontier.incomingCollect = time.Since(incomingStarted)
 	return frontier
 }
 
@@ -2644,52 +2653,161 @@ func (r *Resolver) ResolveFilesAndIncoming(filePaths []string) *ResolveStats {
 		return stats
 	}
 	started := time.Now()
+	logger := r.logger.With(zap.Int("input_files", len(filePaths)))
+	var frontier incrementalFileFrontier
+	var lockDuration, visibilityDuration, pendingDuration, indexDuration, warmDuration time.Duration
+	var outgoingDuration, incomingDuration, attributionDuration time.Duration
+	outcome := "interrupted"
+	defer func() {
+		logger.Info("resolver: incremental files phases",
+			zap.String("outcome", outcome),
+			zap.Int("files", len(frontier.paths)),
+			zap.Int("pending", len(frontier.pending)),
+			zap.Int("outgoing_pending", frontier.outgoingPending),
+			zap.Int("incoming_pending", len(frontier.pending)-frontier.outgoingPending),
+			zap.Duration("wait_lock", lockDuration),
+			zap.Duration("visibility", visibilityDuration),
+			zap.Duration("pending_collect", pendingDuration),
+			zap.Duration("outgoing_collect", frontier.outgoingCollect),
+			zap.Duration("incoming_collect", frontier.incomingCollect),
+			zap.Duration("build_indexes", indexDuration),
+			zap.Duration("warm_lookup", warmDuration),
+			zap.Duration("resolve_outgoing", outgoingDuration),
+			zap.Duration("resolve_incoming", incomingDuration),
+			zap.Duration("resolve", outgoingDuration+incomingDuration),
+			zap.Duration("attribution", attributionDuration),
+			zap.Duration("total", time.Since(started)))
+	}()
+	finish := startIncrementalPhase(logger, "wait_lock")
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	lockDuration = finish()
 	// The edited files may have (re)stamped global usings — reconcile the
 	// persistent index instead of paying the workspace rescan per save.
+	finish = startIncrementalPhase(logger, "visibility")
 	r.scopedCSharpVisibilityInvalidate(filePaths)
+	visibilityDuration = finish()
 
-	pendingStarted := time.Now()
-	frontier := r.collectIncrementalFileFrontier(filePaths)
-	pendingDuration := time.Since(pendingStarted)
+	finish = startIncrementalPhase(logger, "pending_collect")
+	frontier = r.collectIncrementalFileFrontier(filePaths)
+	pendingDuration = finish(
+		zap.Int("files", len(frontier.paths)),
+		zap.Int("outgoing_pending", frontier.outgoingPending),
+		zap.Int("incoming_pending", len(frontier.pending)-frontier.outgoingPending),
+		zap.Int("stub_keys", len(frontier.stubKeys)),
+		zap.Duration("outgoing_collect", frontier.outgoingCollect),
+		zap.Duration("incoming_collect", frontier.incomingCollect))
 	if len(frontier.pending) == 0 {
+		outcome = "no_pending"
 		return stats
 	}
-	indexStarted := time.Now()
+	finish = startIncrementalPhase(logger, "build_indexes")
 	clear := r.buildPassIndexesForPending(frontier.pending)
-	indexDuration := time.Since(indexStarted)
+	indexDuration = finish(zap.Int("pending", len(frontier.pending)))
 	defer clear()
-	warmStarted := time.Now()
+	finish = startIncrementalPhase(logger, "warm_lookup")
 	r.warmLookupCache(frontier.pending)
-	warmDuration := time.Since(warmStarted)
+	warmDuration = finish()
 	defer r.clearLookupCache()
+	repos, omittedRepos, omittedAdmissions := incrementalAdmissionSummary(frontier, r.nodeByID)
+	logger.Info("resolver: incremental pending admissions",
+		zap.Any("repositories", repos),
+		zap.Int("repositories_omitted", omittedRepos),
+		zap.Int("admissions_omitted", omittedAdmissions),
+		zap.Int("outgoing_pending", frontier.outgoingPending),
+		zap.Int("incoming_pending", len(frontier.pending)-frontier.outgoingPending))
 
-	resolveStarted := time.Now()
 	// Resolve every changed file from the preloaded frontier, flush once, then
 	// read the incoming restub buckets afresh. The fresh read preserves the
 	// old forward-before-reverse semantics without one query/transaction per
-	// file.
+	// file. Phase durations include each leg's batched graph mutation.
+	finish = startIncrementalPhase(logger, "resolve_outgoing")
 	r.resolvePreparedFileEdgesLocked(frontier.paths, frontier.nodesByFile, frontier.outByNode, stats)
+	outgoingDuration = finish(
+		zap.Int("resolved", stats.Resolved), zap.Int("unresolved", stats.Unresolved), zap.Int("external", stats.External))
+	beforeIncoming := *stats
+	finish = startIncrementalPhase(logger, "resolve_incoming")
 	r.resolveIncomingStubKeysLocked(frontier.stubKeys, stats)
-	resolveDuration := time.Since(resolveStarted)
-	attributionStarted := time.Now()
+	incomingDuration = finish(
+		zap.Int("resolved", stats.Resolved-beforeIncoming.Resolved),
+		zap.Int("unresolved", stats.Unresolved-beforeIncoming.Unresolved),
+		zap.Int("external", stats.External-beforeIncoming.External))
+	finish = startIncrementalPhase(logger, "attribution")
 	r.prepareIncrementalAttributionCache(frontier)
 	r.runFileAttributionPassesForFilesLocked(frontier)
 	r.clearIncrementalAttributionCache()
-	attributionDuration := time.Since(attributionStarted)
-	if elapsed := time.Since(started); elapsed >= time.Second {
-		r.logger.Info("resolver: incremental files phases",
-			zap.Int("files", len(frontier.paths)),
-			zap.Int("pending", len(frontier.pending)),
-			zap.Duration("pending_collect", pendingDuration),
-			zap.Duration("build_indexes", indexDuration),
-			zap.Duration("warm_lookup", warmDuration),
-			zap.Duration("resolve", resolveDuration),
-			zap.Duration("attribution", attributionDuration),
-			zap.Duration("total", elapsed))
-	}
+	attributionDuration = finish()
+	outcome = "complete"
 	return stats
+}
+
+// Keep one bounded summary per pass, never one log record per admitted edge.
+const incrementalRepoLogLimit = 32
+
+type incrementalRepoAdmission struct {
+	Repo     string `json:"repo"`
+	Outgoing int    `json:"outgoing"`
+	Incoming int    `json:"incoming"`
+}
+
+// incrementalAdmissionSummary only inspects the already hydrated frontier and
+// lookup cache. Missing provenance is reported explicitly, never hydrated with
+// an extra store query just for logging. Counts are admissions, not unique
+// edges: one edge may legitimately occur in both the outgoing and incoming legs.
+func incrementalAdmissionSummary(frontier incrementalFileFrontier, sources map[string]*graph.Node) ([]incrementalRepoAdmission, int, int) {
+	byRepo := make(map[string]*incrementalRepoAdmission)
+	for i, edge := range frontier.pending {
+		repo := "(unknown)"
+		if edge != nil {
+			if source := sources[edge.From]; source != nil && source.RepoPrefix != "" {
+				repo = source.RepoPrefix
+			}
+		}
+		counts := byRepo[repo]
+		if counts == nil {
+			counts = &incrementalRepoAdmission{Repo: repo}
+			byRepo[repo] = counts
+		}
+		if i < frontier.outgoingPending {
+			counts.Outgoing++
+		} else {
+			counts.Incoming++
+		}
+	}
+	repos := make([]incrementalRepoAdmission, 0, len(byRepo))
+	for _, counts := range byRepo {
+		repos = append(repos, *counts)
+	}
+	sort.Slice(repos, func(i, j int) bool {
+		left, right := repos[i].Outgoing+repos[i].Incoming, repos[j].Outgoing+repos[j].Incoming
+		if left != right {
+			return left > right
+		}
+		return repos[i].Repo < repos[j].Repo
+	})
+	omittedRepos, omittedAdmissions := 0, 0
+	if len(repos) > incrementalRepoLogLimit {
+		omittedRepos = len(repos) - incrementalRepoLogLimit
+		for _, counts := range repos[incrementalRepoLogLimit:] {
+			omittedAdmissions += counts.Outgoing + counts.Incoming
+		}
+		repos = repos[:incrementalRepoLogLimit]
+	}
+	return repos, omittedRepos, omittedAdmissions
+}
+
+// A start event leaves the active operation visible even if it blocks or never
+// returns. Durations use the monotonic component of time.Now, not wall-clock
+// subtraction or sleeps.
+func startIncrementalPhase(logger *zap.Logger, phase string) func(...zap.Field) time.Duration {
+	started := time.Now()
+	logger.Info("resolver: incremental phase starting", zap.String("phase", phase))
+	return func(fields ...zap.Field) time.Duration {
+		elapsed := time.Since(started)
+		fields = append(fields, zap.String("phase", phase), zap.Duration("elapsed", elapsed))
+		logger.Info("resolver: incremental phase complete", fields...)
+		return elapsed
+	}
 }
 
 // resolveFileLocked is the forward-pass core. Caller holds r.mu and

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -1,13 +1,142 @@
 package resolver
 
 import (
+	"fmt"
 	"iter"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zzet/gortex/internal/graph"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
+
+func TestResolveFilesAndIncomingLogsPhasesAndAdmissions(t *testing.T) {
+	g := graph.New()
+	for _, node := range []*graph.Node{
+		{ID: "a/pkg/changed.go", Kind: graph.KindFile, Name: "changed.go", FilePath: "a/pkg/changed.go", RepoPrefix: "a", Language: "go"},
+		{ID: "a/pkg/other.go", Kind: graph.KindFile, Name: "other.go", FilePath: "a/pkg/other.go", RepoPrefix: "a", Language: "go"},
+		{ID: "b/pkg/caller.go", Kind: graph.KindFile, Name: "caller.go", FilePath: "b/pkg/caller.go", RepoPrefix: "b", Language: "go"},
+		{ID: "a/pkg/changed.go::Target", Kind: graph.KindFunction, Name: "Target", FilePath: "a/pkg/changed.go", RepoPrefix: "a", Language: "go"},
+		{ID: "a/pkg/other.go::Other", Kind: graph.KindFunction, Name: "Other", FilePath: "a/pkg/other.go", RepoPrefix: "a", Language: "go"},
+		{ID: "b/pkg/caller.go::Caller", Kind: graph.KindFunction, Name: "Caller", FilePath: "b/pkg/caller.go", RepoPrefix: "b", Language: "go"},
+	} {
+		g.AddNode(node)
+	}
+	for _, edge := range []*graph.Edge{
+		{From: "a/pkg/changed.go::Target", To: "unresolved::Other", Kind: graph.EdgeCalls, FilePath: "a/pkg/changed.go", Line: 2},
+		{From: "a/pkg/changed.go::Target", To: "unresolved::Target", Kind: graph.EdgeCalls, FilePath: "a/pkg/changed.go", Line: 3},
+		{From: "b/pkg/caller.go::Caller", To: "unresolved::Target", Kind: graph.EdgeCalls, FilePath: "b/pkg/caller.go", Line: 2},
+	} {
+		g.AddEdge(edge)
+	}
+	core, logs := observer.New(zap.InfoLevel)
+	r := New(g)
+	r.SetLogger(zap.New(core))
+	r.ResolveFilesAndIncoming([]string{"a/pkg/changed.go", "a/pkg/changed.go", ""})
+
+	var starts, completions []string
+	for _, entry := range logs.All() {
+		switch entry.Message {
+		case "resolver: incremental phase starting":
+			starts = append(starts, entry.ContextMap()["phase"].(string))
+		case "resolver: incremental phase complete":
+			completions = append(completions, entry.ContextMap()["phase"].(string))
+			assert.Contains(t, entry.ContextMap(), "elapsed")
+		}
+	}
+	want := []string{"wait_lock", "visibility", "pending_collect", "build_indexes", "warm_lookup", "resolve_outgoing", "resolve_incoming", "attribution"}
+	assert.Equal(t, want, starts)
+	assert.Equal(t, want, completions)
+	admissions := logs.FilterMessage("resolver: incremental pending admissions").All()
+	require.Len(t, admissions, 1)
+	fields := admissions[0].ContextMap()
+	assert.EqualValues(t, 2, fields["outgoing_pending"])
+	assert.EqualValues(t, 2, fields["incoming_pending"])
+	assert.Equal(t, []incrementalRepoAdmission{
+		{Repo: "a", Outgoing: 2, Incoming: 1},
+		{Repo: "b", Incoming: 1},
+	}, fields["repositories"])
+	summaries := logs.FilterMessage("resolver: incremental files phases").All()
+	require.Len(t, summaries, 1)
+	summary := summaries[0].ContextMap()
+	assert.Equal(t, "complete", summary["outcome"])
+	assert.EqualValues(t, 1, summary["files"])
+	assert.EqualValues(t, 4, summary["pending"])
+	for _, key := range []string{"wait_lock", "visibility", "outgoing_collect", "incoming_collect", "resolve_outgoing", "resolve_incoming", "resolve", "total"} {
+		assert.Contains(t, summary, key)
+	}
+}
+
+func TestResolveFilesAndIncomingLogsNoPending(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	r := New(graph.New())
+	r.SetLogger(zap.New(core))
+	r.ResolveFilesAndIncoming([]string{"missing.go"})
+	summaries := logs.FilterMessage("resolver: incremental files phases").All()
+	require.Len(t, summaries, 1)
+	assert.Equal(t, "no_pending", summaries[0].ContextMap()["outcome"])
+	assert.EqualValues(t, 0, summaries[0].ContextMap()["pending"])
+	assert.Empty(t, logs.FilterMessage("resolver: incremental pending admissions").All())
+	assert.Len(t, logs.FilterMessage("resolver: incremental phase starting").All(), 3)
+	assert.Len(t, logs.FilterMessage("resolver: incremental phase complete").All(), 3)
+}
+
+type incrementalTimingPanicStore struct{ graph.Store }
+
+func (incrementalTimingPanicStore) GetOutEdgesByNodeIDs([]string) map[string][]*graph.Edge {
+	panic("frontier read interrupted")
+}
+
+func TestResolveFilesAndIncomingLogsInterruptedPhase(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	r := New(incrementalTimingPanicStore{Store: graph.New()})
+	r.SetLogger(zap.New(core))
+	require.PanicsWithValue(t, "frontier read interrupted", func() {
+		r.ResolveFilesAndIncoming([]string{"missing.go"})
+	})
+	starts := logs.FilterMessage("resolver: incremental phase starting").All()
+	require.NotEmpty(t, starts)
+	assert.Equal(t, "pending_collect", starts[len(starts)-1].ContextMap()["phase"])
+	summaries := logs.FilterMessage("resolver: incremental files phases").All()
+	require.Len(t, summaries, 1)
+	assert.Equal(t, "interrupted", summaries[0].ContextMap()["outcome"])
+}
+
+func TestIncrementalAdmissionSummaryMissingProvenanceAndBound(t *testing.T) {
+	frontier := incrementalFileFrontier{
+		pending: []*graph.Edge{
+			{From: "known"}, {From: "missing"}, {From: "empty-repo"}, nil,
+		},
+		outgoingPending: 2,
+	}
+	sources := map[string]*graph.Node{
+		"known":      {RepoPrefix: "a"},
+		"empty-repo": {},
+	}
+	repos, omittedRepos, omittedAdmissions := incrementalAdmissionSummary(frontier, sources)
+	assert.Equal(t, []incrementalRepoAdmission{
+		{Repo: "(unknown)", Outgoing: 1, Incoming: 2},
+		{Repo: "a", Outgoing: 1},
+	}, repos)
+	assert.Zero(t, omittedRepos)
+	assert.Zero(t, omittedAdmissions)
+
+	frontier = incrementalFileFrontier{}
+	sources = make(map[string]*graph.Node)
+	for i := 0; i < incrementalRepoLogLimit+3; i++ {
+		repo := fmt.Sprintf("repo-%03d", i)
+		frontier.pending = append(frontier.pending, &graph.Edge{From: repo})
+		sources[repo] = &graph.Node{RepoPrefix: repo}
+	}
+	repos, omittedRepos, omittedAdmissions = incrementalAdmissionSummary(frontier, sources)
+	assert.Len(t, repos, incrementalRepoLogLimit)
+	assert.Equal(t, 3, omittedRepos)
+	assert.Equal(t, 3, omittedAdmissions)
+	assert.Equal(t, "repo-000", repos[0].Repo)
+	assert.Equal(t, fmt.Sprintf("repo-%03d", incrementalRepoLogLimit-1), repos[len(repos)-1].Repo)
+}
 
 func TestResolveAll_InternalCall(t *testing.T) {
 	g := graph.New()

--- a/internal/semantic/lsp/router.go
+++ b/internal/semantic/lsp/router.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/zzet/gortex/internal/semantic"
 )
@@ -145,6 +146,7 @@ type Router struct {
 	// of the router. Read via EvictionCount to observe provider churn
 	// during batch enrichment. Atomic so the accessor needn't take r.mu.
 	evictions atomic.Uint64
+	timing    routerTimingCounters
 
 	stopReaper chan struct{}
 
@@ -570,6 +572,20 @@ func (r *Router) ForSpecWorkspace(spec *ServerSpec, workspace string) (*Provider
 // LRU eviction can never Close a freshly-returned-but-not-yet-pinned provider
 // (the spawn→pin TOCTOU). A pinned fetch MUST be paired with ReleaseSpecWorkspace.
 func (r *Router) forSpecWorkspace(spec *ServerSpec, workspace string, pin bool) (*Provider, error) {
+	acquireStarted := time.Now()
+	success, reused := false, false
+	r.timing.acquires.Add(1)
+	defer func() {
+		elapsed := time.Since(acquireStarted)
+		r.timing.acquireNanos.Add(int64(elapsed))
+		if !success {
+			r.timing.acquireFailures.Add(1)
+		}
+		if reused {
+			r.timing.reuses.Add(1)
+			r.timing.reuseNanos.Add(int64(elapsed))
+		}
+	}()
 	if !r.specAvailable(spec) {
 		return nil, fmt.Errorf("LSP server %q not available on PATH", spec.Name)
 	}
@@ -583,7 +599,9 @@ func (r *Router) forSpecWorkspace(spec *ServerSpec, workspace string, pin bool) 
 	workspace = absWorkspace(workspace)
 	key := providerKey{specName: spec.Name, workspace: workspace}
 
+	lockStarted := time.Now()
 	r.mu.Lock()
+	r.timing.waitNanos.Add(int64(time.Since(lockStarted)))
 	rp, ok := r.providers[key]
 	if ok {
 		rp.lastUsed = time.Now()
@@ -591,6 +609,7 @@ func (r *Router) forSpecWorkspace(spec *ServerSpec, workspace string, pin bool) 
 			rp.inUse++
 		}
 		r.mu.Unlock()
+		success, reused = true, true
 		return rp.provider, nil
 	}
 	r.mu.Unlock()
@@ -606,6 +625,7 @@ func (r *Router) forSpecWorkspace(spec *ServerSpec, workspace string, pin bool) 
 	}
 
 	// Spawn outside the lock — initialize() blocks on stdio I/O.
+	constructStarted := time.Now()
 	p := NewProviderFromSpec(spec, r.logger)
 	p.workspaceFolders = r.additionalWorkspaceFolders
 	p.excludeGlobs = r.enrichExcludeGlobs
@@ -629,7 +649,7 @@ func (r *Router) forSpecWorkspace(spec *ServerSpec, workspace string, pin bool) 
 			return nil, fmt.Errorf("ruby-lsp: no Gemfile in %s; skipping composed-bundle install", workspace)
 		}
 	}
-	if err := p.EnsureClient(workspace); err != nil {
+	if err := r.ensureTimedProvider(p, spec.Name, workspace, time.Since(constructStarted)); err != nil {
 		// A binary that resolves on PATH but cannot launch (e.g. a rustup
 		// `rust-analyzer` shim whose toolchain lacks the component) would
 		// otherwise be re-attempted on every repo. Mark it unavailable so the
@@ -642,7 +662,9 @@ func (r *Router) forSpecWorkspace(spec *ServerSpec, workspace string, pin bool) 
 	// burst some servers emit during workspace warmup.
 	r.attachDiagnosticsHook(spec.Name, p)
 
+	lockStarted = time.Now()
 	r.mu.Lock()
+	r.timing.waitNanos.Add(int64(time.Since(lockStarted)))
 	defer r.mu.Unlock()
 	// Race: another goroutine may have spawned it while we were
 	// initializing. Prefer the existing one and shut down our duplicate.
@@ -651,7 +673,9 @@ func (r *Router) forSpecWorkspace(spec *ServerSpec, workspace string, pin bool) 
 		if pin {
 			existing.inUse++
 		}
-		go func() { _ = p.Close() }()
+		go func() { _ = r.closeTimedProvider(p, spec.Name, workspace, "duplicate") }()
+		r.timing.raceReuses.Add(1)
+		success = true
 		return existing.provider, nil
 	}
 	newRP := &routedProvider{
@@ -667,6 +691,7 @@ func (r *Router) forSpecWorkspace(spec *ServerSpec, workspace string, pin bool) 
 	}
 	r.providers[key] = newRP
 	r.maybeEvictLRULocked()
+	success = true
 	return p, nil
 }
 
@@ -855,7 +880,7 @@ func (r *Router) Reap() []string {
 	names := make([]string, 0, len(victims))
 	for _, v := range victims {
 		names = append(names, formatProviderKey(v.spec.Name, v.workspace))
-		_ = v.provider.Close()
+		_ = r.closeTimedProvider(v.provider, v.spec.Name, v.workspace, "idle")
 	}
 	if len(names) > 0 {
 		r.logger.Info("LSP router reaped idle providers", zap.Strings("names", names))
@@ -896,7 +921,7 @@ func (r *Router) CloseCheckoutWorkspace(language, workspace string) int {
 	}
 	r.mu.Unlock()
 	for _, victim := range victims {
-		_ = victim.provider.Close()
+		_ = r.closeTimedProvider(victim.provider, victim.spec.Name, victim.workspace, "checkout")
 	}
 	if len(victims) > 0 {
 		names := make([]string, 0, len(victims))
@@ -946,7 +971,7 @@ func (r *Router) maybeEvictLRULocked() {
 		}
 		delete(r.providers, oldestKey)
 		r.evictions.Add(1)
-		go func() { _ = oldest.provider.Close() }()
+		go func() { _ = r.closeTimedProvider(oldest.provider, oldestKey.specName, oldestKey.workspace, "lru") }()
 		r.logger.Info("LSP router evicted LRU provider",
 			zap.String("name", formatProviderKey(oldestKey.specName, oldestKey.workspace)))
 	}
@@ -987,11 +1012,128 @@ func (r *Router) Close() error {
 
 	var firstErr error
 	for _, rp := range provs {
-		if err := rp.provider.Close(); err != nil && firstErr == nil {
+		if err := r.closeTimedProvider(rp.provider, rp.spec.Name, rp.workspace, "shutdown"); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
 	return firstErr
+}
+
+// RouterTimingStats is a process-lifetime diagnostic snapshot. Durations sum
+// individual operations and can overlap across goroutines; they are not an
+// additive breakdown of wall-clock startup time.
+type RouterTimingStats struct {
+	Acquires         uint64        `json:"acquires"`
+	AcquireFailures  uint64        `json:"acquire_failures"`
+	Reuses           uint64        `json:"reuses"`
+	Starts           uint64        `json:"starts"`
+	StartFailures    uint64        `json:"start_failures"`
+	Evictions        uint64        `json:"evictions"`
+	EvictionDuration time.Duration `json:"eviction_duration"`
+	RaceReuses       uint64        `json:"race_reuses"`
+	Closes           uint64        `json:"closes"`
+	CloseFailures    uint64        `json:"close_failures"`
+	AcquireDuration  time.Duration `json:"acquire_duration"`
+	ReuseDuration    time.Duration `json:"reuse_duration"`
+	StartDuration    time.Duration `json:"start_duration"`
+	CloseDuration    time.Duration `json:"close_duration"`
+	WaitDuration     time.Duration `json:"wait_duration"`
+}
+
+// MarshalLogObject uses the logger's configured duration encoding, matching
+// ordinary zap.Duration fields rather than reflecting raw nanoseconds.
+func (s RouterTimingStats) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddUint64("acquires", s.Acquires)
+	enc.AddUint64("acquire_failures", s.AcquireFailures)
+	enc.AddUint64("reuses", s.Reuses)
+	enc.AddUint64("starts", s.Starts)
+	enc.AddUint64("start_failures", s.StartFailures)
+	enc.AddUint64("race_reuses", s.RaceReuses)
+	enc.AddUint64("evictions", s.Evictions)
+	enc.AddUint64("closes", s.Closes)
+	enc.AddUint64("close_failures", s.CloseFailures)
+	enc.AddDuration("acquire_duration", s.AcquireDuration)
+	enc.AddDuration("reuse_duration", s.ReuseDuration)
+	enc.AddDuration("start_duration", s.StartDuration)
+	enc.AddDuration("close_duration", s.CloseDuration)
+	enc.AddDuration("eviction_duration", s.EvictionDuration)
+	enc.AddDuration("wait_duration", s.WaitDuration)
+	return nil
+}
+
+// Sub reports the work completed since an earlier snapshot of the same router.
+func (s RouterTimingStats) Sub(before RouterTimingStats) RouterTimingStats {
+	return RouterTimingStats{
+		Acquires: s.Acquires - before.Acquires, AcquireFailures: s.AcquireFailures - before.AcquireFailures,
+		Reuses: s.Reuses - before.Reuses, Starts: s.Starts - before.Starts, StartFailures: s.StartFailures - before.StartFailures,
+		Evictions: s.Evictions - before.Evictions, EvictionDuration: s.EvictionDuration - before.EvictionDuration,
+		RaceReuses: s.RaceReuses - before.RaceReuses, Closes: s.Closes - before.Closes, CloseFailures: s.CloseFailures - before.CloseFailures,
+		AcquireDuration: s.AcquireDuration - before.AcquireDuration, ReuseDuration: s.ReuseDuration - before.ReuseDuration,
+		StartDuration: s.StartDuration - before.StartDuration, CloseDuration: s.CloseDuration - before.CloseDuration,
+		WaitDuration: s.WaitDuration - before.WaitDuration,
+	}
+}
+
+type routerTimingCounters struct {
+	acquires, acquireFailures, reuses, starts, startFailures, raceReuses, closes, closeFailures atomic.Uint64
+	acquireNanos, reuseNanos, startNanos, closeNanos, waitNanos, evictionNanos                  atomic.Int64
+}
+
+// TimingStats is lock-free so sampling a slow acquisition does not wait on the
+// provider-map mutex being measured. Concurrent operations may finish between
+// counter loads; snapshots are observational, not transactional.
+func (r *Router) TimingStats() RouterTimingStats {
+	return RouterTimingStats{
+		Acquires: r.timing.acquires.Load(), AcquireFailures: r.timing.acquireFailures.Load(),
+		Reuses: r.timing.reuses.Load(), Starts: r.timing.starts.Load(), StartFailures: r.timing.startFailures.Load(),
+		Evictions: r.evictions.Load(), EvictionDuration: time.Duration(r.timing.evictionNanos.Load()),
+		RaceReuses: r.timing.raceReuses.Load(), Closes: r.timing.closes.Load(), CloseFailures: r.timing.closeFailures.Load(),
+		AcquireDuration: time.Duration(r.timing.acquireNanos.Load()), ReuseDuration: time.Duration(r.timing.reuseNanos.Load()),
+		StartDuration: time.Duration(r.timing.startNanos.Load()), CloseDuration: time.Duration(r.timing.closeNanos.Load()),
+		WaitDuration: time.Duration(r.timing.waitNanos.Load()),
+	}
+}
+
+// closeTimedProvider preserves the caller's synchronous/asynchronous close
+// policy while exposing shutdown latency and errors for every lifecycle reason.
+func (r *Router) closeTimedProvider(p *Provider, spec, workspace, reason string) error {
+	started := time.Now()
+	fields := []zap.Field{zap.String("spec", spec), zap.String("workspace", workspace), zap.String("reason", reason)}
+	r.logger.Info("LSP router provider close starting", fields...)
+	err := p.Close()
+	elapsed := time.Since(started)
+	r.timing.closes.Add(1)
+	r.timing.closeNanos.Add(int64(elapsed))
+	if reason == "lru" {
+		r.timing.evictionNanos.Add(int64(elapsed))
+	}
+	fields = append(fields, zap.Duration("elapsed", elapsed))
+	if err != nil {
+		r.timing.closeFailures.Add(1)
+		r.logger.Warn("LSP router provider close failed", append(fields, zap.Error(err))...)
+	} else {
+		r.logger.Info("LSP router provider close complete", fields...)
+	}
+	return err
+}
+
+// ensureTimedProvider measures construction-independent initialize latency.
+func (r *Router) ensureTimedProvider(p *Provider, spec, workspace string, constructionDuration time.Duration) error {
+	started := time.Now()
+	r.timing.starts.Add(1)
+	fields := []zap.Field{zap.String("spec", spec), zap.String("workspace", workspace), zap.Duration("construct_elapsed", constructionDuration)}
+	r.logger.Info("LSP router provider startup starting", fields...)
+	err := p.EnsureClient(workspace)
+	elapsed := time.Since(started)
+	r.timing.startNanos.Add(int64(elapsed))
+	fields = append(fields, zap.Duration("elapsed", elapsed))
+	if err != nil {
+		r.timing.startFailures.Add(1)
+		r.logger.Warn("LSP router provider startup failed", append(fields, zap.Error(err))...)
+	} else {
+		r.logger.Info("LSP router provider startup complete", fields...)
+	}
+	return err
 }
 
 // Stats reports the live provider names and their last-used times.

--- a/internal/semantic/lsp/router_test.go
+++ b/internal/semantic/lsp/router_test.go
@@ -4,8 +4,123 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
+
+func TestRouterTimingCachedAcquisitionsDoNotLogPerRequest(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	r := NewRouter(t.TempDir(), zap.New(core))
+	spec := &ServerSpec{Name: "timing-cached"}
+	p := &Provider{}
+	key := providerKey{specName: spec.Name, workspace: r.defaultWorkspace}
+	r.avail[spec.Name] = true
+	r.providers[key] = &routedProvider{spec: spec, provider: p, workspace: key.workspace}
+	before := r.TimingStats()
+	for range 3 {
+		got, err := r.forSpecWorkspace(spec, key.workspace, true)
+		require.NoError(t, err)
+		assert.Same(t, p, got)
+		r.ReleaseSpecWorkspace(spec.Name, key.workspace)
+	}
+	delta := r.TimingStats().Sub(before)
+	assert.EqualValues(t, 3, delta.Acquires)
+	assert.EqualValues(t, 3, delta.Reuses)
+	assert.Zero(t, delta.AcquireFailures)
+	assert.Zero(t, delta.Starts)
+	assert.GreaterOrEqual(t, delta.AcquireDuration, time.Duration(0))
+	assert.GreaterOrEqual(t, delta.ReuseDuration, time.Duration(0))
+	assert.GreaterOrEqual(t, delta.WaitDuration, time.Duration(0))
+	assert.Empty(t, logs.All(), "a cache hit is aggregated, not logged once per edge")
+}
+
+func TestRouterTimingFailedStartupIsPairedAndNotRetried(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	r := NewRouter(t.TempDir(), zap.New(core))
+	spec := &ServerSpec{Name: "timing-start-failure", Command: "gortex-timing-test-no-such-lsp"}
+	// Exercise the initialization failure, not PATH availability detection.
+	r.avail[spec.Name] = true
+	_, err := r.ForSpecWorkspace(spec, r.defaultWorkspace)
+	require.Error(t, err)
+	first := r.TimingStats()
+	assert.EqualValues(t, 1, first.Acquires)
+	assert.EqualValues(t, 1, first.AcquireFailures)
+	assert.EqualValues(t, 1, first.Starts)
+	assert.EqualValues(t, 1, first.StartFailures)
+	assert.GreaterOrEqual(t, first.StartDuration, time.Duration(0))
+	require.Len(t, logs.FilterMessage("LSP router provider startup starting").All(), 1)
+	failures := logs.FilterMessage("LSP router provider startup failed").All()
+	require.Len(t, failures, 1)
+	assert.Contains(t, failures[0].ContextMap(), "elapsed")
+	assert.Contains(t, failures[0].ContextMap(), "error")
+	_, err = r.ForSpecWorkspace(spec, r.defaultWorkspace)
+	require.Error(t, err)
+	second := r.TimingStats()
+	assert.EqualValues(t, 2, second.Acquires)
+	assert.EqualValues(t, 2, second.AcquireFailures)
+	assert.EqualValues(t, 1, second.Starts, "existing spawn-failure backoff is unchanged")
+	assert.Len(t, logs.FilterMessage("LSP router provider startup starting").All(), 1)
+}
+
+func TestRouterTimingEvictionMeasuresAsyncClose(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	r := NewRouter(t.TempDir(), zap.New(core))
+	r.maxAlive = 1
+	for i, name := range []string{"older", "newer"} {
+		spec := &ServerSpec{Name: name}
+		key := providerKey{specName: name, workspace: r.defaultWorkspace}
+		r.providers[key] = &routedProvider{
+			spec: spec, workspace: key.workspace, provider: &Provider{},
+			lastUsed: time.Now().Add(time.Duration(i-2) * time.Minute),
+		}
+	}
+	r.mu.Lock()
+	r.maybeEvictLRULocked()
+	r.mu.Unlock()
+	require.Eventually(t, func() bool {
+		return logs.FilterMessage("LSP router provider close complete").Len() == 1
+	}, time.Second, time.Millisecond)
+	stats := r.TimingStats()
+	assert.EqualValues(t, 1, r.EvictionCount())
+	assert.EqualValues(t, 1, stats.Evictions)
+	assert.GreaterOrEqual(t, stats.EvictionDuration, time.Duration(0))
+	assert.EqualValues(t, 1, stats.Closes)
+	assert.Zero(t, stats.CloseFailures)
+	assert.GreaterOrEqual(t, stats.CloseDuration, time.Duration(0))
+	require.Len(t, logs.FilterMessage("LSP router provider close starting").All(), 1)
+	entry := logs.FilterMessage("LSP router provider close complete").All()[0]
+	assert.Equal(t, "lru", entry.ContextMap()["reason"])
+	assert.Equal(t, "older", entry.ContextMap()["spec"])
+	assert.Contains(t, entry.ContextMap(), "elapsed")
+}
+
+func TestRouterTimingStatsLogDurationEncoding(t *testing.T) {
+	stats := RouterTimingStats{Acquires: 2, AcquireDuration: time.Second, WaitDuration: time.Millisecond}
+	encoder := zapcore.NewJSONEncoder(zapcore.EncoderConfig{EncodeDuration: zapcore.StringDurationEncoder})
+	buffer, err := encoder.EncodeEntry(zapcore.Entry{}, []zapcore.Field{zap.Any("timing", stats)})
+	require.NoError(t, err)
+	defer buffer.Free()
+	assert.Contains(t, buffer.String(), `"acquires":2`)
+	assert.Contains(t, buffer.String(), `"acquire_duration":"1s"`)
+	assert.Contains(t, buffer.String(), `"wait_duration":"1ms"`)
+	assert.Contains(t, buffer.String(), `"eviction_duration":"0s"`)
+}
+
+func TestRouterTimingStatsSub(t *testing.T) {
+	before := RouterTimingStats{
+		Acquires: 1, AcquireFailures: 2, Reuses: 3, Starts: 4, StartFailures: 5, RaceReuses: 6,
+		Closes: 7, CloseFailures: 8, AcquireDuration: 9, ReuseDuration: 10,
+		StartDuration: 11, CloseDuration: 12, WaitDuration: 13,
+	}
+	assert.Equal(t, RouterTimingStats{}, before.Sub(before))
+	after := before
+	after.Acquires += 2
+	after.StartDuration += time.Second
+	assert.Equal(t, RouterTimingStats{Acquires: 2, StartDuration: time.Second}, after.Sub(before))
+}
 
 // TestRouter_For_NoSpec returns an error for unknown extensions.
 func TestRouter_For_NoSpec(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds structured timing diagnostics for warm daemon restarts, including the previously unlogged preparation interval before parallel reconciliation. This is instrumentation, not a claim that startup has become faster.

- Log starts and completions for pre-reconcile maintenance, each repository's resolver helper construction, pending-enrichment seeding, workspace backfills, and watcher setup, including no-op/error outcomes.
- Separate census, parsing, graph application, receipt/publication, and fallback work during reconciliation.
- Separate outgoing and incoming resolution and report admitted-edge counts by repository, with bounded per-repository output and explicit omitted totals.
- Record LSP acquire/reuse/start/close/eviction costs and summarize the router delta during warmup resolution.
- Separate resolver computation from its post-queryability tail, and add accounted/unaccounted wall time to the warmup summary.

## Timing interpretation

Nested reconciliation phases are inclusive and should not be summed with their parents. Chunk parsing explicitly includes admission wait; the legacy fallback intentionally reports combined parse/apply time. Directional admission counts may overlap.

LSP counters are global router deltas, so overlapping queries/enrichment may contribute. Summed operation durations can exceed wall time. Durations use the logger's configured duration encoding; repository breakdowns are capped at 32 entries.

## Validation

- Full indexer suite.
- Full resolver and LSP suites with the race detector.
- Full daemon suite with the race detector.
- Focused reconciliation race tests and telemetry regression tests (no-op, error/abort, census panic, bounded attribution, readiness callbacks, timing accounting, and duration encoding).
- `go vet` across all four affected packages; `git diff --check`.

Implemented in the dedicated `feat/warmup-phase-timings` worktree in focused commits. No daemon restart, installation, or main-checkout changes.
