### PR TITLE
fix: unblock automatic worktree discovery and mutation recovery

### DIFF
--- a/cmd/gortex/daemon_mcp.go
+++ b/cmd/gortex/daemon_mcp.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -26,9 +27,12 @@ import (
 // ID into ctx via gortexmcp.WithSessionID before HandleMessage runs.
 // Tool handlers resolve per-client state through Server.sessionFor(ctx).
 type mcpDispatcher struct {
-	srv          *gortexmcp.Server
-	multiIndexer *indexer.MultiIndexer
-	logger       *zap.Logger
+	// checkoutCWDProbe preserves discovery errors across the daemon admission
+	// boundary. Nil delegates to the server's checked checkout resolver.
+	checkoutCWDProbe func(context.Context, string) (bool, error)
+	srv              *gortexmcp.Server
+	multiIndexer     *indexer.MultiIndexer
+	logger           *zap.Logger
 	// router is held behind an atomic.Pointer so ControlProxy can
 	// publish a freshly-built (or torn-down) router live without
 	// racing a concurrent dispatch read.
@@ -92,7 +96,15 @@ func (d *mcpDispatcher) Dispatch(ctx context.Context, sess *daemon.Session, fram
 	// and tools/list answers an empty/track-only list, instead of a
 	// connection-poisoning errored initialize. Only tools/call is refused (with
 	// the structured not-tracked error the agent can act on).
-	untracked := sess.CWD != "" && !d.cwdReachable(ctx, sess.CWD)
+	// Discovery needs the calling CWD for its scope authorization, but binding
+	// a client session must wait until admission has succeeded.
+	ctx = gortexmcp.WithSessionID(ctx, sess.ID)
+	ctx = gortexmcp.WithSessionCWD(ctx, sess.CWD)
+	reachable, admissionErr := d.cwdReachableChecked(ctx, sess.CWD)
+	untracked := sess.CWD != "" && !reachable && admissionErr == nil
+	if admissionErr != nil && !checkoutAdmissionMetadataMethod(peekFrameMethod(frame)) {
+		return checkoutAdmissionError(sess.CWD, frame, admissionErr), nil
+	}
 	if untracked {
 		d.logUncoveredCWDOnce(sess)
 	}
@@ -100,12 +112,10 @@ func (d *mcpDispatcher) Dispatch(ctx context.Context, sess *daemon.Session, fram
 		return d.notTrackedError(sess, frame), nil
 	}
 
-	ctx = gortexmcp.WithSessionID(ctx, sess.ID)
 	// Carry the session's cwd so MCP tool handlers can resolve — and
 	// enforce — the workspace boundary for this session. Without this
 	// every query runs against the whole multi-workspace graph and a
 	// session in workspace A can see workspace B's nodes.
-	ctx = gortexmcp.WithSessionCWD(ctx, sess.CWD)
 	// Run session-aware: attaching the connected client session (wired
 	// by SessionStarted) lets mcp-go's initialize handler mark it
 	// initialized — the gate SendNotificationToAllClients applies
@@ -184,6 +194,9 @@ func (d *mcpDispatcher) Dispatch(ctx context.Context, sess *daemon.Session, fram
 	// "run gortex track" instructions and an empty track-only tool list.
 	if untracked {
 		out = rewriteUntrackedResponse(peekFrameMethod(frame), out, sess.CWD, d.trackedRoots())
+	}
+	if admissionErr != nil {
+		out = rewriteCheckoutAdmissionResponse(peekFrameMethod(frame), out, sess.CWD, admissionErr)
 	}
 	return out, nil
 }
@@ -323,11 +336,93 @@ func (d *mcpDispatcher) SessionEnded(sess *daemon.Session) {
 // in servers.toml, which is the same wrong-result class
 // repo_not_tracked is meant to prevent.
 func (d *mcpDispatcher) cwdReachable(ctx context.Context, cwd string) bool {
-	if cwd == "" {
+	reachable, err := d.cwdReachableChecked(ctx, cwd)
+	return err == nil && reachable
+}
+
+// A failed discovery must not expose graph data or accept source/configuration
+// mutations. Keep only the connection and stable capability metadata available.
+func checkoutAdmissionMetadataMethod(method string) bool {
+	switch method {
+	case "initialize", "tools/list", "ping":
 		return true
+	default:
+		return strings.HasPrefix(method, "notifications/")
+	}
+}
+
+func checkoutAdmissionFailure(err error) (code string, retryable bool) {
+	var committed interface{ Committed() bool }
+	if errors.As(err, &committed) && committed.Committed() {
+		return "checkout_inaccessible", false
+	}
+	if errors.Is(err, indexer.ErrCheckoutMutationBusy) || errors.Is(err, context.DeadlineExceeded) {
+		return "view_building", true
+	}
+	// Catalog readers can surface SQLite contention directly, including an
+	// extended result code. Only BUSY/LOCKED are safe retry classifications.
+	var coded interface{ Code() int }
+	if errors.As(err, &coded) {
+		switch coded.Code() & 0xff {
+		case 5, 6: // SQLITE_BUSY, SQLITE_LOCKED
+			return "view_building", true
+		}
+	}
+	return "checkout_inaccessible", false
+}
+
+func checkoutAdmissionError(cwd string, inbound []byte, err error) []byte {
+	var req struct {
+		ID json.RawMessage `json:"id"`
+	}
+	_ = json.Unmarshal(inbound, &req)
+	code, retryable := checkoutAdmissionFailure(err)
+	out, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      req.ID,
+		"error": map[string]any{
+			"code":    -32000,
+			"message": "checkout discovery unavailable: " + err.Error(),
+			"data": map[string]any{
+				"error_code": code,
+				"path":       cwd,
+				"retryable":  retryable,
+			},
+		},
+	})
+	return out
+}
+
+func rewriteCheckoutAdmissionResponse(method string, out []byte, cwd string, err error) []byte {
+	if method != "initialize" {
+		return out
+	}
+	var reply map[string]any
+	if json.Unmarshal(out, &reply) != nil {
+		return out
+	}
+	result, ok := reply["result"].(map[string]any)
+	if !ok {
+		return out
+	}
+	code, retryable := checkoutAdmissionFailure(err)
+	result["instructions"] = fmt.Sprintf(
+		"Gortex checkout discovery is unavailable for %s (%s, retryable=%t): %v. "+
+			"No graph access has been granted. Retry after discovery can complete; do not change tracking configuration to resolve this admission error.",
+		cwd, code, retryable, err)
+	updated, marshalErr := json.Marshal(reply)
+	if marshalErr != nil {
+		return out
+	}
+	return updated
+}
+
+func (d *mcpDispatcher) cwdReachableChecked(ctx context.Context, cwd string) (bool, error) {
+	if cwd == "" {
+		return true, nil
 	}
 	if d.isCWDTracked(cwd) {
-		return true
+		return true, nil
 	}
 	// Workspace-root fallback: a cwd that CONTAINS tracked repos — an
 	// agent opened at the root above its repos — is reachable when
@@ -345,10 +440,10 @@ func (d *mcpDispatcher) cwdReachable(ctx context.Context, cwd string) bool {
 	// <parent>`) that would have indexed every child a second time.
 	if d.multiIndexer != nil {
 		if _, _, _, ok := d.multiIndexer.ScopeForCWD(cwd); ok {
-			return true
+			return true, nil
 		}
 		if _, _, ok := d.multiIndexer.ContainedReposScope(cwd); ok {
-			return true
+			return true, nil
 		}
 	}
 	// Checkout fallback: a git worktree of a tracked family is a directory
@@ -357,19 +452,26 @@ func (d *mcpDispatcher) cwdReachable(ctx context.Context, cwd string) bool {
 	// resolves it through the same lookup. Refusing it here made that arm
 	// unreachable and left every worktree session with repo_not_tracked and a
 	// remedy that would have indexed the worktree as a second repository.
-	if d.srv != nil && d.srv.CheckoutServesCWD(ctx, cwd) {
-		return true
+	probe := d.checkoutCWDProbe
+	if probe == nil && d.srv != nil {
+		probe = d.srv.CheckoutServesCWDChecked
+	}
+	if probe != nil {
+		reachable, err := probe(ctx, cwd)
+		if err != nil || reachable {
+			return err == nil && reachable, err
+		}
 	}
 	rtr := d.router.Load()
 	if rtr == nil {
-		return false
+		return false, nil
 	}
 	lookup := rtr.LookupForCwd(cwd, "")
 	switch lookup.Source {
 	case "scope-override", "config-yaml", "roster":
-		return true
+		return true, nil
 	}
-	return false
+	return false, nil
 }
 
 // isCWDTracked reports whether the proxy's cwd lies inside any tracked

--- a/cmd/gortex/daemon_mcp_checkout_admission_test.go
+++ b/cmd/gortex/daemon_mcp_checkout_admission_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/daemon"
+	"github.com/zzet/gortex/internal/indexer"
+)
+
+func TestDispatcher_CheckoutAdmissionFailurePreservesClassification(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		err       error
+		code      string
+		retryable bool
+	}{
+		{"busy", fmt.Errorf("observe checkout: %w", indexer.ErrCheckoutMutationBusy), "view_building", true},
+		{"deadline", fmt.Errorf("catalog admission: %w", context.DeadlineExceeded), "view_building", true},
+		{"sqlite_busy", checkoutAdmissionSQLiteError(5), "view_building", true},
+		{"sqlite_locked_sharedcache", checkoutAdmissionSQLiteError(6 | (1 << 8)), "view_building", true},
+		{"sqlite_ioerr", checkoutAdmissionSQLiteError(10), "checkout_inaccessible", false},
+		{"committed_busy", checkoutAdmissionCommittedError{checkoutAdmissionSQLiteError(5)}, "checkout_inaccessible", false},
+		{"inaccessible", errors.New("Git metadata cannot be read"), "checkout_inaccessible", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d, _ := trackedPathMCPSetup(t, t.TempDir())
+			sess := &daemon.Session{ID: "checkout-admission", CWD: t.TempDir()}
+			d.checkoutCWDProbe = func(_ context.Context, cwd string) (bool, error) {
+				require.Equal(t, sess.CWD, cwd)
+				// Even a positive proof does not authorize access on error.
+				return true, tc.err
+			}
+			for _, frame := range []string{
+				`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"search","arguments":{"query":"private"}}}`,
+				`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"workspace_admin","arguments":{"operation":"track"}}}`,
+				`{"jsonrpc":"2.0","id":7,"method":"resources/read","params":{"uri":"gortex://graph"}}`,
+			} {
+				reply, err := d.Dispatch(context.Background(), sess, []byte(frame))
+				require.NoError(t, err)
+				var parsed map[string]any
+				require.NoError(t, json.Unmarshal(reply, &parsed))
+				assert.EqualValues(t, 7, parsed["id"])
+				assert.NotContains(t, parsed, "result", "failed admission cannot expose graph data")
+				failure, ok := parsed["error"].(map[string]any)
+				require.True(t, ok, "wire error missing: %s", reply)
+				data, ok := failure["data"].(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, tc.code, data["error_code"])
+				assert.Equal(t, tc.retryable, data["retryable"])
+				assert.Equal(t, sess.CWD, data["path"])
+				assert.Contains(t, failure["message"], tc.err.Error(), "preserve the cause")
+				assert.NotContains(t, string(reply), "gortex track")
+				assert.NotContains(t, string(reply), "repo_not_tracked")
+			}
+			_, logged := d.loggedUntracked.Load(sess.ID)
+			assert.False(t, logged, "transient discovery is not an untracked session")
+		})
+	}
+}
+
+type checkoutAdmissionSQLiteError int
+
+func (e checkoutAdmissionSQLiteError) Error() string { return fmt.Sprintf("SQLite error %d", e) }
+func (e checkoutAdmissionSQLiteError) Code() int     { return int(e) }
+
+type checkoutAdmissionCommittedError struct{ error }
+
+func (e checkoutAdmissionCommittedError) Committed() bool { return true }
+func (e checkoutAdmissionCommittedError) Unwrap() error   { return e.error }
+
+func TestDispatcher_CheckoutAdmissionBusyHandshakeAndSameSessionRetry(t *testing.T) {
+	d, _ := trackedPathMCPSetup(t, t.TempDir())
+	sess := &daemon.Session{ID: "checkout-admission-retry", CWD: t.TempDir()}
+	busy := true
+	d.checkoutCWDProbe = func(_ context.Context, _ string) (bool, error) {
+		if busy {
+			return false, indexer.ErrCheckoutMutationBusy
+		}
+		return true, nil
+	}
+	dispatch := func(frame string) map[string]any {
+		t.Helper()
+		reply, err := d.Dispatch(context.Background(), sess, []byte(frame))
+		require.NoError(t, err)
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(reply, &parsed))
+		return parsed
+	}
+	init := dispatch(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`)
+	assert.NotContains(t, init, "error", "busy discovery must not break the connection")
+	result, ok := init["result"].(map[string]any)
+	require.True(t, ok)
+	instructions, ok := result["instructions"].(string)
+	require.True(t, ok)
+	assert.Contains(t, instructions, "view_building")
+	assert.Contains(t, instructions, "No graph access has been granted")
+	assert.NotContains(t, instructions, "gortex track")
+
+	listed := dispatch(`{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`)
+	assert.NotContains(t, listed, "error")
+	result, ok = listed["result"].(map[string]any)
+	require.True(t, ok)
+	assert.NotEmpty(t, result["tools"], "stable tool metadata remains discoverable")
+
+	const call = `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"capabilities","arguments":{}}}`
+	blocked := dispatch(call)
+	require.Contains(t, blocked, "error")
+	busy = false
+	reachable, err := d.cwdReachableChecked(context.Background(), sess.CWD)
+	require.NoError(t, err)
+	require.True(t, reachable)
+	retried := dispatch(call)
+	assert.NotContains(t, retried, "error", "the same session must retry without reconnect or tracking")
+	assert.Contains(t, retried, "result")
+	_, logged := d.loggedUntracked.Load(sess.ID)
+	assert.False(t, logged, "busy state must not poison the untracked-session cache")
+}
+
+func BenchmarkCheckoutAdmissionError(b *testing.B) {
+	frame := []byte(`{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"search"}}`)
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = checkoutAdmissionError("/checkout", frame, indexer.ErrCheckoutMutationBusy)
+	}
+}

--- a/docs/worktree-source-mutations.md
+++ b/docs/worktree-source-mutations.md
@@ -186,3 +186,25 @@ Formatting the daemon's retryable admission-error response measured 2.34–2.38 
 per response (three 200 ms benchmark runs, 1,601 bytes and 26 allocations per
 operation). Wire-level tests preserve initialization/capability metadata while
 denying graph reads and source/configuration mutations until admission succeeds.
+
+### CI regression: graph-free pending detection
+
+The first lifecycle patch created an empty in-memory graph to suppress stale
+symbols during pending detection. CI's `TestNewIsFencedToIndexerStaging` correctly
+rejected that production allocation. Pending detection now passes an explicit nil
+reader to the Git diff mapper. Both symbol-join paths skip graph access while
+preserving Git hunks and added, modified, deleted, and renamed file metadata.
+Non-nil readers retain their existing behavior; ordinary untracked files are
+not newly included by this change. Pending analysis remains incomplete with
+unknown risk, not a claim that no symbols changed.
+
+Regression tests cover empty-file deletion, intent-to-add, both non-nil symbol
+joins, Git failures, and a pending reader that panics if consulted. The
+constructor guard remains unchanged. On Apple M1 Pro, three benchmark runs
+measured a median of 7,999 ns / 17,504 B / 313 allocations for the former
+placeholder join versus 234.3 ns / 208 B / 4 allocations for file-only mode.
+The real Git-diff benchmark remained dominated by subprocess time (medians
+9.98 ms and 9.29 ms); these runs do not establish an end-to-end speedup.
+
+Compile-only checks do not execute the constructor guard. Validation must run
+`go test ./internal/graph` as well as the affected analysis and MCP tests.

--- a/docs/worktree-source-mutations.md
+++ b/docs/worktree-source-mutations.md
@@ -208,3 +208,28 @@ The real Git-diff benchmark remained dominated by subprocess time (medians
 
 Compile-only checks do not execute the constructor guard. Validation must run
 `go test ./internal/graph` as well as the affected analysis and MCP tests.
+
+### Windows physical-root identity
+
+Windows CI exposed a real replacement-check failure: `os.Stat` can defer file-ID
+lookup until `os.SameFile`, reopening a pathname after another directory has
+replaced it. Mutation admission and refresh tickets must capture identity before
+waiting, not when comparing later. On Windows, identity now comes from an open
+directory handle's `File.Stat`; that handle is closed immediately. Non-Windows
+platforms retain their eager `os.Stat` path. Rooted hashing also compares identity
+obtained from its opened root, not a lazily resolved pathname. See Go's
+[Windows file identity implementation](https://go.dev/src/os/types_windows.go)
+and [handle-based stat implementation](https://go.dev/src/os/stat_windows.go).
+
+The regression captures identity, renames the original, recreates its pathname,
+and only then compares identities. It must reject the replacement while still
+recognizing the renamed original. This ordering matters: an earlier `SameFile`
+call would hide the Windows bug by populating its lazy ID. Missing roots and
+regular files fail closed, and no persistent directory lock is introduced.
+
+Local mutation/refresh/root race tests passed, as did Windows cross-compilation
+of the standalone identity helper and tests. Windows execution remains a CI
+check, not a claim based on Darwin tests. Three Darwin benchmark runs measured
+2.139–2.527 microseconds for pathname stat and 1.904–2.030 microseconds for the
+final capture helper, both 304 bytes and two allocations per call. These results
+show no material non-Windows overhead; they do not measure Windows performance.

--- a/docs/worktree-source-mutations.md
+++ b/docs/worktree-source-mutations.md
@@ -290,3 +290,49 @@ three runs, about 21.6 KB and 288 allocations per operation. Each run performed
 one inventory across 1,873–2,390 requests, demonstrating coalesced reuse without
 skipping physical-binding checks. This benchmark passes no authorizer callback;
 per-caller authorization is covered separately by denied-caller regressions.
+
+### Reader failures must not invalidate shared discovery
+
+The macOS race/coverage job for PR #759 observed a second inventory in the
+slow-discovery retry test before the shared job's five-second lifetime elapsed.
+Review exposed a foreground lifetime bug: final proof validation unconditionally
+canceled the lifecycle-owned completed job on any error, including a reader's
+expired context or a transient catalog read failure. The next reader could then
+start the expensive inventory again.
+
+Only a positive `ErrCheckoutMutationStale` classification, including wrapped or
+joined errors, may invalidate shared discovery after foreground validation.
+Other errors still refuse that request; they do not confer authority or return a
+checkout. A later reader must independently reauthorize and revalidate the proof
+before reusing the completed job. Expiry, shutdown, the five-second lifetime, and
+the 32-active-job limit are unchanged. Background discovery errors retain their
+existing behavior; this fix introduces no automatic background retry policy.
+
+A deterministic regression supplies deadline, cancellation, busy-catalog,
+generic-catalog, and unavailable-primary errors to the foreground invalidation
+policy. All five cases failed with unconditional cancellation and pass with the
+fix: the same shared job survives, a subsequent public observation succeeds, and
+inventory runs once. Bare, wrapped, and joined stale errors still cancel and drain
+the job. Existing root and Git-binding replacement tests remain in force.
+
+The original CI timing failure did not reproduce in 20 local race/coverage runs;
+its exact cause is therefore not conclusively established by the log alone.
+Background apply errors are another possible reason for a second inventory. The
+original single-inventory assertion and deadlines remain unchanged, with
+channel-synchronized diagnostics added for the first and current job's context,
+proof error, and terminal result if it fails again.
+
+Validation on macOS/arm64 passed the full indexer race/coverage suite in
+928.991 seconds (85.3% statement coverage), the routed/worktree/checkout MCP
+selection repeated three times under the race detector in 747.665 seconds
+(744 passing test/subtest executions), the indexer build, and lint with zero
+issues. The initial three-repeat MCP command exhausted a five-minute total suite
+budget while advancing through tests; the completed run used a fifteen-minute
+suite budget. No individual test deadlines or assertions were relaxed.
+
+Three cached-proof benchmark runs measured 138,269, 137,244, and 143,127 ns/op,
+with 21,678, 21,644, and 21,631 B/op respectively, and 288 allocations per request.
+Each run performed one inventory across 2,388, 2,496, and 2,684 requests
+respectively. These are reuse measurements, not a claimed speedup: the successful
+validation path is unchanged. As above, this benchmark has no authorizer callback;
+authorization behavior is validated by separate regressions.

--- a/docs/worktree-source-mutations.md
+++ b/docs/worktree-source-mutations.md
@@ -233,3 +233,60 @@ check, not a claim based on Darwin tests. Three Darwin benchmark runs measured
 2.139–2.527 microseconds for pathname stat and 1.904–2.030 microseconds for the
 final capture helper, both 304 bytes and two allocations per call. These results
 show no material non-Windows overhead; they do not measure Windows performance.
+
+### Slow Git discovery must make progress across requests
+
+Windows CI exposed starvation in the original first-request budget: the entire
+Git inventory and checkout observation were canceled after 250 ms. If metadata
+work consistently exceeded that budget, every retry restarted it from scratch.
+A second routing bug converted the retryable discovery error into a successful
+empty search. Neither behavior satisfied the new-worktree agent flow.
+
+The 250 ms caller wait remains, but discovery now belongs to the lifecycle:
+
+- Requests for the same canonical path share one job with a five-second
+  cooperative work deadline. A timed-out caller does not discard its progress.
+- At most 32 jobs may exist. Expired or canceled work still occupies its slot
+  until its worker exits, so slow cancellation cannot evade the concurrency cap.
+  Lifecycle shutdown cancels and joins the workers.
+- The first phase only reads Git metadata and the known-family catalog. Every
+  caller independently authorizes the proven primary before observation can
+  start or a shared successful result can be returned. Denied callers cannot
+  start observation or borrow another caller's authority.
+- Cached proof records physical root, Git-directory and common-directory
+  identities, plus `.git` and `commondir` identity/content/absence. A directory
+  resolution after capture verifies that this proof belongs to the inventory's
+  family. This uses the existing Git resolver without repeating the worktree
+  inventory. Later validation is filesystem/catalog-only, including before
+  activation and before returning a cached result.
+- Pending discovery returns typed `view_building`; stale, stopped, denied, and
+  canceled admission cannot become a base result. A generic catalog failure may
+  use labeled fallback only when independent tracked-root metadata proves that
+  the canonical checkout owns the CWD, excluding nested or sibling checkouts.
+
+Agents retry a pending request in the same session. Once admission establishes
+the checkout, ordinary labeled base fallback may serve search while its graph
+builds; edits still require the exact selected view. No explicit tracking or
+additional graph copy is introduced.
+
+Deterministic regressions delay both inventory and HEAD sampling beyond the
+caller budget, then verify eventual success with each operation executed once.
+Other tests cover caller-specific authorization, canceled and expired jobs,
+shutdown, proof replacement, and exact/nonexact search refusal and recovery.
+Windows path assertions use normalized paths, and the relative Git-path fixture
+changes to its own temporary directory so CI's D: checkout/C: temporary-directory
+layout does not invalidate or skip relative-path coverage.
+
+After binding hardening, three five-admission benchmark runs on Apple M1 Pro
+measured 90.49, 79.68, and 105.89 ms per new checkout, with 15/15 successful
+admissions and zero busy responses. The extra binding check costs time compared
+with the earlier 65–77 ms runs; it is not a claimed performance improvement.
+These measurements cover a tiny cold metadata fixture, not Windows runtime,
+large-family inventory, or graph construction. The improvement under slow Git
+is preserved progress with bounded caller waits, not faster subprocesses.
+
+Completed-proof validation measured 0.253, 0.445, and 0.301 ms per request in
+three runs, about 21.6 KB and 288 allocations per operation. Each run performed
+one inventory across 1,873–2,390 requests, demonstrating coalesced reuse without
+skipping physical-binding checks. This benchmark passes no authorizer callback;
+per-caller authorization is covered separately by denied-caller regressions.

--- a/docs/worktree-source-mutations.md
+++ b/docs/worktree-source-mutations.md
@@ -24,17 +24,98 @@ The replacement admits only the audited checkout-aware write paths.
 - Immediately before a real write, the old dirty route becomes pending. Existing
   leased readers remain valid; new requests cannot mistake the old generation
   for the updated working copy.
-- The existing single-file commit ledger still distinguishes disk commit from
-  graph refresh. Refresh uses the selected checkout coordinator, never the
-  primary repository's watcher or incremental indexer. A bounded refresh failure
-  leaves a stale/failed graph outcome and schedules reconciliation; it must not
-  report that a successful disk write did not happen.
+- The existing single-file commit ledger distinguishes disk commit from graph
+  refresh. Once bytes commit, the edit enqueues a checkout refresh ticket and
+  returns `reindexed:false`, `reindex_pending:true`, and `graph_status:pending`.
+  The middleware releases the write lease before background publication; the
+  response does not wait for parsing, enrichment, or the old synchronous refresh
+  budget. It includes a `mutation_receipt` for the disk commit and a
+  `reindex_receipt` for the graph refresh.
+- The existing coordinator loop owns refresh execution. There is no second
+  indexer, per-edit build goroutine, or primary-watcher fallback. The physical
+  build uses coordinator lifetime, not the request's short wait deadline. A
+  disconnected caller does not cancel a committed edit's publication.
+- A ticket becomes fresh only after an active route publishes the expected
+  checkout incarnation, HEAD, and content. Deferred or rescheduled work remains
+  pending. Supersession, disappearance, and terminal failures cannot be mistaken
+  for success; the original failure detail is retained. A primary reindex cannot
+  certify an automatic checkout's receipt.
+- Publication evidence includes the admitted branch/HEAD, checkout/root identity,
+  the dirty snapshot fingerprint, and a SHA-256 of the committed target bytes.
+  An intervening change to another dirty file can conservatively supersede the
+  ticket instead of claiming freshness. This does not strengthen the existing
+  whole-checkout sampler, which fingerprints dirty paths and their size/mtime
+metadata rather than hashing every file. Historical superseded receipts remain
+  inspectable but do not block diagnostics for a newer current view.
 - Coordinator shutdown joins admitted writes before checkout state can retire.
 
 All inexact fallbacks and immutable ref/commit views remain read-only. A missing
 coordinator refuses the operation before touching files. Save or discard active
 session editor buffers before editing on-disk worktree content; buffer-derived
 symbol locations are not authority to modify disk.
+
+## Agent lifecycle and recovery
+
+The supported flow is:
+
+`new worktree -> automatic discovery -> search -> exact edit -> pending refresh -> fresh -> next edit`
+
+1. An agent request from a newly added checkout discovers it without adding
+   explicit tracking intent. Search may return a labeled, read-only base
+   fallback while the selected graph builds. `require_exact:true` refuses that
+   substitution.
+2. Source edits still require an exact, authorized working-copy view. Busy
+   admission is bounded and retryable; graph-dependent operations do not wait
+   indefinitely behind a build or silently edit the primary fallback.
+3. A successful disk edit returns a pending publication receipt promptly. Query
+   `change(operation:"receipt", options:{receipt:"<mutation_receipt>"}, view:...)`
+   to observe `pending -> fresh` or a specific failure. Never repeat the disk
+   edit merely because its graph publication is pending.
+4. Receipt inspection and checkout-scoped recovery validate checkout identity
+   and authorization independently of graph materialization. They work while a
+   route is building. Their checkout-scope metadata is not a claim that an exact
+   graph was served. Successful scoped recovery can clear previously failed
+   tickets from the current-view safety barrier, but leaves their historical
+   failure receipts intact. It cannot clear failures admitted after that recovery
+   request or failures from another checkout/incarnation.
+5. `workspace_admin.reindex` for an automatic checkout queues its coordinator;
+   it does not require promoting the checkout to a dedicated graph or invoke
+   canonical incremental indexing. Scoped paths must remain inside the selected
+   working copy. These working-copy controls accept automatic/worktree selection;
+   explicit base/ref/commit selectors are refused rather than silently operating
+   on a different working copy.
+6. `change.detect` always examines Git changes in the selected checkout. If the
+   corresponding graph is not ready, it reports the file changes with incomplete
+   graph analysis and unknown risk, rather than returning a false clean-tree
+   verdict from the main checkout.
+
+The old flow violated these rules in three connected places: a short synchronous
+refresh error became a frozen terminal receipt even though the coordinator later
+retried; ready-graph routing blocked receipt inspection and recovery; and change
+detection used the canonical repository root despite an exact-worktree rider.
+The repair needs neither a schema migration nor a daemon restart protocol.
+
+First-CWD discovery is limited to a checkout proven by Git's worktree inventory
+to belong to an already known family with a designated primary. It records only
+that missing checkout and activates its coordinator. It does not sweep other
+families, perform retirement/forget cleanup, modify explicit tracking intent, or
+wait for a graph build. Both daemon CWD admission and direct tool routing use the
+same path lookup, so a first request need not wait for a periodic reconciliation.
+
+### Observed slow-refresh incident (2026-09-06)
+
+In the PR-744 worktree, an edit committed at 10:11:51 UTC. A subsequent sparse
+build reached the 200-file dependency-closure cap. Parsing took 46.165 seconds;
+the eight workers accumulated 0.132 seconds reading, 5.739 seconds extracting,
+and 305.566 seconds in batch processing. Those worker times overlap and must
+not be added to derive wall time. Synthesis, store work, and semantic enrichment
+continued until 10:16:40 UTC. The exact route later recovered while the receipt
+still claimed terminal failure. The retained receipt did not expose the original
+refresh error, so this evidence alone does not prove its initial trigger.
+
+This fix removes request-lifetime cancellation and recovery dead ends from that
+flow. It does not claim that a large dependency closure becomes cheap: background
+build cost and interactive request latency must be measured separately.
 
 ## Deliberately unsupported write paths
 
@@ -56,6 +137,13 @@ subsequent exact graph/source reads. Separate tests cover stale epochs, dirty
 state, cancellation, shutdown, panic cleanup, root replacement, and failed
 publication after a successful disk commit.
 
+The lifecycle regressions additionally add a worktree after startup and search
+it without tracking; block the real extractor on post-edit content; verify that
+edit returns pending before the parser is released; query receipts, queue scoped
+recovery, and detect selected-root changes during the blocked build; then release
+the parser, observe fresh publication, and perform a second edit. Pending exact
+writes remain refused and the primary's bytes remain unchanged throughout.
+
 On an Apple M1 Pro, three 10-iteration runs against a tiny fixture measured:
 
 | Operation | Time per operation |
@@ -69,3 +157,32 @@ generation IDs unchanged. Reproduce with
 `go test ./internal/indexer -run '^$' -bench '^BenchmarkCheckoutMutation' -benchmem`
 and
 `go test ./internal/mcp -run '^$' -bench '^BenchmarkWorktreeMutationDryRun$' -benchmem`.
+
+Measure enqueue latency independently of a stalled parser with
+`go test ./internal/mcp -run '^$' -bench '^BenchmarkWorktreeMutationEnqueueWithBlockedIndexer$' -benchtime=5x -benchmem`.
+
+For the lifecycle repair on 2026-09-06, three five-iteration runs measured
+11.74–12.50 ms per dry run, compared with 11.21–12.17 ms before the repair
+(medians 12.38 and 12.07 ms respectively). The median allocation count increased
+from 2,835 to 3,062 with the additional checkout binding and scope checks.
+Committed edits with the real extractor blocked returned in 33.55, 34.45, and
+37.57 ms per operation (three run averages; median 34.45 ms). Fixture setup and
+eventual publication are outside that edit timing. These tiny-repository
+measurements demonstrate separation from the stalled indexer, not a prediction
+of large-repository indexing throughput or a production latency guarantee.
+
+Receipt inspection during pending publication measured 0.167–0.239 ms per call
+(three 100-iteration run averages), including checkout binding and authorization.
+
+First-checkout observation measured 65.40, 64.66, and 76.91 ms per admission
+(three five-admission run averages; 15 successful admissions, zero busy replies
+in that final run). An earlier loaded run reached the 250 ms admission bound;
+this exposed a duplicated Git inventory scan and a lost busy classification.
+Observation now reuses the validated inventory and preserves retryable busy
+errors through daemon admission instead of presenting them as untracked CWDs.
+The bound is not increased, and no pending request is granted graph authority.
+
+Formatting the daemon's retryable admission-error response measured 2.34–2.38 µs
+per response (three 200 ms benchmark runs, 1,601 bytes and 26 allocations per
+operation). Wire-level tests preserve initialization/capability metadata while
+denying graph reads and source/configuration mutations until admission succeeds.

--- a/internal/analysis/diffmap.go
+++ b/internal/analysis/diffmap.go
@@ -80,6 +80,9 @@ type DiffResult struct {
 // The daemon keys every file path as "<prefix>/<rel>" while git emits
 // repo-relative paths; empty only for the standalone Indexer, which
 // mints unprefixed paths.
+// A nil reader requests file-only metadata from the same Git diff: hunks,
+// changed files and file changes are preserved, but symbols are not mapped.
+// This does not add changes that Git diff itself does not report.
 func MapGitDiff(g graph.Reader, repoRoot, repoPrefix, scope, baseRef string) (*DiffResult, error) {
 	if err := gitcmd.ValidateRef(baseRef); err != nil {
 		return nil, err
@@ -194,6 +197,10 @@ func joinHunksToSymbols(g graph.Reader, repoPrefix string, hunks []DiffHunk, fil
 	for _, hunk := range hunks {
 		fileSet[hunk.FilePath] = true
 
+		// A nil reader requests file-only metadata, not a substitute graph.
+		if g == nil {
+			continue
+		}
 		// Find symbols whose line range overlaps the hunk
 		for _, n := range JoinFileNodes(g, repoPrefix, hunk.FilePath, RepoRelativePath) {
 			// Check if symbol's line range overlaps with the hunk
@@ -220,6 +227,9 @@ func joinHunksToSymbols(g graph.Reader, repoPrefix string, hunks []DiffHunk, fil
 			continue
 		}
 		fileSet[vanished] = true
+		if g == nil {
+			continue
+		}
 		for _, n := range JoinFileNodes(g, repoPrefix, vanished, RepoRelativePath) {
 			addSymbol(n)
 		}

--- a/internal/analysis/diffmap_file_only_test.go
+++ b/internal/analysis/diffmap_file_only_test.go
@@ -1,0 +1,179 @@
+package analysis
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func fileOnlyDiffGit(t testing.TB, root string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", root}, args...)...)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, output)
+}
+
+func fileOnlyDiffFixture(t testing.TB) string {
+	t.Helper()
+	root := t.TempDir()
+	fileOnlyDiffGit(t, root, "init")
+	fileOnlyDiffGit(t, root, "config", "user.name", "Gortex Test")
+	fileOnlyDiffGit(t, root, "config", "user.email", "test@gortex.invalid")
+	for name, content := range map[string]string{
+		"modified.go": "package sample\n\nfunc Before() {}\n",
+		"deleted.go":  "package sample\n\nfunc Deleted() {}\n",
+		"renamed.txt": "an unchanged document that moves to a new name\n",
+		"empty.txt":   "",
+	} {
+		require.NoError(t, os.WriteFile(filepath.Join(root, name), []byte(content), 0o644))
+	}
+	fileOnlyDiffGit(t, root, "add", ".")
+	fileOnlyDiffGit(t, root, "commit", "-m", "baseline")
+	return root
+}
+
+func fileOnlyDiffChanges(t testing.TB, root string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "modified.go"), []byte("package sample\n\nfunc After() {}\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "added.go"), []byte("package sample\n\nfunc Added() {}\n"), 0o644))
+	require.NoError(t, os.Remove(filepath.Join(root, "deleted.go")))
+	require.NoError(t, os.Remove(filepath.Join(root, "empty.txt")))
+	require.NoError(t, os.Rename(filepath.Join(root, "renamed.txt"), filepath.Join(root, "moved.txt")))
+	fileOnlyDiffGit(t, root, "add", "-A")
+}
+
+func TestMapGitDiffWithoutGraphPreservesFileMetadata(t *testing.T) {
+	root := fileOnlyDiffFixture(t)
+	fileOnlyDiffChanges(t, root)
+	result, err := MapGitDiff(nil, root, "repo", "staged", "HEAD")
+	require.NoError(t, err)
+	require.Empty(t, result.ChangedSymbols)
+	require.NotEmpty(t, result.Hunks)
+	require.Equal(t, []string{"added.go", "deleted.go", "empty.txt", "modified.go", "moved.txt", "renamed.txt"}, result.ChangedFiles)
+	changes := make(map[string]FileChange)
+	for _, change := range result.FileChanges {
+		changes[change.Path] = change
+	}
+	require.Equal(t, FileAdded, changes["added.go"].Kind)
+	require.Equal(t, FileDeleted, changes["deleted.go"].Kind)
+	require.Equal(t, FileDeleted, changes["empty.txt"].Kind)
+	require.Equal(t, FileModified, changes["modified.go"].Kind)
+	require.Equal(t, FileRenamed, changes["moved.txt"].Kind)
+	require.Equal(t, "renamed.txt", changes["moved.txt"].PreviousPath)
+}
+
+func TestMapGitDiffWithoutGraphPreservesIntentToAdd(t *testing.T) {
+	root := fileOnlyDiffFixture(t)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "intent.go"), []byte("package sample\n\nfunc Intent() {}\n"), 0o644))
+	fileOnlyDiffGit(t, root, "add", "-N", "intent.go")
+	result, err := MapGitDiff(nil, root, "repo", "unstaged", "HEAD")
+	require.NoError(t, err)
+	require.Empty(t, result.ChangedSymbols)
+	require.Equal(t, []string{"intent.go"}, result.ChangedFiles)
+	require.Equal(t, []FileChange{{Path: "intent.go", Kind: FileAdded}}, result.FileChanges)
+	require.NotEmpty(t, result.Hunks)
+}
+
+type diffFileNodeReader struct {
+	graph.Reader
+	nodes []*graph.Node
+	reads int
+}
+
+func (r *diffFileNodeReader) GetFileNodes(string) []*graph.Node {
+	r.reads++
+	return r.nodes
+}
+
+func TestJoinHunksFileOnlyModeDoesNotChangeGraphMapping(t *testing.T) {
+	hunks := []DiffHunk{{FilePath: "source.go", StartLine: 3, EndLine: 3}}
+	files := []FileChange{{Path: "source.go", Kind: FileModified}}
+	reader := &diffFileNodeReader{nodes: []*graph.Node{{
+		ID: "repo/source.go::Changed", Name: "Changed", Kind: graph.KindFunction,
+		FilePath: "repo/source.go", StartLine: 3, EndLine: 5,
+	}}}
+	mapped := joinHunksToSymbols(reader, "repo", hunks, files)
+	require.Equal(t, 1, reader.reads)
+	require.Len(t, mapped.ChangedSymbols, 1)
+	require.Equal(t, "Changed", mapped.ChangedSymbols[0].Name)
+	fileOnly := joinHunksToSymbols(nil, "repo", hunks, files)
+	require.Empty(t, fileOnly.ChangedSymbols)
+	require.Equal(t, mapped.Hunks, fileOnly.Hunks)
+	require.Equal(t, mapped.ChangedFiles, fileOnly.ChangedFiles)
+	require.Equal(t, mapped.FileChanges, fileOnly.FileChanges)
+}
+
+func TestJoinVanishedFileOnlyModeDoesNotChangeGraphMapping(t *testing.T) {
+	files := []FileChange{
+		{Path: "deleted.go", Kind: FileDeleted},
+		{Path: "renamed.go", PreviousPath: "original.go", Kind: FileRenamed},
+	}
+	reader := &diffFileNodeReader{nodes: []*graph.Node{{
+		ID: "repo/deleted.go::Deleted", Name: "Deleted", Kind: graph.KindFunction,
+		FilePath: "repo/deleted.go", StartLine: 3, EndLine: 5,
+	}}}
+	mapped := joinHunksToSymbols(reader, "repo", nil, files)
+	require.Equal(t, 2, reader.reads)
+	require.Len(t, mapped.ChangedSymbols, 1)
+	require.Equal(t, "Deleted", mapped.ChangedSymbols[0].Name)
+	fileOnly := joinHunksToSymbols(nil, "repo", nil, files)
+	require.Empty(t, fileOnly.ChangedSymbols)
+	require.Equal(t, []string{"deleted.go", "original.go", "renamed.go"}, fileOnly.ChangedFiles)
+	require.Equal(t, mapped.ChangedFiles, fileOnly.ChangedFiles)
+	require.Equal(t, mapped.FileChanges, fileOnly.FileChanges)
+}
+
+func TestMapGitDiffWithoutGraphPreservesGitErrors(t *testing.T) {
+	_, err := MapGitDiff(nil, t.TempDir(), "repo", "staged", "HEAD")
+	require.Error(t, err)
+}
+
+func BenchmarkMapGitDiffWithoutGraph(b *testing.B) {
+	root := fileOnlyDiffFixture(b)
+	fileOnlyDiffChanges(b, root)
+	for _, mode := range []string{"legacy_empty_graph", "file_only"} {
+		b.Run(mode, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var reader graph.Reader
+				if mode == "legacy_empty_graph" {
+					// Test-only baseline for the former production placeholder.
+					reader = graph.New()
+				}
+				result, err := MapGitDiff(reader, root, "repo", "staged", "HEAD")
+				if err != nil || len(result.ChangedFiles) != 6 || len(result.ChangedSymbols) != 0 {
+					b.Fatalf("file-only diff failed: %+v, %v", result, err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkJoinHunksFileOnlyMode(b *testing.B) {
+	hunks := []DiffHunk{{FilePath: "source.go", StartLine: 3, EndLine: 5}}
+	files := []FileChange{
+		{Path: "source.go", Kind: FileModified},
+		{Path: "deleted.go", Kind: FileDeleted},
+		{Path: "new.go", PreviousPath: "old.go", Kind: FileRenamed},
+	}
+	for _, mode := range []string{"legacy_empty_graph", "file_only"} {
+		b.Run(mode, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var reader graph.Reader
+				if mode == "legacy_empty_graph" {
+					reader = graph.New()
+				}
+				result := joinHunksToSymbols(reader, "repo", hunks, files)
+				if len(result.ChangedFiles) != 4 || len(result.ChangedSymbols) != 0 {
+					b.Fatalf("file-only join failed: %+v", result)
+				}
+			}
+		})
+	}
+}

--- a/internal/gitstate/family_dirs.go
+++ b/internal/gitstate/family_dirs.go
@@ -1,0 +1,29 @@
+package gitstate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// ResolveFamilyDirs resolves dir's own Git directory and shared common
+// directory without enumerating worktrees. Both returned paths are absolute.
+// It uses the same read-only resolver and old-Git compatibility path as
+// Inventory. A failure returns empty paths and wraps ErrInventoryUnavailable.
+func ResolveFamilyDirs(ctx context.Context, dir string) (gitDir, commonDir string, err error) {
+	abs, err := absDir(dir)
+	if err != nil {
+		return "", "", fmt.Errorf("gitstate: resolve %q: %w: %w", dir, ErrInventoryUnavailable, err)
+	}
+	if err := ctx.Err(); err != nil {
+		return "", "", fmt.Errorf("gitstate: resolve git directories for %s: %w: %w", abs, ErrInventoryUnavailable, err)
+	}
+	gitDir, commonDir, err = resolveFamilyDirs(ctx, abs)
+	if err != nil {
+		if ctx.Err() != nil {
+			err = errors.Join(ctx.Err(), err)
+		}
+		return "", "", fmt.Errorf("gitstate: resolve git directories for %s: %w: %w", abs, ErrInventoryUnavailable, err)
+	}
+	return gitDir, commonDir, nil
+}

--- a/internal/gitstate/family_dirs_test.go
+++ b/internal/gitstate/family_dirs_test.go
@@ -1,0 +1,124 @@
+package gitstate
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func familyDirsGit(t testing.TB, root string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", root, "-c", "commit.gpgsign=false", "-c", "core.hooksPath="}, args...)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, out)
+	}
+}
+
+func familyDirsFixture(t testing.TB) (primary, linked string) {
+	t.Helper()
+	parent := t.TempDir()
+	primary, linked = filepath.Join(parent, "primary root"), filepath.Join(parent, "linked root")
+	familyDirsGit(t, parent, "init", primary)
+	familyDirsGit(t, primary, "config", "user.name", "Gortex Test")
+	familyDirsGit(t, primary, "config", "user.email", "test@gortex.invalid")
+	familyDirsGit(t, primary, "commit", "--allow-empty", "-m", "baseline")
+	familyDirsGit(t, primary, "worktree", "add", "--detach", linked, "HEAD")
+	return primary, linked
+}
+
+func familyDirsSameDirectory(t testing.TB, actual, expected string) {
+	t.Helper()
+	if !filepath.IsAbs(actual) {
+		t.Fatalf("Git directory is not absolute: %q", actual)
+	}
+	a, err := os.Stat(actual)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.Stat(expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !a.IsDir() || !b.IsDir() || !os.SameFile(a, b) {
+		t.Fatalf("Git directory %q does not identify %q", actual, expected)
+	}
+}
+
+func TestResolveFamilyDirsMatchesMainLinkedAndSubdirectory(t *testing.T) {
+	primary, linked := familyDirsFixture(t)
+	// CI may keep the repository on D: and temporary directories on C:.
+	// Stay on the fixture's volume so relative-path coverage runs on Windows.
+	t.Chdir(filepath.Dir(primary))
+	for _, root := range []string{primary, linked} {
+		inv, err := Inventory(t.Context(), root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		subdir := filepath.Join(root, "nested", "source")
+		if err := os.MkdirAll(subdir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		relative, err := filepath.Rel(cwd, subdir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, path := range []string{root, subdir, relative} {
+			gitDir, commonDir, err := ResolveFamilyDirs(t.Context(), path)
+			if err != nil {
+				t.Fatalf("resolve %q: %v", path, err)
+			}
+			familyDirsSameDirectory(t, gitDir, inv.GitDir)
+			familyDirsSameDirectory(t, commonDir, filepath.Join(primary, ".git"))
+		}
+	}
+}
+
+func TestResolveFamilyDirsUnavailableHasNoBinding(t *testing.T) {
+	root := t.TempDir()
+	for _, path := range []string{"", root, filepath.Join(root, "missing")} {
+		gitDir, commonDir, err := ResolveFamilyDirs(t.Context(), path)
+		if !errors.Is(err, ErrInventoryUnavailable) || gitDir != "" || commonDir != "" {
+			t.Fatalf("unavailable path %q returned %q, %q, %v", path, gitDir, commonDir, err)
+		}
+	}
+}
+
+func TestResolveFamilyDirsPreservesContextFailure(t *testing.T) {
+	root := t.TempDir()
+	canceled, cancel := context.WithCancel(t.Context())
+	cancel()
+	expired, stop := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+	defer stop()
+	for _, ctx := range []context.Context{canceled, expired} {
+		gitDir, commonDir, err := ResolveFamilyDirs(ctx, root)
+		if !errors.Is(err, ctx.Err()) || !errors.Is(err, ErrInventoryUnavailable) || gitDir != "" || commonDir != "" {
+			t.Fatalf("context failure returned %q, %q, %v", gitDir, commonDir, err)
+		}
+	}
+}
+
+func BenchmarkResolveFamilyDirs(b *testing.B) {
+	_, linked := familyDirsFixture(b)
+	for _, mode := range []string{"inventory", "directories_only"} {
+		b.Run(mode, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if mode == "inventory" {
+					if _, err := Inventory(b.Context(), linked); err != nil {
+						b.Fatal(err)
+					}
+				} else if _, _, err := ResolveFamilyDirs(b.Context(), linked); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/internal/indexer/checkout_coordinator.go
+++ b/internal/indexer/checkout_coordinator.go
@@ -258,6 +258,13 @@ type CheckoutCoordinator struct {
 	sourceMutationsClosing bool
 	sourceMutations        int
 	sourceMutationsDrained chan struct{}
+	// Refresh tickets observe this coordinator's existing loop; they never
+	// create a competing builder or retain request contexts.
+	refreshMu        sync.Mutex
+	refreshWaiters   map[uint64]*checkoutRefreshRequest
+	refreshHighWater uint64
+	refreshReserved  int
+	refreshClosed    bool
 	// retained is the commit-layer reuse cache, most recently routed first.
 	retained []retainedCommitLayer
 	// backlog holds generations a retire refused. The janitor retries them.
@@ -459,6 +466,7 @@ func (c *CheckoutCoordinator) Running() bool {
 // still has to answer for stop and for signals.
 func (c *CheckoutCoordinator) run() {
 	defer close(c.done)
+	defer c.closeCheckoutRefreshTickets()
 	defer c.releaseTextSearcher()
 	lifetime := c.lifetimeContext()
 
@@ -553,6 +561,8 @@ func (c *CheckoutCoordinator) cycle(ctx context.Context) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	through := c.checkoutRefreshHighWater()
+	defer c.guardCheckoutRefreshCycle(ctx, through)
 	c.mu.Lock()
 	reason := c.reason
 	c.mu.Unlock()
@@ -563,13 +573,15 @@ func (c *CheckoutCoordinator) cycle(ctx context.Context) {
 	}
 	if out, settled := preflight(ctx); settled {
 		recordCoordinatorCycle(out)
-		if c.cycleDone != nil {
-			c.cycleDone(out)
-		}
+		c.reportCheckoutCycle(ctx, through, out)
 		return
 	}
 
-	release, err := c.gate.Acquire(ctx, ViewBuildBackground)
+	priority := ViewBuildBackground
+	if through != 0 {
+		priority = ViewBuildInteractive
+	}
+	release, err := c.gate.Acquire(ctx, priority)
 	if err != nil {
 		if errors.Is(err, ErrViewBuildQueueFull) {
 			c.logger.Debug("checkout coordinator: build deferred by admission capacity",
@@ -577,16 +589,12 @@ func (c *CheckoutCoordinator) cycle(ctx context.Context) {
 				zap.String("reason", reason),
 				zap.Error(err))
 			viewmetrics.Count(viewmetrics.CoordinatorCycleTotal, viewmetrics.OutcomeDeferred)
-			if c.cycleDone != nil {
-				c.cycleDone(CheckoutCycle{Deferred: true})
-			}
+			c.reportCheckoutCycle(ctx, through, CheckoutCycle{Deferred: true})
 			return
 		}
 		out := CheckoutCycle{Err: fmt.Errorf("indexer: wait for checkout build admission: %w", err)}
 		recordCoordinatorCycle(out)
-		if c.cycleDone != nil {
-			c.cycleDone(out)
-		}
+		c.reportCheckoutCycle(ctx, through, out)
 		return
 	}
 	defer release()
@@ -599,9 +607,7 @@ func (c *CheckoutCoordinator) cycle(ctx context.Context) {
 	if err := ctx.Err(); err != nil {
 		out := CheckoutCycle{Err: err}
 		recordCoordinatorCycle(out)
-		if c.cycleDone != nil {
-			c.cycleDone(out)
-		}
+		c.reportCheckoutCycle(ctx, through, out)
 		return
 	}
 	out := c.reconcile(ctx)
@@ -618,9 +624,7 @@ func (c *CheckoutCoordinator) cycle(ctx context.Context) {
 			zap.Int64("dirty_generation", out.DirtyGenerationID),
 			zap.Bool("commit_reused", out.CommitReused))
 	}
-	if c.cycleDone != nil {
-		c.cycleDone(out)
-	}
+	c.reportCheckoutCycle(ctx, through, out)
 }
 
 // settledWithoutBuild recognizes the overwhelmingly common poll result before

--- a/internal/indexer/checkout_lifecycle.go
+++ b/internal/indexer/checkout_lifecycle.go
@@ -152,6 +152,15 @@ type CheckoutLifecycle struct {
 	// crash residue unless a process-local payload flight has adopted it.
 	buildingRecoveryCutoff int64
 
+	// observationMu bounds and coalesces first-request metadata work. Jobs
+	// belong to this lifecycle, not whichever request first waits for them.
+	observationMu     sync.Mutex
+	observationJobs   map[string]*checkoutObservationJob
+	observationWG     sync.WaitGroup
+	observationClosed bool
+	// observationInventory is a test-only latency seam; set before any jobs.
+	observationInventory func(context.Context, string) (*gitstate.FamilyInventory, error)
+
 	// retryMu owns one deadline timer per family. Filesystem events start the
 	// grace; these timers guarantee its expiry is reconciled even when Git is
 	// otherwise quiet. retryClosing rejects new timer and callback admission
@@ -276,18 +285,18 @@ func NewCheckoutLifecycle(cfg CheckoutLifecycleConfig) (*CheckoutLifecycle, erro
 		now:                    now,
 		buildingRecoveryCutoff: now().Unix(),
 		leases:                 cfg.ViewLeases,
-		coordinators:          map[string]*CheckoutCoordinator{},
-		coordinatorHeads:      map[string]checkoutHeadIdentity{},
-		coordinatorActivating: map[string]struct{}{},
-		initialInventoryTaken: map[string]bool{},
-		started:               map[string][]*CheckoutCoordinator{},
-		owed:                  map[int64]struct{}{},
-		familyRetries:     map[string]familyRetry{},
-		refViewRetention:  cfg.RefViews.withDefaults(),
-		indexBarrier:      cfg.indexBarrier,
-		transitionCtx:     transitionCtx,
-		cancelTransitions: cancelTransitions,
-		transitionRuns:    map[string]*modeTransitionRun{},
+		coordinators:           map[string]*CheckoutCoordinator{},
+		coordinatorHeads:       map[string]checkoutHeadIdentity{},
+		coordinatorActivating:  map[string]struct{}{},
+		initialInventoryTaken:  map[string]bool{},
+		started:                map[string][]*CheckoutCoordinator{},
+		owed:                   map[int64]struct{}{},
+		familyRetries:          map[string]familyRetry{},
+		refViewRetention:       cfg.RefViews.withDefaults(),
+		indexBarrier:           cfg.indexBarrier,
+		transitionCtx:          transitionCtx,
+		cancelTransitions:      cancelTransitions,
+		transitionRuns:         map[string]*modeTransitionRun{},
 	}
 	// The env override wins over the config-file setting either way, so a
 	// worktree-heavy tree can opt every discovered worktree into dormancy — or
@@ -2093,6 +2102,7 @@ func (l *CheckoutLifecycle) Close() error {
 	if l == nil {
 		return nil
 	}
+	l.closeCheckoutObservations()
 	l.transitionMu.Lock()
 	if !l.transitionClosed {
 		l.transitionClosed = true

--- a/internal/indexer/checkout_mutation.go
+++ b/internal/indexer/checkout_mutation.go
@@ -21,19 +21,31 @@ var ErrCheckoutMutationStale = errors.New("indexer: checkout mutation view is st
 // routed generation. It does not mean the disk mutation was rolled back.
 var ErrCheckoutMutationPending = errors.New("indexer: checkout mutation refresh is pending")
 
+// ErrCheckoutMutationBusy refuses admission before source is written. Retry
+// once the active checkout build releases its lane; no primary fallback writes.
+var ErrCheckoutMutationBusy = errors.New("indexer: checkout mutation lane is busy; retry")
+
+const checkoutMutationAdmissionTimeout = 250 * time.Millisecond
+
 // CheckoutMutation owns one checkout's physical build lane and route lock for
 // a source edit. Callers must Close it on every exit, including dry runs. It
 // never writes source itself and must not be used to update the primary corpus.
 type CheckoutMutation struct {
-	mu          sync.Mutex
-	coordinator *CheckoutCoordinator
-	checkout    store_sqlite.Checkout
-	rootInfo    os.FileInfo
-	route       store_sqlite.CheckoutRoute
-	release     func()
-	prepared    bool
-	fresh       bool
-	closed      bool
+	mu              sync.Mutex
+	coordinator     *CheckoutCoordinator
+	checkout        store_sqlite.Checkout
+	rootInfo        os.FileInfo
+	route           store_sqlite.CheckoutRoute
+	release         func()
+	prepared        bool
+	fresh           bool
+	closed          bool
+	refreshQueued   bool
+	refreshReserved bool
+	snapshotPinned  bool
+	headRef         string
+	headCommit      string
+	headTree        string
 }
 
 // BeginCheckoutMutation admits a source edit against the exact checkout route
@@ -77,9 +89,11 @@ func (l *CheckoutLifecycle) BeginCheckoutMutation(ctx context.Context, checkoutI
 
 	waitCtx, cancel := checkoutMutationContext(ctx, c.lifetimeContext())
 	defer cancel()
-	releaseGate, err := c.gate.Acquire(waitCtx, ViewBuildInteractive)
+	admissionCtx, cancelAdmission := context.WithTimeout(waitCtx, checkoutMutationAdmissionTimeout)
+	defer cancelAdmission()
+	releaseGate, err := c.gate.Acquire(admissionCtx, ViewBuildInteractive)
 	if err != nil {
-		return nil, err
+		return nil, checkoutMutationAdmissionError(waitCtx, err)
 	}
 	gateOwned := true
 	defer func() {
@@ -87,8 +101,8 @@ func (l *CheckoutLifecycle) BeginCheckoutMutation(ctx context.Context, checkoutI
 			releaseGate()
 		}
 	}()
-	if err := lockCheckoutMutationCycle(waitCtx, c); err != nil {
-		return nil, err
+	if err := lockCheckoutMutationCycle(admissionCtx, c); err != nil {
+		return nil, checkoutMutationAdmissionError(waitCtx, err)
 	}
 	cycleOwned := true
 	defer func() {
@@ -116,12 +130,12 @@ func (l *CheckoutLifecycle) BeginCheckoutMutation(ctx context.Context, checkoutI
 }
 
 // Prepare withdraws the old dirty generation immediately before the disk
-// commit. It is idempotent until Refresh; validation/preview failures and dry
+// commit. It is idempotent until Refresh or EnqueueRefresh; failures and dry
 // runs must not call it. Already-pinned readers retain their immutable view.
 func (m *CheckoutMutation) Prepare(ctx context.Context) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if m.closed || m.fresh {
+	if m.closed || m.fresh || m.refreshQueued {
 		return fmt.Errorf("%w: mutation lease is no longer writable", ErrCheckoutMutationStale)
 	}
 	if m.prepared {
@@ -135,11 +149,24 @@ func (m *CheckoutMutation) Prepare(ctx context.Context) error {
 	if err := m.validateSnapshot(ctx); err != nil {
 		return err
 	}
+	if err := m.coordinator.reserveCheckoutRefresh(); err != nil {
+		return err
+	}
+	m.refreshReserved = true
 	if err := m.coordinator.clearDirtySlot(ctx, &m.route); err != nil {
+		m.coordinator.releaseCheckoutRefreshReservation()
+		m.refreshReserved = false
 		return fmt.Errorf("%w: withdraw dirty route: %w", ErrCheckoutMutationStale, err)
 	}
 	m.prepared = true
 	return nil
+}
+
+func checkoutMutationAdmissionError(ctx context.Context, err error) error {
+	if ctx.Err() == nil && errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("%w: %w", ErrCheckoutMutationBusy, err)
+	}
+	return err
 }
 
 // Refresh publishes the edited checkout through its sparse coordinator, never
@@ -148,7 +175,7 @@ func (m *CheckoutMutation) Prepare(ctx context.Context) error {
 func (m *CheckoutMutation) Refresh(ctx context.Context) (CheckoutCycle, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if m.closed || !m.prepared {
+	if m.closed || !m.prepared || m.refreshQueued {
 		return CheckoutCycle{}, fmt.Errorf("%w: no prepared checkout mutation", ErrCheckoutMutationStale)
 	}
 	ctx, cancel := checkoutMutationContext(ctx, m.coordinator.lifetimeContext())
@@ -187,6 +214,10 @@ func (m *CheckoutMutation) Close() {
 		return
 	}
 	m.closed = true
+	if m.refreshReserved {
+		m.coordinator.releaseCheckoutRefreshReservation()
+		m.refreshReserved = false
+	}
 	if m.prepared && !m.fresh {
 		m.coordinator.Signal("source mutation needs a dirty generation refresh")
 	}
@@ -256,6 +287,11 @@ func (m *CheckoutMutation) validateSnapshot(ctx context.Context) error {
 	if !found || !servableGeneration(dirty.State) || dirty.BaseGenerationID != m.route.CommitGenerationID || dirty.LowerViewFingerprint != sample.Fingerprint {
 		return fmt.Errorf("%w: checkout disk changed; wait for a fresh view and retry", ErrCheckoutMutationStale)
 	}
+	if m.snapshotPinned && (m.headRef != sample.HeadRef || m.headCommit != sample.HeadCommit || m.headTree != sample.HeadTree) {
+		return fmt.Errorf("%w: checkout HEAD changed since source admission", ErrCheckoutMutationStale)
+	}
+	m.snapshotPinned = true
+	m.headRef, m.headCommit, m.headTree = sample.HeadRef, sample.HeadCommit, sample.HeadTree
 	return nil
 }
 

--- a/internal/indexer/checkout_mutation.go
+++ b/internal/indexer/checkout_mutation.go
@@ -66,7 +66,7 @@ func (l *CheckoutLifecycle) BeginCheckoutMutation(ctx context.Context, checkoutI
 	if !found || !sameMutationRoot(checkout.RootPath, expectedRoot) {
 		return nil, fmt.Errorf("%w: checkout root changed", ErrCheckoutMutationStale)
 	}
-	rootInfo, err := os.Stat(checkout.RootPath)
+	rootInfo, err := checkoutRootFileInfo(checkout.RootPath)
 	if err != nil || !rootInfo.IsDir() {
 		return nil, fmt.Errorf("%w: checkout root is unavailable", ErrCheckoutMutationStale)
 	}
@@ -237,7 +237,7 @@ func (m *CheckoutMutation) validateCheckout(ctx context.Context) error {
 	if !found || checkout.Incarnation != m.checkout.Incarnation || checkout.State != store_sqlite.CheckoutStateReady || checkout.EffectiveMode != store_sqlite.CheckoutModeAutomatic || checkout.DesiredMode != store_sqlite.CheckoutModeAutomatic || checkout.ActiveIntentTransitionID != "" || checkout.UnavailableSince != 0 || checkout.RemovalDetectedAt != 0 || !sameMutationRoot(checkout.RootPath, m.checkout.RootPath) {
 		return fmt.Errorf("%w: checkout identity or availability changed", ErrCheckoutMutationStale)
 	}
-	info, err := os.Stat(checkout.RootPath)
+	info, err := checkoutRootFileInfo(checkout.RootPath)
 	if err != nil || !info.IsDir() {
 		return fmt.Errorf("%w: checkout root is unavailable", ErrCheckoutMutationStale)
 	}

--- a/internal/indexer/checkout_observe.go
+++ b/internal/indexer/checkout_observe.go
@@ -1,11 +1,14 @@
 package indexer
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/zzet/gortex/internal/gitstate"
@@ -13,13 +16,50 @@ import (
 	"github.com/zzet/gortex/internal/pathkey"
 )
 
-const checkoutObservationTimeout = 250 * time.Millisecond
+const (
+	checkoutObservationTimeout     = 250 * time.Millisecond
+	checkoutObservationWorkTimeout = 5 * time.Second
+	checkoutObservationCapacity    = 32
+)
+
+type checkoutObservationProof struct {
+	inventory    *gitstate.FamilyInventory
+	familyID     string
+	selected     gitstate.WorktreeRecord
+	primary      store_sqlite.DedicatedGraph
+	rootInfo     os.FileInfo
+	gitInfo      os.FileInfo
+	commonInfo   os.FileInfo
+	gitMarker    checkoutObservationMarker
+	commonMarker checkoutObservationMarker
+}
+
+type checkoutObservationMarker struct {
+	info   os.FileInfo
+	bytes  []byte
+	absent bool
+}
+
+type checkoutObservationJob struct {
+	ctx           context.Context
+	cancel        context.CancelFunc
+	proofReady    chan struct{}
+	authorized    chan struct{}
+	authorizeOnce sync.Once
+	done          chan struct{}
+	proof         *checkoutObservationProof
+	proofErr      error
+	checkout      store_sqlite.Checkout
+	found         bool
+	err           error
+}
 
 // ObserveCheckoutPath gives a first request in a newly added worktree its
 // automatic identity. Only an already known Git family can be observed: this
 // is not explicit tracking, and never creates a dedicated graph or config
-// entry. Metadata work has a short context budget; any resulting graph build
-// belongs to the lifecycle's existing asynchronous activation path.
+// entry. Requests wait at most 250ms, but coalesced metadata work continues for
+// up to five seconds across retries. Slow Git startup therefore cannot restart
+// the same unfinished work indefinitely. Graph builds use existing activation.
 //
 // found=false, err=nil means the path has no known family to serve it from.
 // A busy/error outcome carries no permission to fall through to another graph.
@@ -31,6 +71,9 @@ func (l *CheckoutLifecycle) ObserveCheckoutPath(ctx context.Context, path string
 	}
 	if ctx == nil {
 		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return checkout, false, err
 	}
 	ctx, cancel := context.WithTimeout(ctx, checkoutObservationTimeout)
 	defer cancel()
@@ -45,26 +88,146 @@ func (l *CheckoutLifecycle) ObserveCheckoutPath(ctx context.Context, path string
 			err = fmt.Errorf("%w: selected checkout discovery is pending: %w", ErrCheckoutMutationBusy, err)
 		}
 	}()
-	l.coordMu.Lock()
-	closing := l.coordinatorClosing
-	l.coordMu.Unlock()
-	if closing {
-		return checkout, false, ErrCheckoutRefreshStopped
+	job, err := l.checkoutObservation(pathkey.CanonicalExistingRoot(path))
+	if err != nil {
+		return checkout, false, err
 	}
-	inv, err := gitstate.Inventory(ctx, path)
+	select {
+	case <-ctx.Done():
+		return checkout, false, ctx.Err()
+	case <-job.proofReady:
+	}
+	if job.proofErr != nil || job.proof == nil {
+		return checkout, false, job.proofErr
+	}
+	// Authorizers belong to callers and never run in detached workers. Even a
+	// completed shared job cannot expose its result to an unauthorized caller.
+	for _, allow := range authorize {
+		if allow != nil {
+			if err := allow(job.proof.primary.RepoPrefix); err != nil {
+				return checkout, false, err
+			}
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return checkout, false, err
+	}
+	job.authorizeOnce.Do(func() { close(job.authorized) })
+	select {
+	case <-ctx.Done():
+		return checkout, false, ctx.Err()
+	case <-job.done:
+	}
+	if job.err != nil || !job.found {
+		return checkout, false, job.err
+	}
+	// Cached completion is not permanent authority: deletion, replacement and
+	// primary changes invalidate the proof before any identity is returned.
+	if err := l.validateCheckoutObservation(ctx, job.proof); err != nil {
+		job.cancel()
+		return checkout, false, err
+	}
+	checkout, found, err = l.catalog.GetCheckout(ctx, job.checkout.CheckoutID)
+	if err != nil || !found {
+		return store_sqlite.Checkout{}, false, err
+	}
+	if checkout.Incarnation != job.checkout.Incarnation || !sameMutationRoot(checkout.RootPath, job.proof.selected.Path) {
+		return store_sqlite.Checkout{}, false, ErrCheckoutMutationStale
+	}
+	return checkout, true, nil
+}
+
+func (l *CheckoutLifecycle) checkoutObservation(path string) (*checkoutObservationJob, error) {
+	l.observationMu.Lock()
+	defer l.observationMu.Unlock()
+	if l.observationClosed {
+		return nil, ErrCheckoutRefreshStopped
+	}
+	if job := l.observationJobs[path]; job != nil {
+		if job.ctx.Err() == nil {
+			return job, nil
+		}
+		return nil, fmt.Errorf("%w: expired checkout discovery is draining", ErrCheckoutMutationBusy)
+	}
+	if len(l.observationJobs) >= checkoutObservationCapacity {
+		return nil, fmt.Errorf("%w: checkout discovery capacity reached", ErrCheckoutMutationBusy)
+	}
+	if l.observationJobs == nil {
+		l.observationJobs = make(map[string]*checkoutObservationJob)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), checkoutObservationWorkTimeout)
+	job := &checkoutObservationJob{ctx: ctx, cancel: cancel, proofReady: make(chan struct{}), authorized: make(chan struct{}), done: make(chan struct{})}
+	l.observationJobs[path] = job
+	l.observationWG.Add(1)
+	go l.runCheckoutObservation(path, job)
+	return job, nil
+}
+
+func (l *CheckoutLifecycle) runCheckoutObservation(path string, job *checkoutObservationJob) {
+	defer l.observationWG.Done()
+	defer job.cancel()
+	defer l.forgetCheckoutObservation(path, job)
+	job.proof, job.proofErr = l.prepareCheckoutObservation(job.ctx, path)
+	close(job.proofReady)
+	if job.proofErr != nil || job.proof == nil {
+		job.err = job.proofErr
+		close(job.done)
+		return // No negative cache or automatic adoption of unknown families.
+	}
+	select {
+	case <-job.ctx.Done():
+		job.err = job.ctx.Err()
+	case <-job.authorized:
+		job.checkout, job.found, job.err = l.applyCheckoutObservation(job.ctx, job.proof)
+	}
+	if job.err != nil && job.ctx.Err() != nil {
+		job.err = errors.Join(job.ctx.Err(), job.err)
+	}
+	close(job.done)
+	if job.err == nil && job.found {
+		// A caller that timed out just before publication can retrieve this
+		// result. One bounded worker owns expiry; no unbounded timer registry.
+		<-job.ctx.Done()
+	}
+}
+
+func (l *CheckoutLifecycle) forgetCheckoutObservation(path string, job *checkoutObservationJob) {
+	l.observationMu.Lock()
+	if l.observationJobs[path] == job {
+		delete(l.observationJobs, path)
+	}
+	l.observationMu.Unlock()
+}
+
+func (l *CheckoutLifecycle) closeCheckoutObservations() {
+	l.observationMu.Lock()
+	l.observationClosed = true
+	for _, job := range l.observationJobs {
+		job.cancel()
+	}
+	l.observationMu.Unlock()
+	l.observationWG.Wait()
+}
+
+func (l *CheckoutLifecycle) prepareCheckoutObservation(ctx context.Context, path string) (*checkoutObservationProof, error) {
+	inventory := gitstate.Inventory
+	if l.observationInventory != nil {
+		inventory = l.observationInventory
+	}
+	inv, err := inventory(ctx, path)
 	if err != nil {
 		if ctx.Err() != nil {
-			return checkout, false, ctx.Err()
+			return nil, errors.Join(ctx.Err(), err)
 		}
-		return checkout, false, nil // Not a Git checkout; ordinary scope resolution may continue.
+		return nil, nil // Not a Git checkout; ordinary scope resolution may continue.
 	}
 	familyID := FamilyIDFor(inv.CommonDir)
 	family, known, err := l.catalog.GetRepositoryFamily(ctx, familyID)
 	if err != nil || !known {
-		return checkout, false, err
+		return nil, err
 	}
 	if !sameMutationRoot(family.CommonDirIdentity, inv.CommonDir) {
-		return checkout, false, ErrCheckoutMutationStale
+		return nil, ErrCheckoutMutationStale
 	}
 	var selected *gitstate.WorktreeRecord
 	for i := range inv.Records {
@@ -79,39 +242,132 @@ func (l *CheckoutLifecycle) ObserveCheckoutPath(ctx context.Context, path string
 		}
 	}
 	if selected == nil {
-		return checkout, false, fmt.Errorf("%w: Git did not identify the selected working copy", ErrCheckoutMutationStale)
+		return nil, fmt.Errorf("%w: Git did not identify the selected working copy", ErrCheckoutMutationStale)
 	}
 	primary, err := l.observationPrimary(ctx, familyID)
 	if err != nil {
-		return checkout, false, err
+		return nil, err
 	}
-	for _, allow := range authorize {
-		if allow != nil {
-			if err := allow(primary.RepoPrefix); err != nil {
-				return checkout, false, err
-			}
+	proof := &checkoutObservationProof{inventory: inv, familyID: familyID, selected: *selected, primary: primary}
+	proof.rootInfo, err = checkoutRootFileInfo(selected.Path)
+	if err != nil {
+		return nil, err
+	}
+	proof.gitInfo, err = checkoutRootFileInfo(inv.GitDir)
+	if err != nil {
+		return nil, err
+	}
+	proof.commonInfo, err = checkoutRootFileInfo(inv.CommonDir)
+	if err != nil {
+		return nil, err
+	}
+	proof.gitMarker, err = readCheckoutObservationMarker(filepath.Join(selected.Path, ".git"))
+	if err != nil || proof.gitMarker.absent {
+		return nil, ErrCheckoutMutationStale
+	}
+	proof.commonMarker, err = readCheckoutObservationMarker(filepath.Join(inv.GitDir, "commondir"))
+	if err != nil {
+		return nil, err
+	}
+	// Inventory precedes these snapshots. Confirm they still describe the
+	// inventory's Git family before accepting them as a cached proof; otherwise
+	// a replaced .git marker could pair new physical identity with old scope.
+	// This resolves directories only, without another worktree-list inventory.
+	gitDir, commonDir, err := gitstate.ResolveFamilyDirs(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	if !sameMutationRoot(gitDir, inv.GitDir) || !sameMutationRoot(commonDir, inv.CommonDir) {
+		return nil, ErrCheckoutMutationStale
+	}
+	if err := l.validateCheckoutObservation(ctx, proof); err != nil {
+		return nil, err
+	}
+	return proof, nil
+}
+
+func readCheckoutObservationMarker(path string) (checkoutObservationMarker, error) {
+	file, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return checkoutObservationMarker{absent: true}, nil
+	}
+	if err != nil {
+		return checkoutObservationMarker{}, err
+	}
+	defer file.Close()
+	info, err := file.Stat() // Eager physical identity on Windows as well.
+	if err != nil {
+		return checkoutObservationMarker{}, err
+	}
+	marker := checkoutObservationMarker{info: info}
+	if !info.IsDir() {
+		const maxMarkerBytes = 64 * 1024
+		marker.bytes, err = io.ReadAll(io.LimitReader(file, maxMarkerBytes+1))
+		if len(marker.bytes) > maxMarkerBytes {
+			return checkoutObservationMarker{}, ErrCheckoutMutationStale
 		}
 	}
-	entry, err := l.rec.ObserveCheckout(ctx, familyID, selected.Path, inv)
+	return marker, err
+}
+
+func checkoutObservationMarkerMatches(path string, expected checkoutObservationMarker) bool {
+	actual, err := readCheckoutObservationMarker(path)
+	if err != nil || actual.absent != expected.absent {
+		return false
+	}
+	return actual.absent || (os.SameFile(actual.info, expected.info) && bytes.Equal(actual.bytes, expected.bytes))
+}
+
+func (l *CheckoutLifecycle) validateCheckoutObservation(ctx context.Context, proof *checkoutObservationProof) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	root, err := checkoutRootFileInfo(proof.selected.Path)
+	if err != nil || !os.SameFile(root, proof.rootInfo) {
+		return ErrCheckoutMutationStale
+	}
+	gitDir, err := checkoutRootFileInfo(proof.inventory.GitDir)
+	if err != nil || !os.SameFile(gitDir, proof.gitInfo) {
+		return ErrCheckoutMutationStale
+	}
+	commonDir, err := checkoutRootFileInfo(proof.inventory.CommonDir)
+	if err != nil || !os.SameFile(commonDir, proof.commonInfo) {
+		return ErrCheckoutMutationStale
+	}
+	if !checkoutObservationMarkerMatches(filepath.Join(proof.selected.Path, ".git"), proof.gitMarker) ||
+		!checkoutObservationMarkerMatches(filepath.Join(proof.inventory.GitDir, "commondir"), proof.commonMarker) {
+		return ErrCheckoutMutationStale
+	}
+	primary, err := l.observationPrimary(ctx, proof.familyID)
 	if err != nil {
-		return checkout, false, err
+		return err
 	}
-	if !entry.Durable || entry.CheckoutID == "" {
-		return checkout, false, fmt.Errorf("%w: %s", ErrCheckoutNotTracked, entry.Detail)
+	if primary.GraphID != proof.primary.GraphID || primary.RepoPrefix != proof.primary.RepoPrefix {
+		return ErrCheckoutMutationStale
 	}
-	checkout, found, err = l.catalog.GetCheckout(ctx, entry.CheckoutID)
-	if err != nil || !found {
-		return checkout, found, err
+	return nil
+}
+
+func (l *CheckoutLifecycle) applyCheckoutObservation(ctx context.Context, proof *checkoutObservationProof) (store_sqlite.Checkout, bool, error) {
+	if err := l.validateCheckoutObservation(ctx, proof); err != nil {
+		return store_sqlite.Checkout{}, false, err
 	}
-	if checkout.Incarnation != entry.Incarnation || !sameMutationRoot(checkout.RootPath, selected.Path) {
-		return store_sqlite.Checkout{}, false, ErrCheckoutMutationStale
-	}
-	currentPrimary, err := l.observationPrimary(ctx, familyID)
+	entry, err := l.rec.ObserveCheckout(ctx, proof.familyID, proof.selected.Path, proof.inventory)
 	if err != nil {
 		return store_sqlite.Checkout{}, false, err
 	}
-	if currentPrimary.GraphID != primary.GraphID || currentPrimary.RepoPrefix != primary.RepoPrefix {
+	if !entry.Durable || entry.CheckoutID == "" {
+		return store_sqlite.Checkout{}, false, fmt.Errorf("%w: %s", ErrCheckoutNotTracked, entry.Detail)
+	}
+	checkout, found, err := l.catalog.GetCheckout(ctx, entry.CheckoutID)
+	if err != nil || !found {
+		return checkout, found, err
+	}
+	if checkout.Incarnation != entry.Incarnation || !sameMutationRoot(checkout.RootPath, proof.selected.Path) {
 		return store_sqlite.Checkout{}, false, ErrCheckoutMutationStale
+	}
+	if err := l.validateCheckoutObservation(ctx, proof); err != nil {
+		return store_sqlite.Checkout{}, false, err
 	}
 	if checkout.State == store_sqlite.CheckoutStateReady && checkout.EffectiveMode == store_sqlite.CheckoutModeAutomatic {
 		l.ActivateCheckout(checkout.CheckoutID, "first request observed checkout")

--- a/internal/indexer/checkout_observe.go
+++ b/internal/indexer/checkout_observe.go
@@ -1,0 +1,153 @@
+package indexer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/zzet/gortex/internal/gitstate"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/pathkey"
+)
+
+const checkoutObservationTimeout = 250 * time.Millisecond
+
+// ObserveCheckoutPath gives a first request in a newly added worktree its
+// automatic identity. Only an already known Git family can be observed: this
+// is not explicit tracking, and never creates a dedicated graph or config
+// entry. Metadata work has a short context budget; any resulting graph build
+// belongs to the lifecycle's existing asynchronous activation path.
+//
+// found=false, err=nil means the path has no known family to serve it from.
+// A busy/error outcome carries no permission to fall through to another graph.
+// Explicit selectors must provide an authorizer for the known primary prefix;
+// it runs outside locks and before any catalog observation or build activation.
+func (l *CheckoutLifecycle) ObserveCheckoutPath(ctx context.Context, path string, authorize ...func(string) error) (checkout store_sqlite.Checkout, found bool, err error) {
+	if l == nil || l.catalog == nil || l.rec == nil || path == "" || !filepath.IsAbs(path) {
+		return checkout, false, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(ctx, checkoutObservationTimeout)
+	defer cancel()
+	defer func() {
+		if err != nil && ctx.Err() != nil {
+			err = errors.Join(ctx.Err(), err)
+			if errors.Is(ctx.Err(), context.Canceled) {
+				return
+			}
+		}
+		if err != nil && (errors.Is(err, context.DeadlineExceeded) || retryableCheckoutRefreshError(err)) {
+			err = fmt.Errorf("%w: selected checkout discovery is pending: %w", ErrCheckoutMutationBusy, err)
+		}
+	}()
+	l.coordMu.Lock()
+	closing := l.coordinatorClosing
+	l.coordMu.Unlock()
+	if closing {
+		return checkout, false, ErrCheckoutRefreshStopped
+	}
+	inv, err := gitstate.Inventory(ctx, path)
+	if err != nil {
+		if ctx.Err() != nil {
+			return checkout, false, ctx.Err()
+		}
+		return checkout, false, nil // Not a Git checkout; ordinary scope resolution may continue.
+	}
+	familyID := FamilyIDFor(inv.CommonDir)
+	family, known, err := l.catalog.GetRepositoryFamily(ctx, familyID)
+	if err != nil || !known {
+		return checkout, false, err
+	}
+	if !sameMutationRoot(family.CommonDirIdentity, inv.CommonDir) {
+		return checkout, false, ErrCheckoutMutationStale
+	}
+	var selected *gitstate.WorktreeRecord
+	for i := range inv.Records {
+		record := &inv.Records[i]
+		gitDir := inv.CommonDir
+		if !record.IsMain {
+			gitDir = filepath.Join(inv.CommonDir, "worktrees", record.AdminName)
+		}
+		if !record.Bare && record.AdminName != "" && sameMutationRoot(gitDir, inv.GitDir) && checkoutObservationContains(path, record.Path) {
+			selected = record
+			break
+		}
+	}
+	if selected == nil {
+		return checkout, false, fmt.Errorf("%w: Git did not identify the selected working copy", ErrCheckoutMutationStale)
+	}
+	primary, err := l.observationPrimary(ctx, familyID)
+	if err != nil {
+		return checkout, false, err
+	}
+	for _, allow := range authorize {
+		if allow != nil {
+			if err := allow(primary.RepoPrefix); err != nil {
+				return checkout, false, err
+			}
+		}
+	}
+	entry, err := l.rec.ObserveCheckout(ctx, familyID, selected.Path, inv)
+	if err != nil {
+		return checkout, false, err
+	}
+	if !entry.Durable || entry.CheckoutID == "" {
+		return checkout, false, fmt.Errorf("%w: %s", ErrCheckoutNotTracked, entry.Detail)
+	}
+	checkout, found, err = l.catalog.GetCheckout(ctx, entry.CheckoutID)
+	if err != nil || !found {
+		return checkout, found, err
+	}
+	if checkout.Incarnation != entry.Incarnation || !sameMutationRoot(checkout.RootPath, selected.Path) {
+		return store_sqlite.Checkout{}, false, ErrCheckoutMutationStale
+	}
+	currentPrimary, err := l.observationPrimary(ctx, familyID)
+	if err != nil {
+		return store_sqlite.Checkout{}, false, err
+	}
+	if currentPrimary.GraphID != primary.GraphID || currentPrimary.RepoPrefix != primary.RepoPrefix {
+		return store_sqlite.Checkout{}, false, ErrCheckoutMutationStale
+	}
+	if checkout.State == store_sqlite.CheckoutStateReady && checkout.EffectiveMode == store_sqlite.CheckoutModeAutomatic {
+		l.ActivateCheckout(checkout.CheckoutID, "first request observed checkout")
+	}
+	return checkout, true, nil
+}
+
+func (l *CheckoutLifecycle) observationPrimary(ctx context.Context, familyID string) (store_sqlite.DedicatedGraph, error) {
+	graphs, err := l.catalog.ListDedicatedGraphs(ctx, familyID)
+	if err != nil {
+		return store_sqlite.DedicatedGraph{}, err
+	}
+	for _, graph := range graphs {
+		if graph.IsPrimaryBase && graph.GraphID != "" {
+			return graph, nil
+		}
+	}
+	return store_sqlite.DedicatedGraph{}, fmt.Errorf("%w: known family has no primary graph", ErrCheckoutNotTracked)
+}
+
+// Verify both lexical containment and physical root identity. Case folding is
+// an identity policy, not proof that two differently spelled directories on a
+// case-sensitive volume are the same checkout.
+func checkoutObservationContains(path, root string) bool {
+	path, root = pathkey.CanonicalExistingRoot(path), pathkey.CanonicalExistingRoot(root)
+	if !pathkey.HasPathPrefix(path, root) {
+		return false
+	}
+	for !pathkey.EqualPaths(path, root) {
+		parent := filepath.Dir(path)
+		if pathkey.EqualPaths(parent, path) {
+			return false
+		}
+		path = parent
+	}
+	selected, selectedErr := os.Stat(root)
+	matched, matchedErr := os.Stat(path)
+	return selectedErr == nil && matchedErr == nil && selected.IsDir() && os.SameFile(selected, matched)
+}

--- a/internal/indexer/checkout_observe.go
+++ b/internal/indexer/checkout_observe.go
@@ -124,8 +124,7 @@ func (l *CheckoutLifecycle) ObserveCheckoutPath(ctx context.Context, path string
 	// Cached completion is not permanent authority: deletion, replacement and
 	// primary changes invalidate the proof before any identity is returned.
 	if err := l.validateCheckoutObservation(ctx, job.proof); err != nil {
-		job.cancel()
-		return checkout, false, err
+		return checkout, false, job.invalidateStaleProof(err)
 	}
 	checkout, found, err = l.catalog.GetCheckout(ctx, job.checkout.CheckoutID)
 	if err != nil || !found {
@@ -135,6 +134,17 @@ func (l *CheckoutLifecycle) ObserveCheckoutPath(ctx context.Context, path string
 		return store_sqlite.Checkout{}, false, ErrCheckoutMutationStale
 	}
 	return checkout, true, nil
+}
+
+func (job *checkoutObservationJob) invalidateStaleProof(err error) error {
+	// Reader timeouts and catalog failures refuse that request, but do not
+	// prove the shared identity stale. Leave its bounded completion available
+	// for another caller to reauthorize and revalidate; only positive identity
+	// invalidation discards it.
+	if errors.Is(err, ErrCheckoutMutationStale) {
+		job.cancel()
+	}
+	return err
 }
 
 func (l *CheckoutLifecycle) checkoutObservation(path string) (*checkoutObservationJob, error) {

--- a/internal/indexer/checkout_observe_test.go
+++ b/internal/indexer/checkout_observe_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -61,6 +62,29 @@ func newCheckoutObservationFixture(t testing.TB) (*CheckoutLifecycle, *store_sql
 	return lc, store.Catalog(), primary, tracked.FamilyID, configPath, closeFixture
 }
 
+// Slow Git startup may outlive a request's wait budget, but retries must join
+// the same lifecycle-owned work. Only a typed pending outcome is retryable.
+func observeCheckoutUntilSettled(t testing.TB, lc *CheckoutLifecycle, path string, authorize ...func(string) error) (store_sqlite.Checkout, bool, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	for {
+		started := time.Now()
+		checkout, found, err := lc.ObserveCheckoutPath(ctx, path, authorize...)
+		if elapsed := time.Since(started); elapsed > time.Second {
+			t.Fatalf("discovery request exceeded bounded wait: %s", elapsed)
+		}
+		if !errors.Is(err, ErrCheckoutMutationBusy) || ctx.Err() != nil {
+			return checkout, found, err
+		}
+		select {
+		case <-ctx.Done():
+			return store_sqlite.Checkout{}, false, ctx.Err()
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
 func TestObserveCheckoutPathDiscoversNewWorktreeWithoutTracking(t *testing.T) {
 	lc, catalog, primary, familyID, configPath, _ := newCheckoutObservationFixture(t)
 	before, err := os.ReadFile(configPath)
@@ -72,7 +96,7 @@ func TestObserveCheckoutPathDiscoversNewWorktreeWithoutTracking(t *testing.T) {
 	if err := os.Mkdir(filepath.Join(worktree, "nested"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	checkout, found, err := lc.ObserveCheckoutPath(t.Context(), filepath.Join(worktree, "nested"))
+	checkout, found, err := observeCheckoutUntilSettled(t, lc, filepath.Join(worktree, "nested"))
 	if err != nil || !found || checkout.FamilyID != familyID || !pathkey.EqualPaths(checkout.RootPath, pathkey.CanonicalExistingRoot(worktree)) || checkout.EffectiveMode != store_sqlite.CheckoutModeAutomatic || checkout.DesiredMode != store_sqlite.CheckoutModeAutomatic {
 		t.Fatalf("new CWD observation: %+v found=%v error=%v", checkout, found, err)
 	}
@@ -88,7 +112,7 @@ func TestObserveCheckoutPathDiscoversNewWorktreeWithoutTracking(t *testing.T) {
 	if err != nil || string(after) != string(before) {
 		t.Fatalf("implicit observation changed config: %v", err)
 	}
-	again, found, err := lc.ObserveCheckoutPath(t.Context(), worktree)
+	again, found, err := observeCheckoutUntilSettled(t, lc, worktree)
 	if err != nil || !found || again.CheckoutID != checkout.CheckoutID || again.Incarnation != checkout.Incarnation {
 		t.Fatalf("identity changed on repeated observation: %+v %v", again, err)
 	}
@@ -112,7 +136,7 @@ func TestObserveCheckoutPathUnknownFamilyAndDeniedScopeHaveNoSideEffects(t *test
 		t.Fatal(err)
 	}
 	builderGit(t, unknown, "init", "--initial-branch=main")
-	if _, found, err := lc.ObserveCheckoutPath(t.Context(), unknown); err != nil || found {
+	if _, found, err := observeCheckoutUntilSettled(t, lc, unknown); err != nil || found {
 		t.Fatalf("unknown family was adopted: %v %v", found, err)
 	}
 	inv, err := gitstate.Inventory(t.Context(), unknown)
@@ -126,7 +150,7 @@ func TestObserveCheckoutPathUnknownFamilyAndDeniedScopeHaveNoSideEffects(t *test
 	builderGit(t, primary, "worktree", "add", "-b", "denied", worktree)
 	denied := errors.New("outside authorized workspace")
 	called := false
-	if _, found, err := lc.ObserveCheckoutPath(t.Context(), worktree, func(prefix string) error {
+	if _, found, err := observeCheckoutUntilSettled(t, lc, worktree, func(prefix string) error {
 		called = true
 		if prefix != "primary" {
 			t.Fatalf("authorizer got wrong primary %q", prefix)
@@ -192,6 +216,263 @@ func TestObserveCheckoutPathSlowMetadataReturnsRetryableBusy(t *testing.T) {
 	}
 }
 
+func TestObserveCheckoutPathSlowInventoryMakesProgressAcrossRetries(t *testing.T) {
+	lc, catalog, primary, familyID, _, _ := newCheckoutObservationFixture(t)
+	worktree := filepath.Join(filepath.Dir(primary), "slow-inventory")
+	builderGit(t, primary, "worktree", "add", "-b", "slow-inventory", worktree)
+	var calls atomic.Int32
+	lc.observationInventory = func(ctx context.Context, path string) (*gitstate.FamilyInventory, error) {
+		calls.Add(1)
+		timer := time.NewTimer(350 * time.Millisecond)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-timer.C:
+			return gitstate.Inventory(ctx, path)
+		}
+	}
+	started := time.Now()
+	_, found, err := lc.ObserveCheckoutPath(t.Context(), worktree)
+	if found || !errors.Is(err, ErrCheckoutMutationBusy) || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("slow inventory did not return bounded pending: found=%v err=%v", found, err)
+	}
+	if elapsed := time.Since(started); elapsed < 200*time.Millisecond || elapsed > time.Second {
+		t.Fatalf("unexpected discovery wait: %s", elapsed)
+	}
+	checkout, found, err := observeCheckoutUntilSettled(t, lc, worktree)
+	if err != nil || !found || checkout.FamilyID != familyID {
+		t.Fatalf("retry did not finish continuing discovery: %+v found=%v err=%v", checkout, found, err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("retry restarted slow inventory %d times", got)
+	}
+	rows, err := catalog.ListCheckouts(t.Context(), familyID)
+	if err != nil || len(rows) != 2 {
+		t.Fatalf("continuing job did not allocate exactly one checkout: %+v %v", rows, err)
+	}
+
+	// A successfully shared result still requires each caller's authorization.
+	denied := errors.New("another session cannot access this checkout")
+	_, found, err = lc.ObserveCheckoutPath(t.Context(), worktree, func(string) error { return denied })
+	if found || !errors.Is(err, denied) {
+		t.Fatalf("cached result escaped caller authorization: found=%v err=%v", found, err)
+	}
+}
+
+func TestObserveCheckoutPathSlowObservationRunsOnceAcrossRetries(t *testing.T) {
+	lc, _, primary, _, _, _ := newCheckoutObservationFixture(t)
+	worktree := filepath.Join(filepath.Dir(primary), "slow-observe")
+	builderGit(t, primary, "worktree", "add", "-b", "slow-observe", worktree)
+	var calls atomic.Int32
+	reconcile.WithHEADSampler(func(ctx context.Context, root string) (gitstate.HEADState, error) {
+		calls.Add(1)
+		timer := time.NewTimer(350 * time.Millisecond)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return gitstate.HEADState{}, ctx.Err()
+		case <-timer.C:
+			return gitstate.SampleHEAD(ctx, root)
+		}
+	})(lc.rec)
+	_, found, err := lc.ObserveCheckoutPath(t.Context(), worktree)
+	if found || !errors.Is(err, ErrCheckoutMutationBusy) {
+		t.Fatalf("slow observation did not return pending: found=%v err=%v", found, err)
+	}
+	checkout, found, err := observeCheckoutUntilSettled(t, lc, worktree)
+	if err != nil || !found || checkout.CheckoutID == "" {
+		t.Fatalf("slow observation never progressed: %+v found=%v err=%v", checkout, found, err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("retry restarted HEAD metadata %d times", got)
+	}
+}
+
+func TestObserveCheckoutPathExpiredJobsStayBoundedUntilTheyDrain(t *testing.T) {
+	lc, catalog, primary, familyID, _, _ := newCheckoutObservationFixture(t)
+	release := make(chan struct{})
+	defer close(release)
+	var started atomic.Int32
+	lc.observationInventory = func(context.Context, string) (*gitstate.FamilyInventory, error) {
+		started.Add(1)
+		<-release // Deliberately model a dependency that ignores cancellation.
+		return nil, context.Canceled
+	}
+	jobs := make([]*checkoutObservationJob, 0, checkoutObservationCapacity)
+	for i := 0; i < checkoutObservationCapacity; i++ {
+		job, err := lc.checkoutObservation(filepath.Join(primary, fmt.Sprintf("request-%d", i)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		jobs = append(jobs, job)
+	}
+	deadline := time.Now().Add(time.Second)
+	for started.Load() != checkoutObservationCapacity && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := started.Load(); got != checkoutObservationCapacity {
+		t.Fatalf("workers did not start: %d", got)
+	}
+	for _, job := range jobs {
+		job.cancel() // Expiry must not release capacity before the worker exits.
+	}
+	for i := 0; i < 2*checkoutObservationCapacity; i++ {
+		if _, err := lc.checkoutObservation(filepath.Join(primary, fmt.Sprintf("extra-%d", i))); !errors.Is(err, ErrCheckoutMutationBusy) {
+			t.Fatalf("canceled but running jobs released capacity: %v", err)
+		}
+	}
+	lc.observationMu.Lock()
+	active := len(lc.observationJobs)
+	lc.observationMu.Unlock()
+	if active != checkoutObservationCapacity || started.Load() != checkoutObservationCapacity {
+		t.Fatalf("discovery bound escaped: jobs=%d workers=%d", active, started.Load())
+	}
+	rows, err := catalog.ListCheckouts(t.Context(), familyID)
+	if err != nil || len(rows) != 1 {
+		t.Fatalf("read-only jobs allocated checkout state: %+v %v", rows, err)
+	}
+}
+
+func TestObserveCheckoutPathCloseCancelsAndJoinsMetadata(t *testing.T) {
+	lc, _, primary, _, _, _ := newCheckoutObservationFixture(t)
+	entered := make(chan struct{})
+	exited := make(chan struct{})
+	lc.observationInventory = func(ctx context.Context, _ string) (*gitstate.FamilyInventory, error) {
+		close(entered)
+		<-ctx.Done()
+		close(exited)
+		return nil, ctx.Err()
+	}
+	if _, err := lc.checkoutObservation(primary); err != nil {
+		t.Fatal(err)
+	}
+	<-entered
+	if err := lc.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-exited:
+	default:
+		t.Fatal("Close returned before metadata work stopped")
+	}
+	lc.observationMu.Lock()
+	active := len(lc.observationJobs)
+	lc.observationMu.Unlock()
+	if active != 0 {
+		t.Fatalf("Close retained %d discovery jobs", active)
+	}
+	if _, err := lc.checkoutObservation(primary); !errors.Is(err, ErrCheckoutRefreshStopped) {
+		t.Fatalf("closed lifecycle admitted new work: %v", err)
+	}
+}
+
+func TestObserveCheckoutPathRejectsInventoryWithReboundGitMarker(t *testing.T) {
+	lc, catalog, primary, familyID, _, _ := newCheckoutObservationFixture(t)
+	worktree := filepath.Join(filepath.Dir(primary), "rebound")
+	sibling := filepath.Join(filepath.Dir(primary), "sibling")
+	builderGit(t, primary, "worktree", "add", "-b", "rebound", worktree)
+	builderGit(t, primary, "worktree", "add", "-b", "sibling", sibling)
+	otherMarker, err := os.ReadFile(filepath.Join(sibling, ".git"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lc.observationInventory = func(ctx context.Context, path string) (*gitstate.FamilyInventory, error) {
+		inv, err := gitstate.Inventory(ctx, path)
+		if err != nil {
+			return nil, err
+		}
+		// Force the exact gap between Inventory and the later proof snapshots.
+		if err := os.WriteFile(filepath.Join(worktree, ".git"), otherMarker, 0o644); err != nil {
+			return nil, err
+		}
+		return inv, nil
+	}
+	authorized := false
+	_, found, err := observeCheckoutUntilSettled(t, lc, worktree, func(string) error {
+		authorized = true
+		return nil
+	})
+	if found || !errors.Is(err, ErrCheckoutMutationStale) || authorized {
+		t.Fatalf("old inventory acquired new binding authority: found=%v err=%v authorized=%v", found, err, authorized)
+	}
+	rows, err := catalog.ListCheckouts(t.Context(), familyID)
+	if err != nil || len(rows) != 1 {
+		t.Fatalf("inconsistent proof allocated checkout: %+v %v", rows, err)
+	}
+}
+
+func TestObserveCheckoutPathRejectsBindingChangesWhileProofIsPending(t *testing.T) {
+	for _, change := range []string{"root", "git_marker", "commondir_marker", "common_directory"} {
+		t.Run(change, func(t *testing.T) {
+			lc, catalog, primary, familyID, _, _ := newCheckoutObservationFixture(t)
+			worktree := filepath.Join(filepath.Dir(primary), "pending-proof")
+			builderGit(t, primary, "worktree", "add", "-b", "pending-proof", worktree)
+			job, err := lc.checkoutObservation(pathkey.CanonicalExistingRoot(worktree))
+			if err != nil {
+				t.Fatal(err)
+			}
+			select {
+			case <-job.proofReady:
+			case <-time.After(2 * time.Second):
+				t.Fatal("read-only proof did not finish")
+			}
+			if job.proofErr != nil || job.proof == nil {
+				t.Fatalf("proof failed: %v", job.proofErr)
+			}
+			switch change {
+			case "root":
+				if err := os.Rename(worktree, worktree+"-old"); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Mkdir(worktree, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				marker, err := os.ReadFile(filepath.Join(worktree+"-old", ".git"))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(worktree, ".git"), marker, 0o644); err != nil {
+					t.Fatal(err)
+				}
+			case "git_marker":
+				marker := filepath.Join(worktree, ".git")
+				content, err := os.ReadFile(marker)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(marker, append(content, '\n'), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			case "commondir_marker":
+				if err := os.Remove(filepath.Join(job.proof.inventory.GitDir, "commondir")); err != nil {
+					t.Fatal(err)
+				}
+			case "common_directory":
+				common := job.proof.inventory.CommonDir
+				if err := os.Rename(common, common+"-old"); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Mkdir(common, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				// Preserve the worktree GitDir identity while replacing its family.
+				if err := os.Rename(filepath.Join(common+"-old", "worktrees"), filepath.Join(common, "worktrees")); err != nil {
+					t.Fatal(err)
+				}
+			}
+			_, found, err := observeCheckoutUntilSettled(t, lc, worktree)
+			if found || !errors.Is(err, ErrCheckoutMutationStale) {
+				t.Fatalf("pending proof survived %s replacement: found=%v err=%v", change, found, err)
+			}
+			rows, err := catalog.ListCheckouts(t.Context(), familyID)
+			if err != nil || len(rows) != 1 {
+				t.Fatalf("invalid proof allocated checkout: %+v %v", rows, err)
+			}
+		})
+	}
+}
+
 func BenchmarkObserveCheckoutPath(b *testing.B) {
 	lc, _, primary, _, _, _ := newCheckoutObservationFixture(b)
 	var busy, successful int
@@ -222,4 +503,29 @@ func BenchmarkObserveCheckoutPath(b *testing.B) {
 	if successful != 0 {
 		b.ReportMetric(float64(successTime.Nanoseconds())/float64(successful), "success-ns/admission")
 	}
+}
+
+func BenchmarkObserveCheckoutPathCachedProof(b *testing.B) {
+	lc, _, primary, _, _, _ := newCheckoutObservationFixture(b)
+	worktree := filepath.Join(filepath.Dir(primary), "cached")
+	builderGit(b, primary, "worktree", "add", "-b", "cached", worktree)
+	var inventories atomic.Int32
+	lc.observationInventory = func(ctx context.Context, path string) (*gitstate.FamilyInventory, error) {
+		inventories.Add(1)
+		return gitstate.Inventory(ctx, path)
+	}
+	checkout, found, err := observeCheckoutUntilSettled(b, lc, worktree)
+	if err != nil || !found {
+		b.Fatalf("initial observation: found=%v err=%v", found, err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		again, found, err := lc.ObserveCheckoutPath(context.Background(), worktree)
+		if err != nil || !found || again.CheckoutID != checkout.CheckoutID {
+			b.Fatalf("cached observation: %+v found=%v err=%v", again, found, err)
+		}
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(inventories.Load()), "inventory-calls")
 }

--- a/internal/indexer/checkout_observe_test.go
+++ b/internal/indexer/checkout_observe_test.go
@@ -240,12 +240,15 @@ func TestObserveCheckoutPathSlowInventoryMakesProgressAcrossRetries(t *testing.T
 	if elapsed := time.Since(started); elapsed < 200*time.Millisecond || elapsed > time.Second {
 		t.Fatalf("unexpected discovery wait: %s", elapsed)
 	}
+	firstJob := checkoutObservationJobForTest(lc, worktree)
 	checkout, found, err := observeCheckoutUntilSettled(t, lc, worktree)
 	if err != nil || !found || checkout.FamilyID != familyID {
 		t.Fatalf("retry did not finish continuing discovery: %+v found=%v err=%v", checkout, found, err)
 	}
 	if got := calls.Load(); got != 1 {
-		t.Fatalf("retry restarted slow inventory %d times", got)
+		currentJob := checkoutObservationJobForTest(lc, worktree)
+		t.Fatalf("retry restarted slow inventory %d times; first_job=%p {%s}; current_job=%p {%s}",
+			got, firstJob, checkoutObservationJobStateForTest(firstJob), currentJob, checkoutObservationJobStateForTest(currentJob))
 	}
 	rows, err := catalog.ListCheckouts(t.Context(), familyID)
 	if err != nil || len(rows) != 2 {
@@ -468,6 +471,129 @@ func TestObserveCheckoutPathRejectsBindingChangesWhileProofIsPending(t *testing.
 			rows, err := catalog.ListCheckouts(t.Context(), familyID)
 			if err != nil || len(rows) != 1 {
 				t.Fatalf("invalid proof allocated checkout: %+v %v", rows, err)
+			}
+		})
+	}
+}
+
+func checkoutObservationJobForTest(lc *CheckoutLifecycle, path string) *checkoutObservationJob {
+	lc.observationMu.Lock()
+	defer lc.observationMu.Unlock()
+	return lc.observationJobs[pathkey.CanonicalExistingRoot(path)]
+}
+
+func checkoutObservationJobStateForTest(job *checkoutObservationJob) string {
+	if job == nil {
+		return "not registered"
+	}
+	proof, result := "pending", "pending"
+	select {
+	case <-job.proofReady:
+		proof = fmt.Sprintf("error=%v", job.proofErr)
+	default:
+	}
+	select {
+	case <-job.done:
+		result = fmt.Sprintf("found=%v error=%v", job.found, job.err)
+	default:
+	}
+	return fmt.Sprintf("context=%v proof={%s} result={%s}", job.ctx.Err(), proof, result)
+}
+
+func completedCheckoutObservationForTest(t *testing.T) (*CheckoutLifecycle, *checkoutObservationJob, string, *atomic.Int32) {
+	t.Helper()
+	lc, _, primary, _, _, _ := newCheckoutObservationFixture(t)
+	worktree := filepath.Join(filepath.Dir(primary), "completed")
+	builderGit(t, primary, "worktree", "add", "-b", "completed", worktree)
+	calls := &atomic.Int32{}
+	lc.observationInventory = func(ctx context.Context, path string) (*gitstate.FamilyInventory, error) {
+		calls.Add(1)
+		return gitstate.Inventory(ctx, path)
+	}
+	job, err := lc.checkoutObservation(pathkey.CanonicalExistingRoot(worktree))
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-job.proofReady:
+	case <-time.After(2 * time.Second):
+		t.Fatal("observation proof did not finish")
+	}
+	if job.proofErr != nil || job.proof == nil {
+		t.Fatalf("observation proof failed: %v", job.proofErr)
+	}
+	// This fixture is an authorized own-CWD observation, without a foreground
+	// timeout race during setup. The retry below exercises the public method.
+	job.authorizeOnce.Do(func() { close(job.authorized) })
+	select {
+	case <-job.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("authorized observation did not finish")
+	}
+	if job.err != nil || !job.found {
+		t.Fatalf("authorized observation failed: found=%v err=%v", job.found, job.err)
+	}
+	return lc, job, worktree, calls
+}
+
+func TestObserveCheckoutPathValidationFailuresPreserveCompletedJob(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"caller_deadline", context.DeadlineExceeded},
+		{"caller_canceled", context.Canceled},
+		{"catalog_busy", fmt.Errorf("catalog read: %w", ErrCheckoutMutationBusy)},
+		{"catalog_failure", errors.New("catalog read failed")},
+		{"primary_unavailable", fmt.Errorf("known family has no primary: %w", ErrCheckoutNotTracked)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lc, job, worktree, calls := completedCheckoutObservationForTest(t)
+			// The production foreground validation branch returns this error:
+			// retaining reusable work must never turn a refusal into success.
+			if got := job.invalidateStaleProof(tc.err); got != tc.err {
+				t.Fatalf("validation error was not preserved: got=%v want=%v", got, tc.err)
+			}
+			if err := job.ctx.Err(); err != nil {
+				t.Fatalf("reader failure canceled valid shared discovery: %v", err)
+			}
+			if current := checkoutObservationJobForTest(lc, worktree); current != job {
+				t.Fatal("reader failure discarded the completed shared job")
+			}
+			checkout, found, err := observeCheckoutUntilSettled(t, lc, worktree)
+			if err != nil || !found || checkout.CheckoutID != job.checkout.CheckoutID {
+				t.Fatalf("later reader did not reuse validated completion: %+v found=%v err=%v", checkout, found, err)
+			}
+			if got := calls.Load(); got != 1 {
+				t.Fatalf("later reader restarted Inventory %d times", got)
+			}
+		})
+	}
+}
+
+func TestObserveCheckoutPathStaleValidationStillInvalidatesCompletedJob(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"stale", ErrCheckoutMutationStale},
+		{"wrapped_stale", fmt.Errorf("cached physical proof: %w", ErrCheckoutMutationStale)},
+		{"stale_and_deadline", errors.Join(context.DeadlineExceeded, ErrCheckoutMutationStale)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lc, job, worktree, _ := completedCheckoutObservationForTest(t)
+			if got := job.invalidateStaleProof(tc.err); got != tc.err {
+				t.Fatalf("stale validation error was not preserved: %v", got)
+			}
+			if !errors.Is(job.ctx.Err(), context.Canceled) {
+				t.Fatal("positively stale proof remained live")
+			}
+			deadline := time.Now().Add(time.Second)
+			for checkoutObservationJobForTest(lc, worktree) == job && time.Now().Before(deadline) {
+				time.Sleep(time.Millisecond)
+			}
+			if checkoutObservationJobForTest(lc, worktree) == job {
+				t.Fatal("invalidated proof did not drain from discovery registry")
 			}
 		})
 	}

--- a/internal/indexer/checkout_observe_test.go
+++ b/internal/indexer/checkout_observe_test.go
@@ -1,0 +1,225 @@
+package indexer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/gitstate"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/pathkey"
+	"github.com/zzet/gortex/internal/reconcile"
+	"github.com/zzet/gortex/internal/search"
+)
+
+func newCheckoutObservationFixture(t testing.TB) (*CheckoutLifecycle, *store_sqlite.Catalog, string, string, string, func()) {
+	t.Helper()
+	builderIsolateGit(t)
+	dir := builderTempDir(t, "observe")
+	primary := filepath.Join(dir, "primary")
+	if err := os.Mkdir(primary, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	builderGit(t, primary, "init", "--initial-branch=main")
+	builderWriteTree(t, primary, builderTreeA())
+	builderGit(t, primary, "add", "-A")
+	builderGit(t, primary, "commit", "-m", "primary")
+	store := builderOpenStore(t, "observe")
+	configPath := filepath.Join(dir, "config.yaml")
+	gc := &config.GlobalConfig{}
+	gc.SetConfigPath(configPath)
+	if err := gc.Save(); err != nil {
+		t.Fatal(err)
+	}
+	cm, err := config.NewConfigManager(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mi := NewMultiIndexer(store, newTestRegistry(), search.NewNull(), cm, zap.NewNop())
+	lc, err := NewCheckoutLifecycle(CheckoutLifecycleConfig{MultiIndexer: mi, ConfigManager: cm, Graph: store, Logger: zap.NewNop()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var once sync.Once
+	closeFixture := func() { once.Do(func() { _ = lc.Close(); _ = mi.Close(context.Background()) }) }
+	t.Cleanup(closeFixture)
+	tracked, err := lc.Register(context.Background(), config.RepoEntry{Path: primary, Name: "primary"}, TrackSourceCLI)
+	if err != nil || tracked.CatalogErr != nil {
+		t.Fatalf("register primary: %v %v", err, tracked.CatalogErr)
+	}
+	// Only metadata is measured/asserted here. A closed TEST-LOCAL build gate
+	// makes any accidental synchronous indexing observable as a stalled call.
+	lc.SetBuildGate(NewViewBuildGate())
+	return lc, store.Catalog(), primary, tracked.FamilyID, configPath, closeFixture
+}
+
+func TestObserveCheckoutPathDiscoversNewWorktreeWithoutTracking(t *testing.T) {
+	lc, catalog, primary, familyID, configPath, _ := newCheckoutObservationFixture(t)
+	before, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	worktree := filepath.Join(filepath.Dir(primary), "late")
+	builderGit(t, primary, "worktree", "add", "-b", "late", worktree)
+	if err := os.Mkdir(filepath.Join(worktree, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	checkout, found, err := lc.ObserveCheckoutPath(t.Context(), filepath.Join(worktree, "nested"))
+	if err != nil || !found || checkout.FamilyID != familyID || !pathkey.EqualPaths(checkout.RootPath, pathkey.CanonicalExistingRoot(worktree)) || checkout.EffectiveMode != store_sqlite.CheckoutModeAutomatic || checkout.DesiredMode != store_sqlite.CheckoutModeAutomatic {
+		t.Fatalf("new CWD observation: %+v found=%v error=%v", checkout, found, err)
+	}
+	graphs, err := catalog.ListDedicatedGraphs(t.Context(), familyID)
+	if err != nil || len(graphs) != 1 {
+		t.Fatalf("implicit worktree got a dedicated graph: %+v %v", graphs, err)
+	}
+	intents, err := catalog.ListTrackingIntents(t.Context(), checkout.CheckoutID)
+	if err != nil || len(intents) != 0 {
+		t.Fatalf("implicit worktree got explicit intent: %+v %v", intents, err)
+	}
+	after, err := os.ReadFile(configPath)
+	if err != nil || string(after) != string(before) {
+		t.Fatalf("implicit observation changed config: %v", err)
+	}
+	again, found, err := lc.ObserveCheckoutPath(t.Context(), worktree)
+	if err != nil || !found || again.CheckoutID != checkout.CheckoutID || again.Incarnation != checkout.Incarnation {
+		t.Fatalf("identity changed on repeated observation: %+v %v", again, err)
+	}
+	lc.coordMu.Lock()
+	_, activating := lc.coordinatorActivating[checkout.CheckoutID]
+	live := lc.coordinators[checkout.CheckoutID] != nil
+	lc.coordMu.Unlock()
+	if !activating && !live {
+		t.Fatal("selected worktree was not activated")
+	}
+}
+
+func TestObserveCheckoutPathUnknownFamilyAndDeniedScopeHaveNoSideEffects(t *testing.T) {
+	lc, catalog, primary, familyID, configPath, _ := newCheckoutObservationFixture(t)
+	before, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unknown := filepath.Join(filepath.Dir(primary), "unknown")
+	if err := os.Mkdir(unknown, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	builderGit(t, unknown, "init", "--initial-branch=main")
+	if _, found, err := lc.ObserveCheckoutPath(t.Context(), unknown); err != nil || found {
+		t.Fatalf("unknown family was adopted: %v %v", found, err)
+	}
+	inv, err := gitstate.Inventory(t.Context(), unknown)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, found, err := catalog.GetRepositoryFamily(t.Context(), FamilyIDFor(inv.CommonDir)); err != nil || found {
+		t.Fatalf("unknown family was recorded: %v %v", found, err)
+	}
+	worktree := filepath.Join(filepath.Dir(primary), "denied")
+	builderGit(t, primary, "worktree", "add", "-b", "denied", worktree)
+	denied := errors.New("outside authorized workspace")
+	called := false
+	if _, found, err := lc.ObserveCheckoutPath(t.Context(), worktree, func(prefix string) error {
+		called = true
+		if prefix != "primary" {
+			t.Fatalf("authorizer got wrong primary %q", prefix)
+		}
+		return denied
+	}); !errors.Is(err, denied) || found || !called {
+		t.Fatalf("unauthorized observation: found=%v error=%v called=%v", found, err, called)
+	}
+	rows, err := catalog.ListCheckouts(t.Context(), familyID)
+	if err != nil || len(rows) != 1 {
+		t.Fatalf("authorization happened after allocation: %+v %v", rows, err)
+	}
+	lc.coordMu.Lock()
+	active := len(lc.coordinators) + len(lc.coordinatorActivating)
+	lc.coordMu.Unlock()
+	if active != 0 {
+		t.Fatal("denied observation started a coordinator")
+	}
+	after, err := os.ReadFile(configPath)
+	if err != nil || string(before) != string(after) {
+		t.Fatalf("refused observation changed config: %v", err)
+	}
+}
+
+func TestObserveCheckoutPathCancellationAndClosingDoNotAllocate(t *testing.T) {
+	lc, catalog, primary, familyID, _, closeFixture := newCheckoutObservationFixture(t)
+	worktree := filepath.Join(filepath.Dir(primary), "canceled")
+	builderGit(t, primary, "worktree", "add", "-b", "canceled", worktree)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if _, found, err := lc.ObserveCheckoutPath(ctx, worktree); !errors.Is(err, context.Canceled) || found {
+		t.Fatalf("canceled observation: %v %v", found, err)
+	}
+	closeFixture()
+	if _, found, err := lc.ObserveCheckoutPath(t.Context(), worktree); !errors.Is(err, ErrCheckoutRefreshStopped) || found {
+		t.Fatalf("closed observation: %v %v", found, err)
+	}
+	rows, err := catalog.ListCheckouts(t.Context(), familyID)
+	if err != nil || len(rows) != 1 {
+		t.Fatalf("canceled observation allocated: %+v %v", rows, err)
+	}
+}
+
+func TestObserveCheckoutPathSlowMetadataReturnsRetryableBusy(t *testing.T) {
+	lc, catalog, primary, familyID, _, _ := newCheckoutObservationFixture(t)
+	worktree := filepath.Join(filepath.Dir(primary), "slow")
+	builderGit(t, primary, "worktree", "add", "-b", "slow", worktree)
+	reconcile.WithHEADSampler(func(ctx context.Context, _ string) (gitstate.HEADState, error) {
+		<-ctx.Done()
+		return gitstate.HEADState{}, errors.New("injected Git subprocess killed")
+	})(lc.rec)
+	started := time.Now()
+	_, found, observeErr := lc.ObserveCheckoutPath(t.Context(), worktree)
+	if found || !errors.Is(observeErr, ErrCheckoutMutationBusy) || !errors.Is(observeErr, context.DeadlineExceeded) {
+		t.Fatalf("slow discovery lost bounded retry state: found=%v err=%v", found, observeErr)
+	}
+	if time.Since(started) > 2*time.Second {
+		t.Fatal("metadata admission escaped its deadline")
+	}
+	rows, err := catalog.ListCheckouts(t.Context(), familyID)
+	if err != nil || len(rows) != 1 {
+		t.Fatalf("expired metadata admission allocated a checkout: %+v %v", rows, err)
+	}
+}
+
+func BenchmarkObserveCheckoutPath(b *testing.B) {
+	lc, _, primary, _, _, _ := newCheckoutObservationFixture(b)
+	var busy, successful int
+	var successTime time.Duration
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		worktree := filepath.Join(filepath.Dir(primary), fmt.Sprintf("observed-%d", i))
+		builderGit(b, primary, "worktree", "add", "-b", fmt.Sprintf("observed-%d", i), worktree)
+		b.StartTimer()
+		started := time.Now()
+		checkout, found, err := lc.ObserveCheckoutPath(context.Background(), worktree)
+		elapsed := time.Since(started)
+		b.StopTimer()
+		if errors.Is(err, ErrCheckoutMutationBusy) {
+			busy++
+			continue
+		}
+		if err != nil || !found || checkout.EffectiveMode != store_sqlite.CheckoutModeAutomatic {
+			b.Fatalf("observe: %+v found=%v err=%v", checkout, found, err)
+		}
+		successful++
+		successTime += elapsed
+	}
+	b.ReportMetric(float64(busy), "busy-admissions")
+	b.ReportMetric(float64(successful), "successful-admissions")
+	if successful != 0 {
+		b.ReportMetric(float64(successTime.Nanoseconds())/float64(successful), "success-ns/admission")
+	}
+}

--- a/internal/indexer/checkout_refresh.go
+++ b/internal/indexer/checkout_refresh.go
@@ -1,0 +1,504 @@
+package indexer
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/pathkey"
+)
+
+const (
+	maxCheckoutRefreshTickets     = 1024
+	checkoutRefreshCaptureTimeout = 5 * time.Second
+)
+
+var (
+	ErrCheckoutRefreshQueueFull  = errors.New("indexer: checkout refresh ticket queue is full; retry recovery")
+	ErrCheckoutRefreshSuperseded = errors.New("indexer: checkout refresh was superseded by a different checkout state")
+	ErrCheckoutRefreshStopped    = errors.New("indexer: checkout coordinator stopped before refresh completed")
+	checkoutRefreshSequence      atomic.Uint64
+)
+
+// CheckoutRefreshTicket identifies a checkout-local graph publication. The
+// inner ticket's Generation is an admission sequence; AppliedGeneration in its
+// terminal result is the actual SQLite dirty generation, never a primary index.
+type CheckoutRefreshTicket struct {
+	CheckoutID  string
+	Incarnation string
+	Root        string
+	RepoPrefix  string
+	// ContentHash is raw-file SHA256 for a source ticket, empty for root recovery.
+	// Callers bind it to the bytes they committed, not to a later external edit.
+	ContentHash string
+	Ticket      *MutationTicket
+}
+
+type checkoutRefreshRequest struct {
+	ticket      *CheckoutRefreshTicket
+	done        chan MutationResult
+	checkout    store_sqlite.Checkout
+	rootInfo    os.FileInfo
+	headRef     string
+	headCommit  string
+	headTree    string
+	fingerprint string // Exact snapshot consumed by the published dirty generation.
+	contentHash string
+}
+
+// Identity returns the immutable checkout identity admitted before a disk edit.
+func (m *CheckoutMutation) Identity() (checkoutID, incarnation string) {
+	if m == nil {
+		return "", ""
+	}
+	return m.checkout.CheckoutID, m.checkout.Incarnation
+}
+
+// EnqueueRefresh attaches committed disk content to the coordinator's existing
+// background loop. It does not build a generation or wait on the build gate.
+// The caller must release this mutation lease before waiting for Ticket.Done.
+// Admission after a disk commit outlives request cancellation, but remains
+// bounded and cannot outlive coordinator shutdown.
+func (m *CheckoutMutation) EnqueueRefresh(ctx context.Context, path string) (*CheckoutRefreshTicket, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed || !m.prepared || !m.refreshReserved || m.fresh || m.refreshQueued {
+		return nil, fmt.Errorf("%w: no unqueued committed checkout mutation", ErrCheckoutMutationStale)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), checkoutRefreshCaptureTimeout)
+	defer cancel()
+	ctx, cancelLifetime := checkoutMutationContext(ctx, m.coordinator.lifetimeContext())
+	defer cancelLifetime()
+	if err := m.validateCheckout(ctx); err != nil {
+		return nil, err
+	}
+	request, err := m.coordinator.captureCheckoutRefresh(ctx, m.checkout, m.rootInfo, path)
+	if err != nil {
+		return nil, err
+	}
+	if request.headRef != m.headRef || request.headCommit != m.headCommit || request.headTree != m.headTree {
+		return nil, ErrCheckoutRefreshSuperseded
+	}
+	ticket, err := m.coordinator.enqueueCheckoutRefresh(request, true)
+	m.refreshReserved = false
+	if err == nil {
+		m.refreshQueued = true
+	}
+	return ticket, err
+}
+
+// RequestCheckoutRefresh explicitly retries an automatic checkout whose route
+// may be missing, pending or failed. Identity and availability remain strict,
+// but graph readiness is deliberately not a precondition for graph recovery.
+func (l *CheckoutLifecycle) RequestCheckoutRefresh(ctx context.Context, checkoutID, expectedRoot string) (*CheckoutRefreshTicket, error) {
+	if l == nil || l.catalog == nil || checkoutID == "" || expectedRoot == "" {
+		return nil, fmt.Errorf("%w: checkout identity and root are required", ErrCheckoutMutationStale)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	checkout, found, err := l.catalog.GetCheckout(ctx, checkoutID)
+	if err != nil {
+		return nil, err
+	}
+	if !found || !sameMutationRoot(checkout.RootPath, expectedRoot) {
+		return nil, fmt.Errorf("%w: checkout root changed", ErrCheckoutMutationStale)
+	}
+	rootInfo, err := os.Stat(checkout.RootPath)
+	if err != nil || !rootInfo.IsDir() {
+		return nil, fmt.Errorf("%w: checkout root is unavailable", ErrCheckoutMutationStale)
+	}
+	l.coordMu.Lock()
+	c, closing := l.coordinators[checkoutID], l.coordinatorClosing
+	l.coordMu.Unlock()
+	if closing {
+		return nil, ErrCheckoutRefreshStopped
+	}
+	if c == nil {
+		l.ActivateCheckout(checkoutID, "explicit checkout refresh requested")
+		return nil, fmt.Errorf("%w: checkout coordinator is activating; retry recovery", ErrCheckoutMutationBusy)
+	}
+	if !sameMutationRoot(c.root, expectedRoot) {
+		return nil, ErrCheckoutRefreshStopped
+	}
+	ctx, cancel := context.WithTimeout(ctx, checkoutRefreshCaptureTimeout)
+	defer cancel()
+	ctx, cancelLifetime := checkoutMutationContext(ctx, c.lifetimeContext())
+	defer cancelLifetime()
+	identity := &CheckoutMutation{coordinator: c, checkout: checkout, rootInfo: rootInfo}
+	if err := identity.validateCheckout(ctx); err != nil {
+		return nil, err
+	}
+	request, err := c.captureCheckoutRefresh(ctx, checkout, rootInfo, "")
+	if err != nil {
+		return nil, err
+	}
+	return c.enqueueCheckoutRefresh(request, false)
+}
+
+func (c *CheckoutCoordinator) captureCheckoutRefresh(ctx context.Context, checkout store_sqlite.Checkout, rootInfo os.FileInfo, path string) (*checkoutRefreshRequest, error) {
+	request := &checkoutRefreshRequest{checkout: checkout, rootInfo: rootInfo}
+	if path != "" {
+		canonical, hash, err := checkoutRefreshFileHash(ctx, checkout.RootPath, rootInfo, path)
+		if err != nil {
+			return nil, err
+		}
+		path, request.contentHash = canonical, hash
+	}
+	sample, err := c.sampler.Sample(ctx)
+	if err != nil {
+		return nil, err
+	}
+	request.headRef, request.headCommit, request.headTree = sample.HeadRef, sample.HeadCommit, sample.HeadTree
+	request.fingerprint = sample.Fingerprint
+	if path == "" {
+		path = checkout.RootPath
+	} else {
+		// Bind the snapshot and bytes together. An external edit during capture
+		// must not turn a receipt for old content into a promise about new bytes.
+		_, hash, err := checkoutRefreshFileHash(ctx, checkout.RootPath, rootInfo, path)
+		if err != nil {
+			return nil, err
+		}
+		if hash != request.contentHash {
+			return nil, ErrCheckoutRefreshSuperseded
+		}
+	}
+	identity := &CheckoutMutation{coordinator: c, checkout: checkout, rootInfo: rootInfo}
+	if err := identity.validateCheckout(ctx); err != nil {
+		return nil, err
+	}
+	request.done = make(chan MutationResult, 1)
+	request.ticket = &CheckoutRefreshTicket{
+		CheckoutID: checkout.CheckoutID, Incarnation: checkout.Incarnation,
+		Root: checkout.RootPath, RepoPrefix: c.repoPrefix, ContentHash: request.contentHash,
+		Ticket: &MutationTicket{Path: path, Done: request.done},
+	}
+	return request, nil
+}
+
+func (c *CheckoutCoordinator) reserveCheckoutRefresh() error {
+	c.refreshMu.Lock()
+	defer c.refreshMu.Unlock()
+	if c.refreshClosed || c.lifetimeContext().Err() != nil {
+		return ErrCheckoutRefreshStopped
+	}
+	if len(c.refreshWaiters)+c.refreshReserved >= maxCheckoutRefreshTickets {
+		return ErrCheckoutRefreshQueueFull
+	}
+	c.refreshReserved++
+	return nil
+}
+
+func (c *CheckoutCoordinator) releaseCheckoutRefreshReservation() {
+	c.refreshMu.Lock()
+	c.refreshReserved--
+	c.refreshMu.Unlock()
+}
+
+func (c *CheckoutCoordinator) enqueueCheckoutRefresh(request *checkoutRefreshRequest, reserved bool) (*CheckoutRefreshTicket, error) {
+	c.refreshMu.Lock()
+	if reserved {
+		c.refreshReserved--
+	}
+	if c.refreshClosed || c.lifetimeContext().Err() != nil {
+		c.refreshMu.Unlock()
+		return nil, ErrCheckoutRefreshStopped
+	}
+	if !reserved && len(c.refreshWaiters)+c.refreshReserved >= maxCheckoutRefreshTickets {
+		c.refreshMu.Unlock()
+		return nil, ErrCheckoutRefreshQueueFull
+	}
+	if c.refreshWaiters == nil {
+		c.refreshWaiters = make(map[uint64]*checkoutRefreshRequest)
+	}
+	sequence := checkoutRefreshSequence.Add(1)
+	request.ticket.Ticket.Generation = sequence
+	c.refreshHighWater = sequence
+	c.refreshWaiters[sequence] = request
+	c.refreshMu.Unlock()
+	c.Signal("checkout refresh ticket admitted")
+	return request.ticket, nil
+}
+
+func (c *CheckoutCoordinator) checkoutRefreshHighWater() uint64 {
+	c.refreshMu.Lock()
+	defer c.refreshMu.Unlock()
+	if len(c.refreshWaiters) == 0 {
+		return 0
+	}
+	return c.refreshHighWater
+}
+
+func (c *CheckoutCoordinator) reportCheckoutCycle(ctx context.Context, through uint64, out CheckoutCycle) {
+	c.completeCheckoutRefreshTickets(ctx, through, out)
+	if c.cycleDone != nil {
+		c.cycleDone(out)
+	}
+}
+
+// Moving publication out of the MCP request must not lose its operational
+// storage-panic firewall. Only typed storage faults are recovered; programmer
+// and parser panics still propagate, rather than hiding corrupted execution.
+func (c *CheckoutCoordinator) guardCheckoutRefreshCycle(ctx context.Context, through uint64) {
+	recovered := recover()
+	if recovered == nil {
+		return
+	}
+	err, ok := watcherStoragePanicError("checkout refresh", recovered)
+	if !ok {
+		panic(recovered)
+	}
+	if c.logger != nil {
+		c.logger.Warn("checkout coordinator: storage failure", zap.String("checkout", c.checkoutID), zap.Error(err))
+	}
+	c.completeCheckoutRefreshTickets(ctx, through, CheckoutCycle{Err: err})
+}
+
+// completeCheckoutRefreshTickets observes a real loop result. A ticket admitted
+// during a cycle cannot inherit that earlier cycle's error or stale success;
+// its signal schedules a subsequent cycle (usually the cheap settled path).
+func (c *CheckoutCoordinator) completeCheckoutRefreshTickets(ctx context.Context, through uint64, out CheckoutCycle) {
+	c.refreshMu.Lock()
+	requests := make([]*checkoutRefreshRequest, 0, len(c.refreshWaiters))
+	for sequence, request := range c.refreshWaiters {
+		if sequence <= through {
+			requests = append(requests, request)
+		}
+	}
+	c.refreshMu.Unlock()
+	if len(requests) == 0 {
+		return
+	}
+	if c.lifetimeContext().Err() != nil {
+		c.failCheckoutRefreshRequests(requests, ErrCheckoutRefreshStopped)
+		return
+	}
+	if out.Deferred || out.Rescheduled {
+		return
+	}
+	if out.Err != nil {
+		if retryableCheckoutRefreshError(out.Err) && c.lifetimeContext().Err() == nil {
+			return
+		}
+		for _, request := range requests {
+			c.finishCheckoutRefresh(request, 0, out.Err)
+		}
+		return
+	}
+	if out.CommitGenerationID <= 0 || out.DirtyGenerationID <= 0 {
+		return
+	}
+	route, found, err := c.catalog.GetCheckoutRoute(ctx, c.checkoutID)
+	if err != nil {
+		c.failCheckoutRefreshRequests(requests, err)
+		return
+	}
+	if !found || route.State != store_sqlite.RouteActive || route.CommitGenerationID != out.CommitGenerationID || route.DirtyGenerationID != out.DirtyGenerationID {
+		return
+	}
+	dirty, found, err := c.catalog.GetViewGeneration(ctx, out.DirtyGenerationID)
+	if err != nil {
+		c.failCheckoutRefreshRequests(requests, err)
+		return
+	}
+	if !found || !servableGeneration(dirty.State) || dirty.BaseGenerationID != out.CommitGenerationID {
+		return
+	}
+	sample, err := c.sampler.Sample(ctx)
+	if err != nil {
+		c.failCheckoutRefreshRequests(requests, err)
+		return
+	}
+	if sample.Fingerprint != dirty.LowerViewFingerprint {
+		return
+	}
+	current, found, err := c.catalog.GetCheckout(ctx, c.checkoutID)
+	if err != nil {
+		c.failCheckoutRefreshRequests(requests, err)
+		return
+	}
+	if !found || current.State != store_sqlite.CheckoutStateReady || current.EffectiveMode != store_sqlite.CheckoutModeAutomatic || current.DesiredMode != store_sqlite.CheckoutModeAutomatic || current.ActiveIntentTransitionID != "" || current.UnavailableSince != 0 || current.RemovalDetectedAt != 0 || !sameMutationRoot(current.RootPath, c.root) {
+		c.failCheckoutRefreshRequests(requests, ErrCheckoutRefreshSuperseded)
+		return
+	}
+	rootInfo, err := os.Stat(current.RootPath)
+	if err != nil {
+		c.failCheckoutRefreshRequests(requests, ErrCheckoutRefreshSuperseded)
+		return
+	}
+	// A coalesced cycle hashes each requested file at most once, even when many
+	// callers are waiting for the same content.
+	hashes := make(map[string]string)
+	for _, request := range requests {
+		if current.Incarnation != request.checkout.Incarnation || !os.SameFile(request.rootInfo, rootInfo) || request.headRef != sample.HeadRef || request.headCommit != sample.HeadCommit || request.headTree != sample.HeadTree {
+			c.finishCheckoutRefresh(request, 0, ErrCheckoutRefreshSuperseded)
+			continue
+		}
+		// The graph's persisted publication fingerprint, not a later disk hash
+		// alone, must identify the state admitted by this ticket. Until the
+		// builder exposes per-file publication receipts, even an unrelated
+		// intervening edit explicitly supersedes this exact-snapshot promise.
+		if request.fingerprint != dirty.LowerViewFingerprint {
+			c.finishCheckoutRefresh(request, 0, ErrCheckoutRefreshSuperseded)
+			continue
+		}
+		if request.contentHash != "" {
+			path := request.ticket.Ticket.Path
+			hash, ok := hashes[path]
+			if !ok {
+				_, hash, err = checkoutRefreshFileHash(ctx, current.RootPath, rootInfo, path)
+				if err != nil {
+					c.finishCheckoutRefresh(request, 0, fmt.Errorf("%w: %v", ErrCheckoutRefreshSuperseded, err))
+					continue
+				}
+				hashes[path] = hash
+			}
+			if hash != request.contentHash {
+				c.finishCheckoutRefresh(request, 0, ErrCheckoutRefreshSuperseded)
+				continue
+			}
+		}
+		c.finishCheckoutRefresh(request, uint64(out.DirtyGenerationID), nil)
+	}
+}
+
+func (c *CheckoutCoordinator) finishCheckoutRefresh(request *checkoutRefreshRequest, generation uint64, err error) {
+	c.refreshMu.Lock()
+	sequence := request.ticket.Ticket.Generation
+	if c.refreshWaiters[sequence] != request {
+		c.refreshMu.Unlock()
+		return
+	}
+	delete(c.refreshWaiters, sequence)
+	c.refreshMu.Unlock()
+	request.done <- MutationResult{RequestedGeneration: sequence, AppliedGeneration: generation, Reindexed: err == nil, Err: err}
+	close(request.done)
+}
+
+func (c *CheckoutCoordinator) failCheckoutRefreshRequests(requests []*checkoutRefreshRequest, err error) {
+	if retryableCheckoutRefreshError(err) && c.lifetimeContext().Err() == nil {
+		return
+	}
+	for _, request := range requests {
+		c.finishCheckoutRefresh(request, 0, err)
+	}
+}
+
+func retryableCheckoutRefreshError(err error) bool {
+	if retryableMutationError(err) || errors.Is(err, ErrViewBuildQueueFull) {
+		return true
+	}
+	// SQLite's extended BUSY/LOCKED variants retain the same primary code.
+	// errors.As also reaches driver errors wrapped by typed storage failures.
+	var coded interface{ Code() int }
+	if errors.As(err, &coded) {
+		code := coded.Code() & 0xff
+		return code == 5 || code == 6
+	}
+	return false
+}
+
+func (c *CheckoutCoordinator) closeCheckoutRefreshTickets() {
+	c.refreshMu.Lock()
+	c.refreshClosed = true
+	requests := make([]*checkoutRefreshRequest, 0, len(c.refreshWaiters))
+	for _, request := range c.refreshWaiters {
+		requests = append(requests, request)
+	}
+	c.refreshMu.Unlock()
+	for _, request := range requests {
+		c.finishCheckoutRefresh(request, 0, ErrCheckoutRefreshStopped)
+	}
+}
+
+// checkoutRefreshFileHash confines ticket content reads to the captured physical
+// checkout, including aliases and case-normalized paths. os.Root keeps a later
+// symlink swap from escaping the selected working copy.
+func checkoutRefreshFileHash(ctx context.Context, root string, rootInfo os.FileInfo, path string) (string, string, error) {
+	root = pathkey.CanonicalExistingRoot(root)
+	path = pathkey.CanonicalPath(path)
+	if !filepath.IsAbs(path) || !pathkey.HasPathPrefix(path, root) || pathkey.EqualPaths(path, root) {
+		return "", "", fmt.Errorf("checkout refresh path is outside selected checkout: %q", path)
+	}
+	var components []string
+	ancestor := path
+	for !pathkey.EqualPaths(ancestor, root) {
+		component := filepath.Base(ancestor)
+		if strings.EqualFold(component, ".git") {
+			return "", "", fmt.Errorf("checkout refresh cannot read Git metadata: %q", path)
+		}
+		components = append(components, component)
+		parent := filepath.Dir(ancestor)
+		if pathkey.EqualPaths(parent, ancestor) {
+			return "", "", fmt.Errorf("checkout refresh path has no selected root: %q", path)
+		}
+		ancestor = parent
+	}
+	matched, err := os.Stat(ancestor)
+	if err != nil || !os.SameFile(rootInfo, matched) {
+		return "", "", ErrCheckoutRefreshSuperseded
+	}
+	slices.Reverse(components)
+	rooted, err := os.OpenRoot(root)
+	if err != nil {
+		return "", "", err
+	}
+	defer rooted.Close()
+	openedRoot, err := rooted.Stat(".")
+	if err != nil || !os.SameFile(rootInfo, openedRoot) {
+		return "", "", ErrCheckoutRefreshSuperseded
+	}
+	file, err := rooted.Open(filepath.Join(components...))
+	if err != nil {
+		return "", "", err
+	}
+	defer file.Close()
+	before, err := file.Stat()
+	if err != nil {
+		return "", "", err
+	}
+	if !before.Mode().IsRegular() {
+		return "", "", fmt.Errorf("checkout refresh target is not a regular file: %q", path)
+	}
+	hash := sha256.New()
+	buffer := make([]byte, 32*1024)
+	for {
+		if err := ctx.Err(); err != nil {
+			return "", "", err
+		}
+		n, readErr := file.Read(buffer)
+		if n > 0 {
+			_, _ = hash.Write(buffer[:n])
+		}
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		if readErr != nil {
+			return "", "", readErr
+		}
+	}
+	after, err := file.Stat()
+	if err != nil {
+		return "", "", err
+	}
+	if before.Size() != after.Size() || !before.ModTime().Equal(after.ModTime()) {
+		return "", "", ErrCheckoutRefreshSuperseded
+	}
+	return path, hex.EncodeToString(hash.Sum(nil)), nil
+}

--- a/internal/indexer/checkout_refresh.go
+++ b/internal/indexer/checkout_refresh.go
@@ -119,7 +119,7 @@ func (l *CheckoutLifecycle) RequestCheckoutRefresh(ctx context.Context, checkout
 	if !found || !sameMutationRoot(checkout.RootPath, expectedRoot) {
 		return nil, fmt.Errorf("%w: checkout root changed", ErrCheckoutMutationStale)
 	}
-	rootInfo, err := os.Stat(checkout.RootPath)
+	rootInfo, err := checkoutRootFileInfo(checkout.RootPath)
 	if err != nil || !rootInfo.IsDir() {
 		return nil, fmt.Errorf("%w: checkout root is unavailable", ErrCheckoutMutationStale)
 	}
@@ -337,7 +337,7 @@ func (c *CheckoutCoordinator) completeCheckoutRefreshTickets(ctx context.Context
 		c.failCheckoutRefreshRequests(requests, ErrCheckoutRefreshSuperseded)
 		return
 	}
-	rootInfo, err := os.Stat(current.RootPath)
+	rootInfo, err := checkoutRootFileInfo(current.RootPath)
 	if err != nil {
 		c.failCheckoutRefreshRequests(requests, ErrCheckoutRefreshSuperseded)
 		return
@@ -454,7 +454,7 @@ func checkoutRefreshFileHash(ctx context.Context, root string, rootInfo os.FileI
 		}
 		ancestor = parent
 	}
-	matched, err := os.Stat(ancestor)
+	matched, err := checkoutRootFileInfo(ancestor)
 	if err != nil || !os.SameFile(rootInfo, matched) {
 		return "", "", ErrCheckoutRefreshSuperseded
 	}
@@ -464,8 +464,13 @@ func checkoutRefreshFileHash(ctx context.Context, root string, rootInfo os.FileI
 		return "", "", err
 	}
 	defer rooted.Close()
-	openedRoot, err := rooted.Stat(".")
-	if err != nil || !os.SameFile(rootInfo, openedRoot) {
+	rootFile, err := rooted.Open(".")
+	if err != nil {
+		return "", "", ErrCheckoutRefreshSuperseded
+	}
+	openedRoot, err := rootFile.Stat()
+	closeErr := rootFile.Close()
+	if err != nil || closeErr != nil || !os.SameFile(rootInfo, openedRoot) {
 		return "", "", ErrCheckoutRefreshSuperseded
 	}
 	file, err := rooted.Open(filepath.Join(components...))

--- a/internal/indexer/checkout_refresh.go
+++ b/internal/indexer/checkout_refresh.go
@@ -401,6 +401,10 @@ func (c *CheckoutCoordinator) failCheckoutRefreshRequests(requests []*checkoutRe
 }
 
 func retryableCheckoutRefreshError(err error) bool {
+	var committed interface{ Committed() bool }
+	if errors.As(err, &committed) && committed.Committed() {
+		return false
+	}
 	if retryableMutationError(err) || errors.Is(err, ErrViewBuildQueueFull) {
 		return true
 	}

--- a/internal/indexer/checkout_refresh_test.go
+++ b/internal/indexer/checkout_refresh_test.go
@@ -378,7 +378,7 @@ func TestCheckoutRefreshOperationalStoragePanicFailsTicketOnly(t *testing.T) {
 
 func TestCheckoutRefreshHashRejectsOutsideAndReplacedPhysicalRoot(t *testing.T) {
 	f, _, _ := newCheckoutMutationFixture(t)
-	rootInfo, err := os.Stat(f.worktree)
+	rootInfo, err := checkoutRootFileInfo(f.worktree)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/indexer/checkout_refresh_test.go
+++ b/internal/indexer/checkout_refresh_test.go
@@ -1,0 +1,436 @@
+package indexer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+)
+
+func queueCheckoutSourceEdit(t *testing.T, f *coordinatorFixture, l *CheckoutLifecycle, text string) *CheckoutRefreshTicket {
+	t.Helper()
+	m, err := l.BeginCheckoutMutation(context.Background(), f.checkoutID, f.worktree, f.route().RouteEpoch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	if err := m.Prepare(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	builderWriteFile(t, f.worktree, "helper.go", text)
+	ticket, err := m.EnqueueRefresh(context.Background(), filepath.Join(f.worktree, "helper.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ticket
+}
+
+func assertCheckoutRefreshPending(t testing.TB, ticket *CheckoutRefreshTicket) {
+	t.Helper()
+	select {
+	case result := <-ticket.Ticket.Done:
+		t.Fatalf("ticket completed before requested publication: %+v", result)
+	default:
+	}
+}
+
+func awaitCheckoutRefresh(t testing.TB, ticket *CheckoutRefreshTicket) MutationResult {
+	t.Helper()
+	select {
+	case result, ok := <-ticket.Ticket.Done:
+		if !ok {
+			t.Fatal("ticket closed without a result")
+		}
+		return result
+	case <-time.After(10 * time.Second):
+		t.Fatal("refresh ticket never completed")
+		return MutationResult{}
+	}
+}
+
+func TestCheckoutRefreshEnqueueOutlivesRequestAndPublishesExactGeneration(t *testing.T) {
+	f, c, l := newCheckoutMutationFixture(t)
+	before := f.route()
+	primary, err := os.ReadFile(filepath.Join(f.primary, "helper.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := l.BeginCheckoutMutation(t.Context(), f.checkoutID, f.worktree, before.RouteEpoch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	if err := m.Prepare(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	builderWriteFile(t, f.worktree, "helper.go", "package fixture\nfunc AsyncHelper() {}\n")
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	started := time.Now()
+	ticket, err := m.EnqueueRefresh(ctx, filepath.Join(f.worktree, "helper.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if time.Since(started) >= time.Second {
+		t.Fatal("enqueue waited for a graph build")
+	}
+	checkoutID, incarnation := m.Identity()
+	if ticket.CheckoutID != checkoutID || ticket.Incarnation != incarnation || ticket.Root != f.worktree || ticket.Ticket.Generation == 0 {
+		t.Fatalf("incorrect ticket identity: %+v", ticket)
+	}
+	assertCheckoutRefreshPending(t, ticket)
+	if _, err := m.Refresh(t.Context()); !errors.Is(err, ErrCheckoutMutationStale) {
+		t.Fatalf("queued lease also admitted synchronous publication: %v", err)
+	}
+	if f.route().State != store_sqlite.RoutePending {
+		t.Fatal("queued edit became exact before build")
+	}
+	m.Close()
+	c.cycle(t.Context())
+	result := awaitCheckoutRefresh(t, ticket)
+	if result.Err != nil || !result.Reindexed || result.RequestedGeneration != ticket.Ticket.Generation || result.AppliedGeneration != uint64(f.route().DirtyGenerationID) || result.AppliedGeneration == uint64(before.DirtyGenerationID) {
+		t.Fatalf("refresh did not identify its exact generation: %+v route=%+v", result, f.route())
+	}
+	if after, err := os.ReadFile(filepath.Join(f.primary, "helper.go")); err != nil || string(after) != string(primary) {
+		t.Fatalf("primary changed: %v", err)
+	}
+	if f.route().CommitGenerationID != before.CommitGenerationID {
+		t.Fatal("dirty refresh replaced primary/commit layer")
+	}
+}
+
+func TestCheckoutRefreshRecoveryAdmitsWhileSourceLeaseOwnsBuildGate(t *testing.T) {
+	f, c, l := newCheckoutMutationFixture(t)
+	m, err := l.BeginCheckoutMutation(t.Context(), f.checkoutID, f.worktree, f.route().RouteEpoch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	if err := m.Prepare(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	builderWriteFile(t, f.worktree, "helper.go", "package fixture\nfunc RecoveryHelper() {}\n")
+	started := time.Now()
+	ticket, err := l.RequestCheckoutRefresh(t.Context(), f.checkoutID, f.worktree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if time.Since(started) >= time.Second {
+		t.Fatal("recovery waited on source build gate")
+	}
+	assertCheckoutRefreshPending(t, ticket)
+	m.Close()
+	c.cycle(t.Context())
+	if result := awaitCheckoutRefresh(t, ticket); result.Err != nil || !result.Reindexed {
+		t.Fatalf("recovery: %+v", result)
+	}
+}
+
+func TestCheckoutRefreshExistingLoopCompletesSourceAndMidBuildRecovery(t *testing.T) {
+	f := newCoordinatorFixture(t)
+	gate := NewViewBuildGate()
+	gate.Open()
+	c := f.coordinator(t, CheckoutCoordinatorConfig{Gate: gate, Debounce: time.Millisecond})
+	if out := c.reconcile(t.Context()); out.Err != nil || out.DirtyGenerationID == 0 {
+		t.Fatalf("initial: %+v", out)
+	}
+	l := &CheckoutLifecycle{catalog: f.catalog, store: f.store, coordinators: map[string]*CheckoutCoordinator{f.checkoutID: c}}
+	entered, release := make(chan struct{}), make(chan struct{})
+	var enteredOnce, releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+	c.dirtyBarrier = func() { enteredOnce.Do(func() { close(entered) }); <-release }
+	ticket := queueCheckoutSourceEdit(t, f, l, "package fixture\nfunc BackgroundHelper() {}\n")
+	select {
+	case <-entered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("coordinator did not consume admitted source ticket")
+	}
+	assertCheckoutRefreshPending(t, ticket)
+	recovery, err := l.RequestCheckoutRefresh(t.Context(), f.checkoutID, f.worktree)
+	if err != nil {
+		t.Fatalf("mid-build recovery rejected: %v", err)
+	}
+	assertCheckoutRefreshPending(t, recovery)
+	releaseOnce.Do(func() { close(release) })
+	for _, pending := range []*CheckoutRefreshTicket{ticket, recovery} {
+		if result := awaitCheckoutRefresh(t, pending); result.Err != nil || !result.Reindexed {
+			t.Fatalf("background publication: %+v", result)
+		}
+	}
+}
+
+func TestCheckoutRefreshDeferralAndTimeoutRemainPending(t *testing.T) {
+	f, c, l := newCheckoutMutationFixture(t)
+	ticket := queueCheckoutSourceEdit(t, f, l, "package fixture\nfunc RetriedHelper() {}\n")
+	through := c.checkoutRefreshHighWater()
+	for _, out := range []CheckoutCycle{{Deferred: true}, {Rescheduled: true}, {Err: context.DeadlineExceeded}, {Err: ErrViewBuildQueueFull}, {Err: fmt.Errorf("busy: %w", checkoutRefreshTestCodedError(5))}, {Err: checkoutRefreshTestCodedError(6 | 1<<8)}} {
+		c.completeCheckoutRefreshTickets(t.Context(), through, out)
+		assertCheckoutRefreshPending(t, ticket)
+	}
+	c.cycle(t.Context())
+	if result := awaitCheckoutRefresh(t, ticket); result.Err != nil || !result.Reindexed {
+		t.Fatalf("retry: %+v", result)
+	}
+}
+
+type checkoutRefreshTestCodedError int
+
+func (e checkoutRefreshTestCodedError) Error() string { return "injected SQLite error" }
+func (e checkoutRefreshTestCodedError) Code() int     { return int(e) }
+
+func TestCheckoutRefreshDoesNotRetryPermanentSQLiteFailures(t *testing.T) {
+	for _, code := range []int{1, 7, 10, 13, 19} {
+		if retryableCheckoutRefreshError(fmt.Errorf("storage: %w", checkoutRefreshTestCodedError(code))) {
+			t.Fatalf("permanent SQLite failure %d was retried", code)
+		}
+	}
+}
+
+func TestCheckoutRefreshOldCycleCannotFailNewAdmission(t *testing.T) {
+	f, c, l := newCheckoutMutationFixture(t)
+	first, err := l.RequestCheckoutRefresh(t.Context(), f.checkoutID, f.worktree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	through := c.checkoutRefreshHighWater()
+	second, err := l.RequestCheckoutRefresh(t.Context(), f.checkoutID, f.worktree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := errors.New("old physical build failed")
+	c.completeCheckoutRefreshTickets(t.Context(), through, CheckoutCycle{Err: want})
+	if result := awaitCheckoutRefresh(t, first); !errors.Is(result.Err, want) || result.Reindexed {
+		t.Fatalf("first: %+v", result)
+	}
+	assertCheckoutRefreshPending(t, second)
+	c.cycle(t.Context())
+	if result := awaitCheckoutRefresh(t, second); result.Err != nil || !result.Reindexed {
+		t.Fatalf("new recovery: %+v", result)
+	}
+}
+
+func TestCheckoutRefreshSupersededContentAndSnapshotNeverClaimFresh(t *testing.T) {
+	for _, differentFile := range []bool{false, true} {
+		t.Run(map[bool]string{false: "target_changed", true: "unrelated_snapshot_changed"}[differentFile], func(t *testing.T) {
+			f, c, l := newCheckoutMutationFixture(t)
+			ticket := queueCheckoutSourceEdit(t, f, l, "package fixture\nfunc RequestedHelper() {}\n")
+			path := "helper.go"
+			if differentFile {
+				path = "extra.go"
+			}
+			builderWriteFile(t, f.worktree, path, "package fixture\nfunc DifferentHelper() {}\n")
+			c.cycle(t.Context())
+			result := awaitCheckoutRefresh(t, ticket)
+			if !errors.Is(result.Err, ErrCheckoutRefreshSuperseded) || result.Reindexed || result.AppliedGeneration != 0 {
+				t.Fatalf("false exact success: %+v", result)
+			}
+			recovery, err := l.RequestCheckoutRefresh(t.Context(), f.checkoutID, f.worktree)
+			if err != nil {
+				t.Fatal(err)
+			}
+			c.cycle(t.Context())
+			if result := awaitCheckoutRefresh(t, recovery); result.Err != nil || !result.Reindexed {
+				t.Fatalf("recovery: %+v", result)
+			}
+		})
+	}
+}
+
+func TestCheckoutRefreshNeverAdoptsAnExternalBranchSwitch(t *testing.T) {
+	for _, stage := range []string{"before_prepare", "before_enqueue", "after_enqueue"} {
+		t.Run(stage, func(t *testing.T) {
+			f, c, l := newCheckoutMutationFixture(t)
+			m, err := l.BeginCheckoutMutation(t.Context(), f.checkoutID, f.worktree, f.route().RouteEpoch)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer m.Close()
+			if stage == "before_prepare" {
+				builderGit(t, f.worktree, "switch", "-c", "external-same-commit")
+				if err := m.Prepare(t.Context()); !errors.Is(err, ErrCheckoutMutationStale) {
+					t.Fatalf("branch change admitted: %v", err)
+				}
+				return
+			}
+			if err := m.Prepare(t.Context()); err != nil {
+				t.Fatal(err)
+			}
+			builderWriteFile(t, f.worktree, "helper.go", "package fixture\nfunc BranchBoundHelper() {}\n")
+			if stage == "before_enqueue" {
+				builderGit(t, f.worktree, "switch", "-c", "external-same-commit")
+			}
+			ticket, err := m.EnqueueRefresh(t.Context(), filepath.Join(f.worktree, "helper.go"))
+			if stage == "before_enqueue" {
+				if !errors.Is(err, ErrCheckoutRefreshSuperseded) || ticket != nil {
+					t.Fatalf("post-commit branch was adopted: ticket=%+v err=%v", ticket, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			m.Close()
+			builderGit(t, f.worktree, "switch", "-c", "external-same-commit")
+			c.cycle(t.Context())
+			if result := awaitCheckoutRefresh(t, ticket); !errors.Is(result.Err, ErrCheckoutRefreshSuperseded) || result.Reindexed {
+				t.Fatalf("post-admission branch was adopted: %+v", result)
+			}
+		})
+	}
+}
+
+func TestCheckoutRefreshQueueReservationPrecedesDiskCommit(t *testing.T) {
+	f, c, l := newCheckoutMutationFixture(t)
+	before := f.route()
+	m, err := l.BeginCheckoutMutation(t.Context(), f.checkoutID, f.worktree, before.RouteEpoch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	c.refreshMu.Lock()
+	c.refreshReserved = maxCheckoutRefreshTickets
+	c.refreshMu.Unlock()
+	if err := m.Prepare(t.Context()); !errors.Is(err, ErrCheckoutRefreshQueueFull) {
+		t.Fatalf("prepare accepted full queue: %v", err)
+	}
+	if f.route() != before {
+		t.Fatal("full queue invalidated route before rejecting disk commit")
+	}
+	c.refreshMu.Lock()
+	c.refreshReserved = 0
+	c.refreshMu.Unlock()
+	if err := m.Prepare(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	c.refreshMu.Lock()
+	c.refreshReserved = maxCheckoutRefreshTickets // Includes the source reservation.
+	c.refreshMu.Unlock()
+	builderWriteFile(t, f.worktree, "helper.go", "package fixture\nfunc ReservedHelper() {}\n")
+	if _, err := l.RequestCheckoutRefresh(t.Context(), f.checkoutID, f.worktree); !errors.Is(err, ErrCheckoutRefreshQueueFull) {
+		t.Fatalf("recovery stole reserved capacity: %v", err)
+	}
+	ticket, err := m.EnqueueRefresh(t.Context(), filepath.Join(f.worktree, "helper.go"))
+	if err != nil {
+		t.Fatalf("post-commit reserved enqueue failed: %v", err)
+	}
+	c.refreshMu.Lock()
+	c.refreshReserved = 0 // Release the artificial recovery reservations.
+	c.refreshMu.Unlock()
+	m.Close()
+	c.cycle(t.Context())
+	if result := awaitCheckoutRefresh(t, ticket); result.Err != nil || !result.Reindexed {
+		t.Fatalf("reserved source: %+v", result)
+	}
+}
+
+func TestCheckoutRefreshShutdownCompletesWaiters(t *testing.T) {
+	f, c, l := newCheckoutMutationFixture(t)
+	ticket := queueCheckoutSourceEdit(t, f, l, "package fixture\nfunc StoppedHelper() {}\n")
+	_ = c.Close()
+	if result := awaitCheckoutRefresh(t, ticket); !errors.Is(result.Err, ErrCheckoutRefreshStopped) || result.Reindexed {
+		t.Fatalf("stopped ticket: %+v", result)
+	}
+	c.refreshMu.Lock()
+	defer c.refreshMu.Unlock()
+	if len(c.refreshWaiters) != 0 || c.refreshReserved != 0 || !c.refreshClosed {
+		t.Fatalf("retained ticket state: waiters=%d reservations=%d closed=%v", len(c.refreshWaiters), c.refreshReserved, c.refreshClosed)
+	}
+}
+
+func TestCheckoutRefreshOperationalStoragePanicFailsTicketOnly(t *testing.T) {
+	f, c, l := newCheckoutMutationFixture(t)
+	ticket, err := l.RequestCheckoutRefresh(t.Context(), f.checkoutID, f.worktree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	storageErr := &store_sqlite.StorageError{}
+	func() {
+		defer c.guardCheckoutRefreshCycle(t.Context(), c.checkoutRefreshHighWater())
+		panic(storageErr)
+	}()
+	if result := awaitCheckoutRefresh(t, ticket); !errors.Is(result.Err, storageErr) || result.Reindexed {
+		t.Fatalf("storage panic: %+v", result)
+	}
+	want := errors.New("programmer panic")
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		defer c.guardCheckoutRefreshCycle(t.Context(), 0)
+		panic(want)
+	}()
+	if recovered != want {
+		t.Fatalf("programmer panic was swallowed: %v", recovered)
+	}
+}
+
+func TestCheckoutRefreshHashRejectsOutsideAndReplacedPhysicalRoot(t *testing.T) {
+	f, _, _ := newCheckoutMutationFixture(t)
+	rootInfo, err := os.Stat(f.worktree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{f.worktree, filepath.Join(f.primary, "helper.go"), filepath.Join(f.worktree, ".git")} {
+		if _, _, err := checkoutRefreshFileHash(t.Context(), f.worktree, rootInfo, path); err == nil {
+			t.Fatalf("accepted unsafe target %q", path)
+		}
+	}
+	original := f.worktree + "-removed"
+	if err := os.Rename(f.worktree, original); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(f.worktree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	builderWriteFile(t, f.worktree, "helper.go", "package fixture\nfunc Imposter() {}\n")
+	if _, _, err := checkoutRefreshFileHash(t.Context(), f.worktree, rootInfo, filepath.Join(f.worktree, "helper.go")); !errors.Is(err, ErrCheckoutRefreshSuperseded) {
+		t.Fatalf("accepted reused pathname: %v", err)
+	}
+}
+
+func TestCheckoutMutationBusyAdmissionIsBounded(t *testing.T) {
+	f, _, l := newCheckoutMutationFixture(t)
+	m, err := l.BeginCheckoutMutation(t.Context(), f.checkoutID, f.worktree, f.route().RouteEpoch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer m.Close()
+	started := time.Now()
+	other, err := l.BeginCheckoutMutation(t.Context(), f.checkoutID, f.worktree, f.route().RouteEpoch)
+	if other != nil {
+		other.Close()
+		t.Fatal("admitted concurrent source mutation")
+	}
+	if !errors.Is(err, ErrCheckoutMutationBusy) || time.Since(started) > 2*time.Second {
+		t.Fatalf("unbounded or untyped admission: elapsed=%s error=%v", time.Since(started), err)
+	}
+}
+
+func BenchmarkCheckoutRefreshAdmission(b *testing.B) {
+	f, c, l := newCheckoutMutationFixture(b)
+	checkout, _, err := l.catalog.GetCheckout(context.Background(), f.checkoutID)
+	if err != nil {
+		b.Fatal(err)
+	}
+	rootInfo, err := os.Stat(f.worktree)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		request, err := c.captureCheckoutRefresh(context.Background(), checkout, rootInfo, filepath.Join(f.worktree, "helper.go"))
+		if err != nil {
+			b.Fatal(err)
+		}
+		if _, err := c.enqueueCheckoutRefresh(request, false); err != nil {
+			b.Fatal(err)
+		}
+		c.finishCheckoutRefresh(request, 0, ErrCheckoutRefreshSuperseded)
+	}
+}

--- a/internal/indexer/checkout_refresh_test.go
+++ b/internal/indexer/checkout_refresh_test.go
@@ -184,7 +184,14 @@ type checkoutRefreshTestCodedError int
 func (e checkoutRefreshTestCodedError) Error() string { return "injected SQLite error" }
 func (e checkoutRefreshTestCodedError) Code() int     { return int(e) }
 
+type checkoutRefreshTestCommittedError struct{ checkoutRefreshTestCodedError }
+
+func (checkoutRefreshTestCommittedError) Committed() bool { return true }
+
 func TestCheckoutRefreshDoesNotRetryPermanentSQLiteFailures(t *testing.T) {
+	if retryableCheckoutRefreshError(fmt.Errorf("committed: %w", checkoutRefreshTestCommittedError{checkoutRefreshTestCodedError(5)})) {
+		t.Fatal("committed storage error was retried")
+	}
 	for _, code := range []int{1, 7, 10, 13, 19} {
 		if retryableCheckoutRefreshError(fmt.Errorf("storage: %w", checkoutRefreshTestCodedError(code))) {
 			t.Fatalf("permanent SQLite failure %d was retried", code)

--- a/internal/indexer/checkout_root_identity.go
+++ b/internal/indexer/checkout_root_identity.go
@@ -1,0 +1,38 @@
+package indexer
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+)
+
+// checkoutRootFileInfo captures physical directory identity before the caller
+// waits or publishes a ticket. On Windows, os.Stat may defer loading the file
+// ID until os.SameFile, reopening a pathname that could already be replaced.
+// File.Stat loads identity from the open handle instead. Close that handle
+// before returning so a retained identity never locks a worktree against moves.
+// Other platforms already capture identity in Stat, without opening a handle.
+func checkoutRootFileInfo(root string) (os.FileInfo, error) {
+	var info os.FileInfo
+	var err error
+	if runtime.GOOS == "windows" {
+		var file *os.File
+		file, err = os.Open(root)
+		if err != nil {
+			return nil, err
+		}
+		info, err = file.Stat()
+		if closeErr := file.Close(); err == nil {
+			err = closeErr
+		}
+	} else {
+		info, err = os.Stat(root)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("checkout root is not a directory: %q", root)
+	}
+	return info, nil
+}

--- a/internal/indexer/checkout_root_identity_test.go
+++ b/internal/indexer/checkout_root_identity_test.go
@@ -1,0 +1,76 @@
+package indexer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCheckoutRootFileInfoPinsIdentityBeforePathReplacement(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "checkout")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	original, err := checkoutRootFileInfo(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Do not call SameFile before replacement: that would eagerly populate
+	// Windows' lazy os.Stat identity and conceal the original bug.
+	moved := filepath.Join(parent, "moved-checkout")
+	if err := os.Rename(root, moved); err != nil {
+		t.Fatalf("capturing identity must not retain a directory handle: %v", err)
+	}
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	replacement, err := checkoutRootFileInfo(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if os.SameFile(original, replacement) {
+		t.Fatal("captured identity adopted a replacement at the reused pathname")
+	}
+	renamedOriginal, err := checkoutRootFileInfo(moved)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(original, renamedOriginal) {
+		t.Fatal("captured identity no longer identifies the original directory after rename")
+	}
+}
+
+func TestCheckoutRootFileInfoRejectsMissingOrRegularFile(t *testing.T) {
+	root := t.TempDir()
+	file := filepath.Join(root, "source.go")
+	if err := os.WriteFile(file, []byte("package fixture\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{filepath.Join(root, "missing"), file} {
+		if info, err := checkoutRootFileInfo(path); err == nil || info != nil {
+			t.Fatalf("accepted non-directory root %q: info=%v err=%v", path, info, err)
+		}
+	}
+}
+
+func BenchmarkCheckoutRootFileInfo(b *testing.B) {
+	root := b.TempDir()
+	for _, mode := range []string{"pathname_stat", "captured_identity"} {
+		b.Run(mode, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var info os.FileInfo
+				var err error
+				if mode == "pathname_stat" {
+					info, err = os.Stat(root)
+				} else {
+					info, err = checkoutRootFileInfo(root)
+				}
+				if err != nil || !info.IsDir() {
+					b.Fatalf("capture root identity: info=%v err=%v", info, err)
+				}
+			}
+		})
+	}
+}

--- a/internal/mcp/checkout_binding.go
+++ b/internal/mcp/checkout_binding.go
@@ -1,0 +1,62 @@
+package mcp
+
+import (
+	"context"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/pathkey"
+)
+
+func requestRequiresExactCheckoutView(req *mcp.CallToolRequest) bool {
+	if req.GetBool("require_exact", false) {
+		return true
+	}
+	for _, container := range []string{"options", "arguments"} {
+		fields, _ := req.GetArguments()[container].(map[string]any)
+		if exact, _ := fields["require_exact"].(bool); exact {
+			return true
+		}
+	}
+	return false
+}
+
+// checkoutForRequestPath is the shared catalog boundary for daemon admission,
+// session scope and request view selection. A cache miss observes only this
+// checkout of an already known Git family; it never tracks a new repository or
+// waits for parsing. Existing identities take the catalog-only fast path.
+func (s *Server) checkoutForRequestPath(ctx context.Context, path string) (store_sqlite.Checkout, bool, error) {
+	checkout, found, err := s.registeredCheckoutForPath(ctx, path)
+	if err != nil {
+		return checkout, false, err
+	}
+	var parentErr error
+	if found {
+		parentErr = checkoutControlRootOwnsPath(checkout.RootPath, path)
+		if parentErr == nil {
+			return checkout, true, nil
+		}
+	}
+	if s.lifecycle == nil {
+		return store_sqlite.Checkout{}, false, parentErr
+	}
+	// CWD observation establishes a session's scope. A different explicit
+	// path must pass that scope before allocation or coordinator activation,
+	// not merely before its graph data is returned. The authorizer is called
+	// outside lifecycle locks; deriving the scope may bind the own CWD once.
+	var authorize []func(string) error
+	if cwd := SessionCWDFromContext(ctx); cwd != "" && !pathkey.EqualPaths(canonicalWorktreeSelectorRoot(cwd), canonicalWorktreeSelectorRoot(path)) {
+		authorize = append(authorize, func(prefix string) error {
+			return s.repoPrefixInSessionScope(ctx, prefix, prefix)
+		})
+	}
+	observed, present, observeErr := s.lifecycle.ObserveCheckoutPath(ctx, path, authorize...)
+	if observeErr != nil {
+		return store_sqlite.Checkout{}, false, observeErr
+	}
+	if !present {
+		return store_sqlite.Checkout{}, false, parentErr
+	}
+	return observed, true, nil
+}

--- a/internal/mcp/checkout_control.go
+++ b/internal/mcp/checkout_control.go
@@ -1,0 +1,332 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/graphview"
+	"github.com/zzet/gortex/internal/pathkey"
+)
+
+type checkoutControlKey struct{}
+
+// checkoutControlScope is catalog authority, not a graph reader or edit lease.
+// Recovery and receipts must remain reachable while publication is pending,
+// but may observe only the checkout the session is authorized to address.
+type checkoutControlScope struct {
+	Checkout       store_sqlite.Checkout
+	RepoPrefix     string
+	GraphID        string
+	Route          *store_sqlite.CheckoutRoute
+	Selector       graphview.Selector
+	CheckoutScoped bool
+}
+
+func checkoutControlFromContext(ctx context.Context) *checkoutControlScope {
+	if ctx == nil {
+		return nil
+	}
+	scope, _ := ctx.Value(checkoutControlKey{}).(*checkoutControlScope)
+	return scope
+}
+
+func withCheckoutControl(ctx context.Context, scope *checkoutControlScope) context.Context {
+	if scope == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, checkoutControlKey{}, scope)
+}
+
+func (s *Server) checkoutControlOperation(req *mcp.CallToolRequest) string {
+	name := req.Params.Name
+	if isFacadeToolName(name) {
+		spec, ok := s.viewFacadeOperation(req)
+		if !ok {
+			return ""
+		}
+		name = spec.Legacy
+	}
+	switch name {
+	case "mutation_status", "reindex_repository", "detect_changes":
+		return name
+	default:
+		return ""
+	}
+}
+
+func catalogOnlyCheckoutControl(operation string) bool {
+	return operation == "mutation_status" || operation == "reindex_repository"
+}
+
+// Catalog lookup must not depend on a ready corpus listing its repository:
+// that is precisely the missing state a recovery request is meant to repair.
+func (s *Server) registeredCheckoutForPath(ctx context.Context, path string) (store_sqlite.Checkout, bool, error) {
+	families, err := s.materializer.Catalog.ListRepositoryFamilies(ctx)
+	if err != nil {
+		return store_sqlite.Checkout{}, false, err
+	}
+	ids := make([]string, len(families))
+	for i, family := range families {
+		ids[i] = family.FamilyID
+	}
+	return graphview.CheckoutForPath(ctx, s.materializer.Catalog, ids, path)
+}
+
+// registeredWorktreeSelector shares exact-root matching between control and
+// graph requests. In particular, a new nested worktree cannot resolve to its
+// already registered parent while discovery is still pending.
+func (s *Server) registeredWorktreeSelector(ctx context.Context, selector graphview.Selector) (store_sqlite.Checkout, error) {
+	var checkout store_sqlite.Checkout
+	var found bool
+	var err error
+	subject := selector.CheckoutID
+	if selector.Path != "" {
+		subject = selector.Path
+		root := canonicalWorktreeSelectorRoot(selector.Path)
+		checkout, found, err = s.checkoutForRequestPath(ctx, root)
+		if err == nil && found {
+			found = pathkey.EqualPaths(root, canonicalWorktreeSelectorRoot(checkout.RootPath))
+		}
+	} else {
+		checkout, found, err = s.materializer.Catalog.GetCheckout(ctx, selector.CheckoutID)
+	}
+	if err != nil {
+		return checkout, graphview.WrapViewError(graphview.CodeCheckoutInaccessible, fmt.Sprintf("read checkout %q", subject), err)
+	}
+	if found {
+		return checkout, nil
+	}
+	if selector.Path == "" && filepath.IsAbs(selector.CheckoutID) {
+		return checkout, graphview.NewViewError(graphview.CodeInvalidViewSelector,
+			fmt.Sprintf("view.checkout_id expects a registered identifier, not a filesystem path; use view:{kind:\"worktree\",path:%q} or workspace(operation:\"checkouts\") to find its checkout_id", selector.CheckoutID))
+	}
+	if selector.Path != "" {
+		return checkout, graphview.NewViewError(graphview.CodeCheckoutInaccessible,
+			fmt.Sprintf("no registered worktree root matches path %q; supply the worktree root, and if automatic discovery is pending inspect workspace(operation:\"checkouts\") and retry", selector.Path))
+	}
+	return checkout, graphview.NewViewError(graphview.CodeCheckoutInaccessible,
+		fmt.Sprintf("checkout %q is not registered; use view.path for a filesystem path or workspace(operation:\"checkouts\") to find its checkout_id", selector.CheckoutID))
+}
+
+// checkoutControlPath reads the reindex selector before facade lowering. The
+// legacy handler still validates the complete lowered path and paths arguments.
+func checkoutControlPath(req *mcp.CallToolRequest) string {
+	if path := req.GetString("path", ""); path != "" {
+		return path
+	}
+	for _, container := range []string{"arguments", "options"} {
+		fields, _ := req.GetArguments()[container].(map[string]any)
+		if path, _ := fields["path"].(string); path != "" {
+			return path
+		}
+	}
+	return ""
+}
+
+func (s *Server) resolveCheckoutControlScope(ctx context.Context, selector graphview.Selector, req *mcp.CallToolRequest) (*checkoutControlScope, error) {
+	if s.materializer == nil || s.materializer.Catalog == nil {
+		if selector.Kind == graphview.SelectorAuto {
+			return nil, nil
+		}
+		return nil, graphview.NewViewError(graphview.CodeCapabilityUnavailable, "checkout control requires a checkout catalog")
+	}
+	var checkout store_sqlite.Checkout
+	var found bool
+	var err error
+	switch selector.Kind {
+	case graphview.SelectorWorktree:
+		checkout, err = s.registeredWorktreeSelector(ctx, selector)
+		found = err == nil
+	case graphview.SelectorAuto:
+		path := SessionCWDFromContext(ctx)
+		if s.checkoutControlOperation(req) == "reindex_repository" {
+			if explicit := checkoutControlPath(req); explicit != "" {
+				path, err = s.checkoutControlReindexPath(ctx, path, explicit)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+		if path == "" {
+			return nil, nil
+		}
+		checkout, found, err = s.checkoutForRequestPath(ctx, canonicalWorktreeSelectorRoot(path))
+	case graphview.SelectorBase:
+		return nil, graphview.NewViewError(graphview.CodeViewReadOnly, "base graph selectors do not select a working tree; use an explicit worktree view for checkout recovery, receipts, or working-tree change detection")
+	default:
+		return nil, graphview.NewViewError(graphview.CodeViewReadOnly, "checkout controls require a live checkout; immutable ref and commit views cannot be recovered or inspected as a working tree")
+	}
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		if selector.Kind == graphview.SelectorAuto {
+			return nil, nil
+		}
+		return nil, graphview.NewViewError(graphview.CodeCheckoutInaccessible, "the selected checkout is not registered")
+	}
+	if err := s.checkoutInSessionScope(ctx, checkout); err != nil {
+		return nil, err
+	}
+	scope := &checkoutControlScope{
+		Checkout: checkout, RepoPrefix: s.repoPrefixForCheckout(ctx, checkout), Selector: selector,
+		CheckoutScoped: checkout.EffectiveMode == store_sqlite.CheckoutModeAutomatic || selector.Kind == graphview.SelectorWorktree,
+	}
+	if selector.Kind == graphview.SelectorAuto {
+		scope.Selector = graphview.Selector{Kind: graphview.SelectorWorktree, CheckoutID: checkout.CheckoutID}
+	}
+	route, present, err := s.materializer.Catalog.GetCheckoutRoute(ctx, checkout.CheckoutID)
+	if err != nil {
+		return nil, graphview.WrapViewError(graphview.CodeCheckoutInaccessible, "read checkout control route", err)
+	}
+	if present {
+		scope.Route = &route
+		scope.GraphID = route.GraphID
+	}
+	if scope.GraphID == "" {
+		graphs, graphErr := s.materializer.Catalog.ListDedicatedGraphs(ctx, checkout.FamilyID)
+		if graphErr != nil {
+			return nil, graphErr
+		}
+		for _, graph := range graphs {
+			if graph.RepoPrefix == scope.RepoPrefix {
+				scope.GraphID = graph.GraphID
+				break
+			}
+		}
+	}
+	return scope, nil
+}
+
+func (s *Server) checkoutControlReindexPath(ctx context.Context, cwd, path string) (string, error) {
+	if filepath.IsAbs(path) {
+		return path, nil
+	}
+	if cwd != "" {
+		checkout, found, err := s.checkoutForRequestPath(ctx, canonicalWorktreeSelectorRoot(cwd))
+		if err != nil {
+			return "", err
+		}
+		if found && graphview.ServesAutomaticView(checkout) {
+			prefix := s.repoPrefixForCheckout(ctx, checkout)
+			if prefix != "" && (path == prefix || strings.HasPrefix(path, prefix+"/")) {
+				return filepath.Join(checkout.RootPath, strings.TrimPrefix(strings.TrimPrefix(path, prefix), "/")), nil
+			}
+		}
+	}
+	if s.multiIndexer != nil {
+		if root, ok := s.multiIndexer.RepoRoot(path); ok {
+			return root, nil
+		}
+	}
+	if cwd != "" {
+		return filepath.Join(cwd, path), nil
+	}
+	return path, nil
+}
+
+func (scope *checkoutControlScope) validateRepoSelector(selector string) error {
+	if selector == "" || selector == scope.RepoPrefix || pathkey.EqualPaths(canonicalWorktreeSelectorRoot(selector), canonicalWorktreeSelectorRoot(scope.Checkout.RootPath)) {
+		return nil
+	}
+	return graphview.NewViewError(graphview.CodeSelectorConflict, "repository selector conflicts with the selected checkout")
+}
+
+func (scope *checkoutControlScope) validateReindexPaths(path string, paths []string) error {
+	root, err := checkoutControlCanonicalPath(scope.Checkout.RootPath)
+	if err != nil {
+		return graphview.WrapViewError(graphview.CodeCheckoutInaccessible, "resolve selected checkout root", err)
+	}
+	if path != "" && path != scope.RepoPrefix {
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(scope.Checkout.RootPath, path)
+		}
+		resolved, err := checkoutControlCanonicalPath(path)
+		if err != nil || !pathContainedIn(resolved, root) {
+			return graphview.NewViewError(graphview.CodeSelectorOutOfScope, "reindex path is outside the selected checkout")
+		}
+	}
+	for _, path := range paths {
+		path = strings.TrimPrefix(path, scope.RepoPrefix+"/")
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(scope.Checkout.RootPath, path)
+		}
+		resolved, err := checkoutControlCanonicalPath(path)
+		if err != nil || !pathContainedIn(resolved, root) {
+			return graphview.NewViewError(graphview.CodeSelectorOutOfScope, "reindex paths must remain inside the selected checkout")
+		}
+	}
+	return nil
+}
+
+// Resolve the longest existing ancestor, so aliases remain valid for new files
+// while a nonexistent child of an escaping symlink is still refused.
+func checkoutControlCanonicalPath(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	ancestor := abs
+	for {
+		if _, err := os.Lstat(ancestor); err == nil {
+			resolved, err := filepath.EvalSymlinks(ancestor)
+			if err != nil {
+				return "", err
+			}
+			rel, err := filepath.Rel(ancestor, abs)
+			if err != nil {
+				return "", err
+			}
+			return filepath.Join(resolved, rel), nil
+		} else if !os.IsNotExist(err) {
+			return "", err
+		}
+		parent := filepath.Dir(ancestor)
+		if parent == ancestor {
+			return "", fmt.Errorf("no accessible ancestor for %q", path)
+		}
+		ancestor = parent
+	}
+}
+
+// A catalog's containing parent is not authority for a newly created nested
+// checkout that discovery has not registered yet. Fail closed until that
+// checkout has its own identity rather than recovering the parent's graph.
+func checkoutControlRootOwnsPath(root, path string) error {
+	root, rootErr := checkoutControlCanonicalPath(root)
+	path, pathErr := checkoutControlCanonicalPath(path)
+	if rootErr != nil || pathErr != nil || !pathContainedIn(path, root) {
+		return graphview.NewViewError(graphview.CodeCheckoutInaccessible, "checkout control path cannot be resolved inside its registered root")
+	}
+	if info, err := os.Stat(path); err == nil && !info.IsDir() {
+		path = filepath.Dir(path)
+	}
+	for path != root {
+		if _, err := os.Lstat(filepath.Join(path, ".git")); err == nil {
+			return graphview.NewViewError(graphview.CodeCheckoutInaccessible, "the selected nested checkout is not registered yet; automatic discovery must establish its identity before checkout controls can run")
+		} else if !os.IsNotExist(err) {
+			return graphview.WrapViewError(graphview.CodeCheckoutInaccessible, "inspect checkout control path", err)
+		}
+		path = filepath.Dir(path)
+	}
+	return nil
+}
+
+func (s *Server) attachCheckoutControlScope(ctx context.Context, res *mcp.CallToolResult) *mcp.CallToolResult {
+	scope := checkoutControlFromContext(ctx)
+	if scope == nil || res == nil {
+		return res
+	}
+	// Identity metadata deliberately carries no `exact:true` graph claim.
+	return mergeResultMeta(res, map[string]any{"checkout_scope": map[string]any{
+		"checkout_id": scope.Checkout.CheckoutID, "incarnation": scope.Checkout.Incarnation,
+		"repo": scope.RepoPrefix, "root": scope.Checkout.RootPath, "graph_id": scope.GraphID,
+		"state": string(scope.Checkout.State),
+	}})
+}

--- a/internal/mcp/checkout_control_test.go
+++ b/internal/mcp/checkout_control_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -230,11 +232,18 @@ func TestCheckoutAdmissionContentionIsRetryableWithoutInventingScope(t *testing.
 	checkoutMutationGit(t, f.primary, "worktree", "add", "-b", "admission-busy", root)
 	ctx := WithSessionCWD(WithSessionID(context.Background(), "real-checkout-lifecycle"), root)
 	rec := f.srv.lifecycle.Reconciler()
-	reconcile.WithHEADSampler(func(ctx context.Context, _ string) (gitstate.HEADState, error) {
-		<-ctx.Done()
-		return gitstate.HEADState{}, errors.New("injected Git subprocess killed")
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	unblock := func() { releaseOnce.Do(func() { close(release) }) }
+	reconcile.WithHEADSampler(func(ctx context.Context, root string) (gitstate.HEADState, error) {
+		select {
+		case <-ctx.Done():
+			return gitstate.HEADState{}, errors.New("injected Git subprocess killed")
+		case <-release:
+			return gitstate.SampleHEAD(ctx, root)
+		}
 	})(rec)
-	t.Cleanup(func() { reconcile.WithHEADSampler(gitstate.SampleHEAD)(rec) })
+	t.Cleanup(unblock)
 	started := time.Now()
 	served, err := f.srv.CheckoutServesCWDChecked(ctx, root)
 	require.False(t, served, "pending observation is not a scoped checkout")
@@ -248,14 +257,16 @@ func TestCheckoutAdmissionContentionIsRetryableWithoutInventingScope(t *testing.
 
 	// Exercise the same session's scope cache during the failed observation.
 	// It must not remain unresolved once a retry can establish the checkout.
-	before := f.facade(t, root, "search", map[string]any{
-		"operation": "symbols", "query": "Old", "require_exact": true,
-	})
-	require.True(t, before.IsError)
-	reconcile.WithHEADSampler(gitstate.SampleHEAD)(rec)
-	served, err = f.srv.CheckoutServesCWDChecked(ctx, root)
-	require.NoError(t, err)
-	require.True(t, served)
+	for _, exact := range []bool{false, true} {
+		started := time.Now()
+		before := f.facade(t, root, "search", map[string]any{
+			"operation": "symbols", "query": "Old", "require_exact": exact,
+		})
+		assertToolError(t, before, graphview.CodeViewBuilding)
+		require.Less(t, time.Since(started), time.Second, "pending discovery must not become a successful empty search or wait on the job")
+	}
+	unblock()
+	awaitCheckoutAdmission(t, f.srv, ctx, root, time.Now().Add(2*time.Second))
 	var exact *mcp.CallToolResult
 	require.Eventually(t, func() bool {
 		exact = f.facade(t, root, "search", map[string]any{
@@ -293,6 +304,107 @@ func TestCheckoutAdmissionPreservesPrefixCatalogFailure(t *testing.T) {
 	served, err = stack.srv.CheckoutServesCWDChecked(context.Background(), stack.worktreeRoot)
 	require.NoError(t, err)
 	require.True(t, served)
+}
+
+func TestCheckoutLookupFailureRequiresIndependentCanonicalOwnership(t *testing.T) {
+	f := newRealCheckoutMutationFixture(t)
+	nested := filepath.Join(f.primary, "unregistered-nested")
+	require.NoError(t, os.MkdirAll(nested, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(nested, ".git"), []byte("gitdir: /not-yet-registered"), 0o644))
+	lookupErr := errors.New("injected catalog or proof read failure")
+	for _, tc := range []struct {
+		name, cwd string
+		fallback  bool
+	}{
+		{"canonical", f.primary, true},
+		{"automatic_sibling", f.worktree, false},
+		{"nested_checkout", nested, false},
+		{"unknown", t.TempDir(), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			view, err := f.srv.viewForCWDLookupError(tc.cwd, lookupErr)
+			if tc.fallback {
+				require.NoError(t, err)
+				require.NotNil(t, view)
+				defer view.close()
+				require.NotNil(t, view.rider)
+				require.False(t, view.rider.Exact, "canonical catalog fallback must remain labeled")
+				return
+			}
+			require.Nil(t, view, "a failed proof must not hand out any base reader or fallback")
+			require.Equal(t, graphview.CodeCheckoutInaccessible, graphview.CodeOf(err))
+			require.ErrorIs(t, err, lookupErr)
+		})
+	}
+	for _, tc := range []struct {
+		name string
+		err  error
+		code string
+	}{
+		{"stale", indexer.ErrCheckoutMutationStale, graphview.CodeCheckoutInaccessible},
+		{"stopped", indexer.ErrCheckoutRefreshStopped, graphview.CodeCheckoutInaccessible},
+		{"busy", indexer.ErrCheckoutMutationBusy, graphview.CodeViewBuilding},
+		{"canceled", context.Canceled, graphview.CodeCheckoutInaccessible},
+		{"deadline", context.DeadlineExceeded, graphview.CodeCheckoutInaccessible},
+		{"denied", graphview.NewViewError(graphview.CodeSelectorOutOfScope, "scope denied"), graphview.CodeSelectorOutOfScope},
+		{"wrapped_stale", graphview.WrapViewError(graphview.CodeCheckoutInaccessible, "catalog unavailable", indexer.ErrCheckoutMutationStale), graphview.CodeCheckoutInaccessible},
+		{"wrapped_busy", graphview.WrapViewError(graphview.CodeCheckoutInaccessible, "catalog unavailable", indexer.ErrCheckoutMutationBusy), graphview.CodeViewBuilding},
+		{"wrapped_denied", graphview.WrapViewError(graphview.CodeCheckoutInaccessible, "catalog unavailable", graphview.NewViewError(graphview.CodeSelectorOutOfScope, "scope denied")), graphview.CodeCheckoutInaccessible},
+		{"wrapped_unknown", graphview.WrapViewError(graphview.CodeCheckoutInaccessible, "catalog unavailable", graphview.NewViewError(graphview.CodeInvalidViewSelector, "unknown selector")), graphview.CodeCheckoutInaccessible},
+		{"joined_denied", errors.Join(graphview.NewViewError(graphview.CodeCheckoutInaccessible, "catalog unavailable"), graphview.NewViewError(graphview.CodeSelectorOutOfScope, "scope denied")), graphview.CodeCheckoutInaccessible},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, cwd := range []string{f.primary, f.worktree} {
+				view, err := f.srv.viewForCWDLookupError(cwd, tc.err)
+				require.Nil(t, view, "an explicit admission failure cannot use even a canonical fallback")
+				require.Equal(t, tc.code, graphview.CodeOf(err))
+				require.ErrorIs(t, err, tc.err)
+			}
+		})
+	}
+}
+
+func TestCheckoutStaleDiscoveryProofNeverReturnsBaseData(t *testing.T) {
+	t.Setenv("GORTEX_TOOLS", "facade-v1")
+	f := newRealCheckoutMutationFixture(t)
+	root := filepath.Join(filepath.Dir(f.primary), "stale-proof")
+	checkoutMutationGit(t, f.primary, "worktree", "add", "-b", "stale-proof", root)
+	var changed atomic.Bool
+	reconcile.WithHEADSampler(func(ctx context.Context, observedRoot string) (gitstate.HEADState, error) {
+		head, err := gitstate.SampleHEAD(ctx, observedRoot)
+		if err != nil || filepath.Clean(observedRoot) != filepath.Clean(root) || !changed.CompareAndSwap(false, true) {
+			return head, err
+		}
+		// Proof captured the marker before this sampler. A newline keeps Git's
+		// target valid but changes the proof bytes before final admission.
+		marker := filepath.Join(root, ".git")
+		data, err := os.ReadFile(marker)
+		if err != nil {
+			return gitstate.HEADState{}, err
+		}
+		if err := os.WriteFile(marker, append(data, '\n'), 0o644); err != nil {
+			return gitstate.HEADState{}, err
+		}
+		return head, nil
+	})(f.srv.lifecycle.Reconciler())
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		started := time.Now()
+		result := f.facade(t, root, "search", map[string]any{
+			"operation": "symbols", "query": "Old", "options": map[string]any{"limit": 10},
+		})
+		require.Less(t, time.Since(started), time.Second)
+		require.True(t, result.IsError, "stale proof must not expose the primary's Old symbol: %+v", result.Content)
+		if strings.Contains(viewResultText(t, result), graphview.CodeViewBuilding) {
+			require.True(t, time.Now().Before(deadline), "stale proof was never resolved")
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		assertToolError(t, result, graphview.CodeCheckoutInaccessible)
+		require.True(t, changed.Load(), "the real post-proof Git marker mutation must execute")
+		require.Contains(t, viewResultText(t, result), indexer.ErrCheckoutMutationStale.Error())
+		break
+	}
 }
 
 func TestCheckoutControlClassifiesOnlySupportedOperations(t *testing.T) {

--- a/internal/mcp/checkout_control_test.go
+++ b/internal/mcp/checkout_control_test.go
@@ -1,0 +1,414 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/gitstate"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/graphview"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/reconcile"
+)
+
+func TestCheckoutControlReceiptBypassesUnreadyGraph(t *testing.T) {
+	for _, ownCWD := range []bool{false, true} {
+		name := "explicit_checkout"
+		if ownCWD {
+			name = "own_cwd"
+		}
+		t.Run(name, func(t *testing.T) {
+			stack := newViewStack(t)
+			require.NoError(t, stack.store.Catalog().DeleteCheckoutRoute(context.Background(), viewTestWorktree))
+			cwd, args := stack.repoRoot, worktreeViewArgs()
+			if ownCWD {
+				cwd, args = stack.worktreeRoot, nil
+			}
+			ran := false
+			res, err := stack.callWithView(t, cwd, "mutation_status", args,
+				func(ctx context.Context) (*mcp.CallToolResult, error) {
+					ran = true
+					scope := checkoutControlFromContext(ctx)
+					require.NotNil(t, scope)
+					require.True(t, scope.CheckoutScoped)
+					require.Equal(t, viewTestWorktree, scope.Checkout.CheckoutID)
+					require.Equal(t, "inc-worktree", scope.Checkout.Incarnation)
+					require.Nil(t, scope.Route)
+					require.Nil(t, requestViewFromContext(ctx), "receipt metadata must not claim an exact graph")
+					return mcp.NewToolResultText(`{"receipts":[]}`), nil
+				})
+			require.NoError(t, err)
+			require.False(t, res.IsError, viewResultText(t, res))
+			require.True(t, ran)
+			graphResult, err := stack.callWithView(t, stack.repoRoot, "get_symbol", worktreeViewArgs(), captureReader(stack.srv, new(graph.Reader)))
+			require.NoError(t, err)
+			assertToolError(t, graphResult, graphview.CodeViewBuilding)
+		})
+	}
+}
+
+func TestCheckoutControlScopesBeforeReadiness(t *testing.T) {
+	for _, state := range []store_sqlite.CheckoutState{store_sqlite.CheckoutStateReady, store_sqlite.CheckoutStateUnavailable} {
+		t.Run(string(state), func(t *testing.T) {
+			stack := newViewStack(t)
+			stack.setWorktreeState(t, state)
+			require.NoError(t, stack.store.Catalog().DeleteCheckoutRoute(context.Background(), viewTestWorktree))
+			for _, tool := range []string{"mutation_status", "reindex_repository", "detect_changes"} {
+				ran := false
+				res, err := stack.callWithView(t, stack.otherRoot, tool, worktreeViewArgs(),
+					func(context.Context) (*mcp.CallToolResult, error) {
+						ran = true
+						return mcp.NewToolResultText(`{"ok":true}`), nil
+					})
+				require.NoError(t, err)
+				assertToolError(t, res, graphview.CodeSelectorOutOfScope)
+				require.False(t, ran, tool)
+			}
+		})
+	}
+}
+
+func TestCheckoutControlDistinguishesCanonicalAndSelectedWorktree(t *testing.T) {
+	stack := newViewStack(t)
+	res, err := stack.callWithView(t, stack.repoRoot, "mutation_status", nil,
+		func(ctx context.Context) (*mcp.CallToolResult, error) {
+			scope := checkoutControlFromContext(ctx)
+			require.NotNil(t, scope)
+			require.False(t, scope.CheckoutScoped)
+			require.Equal(t, viewTestPrimary, scope.Checkout.CheckoutID)
+			return mcp.NewToolResultText(`{"ok":true}`), nil
+		})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+}
+
+func TestCheckoutControlDoesNotAdmitImmutableRecovery(t *testing.T) {
+	stack := newViewStack(t)
+	for _, kind := range []string{"git_ref", "commit"} {
+		value := "refs/heads/main"
+		if kind == "commit" {
+			value = strings.Repeat("a", 40)
+		}
+		ran := false
+		res, err := stack.callWithView(t, stack.repoRoot, "reindex_repository",
+			map[string]any{"view": map[string]any{"kind": kind, "value": value}},
+			func(context.Context) (*mcp.CallToolResult, error) {
+				ran = true
+				return mcp.NewToolResultText(`{"ok":true}`), nil
+			})
+		require.NoError(t, err)
+		assertToolError(t, res, graphview.CodeViewReadOnly)
+		require.False(t, ran)
+	}
+}
+
+func TestCheckoutControlPathAndScopeConfinement(t *testing.T) {
+	stack := newViewStack(t)
+	scope := &checkoutControlScope{RepoPrefix: "repo", Checkout: store_sqlite.Checkout{RootPath: stack.worktreeRoot}}
+	for _, paths := range [][]string{{"../repo/edit.go"}, {filepath.Join(stack.repoRoot, "edit.go")}, {filepath.Join(stack.otherRoot, "other.go")}} {
+		require.Error(t, scope.validateReindexPaths("", paths))
+	}
+	require.NoError(t, scope.validateReindexPaths(stack.worktreeRoot, []string{"repo/edit.go", "new/subdir.go"}))
+	require.NoError(t, scope.validateRepoSelector("repo"))
+	require.NoError(t, scope.validateRepoSelector(stack.worktreeRoot))
+	require.Error(t, scope.validateRepoSelector(stack.repoRoot))
+	require.Error(t, scope.validateReindexPaths(stack.repoRoot, nil))
+	alias := filepath.Join(t.TempDir(), "checkout-alias")
+	require.NoError(t, os.Symlink(stack.worktreeRoot, alias))
+	require.NoError(t, scope.validateReindexPaths(alias, []string{filepath.Join(alias, "new/subdir.go")}))
+	escape := filepath.Join(stack.worktreeRoot, "escape")
+	require.NoError(t, os.Symlink(stack.otherRoot, escape))
+	require.Error(t, scope.validateReindexPaths("", []string{filepath.Join(escape, "not-created.go")}))
+}
+
+func TestCheckoutControlBaseNeverFallsBackToCWDWorkingTree(t *testing.T) {
+	stack := newViewStack(t)
+	route, found, err := stack.store.Catalog().GetCheckoutRoute(context.Background(), viewTestWorktree)
+	require.NoError(t, err)
+	require.True(t, found)
+	for _, operation := range []string{"reindex_repository", "detect_changes", "mutation_status"} {
+		t.Run(operation, func(t *testing.T) {
+			ran := false
+			res, err := stack.callWithView(t, stack.worktreeRoot, operation,
+				map[string]any{"view": map[string]any{"kind": "base", "graph_id": route.GraphID}},
+				func(context.Context) (*mcp.CallToolResult, error) {
+					ran = true
+					return mcp.NewToolResultText(`{"ok":true}`), nil
+				})
+			require.NoError(t, err)
+			assertToolError(t, res, graphview.CodeViewReadOnly)
+			require.False(t, ran)
+		})
+	}
+}
+
+func TestCheckoutControlNeverRecoversUnregisteredNestedCheckoutAsParent(t *testing.T) {
+	stack := newViewStack(t)
+	nested := filepath.Join(stack.repoRoot, "nested")
+	require.NoError(t, os.MkdirAll(nested, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(nested, ".git"), []byte("gitdir: /not-yet-cataloged"), 0o644))
+	for _, tc := range []struct {
+		name, cwd, operation string
+		args                 map[string]any
+	}{
+		{"reindex-path", stack.repoRoot, "reindex_repository", map[string]any{"path": nested}},
+		{"receipt-cwd", nested, "mutation_status", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ran := false
+			res, err := stack.callWithView(t, tc.cwd, tc.operation, tc.args,
+				func(context.Context) (*mcp.CallToolResult, error) {
+					ran = true
+					return mcp.NewToolResultText(`{"ok":true}`), nil
+				})
+			require.NoError(t, err)
+			assertToolError(t, res, graphview.CodeCheckoutInaccessible)
+			require.False(t, ran)
+		})
+	}
+}
+
+func TestCheckoutControlResolvesLegacyReindexPathToAutomaticCheckout(t *testing.T) {
+	stack := newViewStack(t)
+	require.NoError(t, stack.store.Catalog().DeleteCheckoutRoute(context.Background(), viewTestWorktree))
+	res, err := stack.callWithView(t, stack.repoRoot, "reindex_repository",
+		map[string]any{"path": stack.worktreeRoot}, func(ctx context.Context) (*mcp.CallToolResult, error) {
+			scope := checkoutControlFromContext(ctx)
+			require.NotNil(t, scope)
+			require.Equal(t, viewTestWorktree, scope.Checkout.CheckoutID)
+			require.True(t, scope.CheckoutScoped)
+			return mcp.NewToolResultText(`{"ok":true}`), nil
+		})
+	require.NoError(t, err)
+	require.False(t, res.IsError, viewResultText(t, res))
+}
+
+func TestCheckoutControlOwnCWDRepoPrefixNeverReindexesPrimary(t *testing.T) {
+	stack := newViewStack(t)
+	require.NoError(t, stack.store.Catalog().DeleteCheckoutRoute(context.Background(), viewTestWorktree))
+	res, err := stack.callWithView(t, stack.worktreeRoot, "reindex_repository",
+		map[string]any{"path": "repo"}, func(ctx context.Context) (*mcp.CallToolResult, error) {
+			scope := checkoutControlFromContext(ctx)
+			require.NotNil(t, scope)
+			require.Equal(t, viewTestWorktree, scope.Checkout.CheckoutID)
+			require.True(t, scope.CheckoutScoped)
+			return mcp.NewToolResultText(`{"ok":true}`), nil
+		})
+	require.NoError(t, err)
+	require.False(t, res.IsError, viewResultText(t, res))
+}
+
+func TestCheckoutBindingUnknownFamilyDoesNotInventScope(t *testing.T) {
+	f := newRealCheckoutMutationFixture(t)
+	ctx := context.Background()
+	before, err := f.store.Catalog().ListRepositoryFamilies(ctx)
+	require.NoError(t, err)
+	unknown := t.TempDir()
+	checkoutMutationGit(t, unknown, "init")
+	require.False(t, f.srv.CheckoutServesCWD(ctx, unknown))
+	_, found, err := f.srv.checkoutForRequestPath(ctx, unknown)
+	require.NoError(t, err)
+	require.False(t, found)
+	after, err := f.store.Catalog().ListRepositoryFamilies(ctx)
+	require.NoError(t, err)
+	require.Equal(t, before, after, "ordinary request binding must not track an unknown Git family")
+}
+
+func TestCheckoutAdmissionContentionIsRetryableWithoutInventingScope(t *testing.T) {
+	t.Setenv("GORTEX_TOOLS", "facade-v1")
+	f := newRealCheckoutMutationFixture(t)
+	root := filepath.Join(filepath.Dir(f.primary), "admission-busy")
+	checkoutMutationGit(t, f.primary, "worktree", "add", "-b", "admission-busy", root)
+	ctx := WithSessionCWD(WithSessionID(context.Background(), "real-checkout-lifecycle"), root)
+	rec := f.srv.lifecycle.Reconciler()
+	reconcile.WithHEADSampler(func(ctx context.Context, _ string) (gitstate.HEADState, error) {
+		<-ctx.Done()
+		return gitstate.HEADState{}, errors.New("injected Git subprocess killed")
+	})(rec)
+	t.Cleanup(func() { reconcile.WithHEADSampler(gitstate.SampleHEAD)(rec) })
+	started := time.Now()
+	served, err := f.srv.CheckoutServesCWDChecked(ctx, root)
+	require.False(t, served, "pending observation is not a scoped checkout")
+	require.ErrorIs(t, err, indexer.ErrCheckoutMutationBusy)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.GreaterOrEqual(t, time.Since(started), 200*time.Millisecond)
+	require.Less(t, time.Since(started), time.Second)
+	_, found, lookupErr := f.srv.registeredCheckoutForPath(context.Background(), root)
+	require.NoError(t, lookupErr)
+	require.False(t, found, "timed-out metadata observation must not invent a catalog identity")
+
+	// Exercise the same session's scope cache during the failed observation.
+	// It must not remain unresolved once a retry can establish the checkout.
+	before := f.facade(t, root, "search", map[string]any{
+		"operation": "symbols", "query": "Old", "require_exact": true,
+	})
+	require.True(t, before.IsError)
+	reconcile.WithHEADSampler(gitstate.SampleHEAD)(rec)
+	served, err = f.srv.CheckoutServesCWDChecked(ctx, root)
+	require.NoError(t, err)
+	require.True(t, served)
+	var exact *mcp.CallToolResult
+	require.Eventually(t, func() bool {
+		exact = f.facade(t, root, "search", map[string]any{
+			"operation": "symbols", "query": "Old", "require_exact": true,
+		})
+		return !exact.IsError && resultFreshness(t, exact)["exact"] == true
+	}, 10*time.Second, 20*time.Millisecond)
+	payload := lifecycleResultPayload(t, exact)
+	require.NotEmpty(t, payload["results"], "retry must recover the session's selected primary scope, not return silent zeros")
+}
+
+func TestCheckoutAdmissionPreservesPrefixCatalogFailure(t *testing.T) {
+	stack := newViewStack(t)
+	var catalogErr error
+	called := false
+	workspace, project, prefix, served, err := stack.srv.scopeForAutomaticCheckoutWithPrefix(
+		context.Background(), stack.worktreeRoot, func(_ context.Context, checkout store_sqlite.Checkout) (string, error) {
+			called = true
+			require.Equal(t, viewTestWorktree, checkout.CheckoutID, "checkout lookup must succeed before this injected catalog failure")
+			canceled, cancel := context.WithCancel(context.Background())
+			cancel()
+			// Execute the real ListDedicatedGraphs read with a failing context,
+			// rather than failing the earlier checkout/family lookup.
+			result, lookupErr := stack.srv.repoPrefixForCheckoutChecked(canceled, checkout)
+			catalogErr = lookupErr
+			require.ErrorIs(t, catalogErr, context.Canceled)
+			return result, lookupErr
+		})
+	require.True(t, called)
+	require.False(t, served)
+	require.Empty(t, workspace)
+	require.Empty(t, project)
+	require.Empty(t, prefix)
+	require.Equal(t, catalogErr, err, "catalog failure must not become false,nil/untracked")
+	served, err = stack.srv.CheckoutServesCWDChecked(context.Background(), stack.worktreeRoot)
+	require.NoError(t, err)
+	require.True(t, served)
+}
+
+func TestCheckoutControlClassifiesOnlySupportedOperations(t *testing.T) {
+	stack := newViewStack(t)
+	for _, tc := range []struct {
+		name string
+		args map[string]any
+		want string
+	}{
+		{"mutation_status", nil, "mutation_status"},
+		{"change", map[string]any{"operation": "receipt"}, "mutation_status"},
+		{"change", map[string]any{"operation": "detect"}, "detect_changes"},
+		{"workspace_admin", map[string]any{"operation": "reindex"}, "reindex_repository"},
+		{"edit", map[string]any{"target": map[string]any{"file": "edit.go"}, "match": "a", "replacement": "b"}, ""},
+		{"change", map[string]any{"operation": "impact"}, ""},
+		{"search_symbols", nil, ""},
+	} {
+		req := mcp.CallToolRequest{}
+		req.Params.Name, req.Params.Arguments = tc.name, tc.args
+		require.Equal(t, tc.want, stack.srv.checkoutControlOperation(&req), tc.name)
+	}
+}
+
+func TestCheckoutControlDoesNotRelaxExactAutoCWDQueries(t *testing.T) {
+	// Before the boundary guard, auto-CWD ignored require_exact and invoked
+	// the leaf successfully with an exact:false base fallback.
+	for _, tc := range []struct {
+		name, operation string
+		args            map[string]any
+	}{
+		{"legacy-source", "get_symbol", map[string]any{"require_exact": true}},
+		{"facade-source", "read", map[string]any{"operation": "source", "target": map[string]any{"symbol": "repo/edit.go::New"}, "require_exact": true}},
+		{"facade-search-options", "search", map[string]any{"operation": "symbols", "query": "New", "options": map[string]any{"require_exact": true}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.operation != "get_symbol" {
+				t.Setenv("GORTEX_TOOLS", "facade-v1")
+			}
+			stack := newViewStack(t)
+			require.NoError(t, stack.store.Catalog().DeleteCheckoutRoute(context.Background(), viewTestWorktree))
+			ran := false
+			res, err := stack.callWithView(t, stack.worktreeRoot, tc.operation, tc.args,
+				func(context.Context) (*mcp.CallToolResult, error) {
+					ran = true
+					return mcp.NewToolResultText(`{"ok":true}`), nil
+				})
+			require.NoError(t, err)
+			assertToolError(t, res, graphview.CodeViewBuilding)
+			require.False(t, ran)
+		})
+	}
+}
+
+func TestDetectChangesUsesSelectedCheckoutAndLabelsPendingGraph(t *testing.T) {
+	for _, pending := range []bool{false, true} {
+		name := "ready"
+		if pending {
+			name = "pending"
+		}
+		t.Run(name, func(t *testing.T) {
+			stack := newViewStack(t)
+			for _, dir := range []string{stack.repoRoot, stack.worktreeRoot} {
+				checkoutMutationGit(t, dir, "init", "--initial-branch=main")
+				if dir == stack.worktreeRoot {
+					require.NoError(t, os.WriteFile(filepath.Join(dir, "edit.go"), []byte(primitiveWorktreeSource), 0o644))
+				}
+				checkoutMutationGit(t, dir, "add", "-A")
+				checkoutMutationGit(t, dir, "commit", "-m", "before")
+			}
+			require.NoError(t, os.WriteFile(filepath.Join(stack.repoRoot, "keep.go"), []byte("package repo\nfunc PrimaryOnlyChanged() {}\n"), 0o644))
+			require.NoError(t, os.WriteFile(filepath.Join(stack.worktreeRoot, "edit.go"), []byte("package repo\n\nfunc New() { println(\"changed\") }\n"), 0o644))
+			if pending {
+				require.NoError(t, stack.store.Catalog().DeleteCheckoutRoute(context.Background(), viewTestWorktree))
+			}
+			args := worktreeViewArgs()
+			args["scope"] = "unstaged"
+			res, err := stack.callWithView(t, stack.repoRoot, "detect_changes", args,
+				func(ctx context.Context) (*mcp.CallToolResult, error) {
+					req := mcp.CallToolRequest{}
+					req.Params.Name, req.Params.Arguments = "detect_changes", args
+					return stack.srv.handleDetectChanges(ctx, req)
+				})
+			require.NoError(t, err)
+			require.False(t, res.IsError, viewResultText(t, res))
+			payload := decodeFileOpsResult(t, res)
+			require.Equal(t, stack.worktreeRoot, payload["repo_root"])
+			files, ok := payload["changed_files"].([]any)
+			require.True(t, ok)
+			require.Len(t, files, 1)
+			require.True(t, strings.HasSuffix(files[0].(string), "edit.go"))
+			if pending {
+				require.Equal(t, false, payload["complete"])
+				require.Equal(t, "pending", payload["graph_status"])
+				require.Equal(t, "UNKNOWN", payload["risk"])
+				require.Empty(t, payload["changed_symbols"])
+			} else {
+				require.NotEmpty(t, payload["changed_symbols"])
+			}
+		})
+	}
+}
+
+func BenchmarkCheckoutControlReceiptWhileGraphPending(b *testing.B) {
+	fixture := newRealCheckoutMutationFixture(b)
+	require.NoError(b, fixture.store.Catalog().DeleteCheckoutRoute(context.Background(), fixture.checkoutID))
+	ctx := WithSessionCWD(WithSessionID(context.Background(), "benchmark-checkout-control"), fixture.primary)
+	handler := fixture.srv.wrapControlToolHandler(fixture.srv.handleMutationStatus)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		req := mcp.CallToolRequest{}
+		req.Params.Name = "mutation_status"
+		req.Params.Arguments = map[string]any{"view": map[string]any{"kind": "worktree", "checkout_id": fixture.checkoutID}}
+		result, err := handler(ctx, req)
+		if err != nil || result == nil || result.IsError {
+			b.Fatalf("receipt control failed: result=%+v error=%v", result, err)
+		}
+	}
+}

--- a/internal/mcp/checkout_mutation_receipt_test.go
+++ b/internal/mcp/checkout_mutation_receipt_test.go
@@ -1,0 +1,422 @@
+package mcp
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/zzet/gortex/internal/indexer"
+)
+
+type receiptCheckoutMutation struct {
+	ticket            *indexer.CheckoutRefreshTicket
+	enqueueErr        error
+	enqueueContextErr error
+	enqueuedPath      string
+}
+
+func (m *receiptCheckoutMutation) Prepare(context.Context) error { return nil }
+func (m *receiptCheckoutMutation) Refresh(context.Context) (indexer.CheckoutCycle, error) {
+	panic("queued checkout mutations must not reconcile while holding the request lease")
+}
+func (m *receiptCheckoutMutation) Identity() (string, string) {
+	return m.ticket.CheckoutID, m.ticket.Incarnation
+}
+func (m *receiptCheckoutMutation) EnqueueRefresh(ctx context.Context, path string) (*indexer.CheckoutRefreshTicket, error) {
+	m.enqueueContextErr = ctx.Err()
+	m.enqueuedPath = path
+	return m.ticket, m.enqueueErr
+}
+
+func newReceiptCheckoutMutation(t *testing.T) (*receiptCheckoutMutation, chan indexer.MutationResult, string) {
+	t.Helper()
+	root := t.TempDir()
+	path := filepath.Join(root, "edit.go")
+	if err := os.WriteFile(path, []byte("package fixture\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan indexer.MutationResult, 1)
+	t.Cleanup(func() { close(done) })
+	return &receiptCheckoutMutation{ticket: &indexer.CheckoutRefreshTicket{
+		CheckoutID: "checkout-1", Incarnation: "incarnation-1", Root: root, RepoPrefix: "fixture",
+		Ticket: &indexer.MutationTicket{Path: path, Generation: 7, Done: done},
+	}}, done, path
+}
+
+func waitCheckoutReceipt(t *testing.T, s *Server, id string) *mutationReceipt {
+	t.Helper()
+	value, ok := s.mutationReceipts.Load(id)
+	if !ok {
+		t.Fatalf("missing freshness receipt %q", id)
+	}
+	receipt := value.(*mutationReceipt)
+	select {
+	case <-receipt.done:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("freshness receipt %q did not complete", id)
+	}
+	return receipt
+}
+
+func TestCheckoutMutationReceiptRemainsPendingUntilPublication(t *testing.T) {
+	mutation, done, path := newReceiptCheckoutMutation(t)
+	s := &Server{mutationReindexWait: time.Nanosecond}
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = withCheckoutMutation(ctx, mutation, filepath.Dir(path))
+	cancel() // Committed bytes must still acquire a real publication ticket.
+	outcome := s.mutationReindexState(ctx, path)
+	if !outcome.Pending || outcome.Reindexed || outcome.Err != nil || outcome.Receipt == "" || !outcome.checkoutScoped {
+		t.Fatalf("committed checkout should be pending, not failed/fresh: %+v", outcome)
+	}
+	if mutation.enqueueContextErr != nil || mutation.enqueuedPath != path {
+		t.Fatalf("publication was not detached and scoped: %v %q", mutation.enqueueContextErr, mutation.enqueuedPath)
+	}
+	record := s.beginMutationCommit(ctx, "edit_file", "key", "fingerprint", "edit.go", path)
+	record.markCommitted("written-sha", 16)
+	record.recordGraph(outcome)
+	payload := s.mutationStatusPayload(record)
+	if payload["graph_status"] != mutationGraphPending || payload["graph_status_terminal"] != false || payload["disk_status"] != mutationDiskCommitted {
+		t.Fatalf("pending receipt misclassified: %#v", payload)
+	}
+	if payload["checkout_id"] != "checkout-1" || payload["checkout_incarnation"] != "incarnation-1" || payload["reindex_receipt"] != outcome.Receipt {
+		t.Fatalf("receipt lost publication identity: %#v", payload)
+	}
+	done <- indexer.MutationResult{RequestedGeneration: 7, AppliedGeneration: 29, Reindexed: true}
+	waitCheckoutReceipt(t, s, outcome.Receipt)
+	payload = s.mutationStatusPayload(record)
+	if payload["graph_status"] != mutationGraphFresh || payload["graph_status_terminal"] != true || payload["applied_generation"] != uint64(29) {
+		t.Fatalf("published generation did not resolve receipt: %#v", payload)
+	}
+	if payload["new_sha"] != "written-sha" || payload["retry_safe"] != false {
+		t.Fatalf("graph publication changed disk evidence: %#v", payload)
+	}
+	// A concurrent poller may still hold the original pending snapshot.
+	record.recordGraph(outcome)
+	if got := record.snapshot().GraphStatus; got != mutationGraphFresh {
+		t.Fatalf("late pending observation regressed terminal receipt to %q", got)
+	}
+}
+
+func TestCheckoutMutationReceiptRetainsTerminalCause(t *testing.T) {
+	for _, cause := range []string{"checkout was deleted", "target content was superseded by branch switch"} {
+		t.Run(cause, func(t *testing.T) {
+			mutation, done, path := newReceiptCheckoutMutation(t)
+			s := &Server{}
+			ctx := withCheckoutMutation(context.Background(), mutation, filepath.Dir(path))
+			outcome := s.mutationReindexState(ctx, path)
+			record := s.beginMutationCommit(ctx, "write_file", "", "", "edit.go", path)
+			record.markCommitted("disk-sha", 4)
+			record.recordGraph(outcome)
+			failure := errors.New(cause)
+			done <- indexer.MutationResult{RequestedGeneration: 7, Err: failure}
+			waitCheckoutReceipt(t, s, outcome.Receipt)
+			state, ok := s.mutationReceiptState(outcome.Receipt)
+			if !ok || !errors.Is(state.Err, failure) || state.Pending || state.Reindexed {
+				t.Fatalf("terminal ticket evidence lost: %+v", state)
+			}
+			payload := s.mutationStatusPayload(record)
+			if payload["graph_status"] != mutationGraphFailed || payload["graph_status_terminal"] != true || payload["error"] != cause || payload["disk_status"] != mutationDiskCommitted {
+				t.Fatalf("terminal graph failure lost original cause/disk verdict: %#v", payload)
+			}
+		})
+	}
+}
+
+func TestCheckoutMutationReceiptCannotBeRepairedByCanonicalSweeps(t *testing.T) {
+	mutation, done, path := newReceiptCheckoutMutation(t)
+	s := &Server{}
+	receipt := s.trackCheckoutRefreshTicket(mutation.ticket)
+	failure := errors.New("checkout incarnation disappeared")
+	done <- indexer.MutationResult{RequestedGeneration: 7, Err: failure}
+	waitCheckoutReceipt(t, s, receipt.id)
+	s.resolveSupersededFailedReceipts(path, 100, indexer.MutationResult{AppliedGeneration: 100, Reindexed: true})
+	if eligible := s.failedReceiptsBefore([]string{path}, filepath.Dir(path)); len(eligible) != 0 {
+		t.Fatalf("canonical reindex admitted checkout receipt: %#v", eligible)
+	}
+	s.resolveReindexedPathReceipts(path, map[string]struct{}{receipt.id: {}})
+	if got := receipt.outcome(false); got.Reindexed || !errors.Is(got.Err, failure) {
+		t.Fatalf("unrelated canonical apply falsely certified checkout bytes: %+v", got)
+	}
+}
+
+func TestCheckoutMutationReceiptScopeAndSummary(t *testing.T) {
+	mutation, done, path := newReceiptCheckoutMutation(t)
+	s := &Server{}
+	receipt := s.trackCheckoutRefreshTicket(mutation.ticket)
+	ctx := withCheckoutMutation(context.Background(), mutation, filepath.Dir(path))
+	if pending, err := s.mutationFreshnessSummaryForRepos(ctx, "fixture"); !pending || err != nil {
+		t.Fatalf("selected pending ticket missing: pending=%t err=%v", pending, err)
+	}
+	if pending, err := s.mutationFreshnessSummaryForRepos(context.Background(), "fixture"); pending || err != nil {
+		t.Fatalf("checkout ticket leaked into canonical prefix scope: pending=%t err=%v", pending, err)
+	}
+	record := s.beginMutationCommit(ctx, "edit_file", "", "", "edit.go", path)
+	if !mutationCommitInScope(ctx, record) || mutationCommitInScope(context.Background(), record) {
+		t.Fatal("receipt identity was not stamped before disk publication")
+	}
+	other := *mutation.ticket
+	other.Incarnation = "incarnation-2"
+	otherCtx := withCheckoutMutation(context.Background(), &receiptCheckoutMutation{ticket: &other}, filepath.Dir(path))
+	if mutationCommitInScope(otherCtx, record) {
+		t.Fatal("recreated checkout inherited previous incarnation receipt")
+	}
+	failure := errors.New("publication failed with original detail")
+	done <- indexer.MutationResult{RequestedGeneration: 7, Err: failure}
+	waitCheckoutReceipt(t, s, receipt.id)
+	if pending, err := s.mutationFreshnessSummaryForRepos(ctx, "fixture"); pending || !errors.Is(err, failure) {
+		t.Fatalf("summary did not preserve terminal cause: pending=%t err=%v", pending, err)
+	}
+	if err := s.awaitMutationFreshnessForRepos(context.Background(), "fixture"); err != nil {
+		t.Fatalf("sibling checkout failure blocked canonical graph: %v", err)
+	}
+}
+
+func TestCheckoutMutationReceiptAdmissionFailureKeepsOriginalCause(t *testing.T) {
+	mutation, _, path := newReceiptCheckoutMutation(t)
+	mutation.enqueueErr = errors.New("checkout stopped during publication admission")
+	s := &Server{}
+	ctx := withCheckoutMutation(context.Background(), mutation, filepath.Dir(path))
+	outcome := s.mutationReindexState(ctx, path)
+	if !errors.Is(outcome.Err, mutation.enqueueErr) || outcome.Pending || outcome.Reindexed {
+		t.Fatalf("admission failed without original cause: %+v", outcome)
+	}
+	if !strings.Contains(outcome.Err.Error(), "after disk commit") {
+		t.Fatalf("admission failure obscures committed bytes: %v", outcome.Err)
+	}
+}
+
+func TestCheckoutMutationReceiptRejectsMismatchedTicket(t *testing.T) {
+	for _, change := range []string{"checkout", "incarnation", "path", "missing completion"} {
+		t.Run(change, func(t *testing.T) {
+			mutation, _, path := newReceiptCheckoutMutation(t)
+			ctx := withCheckoutMutation(context.Background(), mutation, filepath.Dir(path))
+			switch change {
+			case "checkout":
+				mutation.ticket.CheckoutID = "other-checkout"
+			case "incarnation":
+				mutation.ticket.Incarnation = "other-incarnation"
+			case "path":
+				mutation.ticket.Ticket.Path = filepath.Join(filepath.Dir(path), "other.go")
+			case "missing completion":
+				mutation.ticket.Ticket.Done = nil
+			}
+			outcome := (&Server{}).mutationReindexState(ctx, path)
+			if outcome.Err == nil || outcome.Pending || outcome.Reindexed || outcome.Receipt != "" {
+				t.Fatalf("unproven ticket was accepted: %+v", outcome)
+			}
+		})
+	}
+}
+
+func TestCheckoutMutationReceiptRecoveryTicketHasNoDiskVerdict(t *testing.T) {
+	mutation, done, path := newReceiptCheckoutMutation(t)
+	s := &Server{}
+	ctx := withCheckoutMutation(context.Background(), mutation, filepath.Dir(path))
+	receipt := s.trackCheckoutRefreshTicket(mutation.ticket)
+	payload, ok := s.graphRefreshReceiptPayload(ctx, receipt.id)
+	if !ok || payload["graph_status"] != mutationGraphPending || payload["disk_status"] != "unrecorded" || payload["receipt_kind"] != "graph_refresh" {
+		t.Fatalf("recovery receipt invented disk evidence: %#v", payload)
+	}
+	if _, ok := s.graphRefreshReceiptPayload(context.Background(), receipt.id); ok {
+		t.Fatal("canonical request could inspect another checkout's ticket")
+	}
+	done <- indexer.MutationResult{RequestedGeneration: 7, AppliedGeneration: 29, Reindexed: true}
+	waitCheckoutReceipt(t, s, receipt.id)
+	payload, ok = s.graphRefreshReceiptPayload(ctx, receipt.id)
+	if !ok || payload["graph_status"] != mutationGraphFresh || payload["graph_status_terminal"] != true || payload["disk_status"] != "unrecorded" {
+		t.Fatalf("recovery completion changed disk verdict: %#v", payload)
+	}
+}
+
+func TestCheckoutMutationReceiptPathLookupSelectsOwnHistory(t *testing.T) {
+	mutation, _, path := newReceiptCheckoutMutation(t)
+	s := &Server{}
+	ctx := withCheckoutMutation(context.Background(), mutation, filepath.Dir(path))
+	wanted := s.beginMutationCommit(ctx, "edit_file", "", "", "edit.go", path)
+	// More recent primary and sibling mutations must not hide the selected
+	// checkout's older record for the same repo-relative source path.
+	s.beginMutationCommit(context.Background(), "edit_file", "", "", "edit.go", path)
+	other := *mutation.ticket
+	other.CheckoutID = "other-checkout"
+	otherCtx := withCheckoutMutation(context.Background(), &receiptCheckoutMutation{ticket: &other}, filepath.Dir(path))
+	s.beginMutationCommit(otherCtx, "edit_file", "", "", "edit.go", path)
+	if got, ok := s.recentMutationCommitInScope(ctx, "edit.go"); !ok || got != wanted {
+		t.Fatalf("same relative path selected another checkout record: got=%p want=%p", got, wanted)
+	}
+}
+
+func TestCheckoutMutationReceiptSupersededDoesNotPoisonCurrentView(t *testing.T) {
+	mutation, done, path := newReceiptCheckoutMutation(t)
+	s := &Server{}
+	ctx := withCheckoutMutation(context.Background(), mutation, filepath.Dir(path))
+	receipt := s.trackCheckoutRefreshTicket(mutation.ticket)
+	record := s.beginMutationCommit(ctx, "edit_file", "", "", "edit.go", path)
+	record.markCommitted("original-bytes-sha", 4)
+	record.recordGraph(receipt.outcome(true))
+	done <- indexer.MutationResult{RequestedGeneration: 7, Err: fmt.Errorf("%w: branch switched", indexer.ErrCheckoutRefreshSuperseded)}
+	waitCheckoutReceipt(t, s, receipt.id)
+	if pending, err := s.mutationFreshnessSummaryForRepos(ctx, "fixture"); pending || err != nil {
+		t.Fatalf("historical branch poisoned current-view diagnostics: pending=%t err=%v", pending, err)
+	}
+	if err := s.awaitMutationFreshnessForRepos(ctx, "fixture"); err != nil {
+		t.Fatalf("historical branch poisoned current-view barrier: %v", err)
+	}
+	payload := s.mutationStatusPayload(record)
+	if payload["graph_status"] != mutationGraphFailed || payload["graph_status_terminal"] != true || payload["new_sha"] != "original-bytes-sha" {
+		t.Fatalf("historical receipt was falsely certified by current-view exemption: %#v", payload)
+	}
+}
+
+func TestCheckoutMutationReceiptBindsBytesActuallyCommitted(t *testing.T) {
+	for _, overwritten := range []bool{false, true} {
+		t.Run(fmt.Sprintf("overwritten=%t", overwritten), func(t *testing.T) {
+			mutation, done, path := newReceiptCheckoutMutation(t)
+			s := &Server{}
+			ctx := withCheckoutMutation(context.Background(), mutation, filepath.Dir(path))
+			data := []byte("package committed\n")
+			record, err := s.commitFileMutation(ctx, "write_file", "", "", "edit.go", path, data, 0o600)
+			if err != nil {
+				t.Fatal(err)
+			}
+			captured := data
+			if overwritten {
+				captured = []byte("package concurrent_writer\n")
+				if err := os.WriteFile(path, captured, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			sum := sha256.Sum256(captured)
+			mutation.ticket.ContentHash = hex.EncodeToString(sum[:])
+			outcome := s.mutationReindexState(ctx, path)
+			record.recordGraph(outcome)
+			if overwritten {
+				if !errors.Is(outcome.Err, indexer.ErrCheckoutRefreshSuperseded) || outcome.Pending || outcome.Reindexed || outcome.Receipt != "" {
+					t.Fatalf("another writer's bytes were accepted for original edit: %+v", outcome)
+				}
+				if got := record.snapshot(); got.DiskStatus != mutationDiskCommitted || got.NewSHA != gitBlobSHA(data) || got.GraphStatus != mutationGraphFailed {
+					t.Fatalf("original committed evidence lost: %+v", got)
+				}
+				return
+			}
+			if !outcome.Pending || outcome.Err != nil {
+				t.Fatalf("matching committed bytes were rejected: %+v", outcome)
+			}
+			done <- indexer.MutationResult{RequestedGeneration: 7, AppliedGeneration: 29, Reindexed: true}
+			waitCheckoutReceipt(t, s, outcome.Receipt)
+		})
+	}
+}
+
+func TestCheckoutMutationReceiptRecoveryRetiresOnlyPriorBarrierFailures(t *testing.T) {
+	for _, laterFailure := range []bool{false, true} {
+		t.Run(fmt.Sprintf("later_failure=%t", laterFailure), func(t *testing.T) {
+			mutation, done, path := newReceiptCheckoutMutation(t)
+			s := &Server{}
+			ctx := withCheckoutMutation(context.Background(), mutation, filepath.Dir(path))
+			failure := errors.New("original storage failure")
+			old := &mutationReceipt{
+				id: "old", repo: "fixture", path: path, generation: 1, done: make(chan struct{}), completed: true,
+				checkoutScoped: true, checkoutID: "checkout-1", checkoutIncarnation: "incarnation-1",
+				result: indexer.MutationResult{RequestedGeneration: 1, Err: failure},
+			}
+			close(old.done)
+			s.mutationReceipts.Store(old.id, old)
+			record := &mutationCommitRecord{id: "commit-old", disk: mutationDiskCommitted, newSHA: "original-sha"}
+			record.recordGraph(old.outcome(false))
+			var pending *mutationReceipt
+			if laterFailure {
+				pending = &mutationReceipt{id: "pending-before-recovery", repo: "fixture", path: path, generation: 2, done: make(chan struct{}), checkoutScoped: true, checkoutID: "checkout-1", checkoutIncarnation: "incarnation-1"}
+				s.mutationReceipts.Store(pending.id, pending)
+			}
+			// Snapshot is deliberately taken before root recovery admission.
+			eligible := s.failedCheckoutRefreshReceiptsBefore("checkout-1", "incarnation-1")
+			if len(eligible) != 1 {
+				t.Fatalf("pending ticket included in recovery snapshot: %#v", eligible)
+			}
+			mutation.ticket.Ticket.Path = mutation.ticket.Root
+			mutation.ticket.Ticket.Generation = 10
+			recovery := s.trackCheckoutRecoveryTicket(mutation.ticket, eligible)
+			if laterFailure {
+				pending.mu.Lock()
+				pending.completed = true
+				pending.result = indexer.MutationResult{RequestedGeneration: 2, Err: errors.New("failed only after recovery began")}
+				pending.mu.Unlock()
+				close(pending.done)
+				eligible[pending.id] = struct{}{}
+				for _, later := range []*mutationReceipt{
+					{id: "newer", repo: "fixture", path: path, generation: 11, checkoutScoped: true, checkoutID: "checkout-1", checkoutIncarnation: "incarnation-1"},
+					{id: "sibling", repo: "fixture", path: path, generation: 3, checkoutScoped: true, checkoutID: "checkout-2", checkoutIncarnation: "incarnation-1"},
+					{id: "recreated", repo: "fixture", path: path, generation: 3, checkoutScoped: true, checkoutID: "checkout-1", checkoutIncarnation: "incarnation-2"},
+				} {
+					later.done = make(chan struct{})
+					later.completed = true
+					later.result = indexer.MutationResult{Err: errors.New(later.id + " failure")}
+					close(later.done)
+					s.mutationReceipts.Store(later.id, later)
+					// Mutating the caller's snapshot after tracking cannot expand
+					// the recovery worker's eligibility set.
+					eligible[later.id] = struct{}{}
+				}
+			}
+			done <- indexer.MutationResult{RequestedGeneration: 10, AppliedGeneration: 29, Reindexed: true}
+			waitCheckoutReceipt(t, s, recovery.id)
+			if laterFailure {
+				// Even an overly broad caller snapshot cannot cross identity or
+				// admission ordering boundaries at the final retirement gate.
+				s.resolveCheckoutRecoveryReceipts(recovery, map[string]struct{}{"newer": {}, "sibling": {}, "recreated": {}}, 29)
+			}
+			old.mu.RLock()
+			covered := old.barrierRecoveredGeneration
+			old.mu.RUnlock()
+			if covered != 29 {
+				t.Fatalf("verified root recovery did not retire prior barrier: %d", covered)
+			}
+			if got := old.outcome(false); got.Reindexed || !errors.Is(got.Err, failure) {
+				t.Fatalf("recovery rewrote historical publication evidence: %+v", got)
+			}
+			if got := s.mutationStatusPayload(record); got["graph_status"] != mutationGraphFailed || got["error"] != failure.Error() || got["new_sha"] != "original-sha" {
+				t.Fatalf("recovery rewrote original commit receipt: %#v", got)
+			}
+			isPending, err := s.mutationFreshnessSummaryForRepos(ctx, "fixture")
+			if isPending || (!laterFailure && err != nil) || (laterFailure && err == nil) {
+				t.Fatalf("current-view barrier lost failure boundary: pending=%t err=%v", isPending, err)
+			}
+			if laterFailure {
+				for _, id := range []string{"pending-before-recovery", "newer", "sibling", "recreated"} {
+					value, _ := s.mutationReceipts.Load(id)
+					r := value.(*mutationReceipt)
+					r.mu.RLock()
+					covered := r.barrierRecoveredGeneration
+					r.mu.RUnlock()
+					if covered != 0 {
+						t.Fatalf("unrelated or later failure %q was retired", id)
+					}
+				}
+			} else if err := s.awaitMutationFreshnessForRepos(ctx, "fixture"); err != nil {
+				t.Fatalf("verified root recovery left current-view barrier poisoned: %v", err)
+			}
+		})
+	}
+}
+
+func BenchmarkCheckoutMutationReceiptPendingPoll(b *testing.B) {
+	s := &Server{}
+	receipt := &mutationReceipt{id: "mutation-benchmark", generation: 7, done: make(chan struct{}), checkoutScoped: true, checkoutID: "checkout-1", checkoutIncarnation: "incarnation-1"}
+	s.mutationReceipts.Store(receipt.id, receipt)
+	record := &mutationCommitRecord{id: "commit-benchmark", disk: mutationDiskCommitted, graph: mutationGraphPending, graphRecorded: true, reindexReceipt: receipt.id}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		payload := s.mutationStatusPayload(record)
+		if payload["graph_status"] != mutationGraphPending {
+			b.Fatal(fmt.Sprint(payload))
+		}
+	}
+}

--- a/internal/mcp/checkout_reindex.go
+++ b/internal/mcp/checkout_reindex.go
@@ -1,0 +1,41 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/graphview"
+)
+
+func (s *Server) handleCheckoutControlReindex(ctx context.Context, req mcp.CallToolRequest, control *checkoutControlScope, paths []string) (*mcp.CallToolResult, error) {
+	if control.Checkout.State != store_sqlite.CheckoutStateReady {
+		return mcp.NewToolResultError(graphview.NewViewError(graphview.CodeCheckoutInaccessible,
+			fmt.Sprintf("checkout %q is %s", control.Checkout.CheckoutID, control.Checkout.State)).Error()), nil
+	}
+	if s.lifecycle == nil {
+		return mcp.NewToolResultError("checkout recovery is unavailable: no checkout lifecycle is attached"), nil
+	}
+	eligible := s.failedCheckoutRefreshReceiptsBefore(control.Checkout.CheckoutID, control.Checkout.Incarnation)
+	ticket, err := s.lifecycle.RequestCheckoutRefresh(ctx, control.Checkout.CheckoutID, control.Checkout.RootPath)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	receipt := s.trackCheckoutRecoveryTicket(ticket, eligible)
+	outcome := receipt.outcome(true)
+	payload := map[string]any{
+		"scope": "checkout", "status": "queued",
+		"repo": control.RepoPrefix, "repo_root": control.Checkout.RootPath,
+		"checkout_id": control.Checkout.CheckoutID, "checkout_incarnation": control.Checkout.Incarnation,
+		"detail": "the selected checkout coordinator will refresh its sparse layers; inspect reindex_receipt for publication",
+	}
+	if len(paths) > 0 {
+		// The coordinator refreshes one coherent checkout snapshot. These are
+		// validated recovery hints, not a claim that a partial result was built.
+		payload["requested_paths"] = paths
+	}
+	s.attachMutationFreshness(payload, "", "", outcome)
+	return s.respondJSONOrTOON(ctx, req, payload)
+}

--- a/internal/mcp/detect_file_only_test.go
+++ b/internal/mcp/detect_file_only_test.go
@@ -1,0 +1,68 @@
+package mcp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+)
+
+// Any symbol join would consult the stale selected/base graph and incorrectly
+// imply that it describes the currently pending checkout. Other reader calls
+// also fail because the embedded interface deliberately has no implementation.
+type pendingDetectReader struct {
+	graph.Reader
+	reads int
+}
+
+func (r *pendingDetectReader) GetFileNodes(string) []*graph.Node {
+	r.reads++
+	panic("pending checkout detection must not read graph symbols")
+}
+
+func TestDetectChangesPendingCheckoutDoesNotReadGraph(t *testing.T) {
+	stack := newViewStack(t)
+	root := stack.worktreeRoot
+	require.NoError(t, os.MkdirAll(root, 0o755))
+	checkoutMutationGit(t, root, "init")
+	checkoutMutationGit(t, root, "config", "user.name", "Gortex Test")
+	checkoutMutationGit(t, root, "config", "user.email", "test@gortex.invalid")
+	path := filepath.Join(root, "edit.go")
+	require.NoError(t, os.WriteFile(path, []byte("package sample\n\nfunc Before() {}\n"), 0o644))
+	checkoutMutationGit(t, root, "add", ".")
+	checkoutMutationGit(t, root, "commit", "-m", "baseline")
+	require.NoError(t, os.WriteFile(path, []byte("package sample\n\nfunc After() {}\n"), 0o644))
+	checkoutMutationGit(t, root, "add", "edit.go")
+
+	ctx := WithSessionCWD(WithSessionID(context.Background(), "detect-file-only"), stack.repoRoot)
+	ctx = withCheckoutControl(ctx, &checkoutControlScope{
+		Checkout: store_sqlite.Checkout{
+			CheckoutID: viewTestWorktree,
+			RootPath:   root,
+		},
+		RepoPrefix:     "repo",
+		CheckoutScoped: true,
+	})
+	reader := &pendingDetectReader{}
+	ctx = withRequestView(ctx, &requestView{reader: reader})
+	var req mcp.CallToolRequest
+	req.Params.Name = "detect_changes"
+	req.Params.Arguments = map[string]any{"scope": "staged", "format": "json"}
+	result, err := stack.srv.handleDetectChanges(ctx, req)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	payload := lifecycleResultPayload(t, result)
+	require.Equal(t, false, payload["complete"])
+	require.Equal(t, "UNKNOWN", payload["risk"])
+	require.Equal(t, "pending", payload["graph_status"])
+	require.Equal(t, root, payload["repo_root"])
+	require.Equal(t, []any{"edit.go"}, payload["changed_files"])
+	require.Empty(t, payload["changed_symbols"])
+	require.Zero(t, reader.reads)
+}

--- a/internal/mcp/edit_serialization.go
+++ b/internal/mcp/edit_serialization.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -36,8 +37,8 @@ type mutationPathLock struct {
 }
 
 // mutationReindexOutcome is the complete freshness state produced after a disk
-// mutation. A receipt is present only when the bounded request-path wait ended
-// before the watcher ticket did.
+// mutation. A receipt identifies admitted publication work that can outlive the
+// request, either on a watcher or on the selected checkout's coordinator.
 type mutationReindexOutcome struct {
 	Reindexed         bool
 	Pending           bool
@@ -47,18 +48,24 @@ type mutationReindexOutcome struct {
 	Err               error
 	// A checkout generation is not reflected in the canonical syntax-health
 	// reader. Do not attach another checkout's parse errors to this result.
-	checkoutScoped bool
+	checkoutScoped      bool
+	checkoutID          string
+	checkoutIncarnation string
 }
 
 type mutationReceipt struct {
-	id         string
-	repo       string
-	path       string
-	generation uint64
-	done       chan struct{}
-	mu         sync.RWMutex
-	result     indexer.MutationResult
-	completed  bool
+	id                         string
+	repo                       string
+	path                       string
+	generation                 uint64
+	done                       chan struct{}
+	mu                         sync.RWMutex
+	result                     indexer.MutationResult
+	completed                  bool
+	checkoutScoped             bool
+	checkoutID                 string
+	checkoutIncarnation        string
+	barrierRecoveredGeneration uint64
 }
 
 type mutationScheduler interface {
@@ -157,12 +164,37 @@ func (s *Server) trackMutationTicket(ticket *indexer.MutationTicket) *mutationRe
 	if s.multiIndexer != nil {
 		repo = s.multiIndexer.RepoForFile(ticket.Path)
 	}
+	return s.trackScopedMutationTicket(ticket, repo, "", "", nil)
+}
+
+func (s *Server) trackCheckoutRefreshTicket(ticket *indexer.CheckoutRefreshTicket) *mutationReceipt {
+	return s.trackScopedMutationTicket(ticket.Ticket, ticket.RepoPrefix, ticket.CheckoutID, ticket.Incarnation, nil)
+}
+
+// trackCheckoutRecoveryTicket lets verified whole-checkout recovery retire
+// historical freshness gaps without rewriting their original result/error.
+// eligible must be captured before RequestCheckoutRefresh starts sampling.
+func (s *Server) trackCheckoutRecoveryTicket(ticket *indexer.CheckoutRefreshTicket, eligible map[string]struct{}) *mutationReceipt {
+	var captured map[string]struct{}
+	if ticket.ContentHash == "" && filepath.Clean(ticket.Ticket.Path) == filepath.Clean(ticket.Root) {
+		captured = make(map[string]struct{}, len(eligible))
+		for id := range eligible {
+			captured[id] = struct{}{}
+		}
+	}
+	return s.trackScopedMutationTicket(ticket.Ticket, ticket.RepoPrefix, ticket.CheckoutID, ticket.Incarnation, captured)
+}
+
+func (s *Server) trackScopedMutationTicket(ticket *indexer.MutationTicket, repo, checkoutID, incarnation string, recoveryCandidates map[string]struct{}) *mutationReceipt {
 	receipt := &mutationReceipt{
-		id:         fmt.Sprintf("mutation-%d", mutationReceiptSequence.Add(1)),
-		repo:       repo,
-		path:       ticket.Path,
-		generation: ticket.Generation,
-		done:       make(chan struct{}),
+		id:                  fmt.Sprintf("mutation-%d", mutationReceiptSequence.Add(1)),
+		repo:                repo,
+		path:                ticket.Path,
+		generation:          ticket.Generation,
+		done:                make(chan struct{}),
+		checkoutScoped:      checkoutID != "",
+		checkoutID:          checkoutID,
+		checkoutIncarnation: incarnation,
 	}
 	s.mutationReceipts.Store(receipt.id, receipt)
 	go func() {
@@ -177,15 +209,62 @@ func (s *Server) trackMutationTicket(ticket *indexer.MutationTicket) *mutationRe
 		receipt.result = result
 		receipt.completed = true
 		receipt.mu.Unlock()
-		if result.Err == nil && result.Reindexed {
+		if result.Err == nil && result.Reindexed && !receipt.checkoutScoped {
 			s.resolveSupersededFailedReceipts(receipt.path, receipt.generation, result)
 		}
+		if result.Err == nil && result.Reindexed && result.AppliedGeneration > 0 && receipt.checkoutScoped {
+			s.resolveCheckoutRecoveryReceipts(receipt, recoveryCandidates, result.AppliedGeneration)
+		}
 		close(receipt.done)
-		time.AfterFunc(mutationReceiptRetention, func() {
+		retention := mutationReceiptRetention
+		if receipt.checkoutScoped {
+			// A commit receipt can be queried long after publication finished.
+			// Its freshness ticket must outlive that ledger's polling window.
+			retention = mutationCommitRetention
+		}
+		time.AfterFunc(retention, func() {
 			s.mutationReceipts.Delete(receipt.id)
 		})
 	}()
 	return receipt
+}
+
+// Only failures already terminal before recovery admission are eligible. An
+// in-flight edit which fails later, or a newer edit, must retain its own gate.
+func (s *Server) failedCheckoutRefreshReceiptsBefore(checkoutID, incarnation string) map[string]struct{} {
+	eligible := make(map[string]struct{})
+	s.mutationReceipts.Range(func(_, value any) bool {
+		receipt, ok := value.(*mutationReceipt)
+		if !ok || !receipt.checkoutScoped || receipt.checkoutID != checkoutID || receipt.checkoutIncarnation != incarnation {
+			return true
+		}
+		receipt.mu.RLock()
+		failed := receipt.completed && (receipt.result.Err != nil || !receipt.result.Reindexed) && receipt.barrierRecoveredGeneration == 0
+		receipt.mu.RUnlock()
+		if failed {
+			eligible[receipt.id] = struct{}{}
+		}
+		return true
+	})
+	return eligible
+}
+
+func (s *Server) resolveCheckoutRecoveryReceipts(recovery *mutationReceipt, eligible map[string]struct{}, generation uint64) {
+	for id := range eligible {
+		value, ok := s.mutationReceipts.Load(id)
+		if !ok {
+			continue
+		}
+		receipt, ok := value.(*mutationReceipt)
+		if !ok || !receipt.checkoutScoped || receipt.checkoutID != recovery.checkoutID || receipt.checkoutIncarnation != recovery.checkoutIncarnation || receipt.generation >= recovery.generation {
+			continue
+		}
+		receipt.mu.Lock()
+		if receipt.completed && (receipt.result.Err != nil || !receipt.result.Reindexed) {
+			receipt.barrierRecoveredGeneration = generation
+		}
+		receipt.mu.Unlock()
+	}
 }
 
 // resolveSupersededFailedReceipts resolves terminally failed receipts for a
@@ -207,7 +286,7 @@ func (s *Server) resolveSupersededFailedReceipts(succeededPath string, succeeded
 	cleanPath := filepath.Clean(succeededPath)
 	s.mutationReceipts.Range(func(_, value any) bool {
 		other, ok := value.(*mutationReceipt)
-		if !ok {
+		if !ok || other.checkoutScoped {
 			return true
 		}
 		if other.generation >= succeededGeneration || filepath.Clean(other.path) != cleanPath {
@@ -253,7 +332,7 @@ func (s *Server) failedReceiptsBefore(paths []string, root string) map[string]st
 	eligible := make(map[string]struct{})
 	s.mutationReceipts.Range(func(_, value any) bool {
 		receipt, ok := value.(*mutationReceipt)
-		if !ok || filepath.Clean(receipt.path) != candidate {
+		if !ok || receipt.checkoutScoped || filepath.Clean(receipt.path) != candidate {
 			return true
 		}
 		receipt.mu.RLock()
@@ -271,7 +350,7 @@ func (s *Server) resolveReindexedPathReceipts(reindexedPath string, eligible map
 	cleanPath := filepath.Clean(reindexedPath)
 	s.mutationReceipts.Range(func(_, value any) bool {
 		receipt, ok := value.(*mutationReceipt)
-		if !ok || filepath.Clean(receipt.path) != cleanPath {
+		if !ok || receipt.checkoutScoped || filepath.Clean(receipt.path) != cleanPath {
 			return true
 		}
 		if _, wasFailingBeforeThePass := eligible[receipt.id]; !wasFailingBeforeThePass {
@@ -294,9 +373,12 @@ func (r *mutationReceipt) outcome(pending bool) mutationReindexOutcome {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	outcome := mutationReindexOutcome{
-		Pending:    pending,
-		Receipt:    r.id,
-		Generation: r.generation,
+		Pending:             pending,
+		Receipt:             r.id,
+		Generation:          r.generation,
+		checkoutScoped:      r.checkoutScoped,
+		checkoutID:          r.checkoutID,
+		checkoutIncarnation: r.checkoutIncarnation,
 	}
 	if r.completed {
 		outcome.Reindexed = r.result.Reindexed
@@ -368,11 +450,36 @@ func (s *Server) awaitMutationFreshness(ctx context.Context) error {
 	return s.awaitMutationFreshnessForRepos(ctx)
 }
 
-// awaitMutationFreshnessForRepos waits once, under one shared budget, for every
-// ticket in the requested repositories. Receipts with unknown ownership remain
-// in scope so incomplete metadata cannot disarm the safety gate. On timeout it
-// reports every pending and terminally failed generation, not only the first.
-func (s *Server) awaitMutationFreshnessForRepos(ctx context.Context, repos ...string) error {
+// mutationCheckoutScope is metadata-only so receipts remain inspectable while
+// the selected checkout has no materialized graph. An unselected request is
+// canonical; sharing a repository prefix does not give it sibling receipts.
+func mutationCheckoutScope(ctx context.Context) (checkoutID, incarnation string) {
+	if state := checkoutMutationFromContext(ctx); state != nil {
+		return state.checkoutID, state.incarnation
+	}
+	if control := checkoutControlFromContext(ctx); control != nil {
+		if !control.CheckoutScoped {
+			return "", ""
+		}
+		return control.Checkout.CheckoutID, control.Checkout.Incarnation
+	}
+	if view := requestViewFromContext(ctx); view != nil && view.rider != nil {
+		return view.rider.CheckoutID, ""
+	}
+	return "", ""
+}
+
+func mutationCheckoutScopeMatches(checkoutID, incarnation, candidateID, candidateIncarnation string) bool {
+	if checkoutID != candidateID {
+		return false
+	}
+	return incarnation == "" || incarnation == candidateIncarnation
+}
+
+// mutationReceiptsForRepos selects the same coherent checkout view as the
+// request. Unknown repository ownership remains in scope within that view.
+func (s *Server) mutationReceiptsForRepos(ctx context.Context, repos ...string) []*mutationReceipt {
+	checkoutID, incarnation := mutationCheckoutScope(ctx)
 	repoScope := make(map[string]struct{}, len(repos))
 	for _, repo := range repos {
 		if repo != "" {
@@ -386,14 +493,55 @@ func (s *Server) awaitMutationFreshnessForRepos(ctx context.Context, repos ...st
 		if !ok {
 			return true
 		}
+		if !mutationCheckoutScopeMatches(checkoutID, incarnation, receipt.checkoutID, receipt.checkoutIncarnation) {
+			return true
+		}
 		if len(repoScope) > 0 && receipt.repo != "" {
 			if _, included := repoScope[receipt.repo]; !included {
 				return true
 			}
 		}
+		// Superseded content and failures covered by verified root recovery
+		// remain historical receipts, not current-view freshness gaps. This
+		// never marks an original result fresh; exact route readiness remains
+		// the authority for the current view.
+		receipt.mu.RLock()
+		historical := receipt.checkoutScoped && receipt.completed && (errors.Is(receipt.result.Err, indexer.ErrCheckoutRefreshSuperseded) || receipt.barrierRecoveredGeneration > 0)
+		receipt.mu.RUnlock()
+		if historical {
+			return true
+		}
 		receipts = append(receipts, receipt)
 		return true
 	})
+	return receipts
+}
+
+// mutationFreshnessSummaryForRepos is a non-blocking version of the freshness
+// barrier for partial diagnostic results. It uses the same checkout and repo
+// scope as the waiting path, but never turns a pending ticket into a failure.
+func (s *Server) mutationFreshnessSummaryForRepos(ctx context.Context, repos ...string) (pending bool, err error) {
+	var failures []error
+	for _, receipt := range s.mutationReceiptsForRepos(ctx, repos...) {
+		outcome := receipt.outcome(true)
+		if outcome.Pending {
+			pending = true
+			continue
+		}
+		if outcome.Err != nil {
+			failures = append(failures, fmt.Errorf("failed receipt=%s path=%q: %w", receipt.id, receipt.path, outcome.Err))
+		} else if !outcome.Reindexed {
+			failures = append(failures, fmt.Errorf("failed receipt=%s path=%q: reindex not confirmed", receipt.id, receipt.path))
+		}
+	}
+	return pending, errors.Join(failures...)
+}
+
+// awaitMutationFreshnessForRepos waits once, under one shared budget, for every
+// selected ticket. On timeout it reports all pending and terminally failed
+// generations rather than hiding the remaining gaps behind the first one.
+func (s *Server) awaitMutationFreshnessForRepos(ctx context.Context, repos ...string) error {
+	receipts := s.mutationReceiptsForRepos(ctx, repos...)
 	if len(receipts) == 0 {
 		return nil
 	}

--- a/internal/mcp/mutation_commit.go
+++ b/internal/mcp/mutation_commit.go
@@ -113,10 +113,14 @@ type mutationCommitRecord struct {
 	// terminality is the opposite in the two cases.
 	graphRecorded bool
 
-	newSHA         string
-	bytesWritten   int
-	reindexReceipt string
-	errText        string
+	newSHA              string
+	bytesWritten        int
+	reindexReceipt      string
+	reindexGeneration   uint64
+	appliedGeneration   uint64
+	checkoutID          string
+	checkoutIncarnation string
+	errText             string
 
 	startedAt   time.Time
 	committedAt time.Time
@@ -138,28 +142,38 @@ type mutationCommitSnapshot struct {
 	// graph_status_terminal and graph_note, which is the form a caller can act
 	// on. Ordering matters for the listing: it is filled from the same
 	// snapshot the flag is derived from, so the two cannot disagree.
-	GraphRecorded bool   `json:"-"`
-	NewSHA        string `json:"new_sha,omitempty"`
-	BytesWritten  int    `json:"bytes_written,omitempty"`
-	Error         string `json:"error,omitempty"`
-	StartedAt     string `json:"started_at,omitempty"`
-	CommittedAt   string `json:"committed_at,omitempty"`
+	GraphRecorded       bool   `json:"-"`
+	NewSHA              string `json:"new_sha,omitempty"`
+	BytesWritten        int    `json:"bytes_written,omitempty"`
+	Error               string `json:"error,omitempty"`
+	StartedAt           string `json:"started_at,omitempty"`
+	CommittedAt         string `json:"committed_at,omitempty"`
+	ReindexReceipt      string `json:"reindex_receipt,omitempty"`
+	ReindexGeneration   uint64 `json:"reindex_generation,omitempty"`
+	AppliedGeneration   uint64 `json:"applied_generation,omitempty"`
+	CheckoutID          string `json:"checkout_id,omitempty"`
+	CheckoutIncarnation string `json:"checkout_incarnation,omitempty"`
 }
 
 func (r *mutationCommitRecord) snapshot() mutationCommitSnapshot {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	snap := mutationCommitSnapshot{
-		Receipt:       r.id,
-		Tool:          r.tool,
-		MutationID:    r.key,
-		Path:          r.relPath,
-		DiskStatus:    r.disk,
-		GraphStatus:   r.graph,
-		GraphRecorded: r.graphRecorded,
-		NewSHA:        r.newSHA,
-		BytesWritten:  r.bytesWritten,
-		Error:         r.errText,
+		Receipt:             r.id,
+		Tool:                r.tool,
+		MutationID:          r.key,
+		Path:                r.relPath,
+		DiskStatus:          r.disk,
+		GraphStatus:         r.graph,
+		GraphRecorded:       r.graphRecorded,
+		NewSHA:              r.newSHA,
+		BytesWritten:        r.bytesWritten,
+		Error:               r.errText,
+		ReindexReceipt:      r.reindexReceipt,
+		ReindexGeneration:   r.reindexGeneration,
+		AppliedGeneration:   r.appliedGeneration,
+		CheckoutID:          r.checkoutID,
+		CheckoutIncarnation: r.checkoutIncarnation,
 	}
 	if !r.startedAt.IsZero() {
 		snap.StartedAt = r.startedAt.UTC().Format(time.RFC3339Nano)
@@ -217,9 +231,26 @@ func (r *mutationCommitRecord) recordGraph(outcome mutationReindexOutcome) {
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	// Concurrent pollers can hold an earlier pending snapshot after another
+	// poller observed completion. Never regress that same ticket to pending.
+	if outcome.Pending && r.graphRecorded && r.graph != mutationGraphPending && r.reindexReceipt != "" && r.reindexReceipt == outcome.Receipt {
+		return
+	}
 	r.graph = graphStatusFor(outcome)
 	r.graphRecorded = true
 	r.reindexReceipt = outcome.Receipt
+	r.reindexGeneration = outcome.Generation
+	r.appliedGeneration = outcome.AppliedGeneration
+	if outcome.checkoutID != "" {
+		r.checkoutID = outcome.checkoutID
+		r.checkoutIncarnation = outcome.checkoutIncarnation
+	}
+	// Preserve graph publication errors without changing the disk verdict.
+	if outcome.Err != nil {
+		r.errText = outcome.Err.Error()
+	} else if r.disk == mutationDiskCommitted {
+		r.errText = ""
+	}
 }
 
 // retainResponse stores the successful payload for idempotent replay. Only
@@ -457,6 +488,10 @@ func (s *Server) beginMutationCommit(ctx context.Context, tool, mutationID, fing
 		graph:     mutationGraphStale,
 		startedAt: time.Now(),
 	}
+	if state := checkoutMutationFromContext(ctx); state != nil {
+		record.checkoutID = state.checkoutID
+		record.checkoutIncarnation = state.incarnation
+	}
 	s.mutationCommits.put(record)
 	mutationCommitNoteFrom(ctx).observe(record)
 	return record
@@ -497,6 +532,11 @@ func (s *Server) commitFileMutation(
 	if err := agents.AtomicWriteFile(absPath, data, perm); err != nil {
 		record.markFailed(err)
 		return record, err
+	}
+	if state := checkoutMutationFromContext(ctx); state != nil {
+		sum := sha256.Sum256(data)
+		state.committedHash = hex.EncodeToString(sum[:])
+		state.committedPath = absPath
 	}
 	record.markCommitted(gitBlobSHA(data), len(data))
 	return record, nil

--- a/internal/mcp/overlay.go
+++ b/internal/mcp/overlay.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/zzet/gortex/internal/daemon"
+	"github.com/zzet/gortex/internal/graphview"
 )
 
 // SetOverlayManager wires the editor-overlay manager into the MCP
@@ -123,6 +124,7 @@ func (s *Server) wrapToolHandlerMode(h mcpserver.ToolHandlerFunc, injectOverlay 
 		// read and stripped here so every tool honours it and no handler or
 		// schema has to know about it. Stripping precedes reconciliation so
 		// the alias matcher cannot rewrite it into a tool's own parameter.
+		requireExactView := requestRequiresExactCheckoutView(&req)
 		selector, selectorErr := takeViewSelector(&req)
 		if selectorErr != nil {
 			return mcp.NewToolResultError(selectorErr.Error()), nil
@@ -160,13 +162,38 @@ func (s *Server) wrapToolHandlerMode(h mcpserver.ToolHandlerFunc, injectOverlay 
 		// overlay so a session's editor buffers layer on top of whatever
 		// answers here. The lease the materialized view holds is released
 		// with the request, on the same lifecycle that discards the overlay.
-		view, viewErr := s.resolveRequestView(ctx, selector, s.requestViewPolicy(&req))
-		if viewErr != nil {
-			return mcp.NewToolResultError(viewErr.Error()), nil
+		controlOperation := s.checkoutControlOperation(&req)
+		if controlOperation != "" {
+			control, controlErr := s.resolveCheckoutControlScope(ctx, selector, &req)
+			if controlErr != nil {
+				return mcp.NewToolResultError(controlErr.Error()), nil
+			}
+			ctx = withCheckoutControl(ctx, control)
+		}
+		var view *requestView
+		if !catalogOnlyCheckoutControl(controlOperation) {
+			var viewErr error
+			view, viewErr = s.resolveRequestView(ctx, selector, s.requestViewPolicy(&req))
+			if viewErr != nil {
+				control := checkoutControlFromContext(ctx)
+				if controlOperation != "detect_changes" || control == nil || !control.CheckoutScoped {
+					return mcp.NewToolResultError(viewErr.Error()), nil
+				}
+				// A pending graph cannot certify symbol impact. The detect handler
+				// can still report this checkout's Git file changes, explicitly
+				// incomplete, without substituting the primary's working tree.
+				view, _ = viewFallback(false, graphview.NewViewRider(control.Selector), viewErr)
+				view.rider.CheckoutID = control.Checkout.CheckoutID
+				view.rider.GraphID = control.GraphID
+			}
 		}
 		if view != nil {
 			ctx = withRequestView(ctx, view)
 			defer view.close()
+		}
+		if requireExactView && view != nil && view.rider != nil && !view.rider.Exact {
+			return mcp.NewToolResultError(graphview.NewViewError(graphview.CodeViewBuilding,
+				"the requested exact checkout view is unavailable; retry after publication; no fallback was served").Error()), nil
 		}
 		// Approved source tools serialize with the selected checkout's index
 		// coordinator. The lease does not invalidate or rebuild for dry runs;
@@ -183,10 +210,12 @@ func (s *Server) wrapToolHandlerMode(h mcpserver.ToolHandlerFunc, injectOverlay 
 		// What the view can answer, checked against what this operation
 		// needs, before the handler runs — a thin view must refuse rather
 		// than answer thinly and look complete doing it.
-		if refused := s.evaluateRequestCapabilities(ctx, &req, capabilities); refused != nil {
-			return refused, nil
+		if !catalogOnlyCheckoutControl(controlOperation) {
+			if refused := s.evaluateRequestCapabilities(ctx, &req, capabilities); refused != nil {
+				return refused, nil
+			}
 		}
-		if injectOverlay && view.acceptsBufferOverlay() {
+		if injectOverlay && !catalogOnlyCheckoutControl(controlOperation) && view.acceptsBufferOverlay() {
 			var err error
 			ctx, _, err = s.prepareOverlayRequest(ctx)
 			if err != nil {
@@ -252,6 +281,7 @@ func (s *Server) wrapToolHandlerMode(h mcpserver.ToolHandlerFunc, injectOverlay 
 			// came from somewhere other than the base — or fell back to it —
 			// must say so where the caller already looks for provenance.
 			res = s.attachViewRider(ctx, res)
+			res = s.attachCheckoutControlScope(ctx, res)
 		}
 		// The arg guard's warn rider lands here — after the warming and
 		// freshness decorators, both of which rebuild the text result from

--- a/internal/mcp/scope_checkout.go
+++ b/internal/mcp/scope_checkout.go
@@ -5,6 +5,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
 	"github.com/zzet/gortex/internal/graphview"
 )
 
@@ -29,30 +30,43 @@ import (
 // for, or when its family's primary is not a tracked repository. Every one of
 // those leaves the caller on the fail-closed path it took before.
 func (s *Server) scopeForAutomaticCheckout(ctx context.Context, cwd string) (workspaceID, projectID, repoPrefix string, ok bool) {
+	workspaceID, projectID, repoPrefix, ok, _ = s.scopeForAutomaticCheckoutChecked(ctx, cwd)
+	return workspaceID, projectID, repoPrefix, ok
+}
+
+func (s *Server) scopeForAutomaticCheckoutChecked(ctx context.Context, cwd string) (workspaceID, projectID, repoPrefix string, ok bool, err error) {
+	return s.scopeForAutomaticCheckoutWithPrefix(ctx, cwd, s.repoPrefixForCheckoutChecked)
+}
+
+func (s *Server) scopeForAutomaticCheckoutWithPrefix(ctx context.Context, cwd string, lookup func(context.Context, store_sqlite.Checkout) (string, error)) (workspaceID, projectID, repoPrefix string, ok bool, err error) {
 	if s == nil || s.multiIndexer == nil || s.materializer == nil || s.materializer.Catalog == nil {
-		return "", "", "", false
+		return "", "", "", false, nil
 	}
-	checkout, found, err := graphview.CheckoutForPath(ctx, s.materializer.Catalog, s.viewFamilies(ctx), cwd)
+	checkout, found, err := s.checkoutForRequestPath(ctx, cwd)
 	if err != nil {
 		// A catalog that cannot be read leaves the cwd unresolved, which is
 		// the fail-closed answer — never a wider one.
 		if s.logger != nil {
 			s.logger.Debug("session scope: could not bind the cwd to a checkout", zap.Error(err))
 		}
-		return "", "", "", false
+		return "", "", "", false, err
 	}
 	if !found || !graphview.ServesAutomaticView(checkout) {
-		return "", "", "", false
+		return "", "", "", false, nil
 	}
-	prefix := s.repoPrefixForCheckout(ctx, checkout)
+	prefix, err := lookup(ctx, checkout)
+	if err != nil {
+		return "", "", "", false, err
+	}
 	if prefix == "" {
-		return "", "", "", false
+		return "", "", "", false, nil
 	}
 	root, known := s.multiIndexer.RepoRoot(prefix)
 	if !known {
-		return "", "", "", false
+		return "", "", "", false, nil
 	}
-	return s.multiIndexer.ScopeForCWD(root)
+	workspaceID, projectID, repoPrefix, ok = s.multiIndexer.ScopeForCWD(root)
+	return workspaceID, projectID, repoPrefix, ok, nil
 }
 
 // CheckoutServesCWD reports whether a working directory binds to a registered
@@ -64,6 +78,15 @@ func (s *Server) scopeForAutomaticCheckout(ctx context.Context, cwd string) (wor
 // binds to the family's primary, and a cwd refused here is one it would have
 // left unresolved.
 func (s *Server) CheckoutServesCWD(ctx context.Context, cwd string) bool {
-	_, _, _, ok := s.scopeForAutomaticCheckout(ctx, cwd)
+	ok, _ := s.CheckoutServesCWDChecked(ctx, cwd)
 	return ok
+}
+
+// CheckoutServesCWDChecked distinguishes an unknown checkout from transient
+// catalog/discovery contention. Both remain unadmitted, but a daemon must tell
+// the caller to retry the latter rather than incorrectly suggest tracking it.
+// No pending observation is treated as a scoped or ready checkout.
+func (s *Server) CheckoutServesCWDChecked(ctx context.Context, cwd string) (bool, error) {
+	_, _, _, ok, err := s.scopeForAutomaticCheckoutChecked(ctx, cwd)
+	return ok, err
 }

--- a/internal/mcp/tools_analysis.go
+++ b/internal/mcp/tools_analysis.go
@@ -336,15 +336,52 @@ func (s *Server) handleDetectChanges(ctx context.Context, req mcp.CallToolReques
 	// Resolve the working tree: explicit repo selector, lone tracked repo,
 	// or the session's cwd-bound repo. The "." fallback keeps the standalone
 	// (indexer-less) server working from its own cwd.
-	repoRoot, repoPrefix, rootErr := s.resolveDiffRoot(ctx, strings.TrimSpace(req.GetString("repo", "")))
+	repoSelector := strings.TrimSpace(req.GetString("repo", ""))
+	control := checkoutControlFromContext(ctx)
+	var repoRoot, repoPrefix string
+	var rootErr error
+	if control != nil && control.CheckoutScoped {
+		rootErr = control.validateRepoSelector(repoSelector)
+		repoRoot, repoPrefix = control.Checkout.RootPath, control.RepoPrefix
+	} else {
+		repoRoot, repoPrefix, rootErr = s.resolveDiffRoot(ctx, repoSelector)
+	}
 	if rootErr != nil {
 		return mcp.NewToolResultError(rootErr.Error()), nil
 	}
-	if freshnessErr := s.awaitMutationFreshnessForRepos(ctx, repoPrefix); freshnessErr != nil {
-		return mcp.NewToolResultError("change detection refused a stale graph: " + freshnessErr.Error()), nil
+	if scopeErr := s.repoPrefixInSessionScope(ctx, repoPrefix, repoPrefix); scopeErr != nil {
+		return mcp.NewToolResultError(scopeErr.Error()), nil
+	}
+	var pending bool
+	var freshnessErr error
+	if control != nil && control.CheckoutScoped {
+		pending, freshnessErr = s.mutationFreshnessSummaryForRepos(ctx, repoPrefix)
+	} else if err := s.awaitMutationFreshnessForRepos(ctx, repoPrefix); err != nil {
+		return mcp.NewToolResultError("change detection refused a stale graph: " + err.Error()), nil
+	}
+	reader := s.readerFor(ctx)
+	graphStatus, graphDetail := "ready", ""
+	if pending {
+		graphStatus, graphDetail = "pending", "checkout changes are committed but graph publication is pending"
+	}
+	if freshnessErr != nil {
+		graphStatus, graphDetail = "failed", freshnessErr.Error()
+	}
+	if control != nil && control.CheckoutScoped {
+		view := requestViewFromContext(ctx)
+		if view == nil || view.rider == nil || !view.rider.Exact || !view.routed() {
+			if graphStatus == "ready" {
+				graphStatus, graphDetail = "pending", "the selected checkout has no exact published graph view"
+			}
+		}
+	}
+	if graphStatus != "ready" {
+		// Git can still report file changes, but stale/base symbols must not
+		// impersonate the selected checkout's changed symbols or impact.
+		reader = graph.New()
 	}
 
-	diff, err := analysis.MapGitDiff(s.readerFor(ctx), repoRoot, repoPrefix, scope, baseRef)
+	diff, err := analysis.MapGitDiff(reader, repoRoot, repoPrefix, scope, baseRef)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
@@ -359,6 +396,14 @@ func (s *Server) handleDetectChanges(ctx context.Context, req mcp.CallToolReques
 	fileChanges := diff.FileChanges
 	if fileChanges == nil {
 		fileChanges = []analysis.FileChange{}
+	}
+	if graphStatus != "ready" {
+		return s.respondJSONOrTOON(ctx, req, map[string]any{
+			"changed_symbols": []any{}, "changed_files": changedFiles, "file_changes": fileChanges,
+			"risk": "UNKNOWN", "complete": false, "graph_status": graphStatus,
+			"summary": "Git file changes are available; symbol mapping and impact await an exact published graph",
+			"detail":  graphDetail, "scope": scope, "repo": repoPrefix, "repo_root": repoRoot,
+		})
 	}
 
 	if len(diff.ChangedSymbols) == 0 {

--- a/internal/mcp/tools_analysis.go
+++ b/internal/mcp/tools_analysis.go
@@ -378,7 +378,7 @@ func (s *Server) handleDetectChanges(ctx context.Context, req mcp.CallToolReques
 	if graphStatus != "ready" {
 		// Git can still report file changes, but stale/base symbols must not
 		// impersonate the selected checkout's changed symbols or impact.
-		reader = graph.New()
+		reader = nil
 	}
 
 	diff, err := analysis.MapGitDiff(reader, repoRoot, repoPrefix, scope, baseRef)

--- a/internal/mcp/tools_core.go
+++ b/internal/mcp/tools_core.go
@@ -1523,6 +1523,14 @@ func (s *Server) handleReindexRepository(ctx context.Context, req mcp.CallToolRe
 	}
 
 	pathArg := req.GetString("path", "")
+	if control := checkoutControlFromContext(ctx); control != nil {
+		if err := control.validateReindexPaths(pathArg, paths); err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		if control.CheckoutScoped {
+			return s.handleCheckoutControlReindex(ctx, req, control, paths)
+		}
+	}
 
 	var (
 		result      *indexer.IndexResult
@@ -1563,6 +1571,9 @@ func (s *Server) handleReindexRepository(ctx context.Context, req mcp.CallToolRe
 			}
 		}
 		reindexRoot, _ = s.multiIndexer.RepoRoot(prefix)
+		if scopeErr := s.repoPrefixInSessionScope(ctx, prefix, prefix); scopeErr != nil {
+			return mcp.NewToolResultError(scopeErr.Error()), nil
+		}
 		eligible = s.failedReceiptsBefore(paths, reindexRoot)
 		result, err = s.multiIndexer.IncrementalReindexRepo(prefix, paths)
 		if err != nil {

--- a/internal/mcp/tools_mutation_status.go
+++ b/internal/mcp/tools_mutation_status.go
@@ -23,6 +23,11 @@ func (s *Server) handleMutationStatus(ctx context.Context, req mcp.CallToolReque
 	case receipt != "":
 		record, ok := s.mutationCommits.byReceipt(receipt)
 		if !ok {
+			if payload, found := s.graphRefreshReceiptPayload(ctx, receipt); found {
+				return s.respondJSONOrTOON(ctx, req, payload)
+			}
+		}
+		if !ok || !mutationCommitInScope(ctx, record) {
 			return mcp.NewToolResultError(
 				"no mutation receipt " + receipt + " — receipts are kept for " + mutationCommitRetention.String() +
 					"; query by path instead, or read the file to see its current state"), nil
@@ -31,7 +36,7 @@ func (s *Server) handleMutationStatus(ctx context.Context, req mcp.CallToolReque
 
 	case mutationID != "":
 		record, ok := s.mutationCommits.byMutationID(mutationID)
-		if !ok {
+		if !ok || !mutationCommitInScope(ctx, record) {
 			return mcp.NewToolResultError("no mutation recorded for mutation_id " + mutationID), nil
 		}
 		return s.respondJSONOrTOON(ctx, req, s.mutationStatusPayload(record))
@@ -42,12 +47,12 @@ func (s *Server) handleMutationStatus(ctx context.Context, req mcp.CallToolReque
 		// not fatal here: the raw spelling is still matched against the ledger.
 		lookup := rawPath
 		if absPath, relPath, err := s.resolveFilePath(ctx, rawPath); err == nil {
-			if record, ok := s.mutationCommits.recentForPath(relPath); ok {
+			if record, ok := s.recentMutationCommitInScope(ctx, relPath); ok {
 				return s.respondJSONOrTOON(ctx, req, s.mutationStatusPayload(record))
 			}
 			lookup = absPath
 		}
-		record, ok := s.mutationCommits.recentForPath(lookup)
+		record, ok := s.recentMutationCommitInScope(ctx, lookup)
 		if !ok {
 			return s.respondJSONOrTOON(ctx, req, map[string]any{
 				"path":        rawPath,
@@ -60,7 +65,15 @@ func (s *Server) handleMutationStatus(ctx context.Context, req mcp.CallToolReque
 		return s.respondJSONOrTOON(ctx, req, s.mutationStatusPayload(record))
 	}
 
-	records := s.mutationCommits.recent(maxMutationCommitListing)
+	var records []*mutationCommitRecord
+	for _, record := range s.mutationCommits.recent(maxMutationCommits) {
+		if mutationCommitInScope(ctx, record) {
+			records = append(records, record)
+			if len(records) == maxMutationCommitListing {
+				break
+			}
+		}
+	}
 	// Rendered through the same flag as the single-record path. A listing that
 	// showed graph_status without graph_status_terminal would hand an agent
 	// exactly the reading this tool is trying to stop, just by a different
@@ -70,6 +83,69 @@ func (s *Server) handleMutationStatus(ctx context.Context, req mcp.CallToolReque
 		"count":     len(records),
 		"note":      "most recent first; pass receipt, mutation_id, or path to select one. Read graph_status_terminal before waiting on graph_status",
 	})
+}
+
+// Recovery reindexes have a publication ticket but no disk commit. Accept that
+// same ticket ID through change.receipt without inventing a write verdict.
+func (s *Server) graphRefreshReceiptPayload(ctx context.Context, id string) (map[string]any, bool) {
+	value, ok := s.mutationReceipts.Load(id)
+	if !ok {
+		return nil, false
+	}
+	receipt, ok := value.(*mutationReceipt)
+	if !ok {
+		return nil, false
+	}
+	checkoutID, incarnation := mutationCheckoutScope(ctx)
+	if !mutationCheckoutScopeMatches(checkoutID, incarnation, receipt.checkoutID, receipt.checkoutIncarnation) {
+		return nil, false
+	}
+	outcome := receipt.outcome(true)
+	status := graphStatusFor(outcome)
+	payload := map[string]any{
+		"found":                 true,
+		"receipt":               receipt.id,
+		"receipt_kind":          "graph_refresh",
+		"path":                  receipt.path,
+		"disk_status":           "unrecorded",
+		"graph_status_terminal": !outcome.Pending,
+		"graph_note":            mutationGraphStatusNote(status, true, receipt.checkoutID),
+		"guidance":              "this receipt tracks graph publication only; use the mutation_receipt for disk commit evidence",
+	}
+	// This endpoint has no source-file syntax-health target, including for a
+	// canonical watcher receipt. Only render the publication evidence.
+	outcome.checkoutScoped = true
+	s.attachMutationFreshness(payload, "", "", outcome)
+	if receipt.checkoutID != "" {
+		payload["checkout_id"] = receipt.checkoutID
+		payload["checkout_incarnation"] = receipt.checkoutIncarnation
+	}
+	if outcome.Err != nil {
+		payload["error"] = outcome.Err.Error()
+	}
+	return payload, true
+}
+
+func mutationCommitInScope(ctx context.Context, record *mutationCommitRecord) bool {
+	checkoutID, incarnation := mutationCheckoutScope(ctx)
+	record.mu.RLock()
+	defer record.mu.RUnlock()
+	return mutationCheckoutScopeMatches(checkoutID, incarnation, record.checkoutID, record.checkoutIncarnation)
+}
+
+func (s *Server) recentMutationCommitInScope(ctx context.Context, path string) (*mutationCommitRecord, bool) {
+	for _, record := range s.mutationCommits.recent(maxMutationCommits) {
+		if !mutationCommitInScope(ctx, record) {
+			continue
+		}
+		record.mu.RLock()
+		match := record.relPath == path || record.absPath == path
+		record.mu.RUnlock()
+		if match {
+			return record, true
+		}
+	}
+	return nil, false
 }
 
 // mutationStatusPayload renders one record, refreshing the graph half if the
@@ -91,6 +167,7 @@ func (s *Server) mutationStatusPayload(record *mutationCommitRecord) map[string]
 		"disk_status":  snap.DiskStatus,
 		"graph_status": snap.GraphStatus,
 	}
+	attachMutationRefreshSnapshot(payload, snap)
 	if snap.MutationID != "" {
 		payload["mutation_id"] = snap.MutationID
 	}
@@ -111,11 +188,36 @@ func (s *Server) mutationStatusPayload(record *mutationCommitRecord) map[string]
 	}
 	payload["retry_safe"] = snap.DiskStatus == mutationDiskNotApplied || snap.DiskStatus == mutationDiskFailed
 	payload["graph_status_terminal"] = graphStatusTerminal(snap.GraphStatus, snap.GraphRecorded)
-	if note := graphStatusNote(snap.GraphStatus, snap.GraphRecorded); note != "" {
+	if note := mutationGraphStatusNote(snap.GraphStatus, snap.GraphRecorded, snap.CheckoutID); note != "" {
 		payload["graph_note"] = note
 	}
 	payload["guidance"] = mutationStatusGuidance(snap.DiskStatus)
 	return payload
+}
+
+func mutationGraphStatusNote(graph string, recorded bool, checkoutID string) string {
+	if recorded && checkoutID != "" && graph == mutationGraphFailed {
+		return "publication of the original checkout content failed terminally; inspect the error and the current exact checkout view. A different branch or later edit cannot certify this receipt; request a new scoped refresh if needed"
+	}
+	return graphStatusNote(graph, recorded)
+}
+
+func attachMutationRefreshSnapshot(payload map[string]any, snap mutationCommitSnapshot) {
+	if snap.ReindexReceipt != "" {
+		payload["reindex_receipt"] = snap.ReindexReceipt
+	}
+	if snap.ReindexGeneration != 0 {
+		payload["reindex_generation"] = snap.ReindexGeneration
+	}
+	if snap.AppliedGeneration != 0 {
+		payload["applied_generation"] = snap.AppliedGeneration
+	}
+	if snap.CheckoutID != "" {
+		payload["checkout_id"] = snap.CheckoutID
+	}
+	if snap.CheckoutIncarnation != "" {
+		payload["checkout_incarnation"] = snap.CheckoutIncarnation
+	}
 }
 
 // graphStatusTerminal answers the only question a caller actually has about
@@ -198,6 +300,7 @@ func mutationCommitListingPayload(records []*mutationCommitRecord) []map[string]
 			"graph_status":          snap.GraphStatus,
 			"graph_status_terminal": graphStatusTerminal(snap.GraphStatus, snap.GraphRecorded),
 		}
+		attachMutationRefreshSnapshot(entry, snap)
 		// Every remaining field mirrors mutationCommitSnapshot's omitempty
 		// exactly. Rendering by hand is what dropped new_sha and
 		// bytes_written the first time, so the parity is asserted against the

--- a/internal/mcp/view_metrics_test.go
+++ b/internal/mcp/view_metrics_test.go
@@ -83,15 +83,20 @@ func TestHalfRoutedRequestCountsABuildingFallback(t *testing.T) {
 
 // TestUnreadableBindingCountsAnInaccessibleFallback pins the other reason: a
 // catalog that cannot be read is a different operational problem from a view
-// that is still being built, and one counter for both would hide it.
+// that is still being built. Independent canonical ownership permits this
+// fallback; an unbound automatic checkout is refused and is not counted served.
 func TestUnreadableBindingCountsAnInaccessibleFallback(t *testing.T) {
 	stack := newViewStack(t)
 	breakCheckoutReads(t, stack.dbPath)
 
 	var reader graph.Reader
 	before := viewmetrics.Read()
-	if _, err := stack.callWithView(t, stack.worktreeRoot, "get_symbol", nil, captureReader(stack.srv, &reader)); err != nil {
+	res, err := stack.callWithView(t, stack.repoRoot, "get_symbol", nil, captureReader(stack.srv, &reader))
+	if err != nil {
 		t.Fatalf("call: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("canonical fallback was refused: %s", viewResultText(t, res))
 	}
 	after := viewmetrics.Read()
 
@@ -100,6 +105,36 @@ func TestUnreadableBindingCountsAnInaccessibleFallback(t *testing.T) {
 	}
 	if got := fallbackDelta(before, after, graphview.CodeViewBuilding); got != 0 {
 		t.Fatalf("an unreadable catalog was counted as a building view (%d)", got)
+	}
+	if got := servedDelta(before, after, viewmetrics.ViewBase); got != 1 {
+		t.Fatalf("canonical base views served = %d, want 1", got)
+	}
+}
+
+func TestUnreadableAutomaticBindingCountsNeitherServedNorFallback(t *testing.T) {
+	stack := newViewStack(t)
+	breakCheckoutReads(t, stack.dbPath)
+
+	var reader graph.Reader
+	before := viewmetrics.Read()
+	res, err := stack.callWithView(t, stack.worktreeRoot, "get_symbol", nil, captureReader(stack.srv, &reader))
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	after := viewmetrics.Read()
+	assertToolError(t, res, graphview.CodeCheckoutInaccessible)
+	if reader != nil {
+		t.Fatal("refused automatic checkout reached the graph handler")
+	}
+	for _, kind := range []string{viewmetrics.ViewBase, viewmetrics.ViewWorktree} {
+		if got := servedDelta(before, after, kind); got != 0 {
+			t.Fatalf("refused checkout counted a %s answer (%d)", kind, got)
+		}
+	}
+	for _, reason := range viewmetrics.ViewErrorCodes {
+		if got := fallbackDelta(before, after, reason); got != 0 {
+			t.Fatalf("refused checkout counted a %s fallback (%d)", reason, got)
+		}
 	}
 }
 

--- a/internal/mcp/view_mutation_state.go
+++ b/internal/mcp/view_mutation_state.go
@@ -19,18 +19,36 @@ type checkoutMutationLifecycle interface {
 	Refresh(context.Context) (indexer.CheckoutCycle, error)
 }
 
+// checkoutMutationScheduler queues publication on the existing coordinator loop.
+// The request must return before that loop can acquire the checkout lease.
+type checkoutMutationScheduler interface {
+	EnqueueRefresh(context.Context, string) (*indexer.CheckoutRefreshTicket, error)
+}
+
+type checkoutMutationIdentity interface {
+	Identity() (checkoutID, incarnation string)
+}
+
 type checkoutMutationContextKey struct{}
 
 type checkoutMutationState struct {
-	mutation checkoutMutationLifecycle
-	root     string
+	mutation      checkoutMutationLifecycle
+	root          string
+	checkoutID    string
+	incarnation   string
+	committedHash string
+	committedPath string
 }
 
 func withCheckoutMutation(ctx context.Context, mutation checkoutMutationLifecycle, root string) context.Context {
-	return context.WithValue(ctx, checkoutMutationContextKey{}, &checkoutMutationState{
+	state := &checkoutMutationState{
 		mutation: mutation,
 		root:     resolveNearestExistingAncestor(root),
-	})
+	}
+	if identity, ok := mutation.(checkoutMutationIdentity); ok {
+		state.checkoutID, state.incarnation = identity.Identity()
+	}
+	return context.WithValue(ctx, checkoutMutationContextKey{}, state)
 }
 
 func checkoutMutationFromContext(ctx context.Context) *checkoutMutationState {
@@ -122,8 +140,34 @@ func (s *Server) refreshCheckoutMutation(ctx context.Context, path string, state
 		outcome.Err = err
 		return outcome
 	}
-	// Disk has committed. Give its selected checkout a bounded refresh even
-	// when the caller has disconnected, then let Close signal a retry on failure.
+	if scheduler, ok := state.mutation.(checkoutMutationScheduler); ok {
+		// Disk has committed, so caller cancellation must not abandon graph
+		// publication. Admission only captures evidence and signals the existing
+		// coordinator: never wait here while the handler still holds its lease.
+		ticket, err := scheduler.EnqueueRefresh(context.WithoutCancel(ctx), path)
+		if err != nil {
+			outcome.Err = fmt.Errorf("checkout graph refresh admission failed after disk commit: %w", err)
+			return outcome
+		}
+		if ticket == nil || ticket.Ticket == nil || ticket.Ticket.Done == nil || ticket.CheckoutID == "" || ticket.Incarnation == "" {
+			outcome.Err = fmt.Errorf("checkout graph refresh admission returned no scoped completion ticket")
+			return outcome
+		}
+		if state.checkoutID != "" && (ticket.CheckoutID != state.checkoutID || ticket.Incarnation != state.incarnation) {
+			outcome.Err = fmt.Errorf("checkout graph refresh ticket does not belong to the committed checkout incarnation")
+			return outcome
+		}
+		if !pathkey.EqualPaths(ticket.Ticket.Path, path) {
+			outcome.Err = fmt.Errorf("checkout graph refresh ticket does not name the committed file")
+			return outcome
+		}
+		if state.committedHash != "" && (!pathkey.EqualPaths(state.committedPath, path) || ticket.ContentHash != state.committedHash) {
+			outcome.Err = fmt.Errorf("%w: checkout file changed after disk commit before publication admission", indexer.ErrCheckoutRefreshSuperseded)
+			return outcome
+		}
+		return s.trackCheckoutRefreshTicket(ticket).outcome(true)
+	}
+	// Embedded adapters without queue support retain their synchronous contract.
 	refreshCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), s.mutationWaitDuration())
 	defer cancel()
 	cycle, err := state.mutation.Refresh(refreshCtx)
@@ -131,8 +175,12 @@ func (s *Server) refreshCheckoutMutation(ctx context.Context, path string, state
 		outcome.Err = fmt.Errorf("checkout graph refresh failed after disk commit: %w", err)
 		return outcome
 	}
-	if cycle.Err != nil || cycle.Rescheduled || cycle.Deferred || cycle.DirtyGenerationID <= 0 || cycle.CommitGenerationID <= 0 {
-		outcome.Err = fmt.Errorf("checkout graph refresh did not publish an exact view")
+	if cycle.Err != nil {
+		outcome.Err = fmt.Errorf("checkout graph refresh did not publish an exact view: %w", cycle.Err)
+		return outcome
+	}
+	if cycle.Rescheduled || cycle.Deferred || cycle.DirtyGenerationID <= 0 || cycle.CommitGenerationID <= 0 {
+		outcome.Err = fmt.Errorf("checkout graph refresh did not publish an exact view (rescheduled=%t deferred=%t commit_generation=%d dirty_generation=%d)", cycle.Rescheduled, cycle.Deferred, cycle.CommitGenerationID, cycle.DirtyGenerationID)
 		return outcome
 	}
 	outcome.Reindexed = true

--- a/internal/mcp/view_request.go
+++ b/internal/mcp/view_request.go
@@ -15,7 +15,6 @@ import (
 	"github.com/zzet/gortex/internal/graph/store_sqlite"
 	"github.com/zzet/gortex/internal/graphview"
 	"github.com/zzet/gortex/internal/indexer"
-	"github.com/zzet/gortex/internal/pathkey"
 	"github.com/zzet/gortex/internal/query"
 	"github.com/zzet/gortex/internal/reconcile"
 	"github.com/zzet/gortex/internal/viewmetrics"
@@ -537,7 +536,7 @@ func (s *Server) viewForSessionCWD(ctx context.Context) (*requestView, error) {
 	if cwd == "" {
 		return nil, nil
 	}
-	checkout, found, err := graphview.CheckoutForPath(ctx, s.materializer.Catalog, s.viewFamilies(ctx), cwd)
+	checkout, found, err := s.checkoutForRequestPath(ctx, cwd)
 	if err != nil {
 		// The binding is an optimization over the base corpus, not a
 		// precondition for answering: a catalog that cannot be read still
@@ -552,6 +551,9 @@ func (s *Server) viewForSessionCWD(ctx context.Context) (*requestView, error) {
 	if !found || !graphview.ServesAutomaticView(checkout) {
 		return nil, nil
 	}
+	if err := s.checkoutInSessionScope(ctx, checkout); err != nil {
+		return nil, err
+	}
 	requested := graphview.Selector{Kind: graphview.SelectorWorktree, CheckoutID: checkout.CheckoutID}
 	return s.materializeRequestView(ctx, requested, checkout, false)
 }
@@ -564,39 +566,9 @@ func (s *Server) viewForWorktreeSelector(
 	selector graphview.Selector,
 	policy requestViewPolicy,
 ) (*requestView, error) {
-	catalog := s.materializer.Catalog
-	var checkout store_sqlite.Checkout
-	var found bool
-	var err error
-	subject := selector.CheckoutID
-	if selector.Path != "" {
-		subject = selector.Path
-		root := canonicalWorktreeSelectorRoot(selector.Path)
-		checkout, found, err = graphview.CheckoutForPath(ctx, catalog, s.viewFamilies(ctx), root)
-		// A new nested worktree must not be mistaken for its already-indexed
-		// parent while discovery is pending. Path selectors name roots, unlike
-		// implicit session-CWD binding which also accepts directories inside one.
-		if err == nil && found {
-			found = pathkey.EqualPaths(root, canonicalWorktreeSelectorRoot(checkout.RootPath))
-		}
-	} else {
-		checkout, found, err = catalog.GetCheckout(ctx, selector.CheckoutID)
-	}
-	switch {
-	case err != nil:
-		return nil, graphview.WrapViewError(graphview.CodeCheckoutInaccessible,
-			fmt.Sprintf("read checkout %q", subject), err)
-	case !found:
-		if selector.Path == "" && filepath.IsAbs(selector.CheckoutID) {
-			return nil, graphview.NewViewError(graphview.CodeInvalidViewSelector,
-				fmt.Sprintf("view.checkout_id expects a registered identifier, not a filesystem path; use view:{kind:\"worktree\",path:%q} or workspace(operation:\"checkouts\") to find its checkout_id", selector.CheckoutID))
-		}
-		if selector.Path != "" {
-			return nil, graphview.NewViewError(graphview.CodeCheckoutInaccessible,
-				fmt.Sprintf("no registered worktree root matches path %q; supply the worktree root, and if automatic discovery is pending inspect workspace(operation:\"checkouts\") and retry", selector.Path))
-		}
-		return nil, graphview.NewViewError(graphview.CodeCheckoutInaccessible,
-			fmt.Sprintf("checkout %q is not registered; use view.path for a filesystem path or workspace(operation:\"checkouts\") to find its checkout_id", selector.CheckoutID))
+	checkout, err := s.registeredWorktreeSelector(ctx, selector)
+	if err != nil {
+		return nil, err
 	}
 	if checkout.State != store_sqlite.CheckoutStateReady {
 		stateErr := graphview.NewViewError(graphview.CodeCheckoutInaccessible,
@@ -720,6 +692,7 @@ func (s *Server) materializeRequestView(
 	strict bool,
 ) (*requestView, error) {
 	rider := graphview.NewViewRider(requested)
+	rider.CheckoutID = checkout.CheckoutID
 	route, found, err := s.materializer.Catalog.GetCheckoutRoute(ctx, checkout.CheckoutID)
 	switch {
 	case err != nil:
@@ -900,20 +873,25 @@ func (s *Server) repoPrefixInSessionScope(ctx context.Context, repoPrefix, subje
 // its own dedicated graph when it has one, and otherwise the family's primary
 // base graph, which is the lane an automatic checkout reads through.
 func (s *Server) repoPrefixForCheckout(ctx context.Context, checkout store_sqlite.Checkout) string {
+	prefix, _ := s.repoPrefixForCheckoutChecked(ctx, checkout)
+	return prefix
+}
+
+func (s *Server) repoPrefixForCheckoutChecked(ctx context.Context, checkout store_sqlite.Checkout) (string, error) {
 	graphs, err := s.materializer.Catalog.ListDedicatedGraphs(ctx, checkout.FamilyID)
 	if err != nil {
-		return ""
+		return "", err
 	}
 	primary := ""
 	for _, dedicated := range graphs {
 		if dedicated.OwnerCheckoutID == checkout.CheckoutID && dedicated.RepoPrefix != "" {
-			return dedicated.RepoPrefix
+			return dedicated.RepoPrefix, nil
 		}
 		if dedicated.IsPrimaryBase && dedicated.RepoPrefix != "" {
 			primary = dedicated.RepoPrefix
 		}
 	}
-	return primary
+	return primary, nil
 }
 
 // refuseRoutedViewMutation admits only mutations that obtained checkout-local

--- a/internal/mcp/view_request.go
+++ b/internal/mcp/view_request.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"slices"
@@ -538,15 +539,7 @@ func (s *Server) viewForSessionCWD(ctx context.Context) (*requestView, error) {
 	}
 	checkout, found, err := s.checkoutForRequestPath(ctx, cwd)
 	if err != nil {
-		// The binding is an optimization over the base corpus, not a
-		// precondition for answering: a catalog that cannot be read still
-		// answers from the base. The cwd may well sit inside a routed
-		// checkout, so the degradation rides on the response rather than
-		// passing for an exact answer.
-		if s.logger != nil {
-			s.logger.Debug("view routing: could not bind the session cwd to a checkout", zap.Error(err))
-		}
-		return viewFallback(false, graphview.NewViewRider(graphview.Selector{Kind: graphview.SelectorAuto}), err)
+		return s.viewForCWDLookupError(cwd, err)
 	}
 	if !found || !graphview.ServesAutomaticView(checkout) {
 		return nil, nil
@@ -556,6 +549,58 @@ func (s *Server) viewForSessionCWD(ctx context.Context) (*requestView, error) {
 	}
 	requested := graphview.Selector{Kind: graphview.SelectorWorktree, CheckoutID: checkout.CheckoutID}
 	return s.materializeRequestView(ctx, requested, checkout, false)
+}
+
+// A lookup error is not proof that the canonical corpus owns this CWD. Only
+// independent tracked-root metadata may authorize the legacy catalog fallback;
+// an unknown, nested, or automatic sibling checkout must fail closed instead.
+func (s *Server) viewForCWDLookupError(cwd string, err error) (*requestView, error) {
+	if errors.Is(err, indexer.ErrCheckoutMutationStale) || errors.Is(err, indexer.ErrCheckoutRefreshStopped) {
+		return nil, graphview.WrapViewError(graphview.CodeCheckoutInaccessible,
+			"automatic checkout discovery no longer has a valid checkout identity", err)
+	}
+	if errors.Is(err, indexer.ErrCheckoutMutationBusy) {
+		return nil, graphview.WrapViewError(graphview.CodeViewBuilding,
+			"automatic checkout discovery is still pending; retry this request", err)
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return nil, graphview.WrapViewError(graphview.CodeCheckoutInaccessible,
+			"automatic checkout discovery was interrupted", err)
+	}
+	if checkoutLookupErrorRequiresRefusal(err) {
+		return nil, err
+	}
+	if s.logger != nil {
+		s.logger.Debug("view routing: could not bind the session cwd to a checkout", zap.Error(err))
+	}
+	if s.multiIndexer != nil {
+		_, _, prefix, bound := s.multiIndexer.ScopeForCWD(cwd)
+		if root, found := s.multiIndexer.RepoRoot(prefix); bound && found && checkoutControlRootOwnsPath(root, cwd) == nil {
+			return viewFallback(false, graphview.NewViewRider(graphview.Selector{Kind: graphview.SelectorAuto}), err)
+		}
+	}
+	return nil, graphview.WrapViewError(graphview.CodeCheckoutInaccessible,
+		"checkout lookup failed before a canonical root could be established", err)
+}
+
+// Catalog reads use checkout_inaccessible too; that code may reach the
+// independent canonical-ownership gate. No wrapper or joined cause may hide
+// a more specific refusal such as a denied scope or invalid selector.
+func checkoutLookupErrorRequiresRefusal(err error) bool {
+	if code := graphview.CodeOf(err); code != "" && code != graphview.CodeCheckoutInaccessible {
+		return true
+	}
+	switch wrapped := err.(type) {
+	case interface{ Unwrap() []error }:
+		for _, cause := range wrapped.Unwrap() {
+			if checkoutLookupErrorRequiresRefusal(cause) {
+				return true
+			}
+		}
+	case interface{ Unwrap() error }:
+		return checkoutLookupErrorRequiresRefusal(wrapped.Unwrap())
+	}
+	return false
 }
 
 // viewForWorktreeSelector serves an explicitly named checkout. Every refusal

--- a/internal/mcp/view_request_test.go
+++ b/internal/mcp/view_request_test.go
@@ -950,9 +950,14 @@ func TestUnreadableCWDBindingSaysItFellBack(t *testing.T) {
 	breakCheckoutReads(t, stack.dbPath)
 
 	var reader graph.Reader
-	res, err := stack.callWithView(t, stack.worktreeRoot, "get_symbol", nil, captureReader(stack.srv, &reader))
+	// Tracked-root metadata proves this canonical CWD independently of the
+	// unreadable checkout table. The automatic sibling has no such proof.
+	res, err := stack.callWithView(t, stack.repoRoot, "get_symbol", nil, captureReader(stack.srv, &reader))
 	if err != nil {
 		t.Fatalf("call: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("canonical fallback was refused: %s", viewResultText(t, res))
 	}
 	if hasNode(reader, "repo/added.go::Fresh") {
 		t.Error("an unreadable binding served the routed generations anyway")
@@ -975,6 +980,21 @@ func TestUnreadableCWDBindingSaysItFellBack(t *testing.T) {
 	}
 	if rider["fallback_reason"] != graphview.CodeCheckoutInaccessible {
 		t.Errorf("fallback_reason = %v, want %q", rider["fallback_reason"], graphview.CodeCheckoutInaccessible)
+	}
+}
+
+func TestUnreadableAutomaticBindingDoesNotReturnBaseData(t *testing.T) {
+	stack := newViewStack(t)
+	breakCheckoutReads(t, stack.dbPath)
+
+	var reader graph.Reader
+	res, err := stack.callWithView(t, stack.worktreeRoot, "get_symbol", nil, captureReader(stack.srv, &reader))
+	if err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	assertToolError(t, res, graphview.CodeCheckoutInaccessible)
+	if reader != nil {
+		t.Fatal("unreadable automatic binding reached a graph reader without checkout authority")
 	}
 }
 

--- a/internal/mcp/worktree_agent_lifecycle_test.go
+++ b/internal/mcp/worktree_agent_lifecycle_test.go
@@ -1,0 +1,303 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/parser"
+)
+
+// Delay the real parser, not the receipt or coordinator. Only post-edit bytes
+// contain the marker, so registration and the initial exact view build normally.
+type lifecycleBlockingExtractor struct {
+	parser.Extractor
+	marker   []byte
+	entered  chan struct{}
+	release  chan struct{}
+	once     sync.Once
+	done     sync.Once
+	diskPath atomic.Pointer[string]
+}
+
+func (e *lifecycleBlockingExtractor) Extract(path string, src []byte) (*parser.ExtractionResult, error) {
+	if path := e.diskPath.Load(); path != nil && bytes.Contains(src, e.marker) {
+		// Edit preview parses proposed bytes too. Block only after the actual
+		// file has committed, when the coordinator is publishing those bytes.
+		current, err := os.ReadFile(*path)
+		if err == nil && bytes.Contains(current, e.marker) {
+			e.once.Do(func() { close(e.entered) })
+			<-e.release
+		}
+	}
+	return e.Extractor.Extract(path, src)
+}
+
+func (e *lifecycleBlockingExtractor) unblock() { e.done.Do(func() { close(e.release) }) }
+
+func newBlockedLifecycleFixture(t testing.TB) (*realCheckoutMutationFixture, *lifecycleBlockingExtractor) {
+	t.Helper()
+	e := &lifecycleBlockingExtractor{
+		marker: []byte("LifecycleBlocked"), entered: make(chan struct{}), release: make(chan struct{}),
+	}
+	f := newRealCheckoutMutationFixtureWithRegistry(t, func(registry *parser.Registry) {
+		var found bool
+		e.Extractor, found = registry.GetByLanguage("go")
+		require.True(t, found)
+		registry.Register(e)
+	})
+	path := filepath.Join(f.worktree, "edit.go")
+	e.diskPath.Store(&path)
+	// Unblock before the fixture's lifecycle cleanup waits for its real worker.
+	t.Cleanup(e.unblock)
+	f.srv.mutationReindexWait = 20 * time.Millisecond
+	f.srv.mutationSafetyWait = 20 * time.Millisecond
+	return f, e
+}
+
+func lifecycleResultPayload(t testing.TB, result *mcplib.CallToolResult) map[string]any {
+	t.Helper()
+	require.NotNil(t, result)
+	require.False(t, result.IsError, "%+v", result.Content)
+	for _, content := range result.Content {
+		if text, ok := content.(mcplib.TextContent); ok {
+			var payload map[string]any
+			if json.Unmarshal([]byte(text.Text), &payload) == nil {
+				return payload
+			}
+		}
+	}
+	t.Fatalf("no JSON object in result: %+v", result.Content)
+	return nil
+}
+
+func (f *realCheckoutMutationFixture) facade(t testing.TB, cwd, name string, args map[string]any) *mcplib.CallToolResult {
+	t.Helper()
+	tool := f.srv.mcpServer.GetTool(name)
+	require.NotNil(t, tool, "registered facade %q is required", name)
+	req := mcplib.CallToolRequest{}
+	req.Params.Name, req.Params.Arguments = name, args
+	ctx := WithSessionCWD(WithSessionID(context.Background(), "real-checkout-lifecycle"), cwd)
+	result, err := tool.Handler(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	return result
+}
+
+func (f *realCheckoutMutationFixture) mutationStatus(t testing.TB, cwd, root, receipt string) map[string]any {
+	t.Helper()
+	if os.Getenv("GORTEX_TOOLS") == "facade-v1" {
+		return lifecycleResultPayload(t, f.facade(t, cwd, "change", map[string]any{
+			"operation": "receipt", "options": map[string]any{"receipt": receipt},
+			"view": map[string]any{"kind": "worktree", "path": root},
+		}))
+	}
+	req := mcplib.CallToolRequest{}
+	req.Params.Name = "mutation_status"
+	req.Params.Arguments = map[string]any{
+		"receipt": receipt,
+		"view":    map[string]any{"kind": "worktree", "path": root},
+	}
+	ctx := WithSessionCWD(WithSessionID(context.Background(), "real-checkout-lifecycle"), cwd)
+	result, err := f.srv.wrapToolHandler(f.srv.handleMutationStatus)(ctx, req)
+	require.NoError(t, err)
+	return lifecycleResultPayload(t, result)
+}
+
+func (f *realCheckoutMutationFixture) awaitMutation(t testing.TB, cwd string, result *mcplib.CallToolResult) {
+	t.Helper()
+	f.awaitMutationInRoot(t, cwd, f.worktree, result)
+}
+
+func (f *realCheckoutMutationFixture) awaitMutationInRoot(t testing.TB, cwd, root string, result *mcplib.CallToolResult) {
+	t.Helper()
+	payload := lifecycleResultPayload(t, result)
+	receipt, ok := payload["mutation_receipt"].(string)
+	require.True(t, ok, "committed write needs a pollable receipt: %+v", payload)
+	require.NotEmpty(t, receipt)
+	var status map[string]any
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		status = f.mutationStatus(t, cwd, root, receipt)
+		if status["graph_status"] == "fresh" {
+			return
+		}
+		require.NotEqual(t, true, status["graph_status_terminal"], "unexpected terminal receipt: %+v", status)
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("mutation did not become fresh: %+v", status)
+}
+
+func TestNewWorktreeSearchDiscoversCheckoutWithoutTracking(t *testing.T) {
+	for _, name := range []string{"direct_handler", "daemon_scope_handshake"} {
+		t.Run(name, func(t *testing.T) {
+			testNewWorktreeAgentLifecycle(t, name == "daemon_scope_handshake")
+		})
+	}
+}
+
+func testNewWorktreeAgentLifecycle(t *testing.T, handshake bool) {
+	t.Helper()
+	t.Setenv("GORTEX_TOOLS", "facade-v1")
+	f := newRealCheckoutMutationFixture(t)
+	// Add AFTER registration/startup, not as another entry in the initial Git
+	// topology. The first agent request must discover this automatic checkout.
+	root := filepath.Join(filepath.Dir(f.primary), "newly-added")
+	checkoutMutationGit(t, f.primary, "worktree", "add", "-b", "newly-added", root)
+	require.NoError(t, os.WriteFile(filepath.Join(root, "added.go"), []byte("package repo\n\nfunc NewlyDiscovered() {}\n"), 0o644))
+	started := time.Now()
+	if handshake {
+		// The daemon checks this before dispatching tools/call with the CWD.
+		require.True(t, f.srv.CheckoutServesCWD(context.Background(), root), "daemon must admit the automatically discovered checkout")
+	}
+	first := f.facade(t, root, "search", map[string]any{
+		"operation": "symbols", "query": "Old", "options": map[string]any{"limit": 10},
+	})
+	require.False(t, first.IsError, "%+v", first.Content)
+	require.Less(t, time.Since(started), 2*time.Second, "cold search must not wait for indexing")
+	freshness := resultFreshness(t, first)
+	require.Contains(t, freshness, "exact", "a cold fallback must identify whether it served the checkout: %+v", first.Content)
+	require.NotEmpty(t, lifecycleResultPayload(t, first)["results"], "the unchanged Old symbol must be available from the checkout or labeled base fallback")
+
+	var last *mcplib.CallToolResult
+	require.Eventually(t, func() bool {
+		last = f.facade(t, root, "search", map[string]any{
+			"operation": "symbols", "query": "NewlyDiscovered", "require_exact": true,
+			"options": map[string]any{"limit": 10},
+		})
+		if last.IsError {
+			return false
+		}
+		for _, content := range last.Content {
+			if text, ok := content.(mcplib.TextContent); ok && strings.Contains(text.Text, "NewlyDiscovered") {
+				return true
+			}
+		}
+		return false
+	}, 20*time.Second, 20*time.Millisecond, "new worktree never became exactly searchable")
+	require.Equal(t, true, resultFreshness(t, last)["exact"])
+	written := f.facade(t, root, "edit", map[string]any{
+		"operation": "file", "target": map[string]any{"file": "repo/added.go"},
+		"match": "func NewlyDiscovered() {}", "replacement": "func NewlyEdited() {}",
+	})
+	f.awaitMutationInRoot(t, root, root, written)
+	read := f.facade(t, root, "read", map[string]any{
+		"operation": "source", "target": map[string]any{"symbol": "repo/added.go::NewlyEdited"},
+		"require_exact": true,
+	})
+	require.False(t, read.IsError, "%+v", read.Content)
+	require.Equal(t, true, resultFreshness(t, read)["exact"])
+	_, err := os.Stat(filepath.Join(f.primary, "added.go"))
+	require.True(t, os.IsNotExist(err), "new checkout source must not be copied into the primary")
+}
+
+func TestWorktreeAgentLifecycleSlowRefreshRemainsRecoverable(t *testing.T) {
+	t.Setenv("GORTEX_TOOLS", "facade-v1")
+	f, blocker := newBlockedLifecycleFixture(t)
+	primaryBefore, err := os.ReadFile(filepath.Join(f.primary, "edit.go"))
+	require.NoError(t, err)
+	view := map[string]any{"kind": "worktree", "path": f.worktree}
+	started := time.Now()
+	written := f.facade(t, f.primary, "edit", map[string]any{
+		"operation": "file", "target": map[string]any{"file": "repo/edit.go"},
+		"match": "func New() {}", "replacement": "func LifecycleBlocked() {}", "view": view,
+	})
+	require.Less(t, time.Since(started), time.Second, "disk commit must not wait for the blocked indexer")
+	payload := lifecycleResultPayload(t, written)
+	require.Equal(t, false, payload["reindexed"])
+	require.Equal(t, "pending", payload["graph_status"])
+	receipt, ok := payload["mutation_receipt"].(string)
+	require.True(t, ok)
+	select {
+	case <-blocker.entered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("real coordinator never reached the post-edit parser")
+	}
+	// Exceed the old synchronous wait budget while the actual build is held.
+	time.Sleep(2 * f.srv.mutationReindexWait)
+	statusResult := f.facade(t, f.primary, "change", map[string]any{
+		"operation": "receipt", "options": map[string]any{"receipt": receipt}, "view": view,
+	})
+	status := lifecycleResultPayload(t, statusResult)
+	require.Equal(t, "committed", status["disk_status"])
+	require.Equal(t, "pending", status["graph_status"])
+	require.NotEqual(t, true, status["graph_status_terminal"])
+
+	started = time.Now()
+	recovery := f.facade(t, f.primary, "workspace_admin", map[string]any{
+		"operation": "reindex", "arguments": map[string]any{"path": f.worktree, "paths": []string{"edit.go"}}, "view": view,
+	})
+	require.False(t, recovery.IsError, "%+v", recovery.Content)
+	require.Less(t, time.Since(started), time.Second, "scoped recovery must queue, not wait on the build lock")
+
+	detected := f.facade(t, f.primary, "change", map[string]any{
+		"operation": "detect", "target": map[string]any{"repo": "repo"}, "view": view,
+	})
+	diff := lifecycleResultPayload(t, detected)
+	require.Equal(t, f.worktree, diff["repo_root"])
+	require.Equal(t, false, diff["complete"])
+	require.Equal(t, "UNKNOWN", diff["risk"])
+	files, err := json.Marshal(diff["changed_files"])
+	require.NoError(t, err)
+	require.Contains(t, string(files), "edit.go")
+
+	// A graph-dependent edit must refuse the pending exact view promptly, not
+	// write through the primary fallback or wait behind the held build lock.
+	started = time.Now()
+	refused := f.facade(t, f.primary, "edit", map[string]any{
+		"operation": "file", "target": map[string]any{"file": "repo/edit.go"},
+		"match": "LifecycleBlocked", "replacement": "MustNotLand", "view": view, "require_exact": true,
+	})
+	require.True(t, refused.IsError)
+	require.Less(t, time.Since(started), time.Second)
+	current, err := os.ReadFile(filepath.Join(f.worktree, "edit.go"))
+	require.NoError(t, err)
+	require.Contains(t, string(current), "LifecycleBlocked")
+
+	blocker.unblock()
+	f.awaitMutation(t, f.primary, written)
+	exact := f.facade(t, f.primary, "read", map[string]any{
+		"operation": "source", "target": map[string]any{"symbol": "repo/edit.go::LifecycleBlocked"},
+		"view": view, "require_exact": true,
+	})
+	require.False(t, exact.IsError, "%+v", exact.Content)
+	require.Equal(t, true, resultFreshness(t, exact)["exact"])
+
+	// Continue normally, without tracking, reapplying the first edit, or
+	// restarting anything, and certify the second publication independently.
+	second := f.facade(t, f.primary, "edit", map[string]any{
+		"operation": "file", "target": map[string]any{"file": "repo/edit.go"},
+		"match": "LifecycleBlocked", "replacement": "LifecycleContinued", "view": view,
+	})
+	f.awaitMutation(t, f.primary, second)
+	primaryAfter, err := os.ReadFile(filepath.Join(f.primary, "edit.go"))
+	require.NoError(t, err)
+	require.Equal(t, primaryBefore, primaryAfter)
+}
+
+func BenchmarkWorktreeMutationEnqueueWithBlockedIndexer(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		f, blocker := newBlockedLifecycleFixture(b)
+		b.StartTimer()
+		written := f.edit(b, f.worktree, map[string]any{
+			"path": "repo/edit.go", "old_string": "func New() {}", "new_string": "func LifecycleBlocked() {}",
+		})
+		b.StopTimer()
+		payload := lifecycleResultPayload(b, written)
+		require.Equal(b, "pending", payload["graph_status"])
+		blocker.unblock()
+		f.awaitMutation(b, f.worktree, written)
+	}
+}

--- a/internal/mcp/worktree_agent_lifecycle_test.go
+++ b/internal/mcp/worktree_agent_lifecycle_test.go
@@ -15,6 +15,8 @@ import (
 	mcplib "github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/require"
 
+	"github.com/zzet/gortex/internal/graphview"
+	"github.com/zzet/gortex/internal/indexer"
 	"github.com/zzet/gortex/internal/parser"
 )
 
@@ -146,6 +148,23 @@ func TestNewWorktreeSearchDiscoversCheckoutWithoutTracking(t *testing.T) {
 	}
 }
 
+func awaitCheckoutAdmission(t testing.TB, srv *Server, ctx context.Context, root string, deadline time.Time) {
+	t.Helper()
+	for {
+		started := time.Now()
+		served, err := srv.CheckoutServesCWDChecked(ctx, root)
+		require.Less(t, time.Since(started), time.Second, "each admission attempt must remain responsive")
+		if err == nil {
+			require.True(t, served, "a known checkout must not become untracked")
+			return
+		}
+		require.False(t, served, "pending observation must not grant scope")
+		require.ErrorIs(t, err, indexer.ErrCheckoutMutationBusy, "only explicit pending discovery is retryable")
+		require.True(t, time.Now().Before(deadline), "checkout admission never completed: %v", err)
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 func testNewWorktreeAgentLifecycle(t *testing.T, handshake bool) {
 	t.Helper()
 	t.Setenv("GORTEX_TOOLS", "facade-v1")
@@ -156,13 +175,26 @@ func testNewWorktreeAgentLifecycle(t *testing.T, handshake bool) {
 	checkoutMutationGit(t, f.primary, "worktree", "add", "-b", "newly-added", root)
 	require.NoError(t, os.WriteFile(filepath.Join(root, "added.go"), []byte("package repo\n\nfunc NewlyDiscovered() {}\n"), 0o644))
 	started := time.Now()
+	deadline := started.Add(2 * time.Second)
 	if handshake {
 		// The daemon checks this before dispatching tools/call with the CWD.
-		require.True(t, f.srv.CheckoutServesCWD(context.Background(), root), "daemon must admit the automatically discovered checkout")
+		ctx := WithSessionCWD(WithSessionID(context.Background(), "real-checkout-lifecycle"), root)
+		awaitCheckoutAdmission(t, f.srv, ctx, root, deadline)
 	}
-	first := f.facade(t, root, "search", map[string]any{
-		"operation": "symbols", "query": "Old", "options": map[string]any{"limit": 10},
-	})
+	var first *mcplib.CallToolResult
+	for {
+		callStarted := time.Now()
+		first = f.facade(t, root, "search", map[string]any{
+			"operation": "symbols", "query": "Old", "options": map[string]any{"limit": 10},
+		})
+		require.Less(t, time.Since(callStarted), 2*time.Second, "each cold search must remain responsive")
+		if !first.IsError {
+			break
+		}
+		assertToolError(t, first, graphview.CodeViewBuilding)
+		require.True(t, time.Now().Before(deadline), "cold discovery never completed: %+v", first.Content)
+		time.Sleep(10 * time.Millisecond)
+	}
 	require.False(t, first.IsError, "%+v", first.Content)
 	require.Less(t, time.Since(started), 2*time.Second, "cold search must not wait for indexing")
 	freshness := resultFreshness(t, first)
@@ -244,7 +276,7 @@ func TestWorktreeAgentLifecycleSlowRefreshRemainsRecoverable(t *testing.T) {
 		"operation": "detect", "target": map[string]any{"repo": "repo"}, "view": view,
 	})
 	diff := lifecycleResultPayload(t, detected)
-	require.Equal(t, f.worktree, diff["repo_root"])
+	require.Equal(t, filepath.ToSlash(f.worktree), diff["repo_root"])
 	require.Equal(t, false, diff["complete"])
 	require.Equal(t, "UNKNOWN", diff["risk"])
 	files, err := json.Marshal(diff["changed_files"])

--- a/internal/mcp/worktree_discovery_scope_test.go
+++ b/internal/mcp/worktree_discovery_scope_test.go
@@ -1,0 +1,70 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/pathkey"
+)
+
+func TestWorktreeDiscoveryDeniesForeignSelectorBeforeCatalogSideEffects(t *testing.T) {
+	f := newRealCheckoutMutationFixture(t)
+	foreignPrimary := filepath.Join(filepath.Dir(f.primary), "foreign")
+	foreignWorktree := filepath.Join(filepath.Dir(f.primary), "foreign-agent")
+	require.NoError(t, os.Mkdir(foreignPrimary, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(foreignPrimary, "foreign.go"), []byte("package foreign\n\nfunc Foreign() {}\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(foreignPrimary, ".gortex.yaml"), []byte("workspace: foreign-workspace\n"), 0o644))
+	checkoutMutationGit(t, foreignPrimary, "init", "--initial-branch=main")
+	checkoutMutationGit(t, foreignPrimary, "add", "-A")
+	checkoutMutationGit(t, foreignPrimary, "commit", "-m", "foreign base")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	registered, err := f.srv.lifecycle.Register(ctx, config.RepoEntry{Path: foreignPrimary, Name: "foreign"}, indexer.TrackSourceCLI)
+	require.NoError(t, err)
+	require.NoError(t, registered.CatalogErr)
+
+	// Register only discovers the worktrees present at that instant. This
+	// fixture never starts the daemon's topology watcher or family sweep.
+	// Creating the linked worktree afterwards makes the explicit selector the
+	// first possible observation of this previously unknown checkout.
+	checkoutMutationGit(t, foreignPrimary, "worktree", "add", "-b", "foreign-agent", foreignWorktree)
+	before, err := f.srv.lifecycle.FamiliesOverview(ctx, registered.FamilyID)
+	require.NoError(t, err)
+	require.Len(t, before.Families, 1)
+	require.Len(t, before.Families[0].Checkouts, 1, "foreign linked checkout must be unseen before the request")
+	primaryBefore := before.Families[0].Checkouts[0]
+	require.True(t, pathkey.EqualPaths(primaryBefore.RootPath, foreignPrimary))
+
+	result := f.edit(t, f.primary, map[string]any{
+		"path": "foreign.go", "old_string": "Foreign", "new_string": "Changed", "dry_run": true,
+		"view": map[string]any{"kind": "worktree", "path": foreignWorktree},
+	})
+	require.True(t, result.IsError, "a selector in another workspace must be denied")
+	require.Contains(t, fmt.Sprint(result.Content), "selector_out_of_scope", "deny authorization, not merely unavailable graph readiness")
+
+	after, err := f.srv.lifecycle.FamiliesOverview(ctx, registered.FamilyID)
+	require.NoError(t, err)
+	require.Len(t, after.Families, 1)
+	require.Len(t, after.Families[0].Checkouts, 1, "authorization must precede checkout registration and activation")
+	primaryAfter := after.Families[0].Checkouts[0]
+	require.Equal(t, primaryBefore.CheckoutID, primaryAfter.CheckoutID)
+	require.True(t, pathkey.EqualPaths(primaryAfter.RootPath, foreignPrimary))
+	require.Equal(t, primaryBefore.CoordinatorLive, primaryAfter.CoordinatorLive,
+		"denied observation must not change the foreign family's coordinator state")
+	// A coordinator requires a catalog checkout ID. No linked checkout row,
+	// plus unchanged family coordinator state, proves no foreign activation
+	// was admitted through this real MCP request; the indexer-level regression
+	// separately checks its private pending-activation registry.
+	contents, err := os.ReadFile(filepath.Join(foreignWorktree, "foreign.go"))
+	require.NoError(t, err)
+	require.Equal(t, "package foreign\n\nfunc Foreign() {}\n", string(contents))
+}

--- a/internal/mcp/worktree_source_mutation_test.go
+++ b/internal/mcp/worktree_source_mutation_test.go
@@ -304,6 +304,10 @@ func checkoutMutationGit(t testing.TB, dir string, args ...string) string {
 }
 
 func newRealCheckoutMutationFixture(t testing.TB) *realCheckoutMutationFixture {
+	return newRealCheckoutMutationFixtureWithRegistry(t, nil)
+}
+
+func newRealCheckoutMutationFixtureWithRegistry(t testing.TB, configure func(*parser.Registry)) *realCheckoutMutationFixture {
 	t.Helper()
 	base, err := filepath.EvalSymlinks(t.TempDir())
 	require.NoError(t, err)
@@ -329,6 +333,9 @@ func newRealCheckoutMutationFixture(t testing.TB) *realCheckoutMutationFixture {
 	require.NoError(t, err)
 	registry := parser.NewRegistry()
 	languages.RegisterAll(registry)
+	if configure != nil {
+		configure(registry)
+	}
 	bm := search.NewNull()
 	mi := indexer.NewMultiIndexer(store, registry, bm, cm, zap.NewNop())
 	leases := graphview.NewLeaseManager()
@@ -432,7 +439,7 @@ func TestWorktreeMutationCoordinatorEndToEnd(t *testing.T) {
 			writeArgs := args(false)
 			written := fixture.edit(t, cwd, writeArgs)
 			require.False(t, written.IsError, viewResultText(t, written))
-			require.Equal(t, true, decodeFileOpsResult(t, written)["reindexed"])
+			fixture.awaitMutation(t, cwd, written)
 			afterWrite, found, err := fixture.store.Catalog().GetCheckoutRoute(ctx, fixture.checkoutID)
 			require.NoError(t, err)
 			require.True(t, found)
@@ -510,7 +517,7 @@ func TestWorktreeMutationFacadeEndToEnd(t *testing.T) {
 						require.Equal(t, primitiveWorktreeSource, string(body))
 					} else {
 						require.Equal(t, after, string(body))
-						require.Equal(t, true, decodeFileOpsResult(t, result)["reindexed"])
+						fixture.awaitMutation(t, fixture.primary, result)
 					}
 				}
 				primaryAfter, err := os.ReadFile(filepath.Join(fixture.primary, "edit.go"))

--- a/internal/reconcile/observe_checkout.go
+++ b/internal/reconcile/observe_checkout.go
@@ -1,0 +1,92 @@
+package reconcile
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/zzet/gortex/internal/gitstate"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/pathkey"
+)
+
+// ObserveCheckout records only the selected working copy in an already known
+// family. Unlike ReconcileFamily, it never advances other checkouts' absence
+// clocks or runs a teardown saga. First-request discovery must not turn into
+// administrative cleanup or a full-family indexing pass.
+// sampled may carry the caller's just-read inventory; it is validated against
+// the catalog exactly like an inventory read here, and never retained. This
+// avoids a second whole-family Git probe in the first-request admission path.
+func (r *Reconciler) ObserveCheckout(ctx context.Context, familyID, root string, sampled ...*gitstate.FamilyInventory) (CheckoutReport, error) {
+	family, found, err := r.catalog.GetRepositoryFamily(ctx, familyID)
+	if err != nil {
+		return CheckoutReport{}, err
+	}
+	if !found {
+		return CheckoutReport{}, fmt.Errorf("%w: family %s", store_sqlite.ErrCatalogNotFound, familyID)
+	}
+	var inv *gitstate.FamilyInventory
+	if len(sampled) == 0 {
+		inv, err = r.inventory(ctx, root)
+	} else if len(sampled) == 1 {
+		inv = sampled[0]
+	} else {
+		return CheckoutReport{}, fmt.Errorf("observe checkout accepts at most one inventory")
+	}
+	if err := ValidateInventory(inv, err, family.CommonDirIdentity); err != nil {
+		return CheckoutReport{}, err
+	}
+	var selected *gitstate.WorktreeRecord
+	for i := range inv.Records {
+		record := &inv.Records[i]
+		if pathkey.EqualPaths(pathkey.CanonicalExistingRoot(record.Path), pathkey.CanonicalExistingRoot(root)) {
+			selected = record
+			break
+		}
+	}
+	if selected == nil || selected.Bare {
+		return CheckoutReport{}, fmt.Errorf("%w: selected path is not a working copy in this family", store_sqlite.ErrCatalogNotFound)
+	}
+	if entry, found, err := r.observedCheckout(ctx, familyID, selected); err != nil || found {
+		return entry, err
+	}
+	graphs, err := r.catalog.ListDedicatedGraphs(ctx, familyID)
+	if err != nil {
+		return CheckoutReport{}, err
+	}
+	pass := &familyPass{family: family, inventory: inv, now: r.now()}
+	for _, graph := range graphs {
+		if graph.IsPrimaryBase {
+			pass.primaryGraphID = graph.GraphID
+			break
+		}
+	}
+	entry, err := r.observeNew(ctx, pass, selected)
+	if err != nil {
+		return entry, err
+	}
+	if entry.Action == ActionGuardLost {
+		// A simultaneous topology event may have won the guarded allocation.
+		// Adopt only that same admin/root identity; never allocate a duplicate.
+		if current, found, err := r.observedCheckout(ctx, familyID, selected); err != nil || found {
+			return current, err
+		}
+	}
+	return entry, nil
+}
+
+func (r *Reconciler) observedCheckout(ctx context.Context, familyID string, record *gitstate.WorktreeRecord) (CheckoutReport, bool, error) {
+	known, err := r.catalog.ListCheckouts(ctx, familyID)
+	if err != nil {
+		return CheckoutReport{}, false, err
+	}
+	for _, checkout := range known {
+		if checkout.AdminName != record.AdminName {
+			continue
+		}
+		if !pathkey.EqualPaths(pathkey.CanonicalExistingRoot(checkout.RootPath), pathkey.CanonicalExistingRoot(record.Path)) {
+			return CheckoutReport{}, false, fmt.Errorf("%w: checkout admin name moved; wait for topology reconciliation", store_sqlite.ErrCatalogStaleGuard)
+		}
+		return CheckoutReport{CheckoutID: checkout.CheckoutID, Incarnation: checkout.Incarnation, AdminName: checkout.AdminName, RootPath: checkout.RootPath, Main: record.IsMain, Durable: true, State: checkout.State, Action: ActionObserved}, true, nil
+	}
+	return CheckoutReport{}, false, nil
+}

--- a/internal/reconcile/observe_checkout_test.go
+++ b/internal/reconcile/observe_checkout_test.go
@@ -1,0 +1,125 @@
+package reconcile
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/zzet/gortex/internal/gitstate"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+)
+
+func TestObserveCheckoutOnlyAllocatesSelectedAutomaticIdentity(t *testing.T) {
+	f := newFixture(t, Default())
+	f.seedPrimaryGraph("graph-primary")
+	f.seedCheckout("known-gone", "inc-gone", "gone", store_sqlite.CheckoutModeAutomatic)
+	before := f.checkouts()[0]
+	f.git.setRecords(presentRecord("selected", "/repo/selected"), presentRecord("unselected", "/repo/unselected"))
+	f.git.samples["/repo/selected"] = gitSampleExisting(volumeA)
+	entry, err := f.rec.ObserveCheckout(t.Context(), before.FamilyID, "/repo/selected")
+	if err != nil || !entry.Durable || entry.Action != ActionIdentityAllocated {
+		t.Fatalf("observe: %+v %v", entry, err)
+	}
+	rows := f.checkouts()
+	if len(rows) != 2 {
+		t.Fatalf("observed unselected checkout: %+v", rows)
+	}
+	for _, row := range rows {
+		if row.CheckoutID == before.CheckoutID {
+			if row != before {
+				t.Fatalf("observation advanced unrelated absence clocks: before=%+v after=%+v", before, row)
+			}
+		} else if row.CheckoutID != entry.CheckoutID || row.EffectiveMode != store_sqlite.CheckoutModeAutomatic || row.DesiredMode != store_sqlite.CheckoutModeAutomatic {
+			t.Fatalf("not an automatic selected identity: %+v", row)
+		}
+	}
+	again, err := f.rec.ObserveCheckout(t.Context(), before.FamilyID, "/repo/selected")
+	if err != nil || again.CheckoutID != entry.CheckoutID || again.Incarnation != entry.Incarnation || len(f.checkouts()) != 2 {
+		t.Fatalf("duplicate observation: %+v %v", again, err)
+	}
+}
+
+func TestObserveCheckoutRequiresKnownMatchingFamilyAndPrimary(t *testing.T) {
+	f := newFixture(t, Default())
+	f.seedCheckout("known", "inc-known", "known", store_sqlite.CheckoutModeAutomatic)
+	familyID := f.checkouts()[0].FamilyID
+	f.git.setRecords(presentRecord("selected", "/repo/selected"))
+	f.git.samples["/repo/selected"] = gitSampleExisting(volumeA)
+	if _, err := f.rec.ObserveCheckout(t.Context(), "unknown-family", "/repo/selected"); !errors.Is(err, store_sqlite.ErrCatalogNotFound) {
+		t.Fatalf("unknown family: %v", err)
+	}
+	entry, err := f.rec.ObserveCheckout(t.Context(), familyID, "/repo/selected")
+	if err != nil || entry.Durable || len(f.checkouts()) != 1 {
+		t.Fatalf("allocated without primary: %+v %v", entry, err)
+	}
+	f.seedPrimaryGraph("graph-primary")
+	if _, err := f.rec.ObserveCheckout(t.Context(), familyID, "/repo/not-listed"); err == nil {
+		t.Fatal("accepted root Git never listed")
+	}
+	inventory := f.rec.inventory
+	f.rec.inventory = func(ctx context.Context, root string) (*gitstate.FamilyInventory, error) {
+		inv, err := inventory(ctx, root)
+		if err == nil {
+			copy := *inv
+			copy.CommonDir = "/different-family/.git"
+			inv = &copy
+		}
+		return inv, err
+	}
+	if _, err := f.rec.ObserveCheckout(t.Context(), familyID, "/repo/selected"); err == nil || len(f.checkouts()) != 1 {
+		t.Fatalf("accepted foreign inventory: %v", err)
+	}
+}
+
+func TestObserveCheckoutAdoptsGuardedAllocationWinner(t *testing.T) {
+	f := newFixture(t, Default())
+	f.seedPrimaryGraph("graph-primary")
+	f.seedCheckout("known", "inc-known", "known", store_sqlite.CheckoutModeAutomatic)
+	familyID := f.checkouts()[0].FamilyID
+	f.git.setRecords(presentRecord("wt", "/repo/wt"))
+	f.git.samples["/repo/wt"] = gitSampleExisting(volumeA)
+	racing := &racingSampler{root: "/repo/wt", sample: f.git.sample, race: func() { f.seedCheckout("co-rival", "inc-rival", "wt", store_sqlite.CheckoutModeAutomatic) }}
+	WithPathSampler(racing.sampleAndRace)(f.rec)
+	entry, err := f.rec.ObserveCheckout(t.Context(), familyID, "/repo/wt")
+	if err != nil || entry.CheckoutID != "co-rival" || entry.Incarnation != "inc-rival" || !entry.Durable || len(f.checkouts()) != 2 {
+		t.Fatalf("lost winner: %+v %v rows=%+v", entry, err, f.checkouts())
+	}
+}
+
+func TestObserveCheckoutLeavesExistingDedicatedModeUntouched(t *testing.T) {
+	f := newFixture(t, Default())
+	f.seedPrimaryGraph("graph-primary")
+	f.seedCheckout("dedicated", "inc-dedicated", "wt", store_sqlite.CheckoutModeDedicated)
+	before := f.checkouts()[0]
+	f.git.setRecords(presentRecord("wt", "/repo/wt"))
+	entry, err := f.rec.ObserveCheckout(t.Context(), before.FamilyID, "/repo/wt")
+	if err != nil || entry.CheckoutID != before.CheckoutID || f.checkouts()[0] != before {
+		t.Fatalf("observation changed explicit intent/mode: %+v %v", entry, err)
+	}
+}
+
+func TestObserveCheckoutReusesAndValidatesSuppliedInventory(t *testing.T) {
+	f := newFixture(t, Default())
+	f.seedPrimaryGraph("graph-primary")
+	f.seedCheckout("known", "inc-known", "known", store_sqlite.CheckoutModeAutomatic)
+	familyID := f.checkouts()[0].FamilyID
+	f.git.setRecords(presentRecord("selected", "/repo/selected"))
+	f.git.samples["/repo/selected"] = gitSampleExisting(volumeA)
+	inv, err := f.rec.inventory(t.Context(), "/repo/selected")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.rec.inventory = func(context.Context, string) (*gitstate.FamilyInventory, error) {
+		t.Fatal("observer repeated the inventory probe")
+		return nil, errors.New("unexpected inventory")
+	}
+	entry, err := f.rec.ObserveCheckout(t.Context(), familyID, "/repo/selected", inv)
+	if err != nil || !entry.Durable {
+		t.Fatalf("supplied inventory: %+v %v", entry, err)
+	}
+	foreign := *inv
+	foreign.CommonDir = "/foreign/.git"
+	if _, err := f.rec.ObserveCheckout(t.Context(), familyID, "/repo/selected", &foreign); err == nil {
+		t.Fatal("supplied foreign inventory was accepted")
+	}
+}


### PR DESCRIPTION
## Summary

Repair the complete agent lifecycle for automatic worktrees:

- Discover a newly added checkout on its first CWD request within an already known Git family, without explicit tracking or a synchronous index.
- Separate successful source writes from asynchronous checkout publication. Return pollable pending receipts; bind publication to checkout incarnation, branch/HEAD, snapshot, and committed bytes.
- Keep receipt inspection and checkout-scoped recovery available while the graph builds. Detect changes in the selected working copy, with incomplete/unknown graph analysis when necessary.
- Preserve read-only fallbacks and reject `require_exact` requests that would otherwise silently receive a fallback.
- Preserve bounded discovery contention through daemon admission as retryable `view_building`, not an erroneous untracked/track response.

The coordinator owns publication independently of request lifetime. Recovery cannot certify another checkout's content, and a successful scoped recovery only retires eligible historical failures from the current-view barrier; historical errors remain inspectable.

## Validation

- Full indexer suite: passed, 401.650 seconds.
- Full MCP suite: passed, 273.348 seconds.
- Full reconcile and graphview suites: passed.
- Repository-wide package/test compilation (`go test -p 2 ./... -run '^$'`): passed.
- Lint across the changed packages: zero issues.
- Real-parser blocked lifecycle, selector variants, and facade variants: passed repeatedly; race run passed in 68.535 seconds.
- Broad worktree/checkout/mutation race suite: passed, 199.629 seconds. Repeated real admission-contention/recovery race test: passed, 12.985 seconds.
- Final admission/prefix-catalog failure race tests ×3: passed, 17.963 seconds. Daemon admission/handshake regression race suite: passed, 8.778 seconds; new wire tests ×3 passed in 13.867 seconds.
- Focused queue, publication identity, cancellation, supersession, SQLite contention, scope, and receipt regressions included.
- Benchmarks and incident analysis recorded in `docs/worktree-source-mutations.md`. Median dry-run latency was 12.38 ms versus 12.07 ms at baseline; blocked-indexer edits returned in 33.55–37.57 ms independently of publication.

New-worktree discovery/search/edit/exact-read succeeds both through the daemon CWD admission hook and direct tool routing. Unknown families remain unregistered.
The real cross-workspace regression confirms rejection before checkout registration/coordinator activation. First-CWD contention is retryable and the same session recovers without changing tracking intent.

## Boundaries

No schema migration, live daemon restart, graph-store rebuild, or tracking-config changes were performed. Validation uses isolated real-Git/SQLite fixtures and in-process MCP handlers/coordinators. This repairs interactive lifecycle behavior; it does not claim to make large dependency-closure indexing inexpensive.

Native graph post-checks against the isolated implementation checkout were attempted but rejected with `view_building` by the currently running daemon. They are not counted as successful validation; the executable tests above exercise the new implementation without replacing that daemon.
