### PR TITLE
Fix profiled cold-index and warm-restart costs

### DIFF
--- a/internal/contracts/load_from_graph.go
+++ b/internal/contracts/load_from_graph.go
@@ -1,6 +1,9 @@
 package contracts
 
 import (
+	"iter"
+	"slices"
+
 	"github.com/zzet/gortex/internal/graph"
 )
 
@@ -21,12 +24,18 @@ func LoadRegistryFromGraph(g graph.Store, repoPrefix string) *Registry {
 	if g == nil {
 		return nil
 	}
-	all := g.GetRepoNodes(repoPrefix)
-	if len(all) == 0 {
-		return nil
+	var nodes iter.Seq[*graph.Node]
+	if repoPrefix == "" {
+		// Preserve the store's global empty-prefix behavior; scoped readers
+		// require an explicit repository or file frontier.
+		nodes = slices.Values(g.GetRepoNodes(""))
+	} else {
+		// Filter before hydration, retaining full metadata for sparse and
+		// wrapper-generated contracts. SQLite streams bounded pages here.
+		nodes = graph.NodesInScopeSeq(g, []string{repoPrefix}, nil, graph.KindContract)
 	}
 	reg := NewRegistry()
-	for _, n := range all {
+	for n := range nodes {
 		if n == nil || n.Kind != graph.KindContract {
 			continue
 		}

--- a/internal/contracts/load_from_graph.go
+++ b/internal/contracts/load_from_graph.go
@@ -144,6 +144,7 @@ func loadRegistryFromGraph(g graph.Store, repoPrefix, workspaceID, projectID str
 			}
 		}
 	}
+	var sparseOwnerIdentities map[persistedContractRecordKey]struct{}
 	ids = ids[:0]
 	for id := range nodes {
 		ids = append(ids, id)
@@ -165,7 +166,23 @@ func loadRegistryFromGraph(g graph.Store, repoPrefix, workspaceID, projectID str
 			// indexer's scope even when stale scalar scope is populated.
 			c.RepoPrefix, c.WorkspaceID, c.ProjectID = repoPrefix, workspaceID, projectID
 		}
-		if _, ownerExists := ownerIdentities[persistedContractKey(c)]; !ownerExists {
+		key := persistedContractKey(c)
+		_, ownerExists := ownerIdentities[key]
+		if _, symbolPresent := node.Meta["symbol_id"]; !symbolPresent && !ownerExists && len(ownerIdentities) > 0 {
+			// Missing symbol identity is sparse legacy data, unlike an
+			// explicitly empty string. Modern owner-backed loads never
+			// allocate this fallback index; build it only once if needed.
+			if sparseOwnerIdentities == nil {
+				sparseOwnerIdentities = make(map[persistedContractRecordKey]struct{}, len(ownerIdentities))
+				for ownerKey := range ownerIdentities {
+					ownerKey.symbol = ""
+					sparseOwnerIdentities[ownerKey] = struct{}{}
+				}
+			}
+			key.symbol = ""
+			_, ownerExists = sparseOwnerIdentities[key]
+		}
+		if !ownerExists {
 			add(c)
 		}
 	}

--- a/internal/contracts/load_from_graph.go
+++ b/internal/contracts/load_from_graph.go
@@ -1,91 +1,298 @@
 package contracts
 
 import (
-	"iter"
-	"slices"
+	"encoding/json"
+	"reflect"
+	"sort"
 
 	"github.com/zzet/gortex/internal/graph"
 )
 
-// LoadRegistryFromGraph rebuilds a Registry by scanning every
-// KindContract node under repoPrefix and reconstructing the Contract
-// struct from Node.Meta. The reverse of the AddNode stamping the
-// indexer's commitContracts (and contracts/wrapper.go's
-// commitInlinedContractToGraph) do — both write the full record onto
-// Meta so a daemon restart can rehydrate without replaying the gob
-// snapshot.
-//
-// Empty repoPrefix loads every contract — useful for ad-hoc probes,
-// not a path the daemon normally takes (the warmup rehydrates the
-// per-repo registries one prefix at a time so a stale repo's
-// contracts don't bleed into a fresh sibling). Returns nil when no
-// contracts are recorded for the prefix.
+type persistedContractRecordKey struct {
+	id, file, symbol, repo, workspace, project string
+	role                                       Role
+}
+
+func persistedContractKey(c Contract) persistedContractRecordKey {
+	return persistedContractRecordKey{c.ID, c.FilePath, c.SymbolID, c.RepoPrefix, c.WorkspaceID, c.ProjectID, c.Role}
+}
+
+// LoadRegistryFromGraph reconstructs records from repo-owned provides/consumes
+// rows plus recoverable legacy scalar nodes. Canonical IDs are shared semantic
+// identities: a canonical node's last-writer scope does not own every record.
+// Empty prefix remains the exact single-repository namespace, not global.
 func LoadRegistryFromGraph(g graph.Store, repoPrefix string) *Registry {
+	return loadRegistryFromGraph(g, repoPrefix, "", "", false)
+}
+
+// LoadRegistryFromGraphWithScope restores an indexer's legacy scope while
+// preserving explicitly persisted owner scope, including empty strings. The
+// ordinary loader continues to derive its fallback from the canonical node.
+func LoadRegistryFromGraphWithScope(g graph.Store, repoPrefix, workspaceID, projectID string) *Registry {
+	return loadRegistryFromGraph(g, repoPrefix, workspaceID, projectID, true)
+}
+
+func loadRegistryFromGraph(g graph.Store, repoPrefix, workspaceID, projectID string, useScope bool) *Registry {
 	if g == nil {
 		return nil
 	}
-	var nodes iter.Seq[*graph.Node]
+	owners := graph.ReadRepoEdgesByKinds(g, []string{repoPrefix}, []graph.EdgeKind{graph.EdgeProvides, graph.EdgeConsumes})
+	nodes := make(map[string]*graph.Node)
+	rememberNode := func(node *graph.Node) {
+		if node != nil && node.ID != "" && node.Kind == graph.KindContract {
+			nodes[node.ID] = node
+		}
+	}
 	if repoPrefix == "" {
-		// Preserve the store's global empty-prefix behavior; scoped readers
-		// require an explicit repository or file frontier.
-		nodes = slices.Values(g.GetRepoNodes(""))
+		// Retain the original branch's backend-defined exact empty scope.
+		for _, node := range g.GetRepoNodes("") {
+			rememberNode(node)
+		}
 	} else {
-		// Filter before hydration, retaining full metadata for sparse and
-		// wrapper-generated contracts. SQLite streams bounded pages here.
-		nodes = graph.NodesInScopeSeq(g, []string{repoPrefix}, nil, graph.KindContract)
+		for node := range graph.NodesInScopeSeq(g, []string{repoPrefix}, nil, graph.KindContract) {
+			rememberNode(node)
+		}
 	}
-	reg := NewRegistry()
-	for n := range nodes {
-		if n == nil || n.Kind != graph.KindContract {
+	missing := make(map[string]struct{})
+	for _, row := range owners {
+		if row.Edge != nil && row.Edge.To != "" && nodes[row.Edge.To] == nil {
+			missing[row.Edge.To] = struct{}{}
+		}
+	}
+	ids := make([]string, 0, len(missing))
+	for id := range missing {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for start := 0; start < len(ids); start += 128 {
+		for _, node := range g.GetNodesByIDs(ids[start:min(start+128, len(ids))]) {
+			rememberNode(node)
+		}
+	}
+	registry := NewRegistry()
+	seenRecords := make(map[string][]Contract)
+	ownerIdentities := make(map[persistedContractRecordKey]struct{})
+	add := func(c Contract) {
+		if c.ID == "" || c.RepoPrefix != repoPrefix {
+			return
+		}
+		// Deduplicate exact recovered records only. Line and metadata can
+		// distinguish records even when their semantic contract ID is shared.
+		// If an in-memory adapter exposes a non-serializable metadata value,
+		// preserve its record rather than silently discarding it.
+		if encoded, err := json.Marshal(c); err == nil {
+			key := string(encoded)
+			// JSON is only a bucket key: concrete metadata types such as
+			// int and float64 can encode identically but remain distinct.
+			for _, existing := range seenRecords[key] {
+				if reflect.DeepEqual(existing, c) {
+					return
+				}
+			}
+			seenRecords[key] = append(seenRecords[key], c)
+		}
+		registry.Add(c)
+	}
+	// A scalar payload for an existing owner identity is stale fallback, not
+	// another owner merely because its confidence/type/metadata differs.
+	// Recovered owner rows remain complete even where Registry.All deliberately
+	// coalesces line/payload variants; ByID and other scoped indices retain them.
+	for _, row := range owners {
+		edge := row.Edge
+		if edge == nil {
 			continue
 		}
-		c := contractFromNode(n)
-		if c.ID == "" {
+		var c Contract
+		if useScope {
+			c, _ = ContractFromOwnerEdge(nodes[edge.To], edge, repoPrefix, workspaceID, projectID)
+		} else {
+			c = contractFromOwnerNode(nodes[edge.To], edge, repoPrefix)
+		}
+		if c.ID != "" && c.RepoPrefix == repoPrefix {
+			ownerIdentities[persistedContractKey(c)] = struct{}{}
+		}
+		add(c)
+	}
+	scalarLiveness := false
+	if guarantee, ok := g.(graph.ContractOwnerScalarLiveness); ok {
+		scalarLiveness = guarantee.ContractOwnerScalarLivenessGuaranteed()
+	}
+	conservativeOwners := make(map[string]bool)
+	if !scalarLiveness {
+		// Opaque adapters keep the old non-atomic replacement behavior. They
+		// cannot safely invalidate a legacy scalar through read -> AddNode.
+		// A surviving owner anywhere in this selected store/view makes scalar
+		// fallback ambiguous, so omit it conservatively instead of reviving a
+		// deleted record. Scalar-only legacy contracts still remain readable.
+		candidates := make([]string, 0, len(nodes))
+		for id, node := range nodes {
+			ownerBacked, _ := node.Meta["contract_owner_record"].(bool)
+			removed, _ := node.Meta["contract_owner_removed"].(bool)
+			if node.RepoPrefix == repoPrefix && !ownerBacked && !removed {
+				candidates = append(candidates, id)
+			}
+		}
+		sort.Strings(candidates)
+		for start := 0; start < len(candidates); start += 128 {
+			for id, incoming := range g.GetInEdgesByNodeIDs(candidates[start:min(start+128, len(candidates))]) {
+				for _, edge := range incoming {
+					if edge != nil && (edge.Kind == graph.EdgeProvides || edge.Kind == graph.EdgeConsumes || edge.Kind == graph.EdgeHandlesRoute) {
+						conservativeOwners[id] = true
+						break
+					}
+				}
+			}
+		}
+	}
+	ids = ids[:0]
+	for id := range nodes {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		node := nodes[id]
+		if node.RepoPrefix != repoPrefix {
 			continue
 		}
-		reg.Add(c)
+		ownerBacked, _ := node.Meta["contract_owner_record"].(bool)
+		removed, _ := node.Meta["contract_owner_removed"].(bool)
+		if ownerBacked || removed || conservativeOwners[id] {
+			continue
+		}
+		c := contractFromNode(node)
+		if useScope {
+			// Legacy scalar reconstruction historically uses the owning
+			// indexer's scope even when stale scalar scope is populated.
+			c.RepoPrefix, c.WorkspaceID, c.ProjectID = repoPrefix, workspaceID, projectID
+		}
+		if _, ownerExists := ownerIdentities[persistedContractKey(c)]; !ownerExists {
+			add(c)
+		}
 	}
-	if len(reg.All()) == 0 {
+	if len(registry.All()) == 0 {
 		return nil
 	}
-	return reg
+	return registry
 }
 
-// contractFromNode decodes a Contract from a KindContract graph node's
-// Meta payload. Inverse of the AddNode stamping the indexer does.
-// Missing fields are left at their zero value — preserves forward
-// compatibility if the indexer adds new Meta keys before this loader
-// learns about them.
-func contractFromNode(n *graph.Node) Contract {
-	c := Contract{
-		ID:         n.ID,
-		FilePath:   n.FilePath,
-		RepoPrefix: n.RepoPrefix,
+func contractFromNode(node *graph.Node) Contract {
+	if node == nil || node.Kind != graph.KindContract || node.ID == "" {
+		return Contract{}
 	}
-	if n.Meta == nil {
+	c := Contract{ID: node.ID, FilePath: node.FilePath, RepoPrefix: node.RepoPrefix, WorkspaceID: node.WorkspaceID, ProjectID: node.ProjectID}
+	if node.Meta == nil {
 		return c
 	}
-	if v, ok := n.Meta["type"].(string); ok {
-		c.Type = ContractType(v)
+	if value, ok := node.Meta["type"].(string); ok {
+		c.Type = ContractType(value)
 	}
-	if v, ok := n.Meta["role"].(string); ok {
-		c.Role = Role(v)
+	if value, ok := node.Meta["role"].(string); ok {
+		c.Role = Role(value)
 	}
-	if v, ok := n.Meta["symbol_id"].(string); ok {
-		c.SymbolID = v
+	if value, ok := node.Meta["symbol_id"].(string); ok {
+		c.SymbolID = value
 	}
-	if v, ok := n.Meta["line"].(int); ok {
-		c.Line = v
-	} else if v, ok := n.Meta["line"].(int64); ok {
-		c.Line = int(v)
-	}
-	if v, ok := n.Meta["confidence"].(float64); ok {
-		c.Confidence = v
-	}
-	c.WorkspaceID = n.WorkspaceID
-	c.ProjectID = n.ProjectID
-	if v, ok := n.Meta["contract_meta"].(map[string]any); ok && len(v) > 0 {
-		c.Meta = v
+	c.Line = persistedContractLine(node.Meta["line"])
+	c.Confidence = persistedContractConfidence(node.Meta["confidence"])
+	if value, ok := node.Meta["contract_meta"].(map[string]any); ok {
+		c.Meta = value
 	}
 	return c
+}
+
+// ContractFromGraphNode decodes the scalar payload, not its ownership liveness.
+// LoadRegistryFromGraph applies persisted-owner/removal fallback policy.
+func ContractFromGraphNode(node *graph.Node) (Contract, bool) {
+	c := contractFromNode(node)
+	return c, c.ID != ""
+}
+
+func contractFromOwnerNode(node *graph.Node, edge *graph.Edge, repo string) Contract {
+	workspace, project := "", ""
+	if node != nil && node.RepoPrefix == repo {
+		workspace, project = node.WorkspaceID, node.ProjectID
+	}
+	c, _ := ContractFromOwnerEdge(node, edge, repo, workspace, project)
+	return c
+}
+
+// ContractFromOwnerEdge is shared with incremental reconstruction. Scope
+// arguments are fallbacks only; explicit durable owner payload is authoritative.
+func ContractFromOwnerEdge(node *graph.Node, edge *graph.Edge, repo, workspace, project string) (Contract, bool) {
+	c := contractFromNode(node)
+	if c.ID == "" || edge == nil || edge.From == "" || (edge.Kind != graph.EdgeProvides && edge.Kind != graph.EdgeConsumes) {
+		return Contract{}, false
+	}
+	c.WorkspaceID, c.ProjectID = workspace, project
+	c.RepoPrefix, c.FilePath, c.SymbolID, c.Line = repo, edge.FilePath, edge.From, edge.Line
+	if symbol, explicit := edge.Meta["contract_owner_symbol_id"].(string); explicit {
+		c.SymbolID = symbol
+		// New complete owner payloads must not inherit another record's
+		// canonical metadata when this owner's metadata is genuinely nil.
+		c.Meta = nil
+	}
+	c.Role = RoleProvider
+	if edge.Kind == graph.EdgeConsumes {
+		c.Role = RoleConsumer
+	}
+	if value, ok := edge.Meta["contract_owner_repo_prefix"].(string); ok {
+		c.RepoPrefix = value
+	}
+	if value, ok := edge.Meta["contract_owner_workspace"].(string); ok {
+		c.WorkspaceID = value
+	}
+	if value, ok := edge.Meta["contract_owner_project"].(string); ok {
+		c.ProjectID = value
+	}
+	if value, ok := edge.Meta["contract_owner_type"].(string); ok {
+		c.Type = ContractType(value)
+	}
+	if value, exists := edge.Meta["contract_owner_confidence"]; exists {
+		c.Confidence = persistedContractConfidence(value)
+	}
+	if value, exists := edge.Meta["contract_owner_meta"]; exists {
+		if value == nil {
+			c.Meta = nil
+		} else if meta, ok := value.(map[string]any); ok {
+			c.Meta = meta
+		}
+	}
+	if value, ok := edge.Meta["contract_owner_symbol_id"].(string); ok {
+		c.SymbolID = value
+	}
+	return c, true
+}
+
+func persistedContractLine(value any) int {
+	switch value := value.(type) {
+	case int:
+		return value
+	case int64:
+		return int(value)
+	case float64:
+		return int(value)
+	case json.Number:
+		parsed, _ := value.Int64()
+		return int(parsed)
+	default:
+		return 0
+	}
+}
+
+func persistedContractConfidence(value any) float64 {
+	switch value := value.(type) {
+	case float64:
+		return value
+	case float32:
+		return float64(value)
+	case int:
+		return float64(value)
+	case int64:
+		return float64(value)
+	case json.Number:
+		parsed, _ := value.Float64()
+		return parsed
+	default:
+		return 0
+	}
 }

--- a/internal/contracts/load_from_graph_projection_test.go
+++ b/internal/contracts/load_from_graph_projection_test.go
@@ -1,0 +1,234 @@
+package contracts_test
+
+import (
+	"fmt"
+	"iter"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/contracts"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+)
+
+// Route the retained global loader path to one repository, exercising the old
+// full-repository hydration without copying or changing the contract decoder.
+type legacyRepoStore struct {
+	graph.Store
+	repoPrefix string
+}
+
+func (s legacyRepoStore) GetRepoNodes(string) []*graph.Node {
+	return s.Store.GetRepoNodes(s.repoPrefix)
+}
+
+func legacyLoadRegistryFromGraph(g graph.Store, repoPrefix string) *contracts.Registry {
+	if g == nil {
+		return nil
+	}
+	return contracts.LoadRegistryFromGraph(legacyRepoStore{Store: g, repoPrefix: repoPrefix}, "")
+}
+
+func registryContractsByID(reg *contracts.Registry) map[string]contracts.Contract {
+	if reg == nil {
+		return nil
+	}
+	out := make(map[string]contracts.Contract)
+	for _, c := range reg.All() {
+		out[c.ID] = c
+	}
+	return out
+}
+
+func openContractLoaderSQLite(tb testing.TB) *store_sqlite.Store {
+	tb.Helper()
+	g, err := store_sqlite.Open(filepath.Join(tb.TempDir(), "contracts.sqlite"))
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(func() {
+		if err := g.Close(); err != nil {
+			tb.Error(err)
+		}
+	})
+	return g
+}
+
+// Erase optional projection capabilities to exercise the generic adapter path.
+type contractLoaderAdapter struct {
+	graph.Store
+}
+
+func TestLoadRegistryFromGraphProjectionEquivalent(t *testing.T) {
+	factories := map[string]func(*testing.T) graph.Store{
+		"memory": func(t *testing.T) graph.Store { return graph.New() },
+		"sqlite": func(t *testing.T) graph.Store { return openContractLoaderSQLite(t) },
+		"adapter": func(t *testing.T) graph.Store {
+			return contractLoaderAdapter{Store: graph.New()}
+		},
+	}
+	for name, factory := range factories {
+		t.Run(name, func(t *testing.T) {
+			g := factory(t)
+			g.AddBatch([]*graph.Node{
+				{
+					ID: "alpha::ordinary", Kind: graph.KindFunction, RepoPrefix: "alpha",
+					FilePath: "api.go", Meta: map[string]any{"type": "not-a-contract"},
+				},
+				{
+					ID: "alpha::full", Kind: graph.KindContract, RepoPrefix: "alpha",
+					FilePath: "api.go", WorkspaceID: "workspace", ProjectID: "project",
+					Meta: map[string]any{
+						"type": "http", "role": "provider", "symbol_id": "alpha::ordinary",
+						"line": 31, "confidence": 0.75,
+						"contract_meta": map[string]any{
+							"route": "/api", "nested": map[string]any{"method": "GET"},
+						},
+					},
+				},
+				{
+					ID: "alpha::wrapper", Kind: graph.KindContract, RepoPrefix: "alpha",
+					FilePath: "wrapper.go", WorkspaceID: "workspace", ProjectID: "project",
+					Meta: map[string]any{
+						"type": "http", "role": "consumer", "line": int64(47),
+						"contract_meta": map[string]any{"wrapped_symbol": "alpha::ordinary"},
+					},
+				},
+				{
+					ID: "alpha::sparse", Kind: graph.KindContract, RepoPrefix: "alpha",
+					FilePath: "sparse.go", WorkspaceID: "workspace", ProjectID: "project",
+				},
+				{
+					ID: "alpha::bridge", Kind: graph.KindContractBridge, RepoPrefix: "alpha",
+					FilePath: "api.go",
+				},
+				{
+					ID: "beta::contract", Kind: graph.KindContract, RepoPrefix: "beta",
+					FilePath: "api.go", Meta: map[string]any{"type": "http"},
+				},
+			}, nil)
+			for _, prefix := range []string{"alpha", "beta", "missing", ""} {
+				t.Run(prefix, func(t *testing.T) {
+					want := registryContractsByID(legacyLoadRegistryFromGraph(g, prefix))
+					got := registryContractsByID(contracts.LoadRegistryFromGraph(g, prefix))
+					if !reflect.DeepEqual(got, want) {
+						t.Fatalf("loaded contracts differ: got %#v; want %#v", got, want)
+					}
+					if prefix == "alpha" {
+						if len(got) != 3 {
+							t.Fatalf("alpha contracts = %d, want 3", len(got))
+						}
+						wantFull := contracts.Contract{
+							ID: "alpha::full", FilePath: "api.go", RepoPrefix: "alpha",
+							WorkspaceID: "workspace", ProjectID: "project",
+							Type: contracts.ContractType("http"), Role: contracts.Role("provider"),
+							SymbolID: "alpha::ordinary", Line: 31, Confidence: 0.75,
+							Meta: map[string]any{
+								"route": "/api", "nested": map[string]any{"method": "GET"},
+							},
+						}
+						if !reflect.DeepEqual(got["alpha::full"], wantFull) {
+							t.Fatalf("full contract = %#v; want %#v", got["alpha::full"], wantFull)
+						}
+						if got["alpha::full"].Line != 31 || got["alpha::wrapper"].Line != 47 {
+							t.Fatal("metadata line numbers were not preserved")
+						}
+						if got["alpha::full"].WorkspaceID != "workspace" ||
+							got["alpha::full"].ProjectID != "project" {
+							t.Fatal("contract workspace/project identity was not preserved")
+						}
+					}
+				})
+			}
+		})
+	}
+	if got := contracts.LoadRegistryFromGraph(nil, "alpha"); got != nil {
+		t.Fatalf("nil store returned %#v", got)
+	}
+}
+
+type contractLoaderProjectionSpy struct {
+	graph.Store
+	graph.ScopedProjectionSequencer
+	t     *testing.T
+	nodes []*graph.Node
+	calls int
+}
+
+func (s *contractLoaderProjectionSpy) GetRepoNodes(string) []*graph.Node {
+	s.t.Fatal("scoped contract loading must not hydrate the whole repository")
+	return nil
+}
+
+func (s *contractLoaderProjectionSpy) NodesInScopeSeq(repos, files []string, kinds ...graph.NodeKind) iter.Seq[*graph.Node] {
+	s.calls++
+	if !reflect.DeepEqual(repos, []string{"alpha"}) || len(files) != 0 ||
+		!reflect.DeepEqual(kinds, []graph.NodeKind{graph.KindContract}) {
+		s.t.Fatalf("unexpected contract projection: repos=%v files=%v kinds=%v", repos, files, kinds)
+	}
+	return func(yield func(*graph.Node) bool) {
+		for _, n := range s.nodes {
+			if !yield(n) {
+				return
+			}
+		}
+	}
+}
+
+func TestLoadRegistryFromGraphUsesScopedProjection(t *testing.T) {
+	spy := &contractLoaderProjectionSpy{t: t, nodes: []*graph.Node{
+		nil,
+		{ID: "", Kind: graph.KindContract, RepoPrefix: "alpha"},
+		{ID: "alpha::ordinary", Kind: graph.KindFunction, RepoPrefix: "alpha"},
+		{ID: "alpha::sparse", Kind: graph.KindContract, RepoPrefix: "alpha"},
+	}}
+	got := registryContractsByID(contracts.LoadRegistryFromGraph(spy, "alpha"))
+	if spy.calls != 1 || len(got) != 1 || got["alpha::sparse"].ID != "alpha::sparse" {
+		t.Fatalf("projection calls=%d, contracts=%#v", spy.calls, got)
+	}
+}
+
+func BenchmarkLoadRegistryFromGraph(b *testing.B) {
+	g := openContractLoaderSQLite(b)
+	const ordinaryCount = 10000
+	const contractCount = 100
+	nodes := make([]*graph.Node, 0, ordinaryCount+contractCount)
+	payload := strings.Repeat("source and documentation ", 64)
+	for i := 0; i < ordinaryCount; i++ {
+		nodes = append(nodes, &graph.Node{
+			ID: fmt.Sprintf("bench::function-%d", i), Kind: graph.KindFunction,
+			RepoPrefix: "bench", FilePath: "api.go",
+			Meta: map[string]any{"documentation": payload, "signature": "func Example()"},
+		})
+	}
+	for i := 0; i < contractCount; i++ {
+		nodes = append(nodes, &graph.Node{
+			ID: fmt.Sprintf("bench::contract-%d", i), Kind: graph.KindContract,
+			RepoPrefix: "bench", FilePath: "api.go",
+			Meta: map[string]any{
+				"type": "http", "role": "provider", "line": i + 1,
+				"contract_meta": map[string]any{"path": fmt.Sprintf("/api/%d", i)},
+			},
+		})
+	}
+	g.AddBatch(nodes, nil)
+	for _, tc := range []struct {
+		name string
+		load func(graph.Store, string) *contracts.Registry
+	}{
+		{"legacy_full_repo", legacyLoadRegistryFromGraph},
+		{"scoped_contracts", contracts.LoadRegistryFromGraph},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				reg := tc.load(g, "bench")
+				if reg == nil || len(reg.All()) != contractCount {
+					b.Fatal("contract fixture did not load completely")
+				}
+			}
+		})
+	}
+}

--- a/internal/contracts/load_from_graph_projection_test.go
+++ b/internal/contracts/load_from_graph_projection_test.go
@@ -1,6 +1,8 @@
 package contracts_test
 
 import (
+	"database/sql"
+	"encoding/json"
 	"fmt"
 	"iter"
 	"path/filepath"
@@ -8,27 +10,74 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/zzet/gortex/internal/contracts"
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/graph/store_sqlite"
 )
 
-// Route the retained global loader path to one repository, exercising the old
-// full-repository hydration without copying or changing the contract decoder.
-type legacyRepoStore struct {
-	graph.Store
-	repoPrefix string
-}
-
-func (s legacyRepoStore) GetRepoNodes(string) []*graph.Node {
-	return s.Store.GetRepoNodes(s.repoPrefix)
-}
-
+// Frozen pre-owner-loader baseline: full exact-repository node hydration and
+// the original scalar decoder. Do not route through the new loader: its owner
+// projection, fallback policy and exact-prefix checks are the behavior under
+// measurement, so reusing it would invalidate the baseline comparison.
 func legacyLoadRegistryFromGraph(g graph.Store, repoPrefix string) *contracts.Registry {
 	if g == nil {
 		return nil
 	}
-	return contracts.LoadRegistryFromGraph(legacyRepoStore{Store: g, repoPrefix: repoPrefix}, "")
+	all := g.GetRepoNodes(repoPrefix)
+	if len(all) == 0 {
+		return nil
+	}
+	reg := contracts.NewRegistry()
+	for _, n := range all {
+		if n == nil || n.Kind != graph.KindContract {
+			continue
+		}
+		c := legacyContractFromNode(n)
+		if c.ID == "" {
+			continue
+		}
+		reg.Add(c)
+	}
+	if len(reg.All()) == 0 {
+		return nil
+	}
+	return reg
+}
+
+func legacyContractFromNode(n *graph.Node) contracts.Contract {
+	c := contracts.Contract{
+		ID:         n.ID,
+		FilePath:   n.FilePath,
+		RepoPrefix: n.RepoPrefix,
+	}
+	if n.Meta == nil {
+		return c
+	}
+	if v, ok := n.Meta["type"].(string); ok {
+		c.Type = contracts.ContractType(v)
+	}
+	if v, ok := n.Meta["role"].(string); ok {
+		c.Role = contracts.Role(v)
+	}
+	if v, ok := n.Meta["symbol_id"].(string); ok {
+		c.SymbolID = v
+	}
+	if v, ok := n.Meta["line"].(int); ok {
+		c.Line = v
+	} else if v, ok := n.Meta["line"].(int64); ok {
+		c.Line = int(v)
+	}
+	if v, ok := n.Meta["confidence"].(float64); ok {
+		c.Confidence = v
+	}
+	c.WorkspaceID = n.WorkspaceID
+	c.ProjectID = n.ProjectID
+	if v, ok := n.Meta["contract_meta"].(map[string]any); ok && len(v) > 0 {
+		c.Meta = v
+	}
+	return c
 }
 
 func registryContractsByID(reg *contracts.Registry) map[string]contracts.Contract {
@@ -112,6 +161,13 @@ func TestLoadRegistryFromGraphProjectionEquivalent(t *testing.T) {
 			for _, prefix := range []string{"alpha", "beta", "missing", ""} {
 				t.Run(prefix, func(t *testing.T) {
 					want := registryContractsByID(legacyLoadRegistryFromGraph(g, prefix))
+					// The owner-loader also fixes the old nil-Meta early return
+					// dropping sparse contract scope. Keep the benchmark decoder
+					// frozen and express this intended correction only here.
+					if sparse, ok := want["alpha::sparse"]; ok {
+						sparse.WorkspaceID, sparse.ProjectID = "workspace", "project"
+						want["alpha::sparse"] = sparse
+					}
 					got := registryContractsByID(contracts.LoadRegistryFromGraph(g, prefix))
 					if !reflect.DeepEqual(got, want) {
 						t.Fatalf("loaded contracts differ: got %#v; want %#v", got, want)
@@ -178,7 +234,7 @@ func (s *contractLoaderProjectionSpy) NodesInScopeSeq(repos, files []string, kin
 }
 
 func TestLoadRegistryFromGraphUsesScopedProjection(t *testing.T) {
-	spy := &contractLoaderProjectionSpy{t: t, nodes: []*graph.Node{
+	spy := &contractLoaderProjectionSpy{Store: graph.New(), t: t, nodes: []*graph.Node{
 		nil,
 		{ID: "", Kind: graph.KindContract, RepoPrefix: "alpha"},
 		{ID: "alpha::ordinary", Kind: graph.KindFunction, RepoPrefix: "alpha"},
@@ -228,6 +284,917 @@ func BenchmarkLoadRegistryFromGraph(b *testing.B) {
 				if reg == nil || len(reg.All()) != contractCount {
 					b.Fatal("contract fixture did not load completely")
 				}
+			}
+		})
+	}
+}
+
+// Deliberately erase native optional capabilities to exercise the documented
+// conservative legacy policy without adding new errors to existing writers.
+type opaqueOwnerLoaderStore struct{ graph.Store }
+
+type boundedOwnerLoaderStore struct {
+	graph.Store
+	incomingCalls, largestIncoming int
+}
+
+func (store *boundedOwnerLoaderStore) GetRepoNodes(repo string) []*graph.Node {
+	if repo != "" {
+		panic("scoped owner loader must not hydrate all repository nodes")
+	}
+	return store.Store.GetRepoNodes(repo)
+}
+
+func (store *boundedOwnerLoaderStore) GetInEdgesByNodeIDs(ids []string) map[string][]*graph.Edge {
+	store.incomingCalls++
+	store.largestIncoming = max(store.largestIncoming, len(ids))
+	return store.Store.GetInEdgesByNodeIDs(ids)
+}
+
+func ownerLoaderRecords(t *testing.T, records []contracts.Contract) map[string]int {
+	t.Helper()
+	set := make(map[string]int, len(records))
+	for _, record := range records {
+		encoded, err := json.Marshal(record)
+		require.NoError(t, err)
+		set[string(encoded)]++
+	}
+	return set
+}
+
+func ownerLoaderAll(store graph.Store, repo string) []contracts.Contract {
+	if registry := contracts.LoadRegistryFromGraph(store, repo); registry != nil {
+		return registry.All()
+	}
+	return nil
+}
+
+func ownerLoaderRecord(repo, workspace, role, file, symbol string) contracts.Contract {
+	return contracts.Contract{
+		ID: "env::OWNER_ROUNDTRIP", Type: contracts.ContractType("env"), Role: contracts.Role(role),
+		RepoPrefix: repo, WorkspaceID: workspace, ProjectID: workspace + "-project",
+		FilePath: file, SymbolID: symbol, Line: 7, Confidence: 0.75,
+		Meta: map[string]any{"var": "OWNER_ROUNDTRIP", "nested": map[string]any{"values": []any{"one", "two"}}},
+	}
+}
+
+func ownerLoaderNode(c contracts.Contract, marker string) *graph.Node {
+	meta := map[string]any{
+		"type": string(c.Type), "role": string(c.Role), "symbol_id": c.SymbolID,
+		"line": c.Line, "confidence": c.Confidence, "contract_meta": c.Meta,
+	}
+	if marker != "" {
+		meta[marker] = true
+	}
+	return &graph.Node{
+		ID: c.ID, Kind: graph.KindContract, FilePath: c.FilePath, RepoPrefix: c.RepoPrefix,
+		WorkspaceID: c.WorkspaceID, ProjectID: c.ProjectID, Meta: meta,
+	}
+}
+
+func ownerLoaderSourceAndEdge(c contracts.Contract, explicitSymbol bool) (*graph.Node, *graph.Edge) {
+	from, kind := c.SymbolID, graph.KindFunction
+	if from == "" {
+		from, kind = c.FilePath, graph.KindFile
+	}
+	edgeKind := graph.EdgeProvides
+	if string(c.Role) == "consumer" {
+		edgeKind = graph.EdgeConsumes
+	}
+	meta := map[string]any{
+		"contract_owner_repo_prefix": c.RepoPrefix,
+		"contract_owner_workspace":   c.WorkspaceID, "contract_owner_project": c.ProjectID,
+		"contract_owner_type": string(c.Type), "contract_owner_confidence": c.Confidence,
+		"contract_owner_meta": c.Meta,
+	}
+	if explicitSymbol {
+		meta["contract_owner_symbol_id"] = c.SymbolID
+	}
+	return &graph.Node{ID: from, Kind: kind, FilePath: c.FilePath, RepoPrefix: c.RepoPrefix, WorkspaceID: c.WorkspaceID, ProjectID: c.ProjectID},
+		&graph.Edge{From: from, To: c.ID, Kind: edgeKind, FilePath: c.FilePath, Line: c.Line, Meta: meta}
+}
+
+func ownerLoaderFactories() map[string]func(*testing.T) graph.Store {
+	return map[string]func(*testing.T) graph.Store{
+		"memory": func(t *testing.T) graph.Store { return graph.New() },
+		"sqlite": func(t *testing.T) graph.Store {
+			store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, store.Close()) })
+			return store
+		},
+	}
+}
+
+func TestContractOwnerLoaderPreservesCrossRepoScope(t *testing.T) {
+	for backend, factory := range ownerLoaderFactories() {
+		t.Run(backend, func(t *testing.T) {
+			store := factory(t)
+			provider := ownerLoaderRecord("repo-a", "workspace-a", "provider", "repo-a/.env", "")
+			consumer := ownerLoaderRecord("repo-b", "workspace-b", "consumer", "repo-b/use.go", "repo-b/use.go::Use")
+			aNode, aEdge := ownerLoaderSourceAndEdge(provider, true)
+			bNode, bEdge := ownerLoaderSourceAndEdge(consumer, true)
+			// B is the last scalar owner. A must still be discovered from its
+			// repo-owned edge rather than from the canonical node's repo scope.
+			store.AddBatch([]*graph.Node{aNode, bNode, ownerLoaderNode(consumer, "contract_owner_record")}, []*graph.Edge{aEdge, bEdge})
+			require.Len(t, store.GetOutEdges(aNode.ID), 1, "file ownership fixture must pass real store admission")
+			require.Len(t, store.GetOutEdges(bNode.ID), 1)
+			assert.Equal(t, ownerLoaderRecords(t, []contracts.Contract{provider}), ownerLoaderRecords(t, ownerLoaderAll(store, "repo-a")))
+			assert.Equal(t, ownerLoaderRecords(t, []contracts.Contract{consumer}), ownerLoaderRecords(t, ownerLoaderAll(store, "repo-b")))
+			assert.Nil(t, contracts.LoadRegistryFromGraph(store, "unrelated"))
+		})
+	}
+}
+
+func TestContractOwnerFileRowsAreAcceptedByStores(t *testing.T) {
+	for backend, factory := range ownerLoaderFactories() {
+		t.Run(backend, func(t *testing.T) {
+			store := factory(t)
+			provider := ownerLoaderRecord("repo", "workspace", "provider", "repo/provider.env", "")
+			consumer := ownerLoaderRecord("repo", "workspace", "consumer", "repo/consumer.env", "")
+			aNode, aEdge := ownerLoaderSourceAndEdge(provider, true)
+			bNode, bEdge := ownerLoaderSourceAndEdge(consumer, true)
+			store.AddBatch([]*graph.Node{aNode, bNode, ownerLoaderNode(consumer, "contract_owner_record")}, []*graph.Edge{aEdge, bEdge})
+			require.Len(t, store.GetOutEdges(aNode.ID), 1)
+			require.Len(t, store.GetOutEdges(bNode.ID), 1)
+			rows := graph.ReadRepoEdgesByKinds(store, []string{"repo"}, []graph.EdgeKind{graph.EdgeProvides, graph.EdgeConsumes})
+			require.Len(t, rows, 2, "existing projections accept genuine file-owned records")
+		})
+	}
+}
+
+func TestContractOwnerLoaderDoesNotInheritSiblingMetadataForNilOwnerPayload(t *testing.T) {
+	for backend, factory := range ownerLoaderFactories() {
+		t.Run(backend, func(t *testing.T) {
+			store := factory(t)
+			provider := ownerLoaderRecord("repo", "workspace", "provider", "repo/provider.go", "repo/provider.go::Provide")
+			provider.Meta = nil
+			provider.Confidence = 0
+			consumer := ownerLoaderRecord("repo", "workspace", "consumer", "repo/consumer.go", "repo/consumer.go::Consume")
+			aNode, aEdge := ownerLoaderSourceAndEdge(provider, true)
+			bNode, bEdge := ownerLoaderSourceAndEdge(consumer, true)
+			store.AddBatch([]*graph.Node{aNode, bNode, ownerLoaderNode(consumer, "contract_owner_record")}, []*graph.Edge{aEdge, bEdge})
+			assert.Equal(t, ownerLoaderRecords(t, []contracts.Contract{provider, consumer}), ownerLoaderRecords(t, ownerLoaderAll(store, "repo")), "nil/zero owner values must not inherit last scalar sibling payload")
+		})
+	}
+}
+
+func TestContractOwnerLoaderLegacyUnionAndRemovedFallback(t *testing.T) {
+	for backend, factory := range ownerLoaderFactories() {
+		for _, marker := range []string{"", "contract_owner_record", "contract_owner_removed"} {
+			name := marker
+			if name == "" {
+				name = "legacy_unmarked"
+			}
+			t.Run(backend+"/"+name, func(t *testing.T) {
+				store := factory(t)
+				provider := ownerLoaderRecord("repo", "workspace", "provider", "repo/.env", "")
+				consumer := ownerLoaderRecord("repo", "workspace", "consumer", "repo/use.go", "repo/use.go::Use")
+				source, edge := ownerLoaderSourceAndEdge(consumer, false) // genuine legacy edge
+				store.AddBatch([]*graph.Node{source, ownerLoaderNode(provider, marker)}, []*graph.Edge{edge})
+				want := []contracts.Contract{consumer}
+				if marker == "" {
+					want = append(want, provider)
+				}
+				assert.Equal(t, ownerLoaderRecords(t, want), ownerLoaderRecords(t, ownerLoaderAll(store, "repo")))
+			})
+		}
+	}
+}
+
+func TestContractOwnerLoaderEmptyPrefixRemainsExact(t *testing.T) {
+	for backend, factory := range ownerLoaderFactories() {
+		t.Run(backend, func(t *testing.T) {
+			store := factory(t)
+			empty := ownerLoaderRecord("", "workspace", "provider", "plain.env", "")
+			other := ownerLoaderRecord("other", "workspace", "consumer", "other/use.go", "other/use.go::Use")
+			other.ID = "env::OTHER_NAMESPACE"
+			emptySource, emptyEdge := ownerLoaderSourceAndEdge(empty, true)
+			otherSource, otherEdge := ownerLoaderSourceAndEdge(other, true)
+			store.AddBatch([]*graph.Node{emptySource, otherSource, ownerLoaderNode(empty, "contract_owner_record"), ownerLoaderNode(other, "contract_owner_record")}, []*graph.Edge{emptyEdge, otherEdge})
+			assert.Equal(t, ownerLoaderRecords(t, []contracts.Contract{empty}), ownerLoaderRecords(t, ownerLoaderAll(store, "")))
+		})
+	}
+}
+
+func TestContractOwnerLoaderRepeatedRowsAndReopen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "graph.sqlite")
+	store, err := store_sqlite.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if store != nil {
+			require.NoError(t, store.Close())
+		}
+	})
+	provider := ownerLoaderRecord("repo", "workspace", "provider", "repo/.env", "")
+	consumer := ownerLoaderRecord("repo", "workspace", "consumer", "repo/consumer.env", "")
+	aNode, aEdge := ownerLoaderSourceAndEdge(provider, true)
+	bNode, bEdge := ownerLoaderSourceAndEdge(consumer, true)
+	nodes := []*graph.Node{aNode, bNode, ownerLoaderNode(consumer, "contract_owner_record")}
+	for range 3 {
+		store.AddBatch(nodes, []*graph.Edge{aEdge, bEdge})
+	}
+	want := ownerLoaderRecords(t, []contracts.Contract{provider, consumer})
+	assert.Equal(t, want, ownerLoaderRecords(t, ownerLoaderAll(store, "repo")), "same rows do not duplicate full records")
+	require.NoError(t, store.Close())
+	store = nil
+	store, err = store_sqlite.Open(path)
+	require.NoError(t, err)
+	assert.Equal(t, want, ownerLoaderRecords(t, ownerLoaderAll(store, "repo")), "empty symbols and nested metadata survive reopen")
+}
+
+func TestContractOwnerLoaderNilAndSparseCompatibility(t *testing.T) {
+	assert.Nil(t, contracts.LoadRegistryFromGraph(nil, "repo"))
+	for backend, factory := range ownerLoaderFactories() {
+		t.Run(backend, func(t *testing.T) {
+			store := factory(t)
+			assert.Nil(t, contracts.LoadRegistryFromGraph(store, "repo"))
+			sparse := contracts.Contract{ID: "legacy::sparse", RepoPrefix: "repo", WorkspaceID: "workspace", ProjectID: "project", FilePath: "repo/source"}
+			store.AddNode(&graph.Node{ID: sparse.ID, Kind: graph.KindContract, RepoPrefix: sparse.RepoPrefix, WorkspaceID: sparse.WorkspaceID, ProjectID: sparse.ProjectID, FilePath: sparse.FilePath})
+			assert.Equal(t, ownerLoaderRecords(t, []contracts.Contract{sparse}), ownerLoaderRecords(t, ownerLoaderAll(store, "repo")))
+		})
+	}
+}
+
+func TestContractOwnerLoaderOpaqueAdapterConservativelyOmitsAmbiguousScalar(t *testing.T) {
+	for backend, factory := range ownerLoaderFactories() {
+		t.Run(backend, func(t *testing.T) {
+			store := factory(t)
+			provider := ownerLoaderRecord("repo-a", "workspace-a", "provider", "repo-a/.env", "")
+			consumer := ownerLoaderRecord("repo-b", "workspace-b", "consumer", "repo-b/use.go", "repo-b/use.go::Use")
+			source, edge := ownerLoaderSourceAndEdge(consumer, false)
+			store.AddBatch([]*graph.Node{source, ownerLoaderNode(provider, "")}, []*graph.Edge{edge})
+			opaque := opaqueOwnerLoaderStore{store}
+			// This is an intentional conservative limitation, not full parity:
+			// legitimate scalar A cannot be distinguished from removed A in a
+			// capability-erasing adapter, so a surviving B suppresses A already
+			// before deletion. Native stores preserve A via exact invalidation.
+			assert.Empty(t, ownerLoaderAll(opaque, "repo-a"))
+			assert.Equal(t, ownerLoaderRecords(t, []contracts.Contract{consumer}), ownerLoaderRecords(t, ownerLoaderAll(opaque, "repo-b")))
+			scalarOnly := ownerLoaderRecord("repo-a", "workspace-a", "provider", "repo-a/unique.env", "")
+			scalarOnly.ID = "env::SCALAR_ONLY"
+			store.AddNode(ownerLoaderNode(scalarOnly, ""))
+			assert.Equal(t, ownerLoaderRecords(t, []contracts.Contract{scalarOnly}), ownerLoaderRecords(t, ownerLoaderAll(opaque, "repo-a")), "unambiguous scalar-only compatibility remains")
+		})
+	}
+}
+
+func TestContractOwnerLoaderOpaqueIncomingProbeIsBounded(t *testing.T) {
+	base := graph.New()
+	for i := range 257 {
+		c := ownerLoaderRecord("repo", "workspace", "provider", fmt.Sprintf("repo/%d.env", i), "")
+		c.ID = fmt.Sprintf("env::SCALAR_%d", i)
+		base.AddNode(ownerLoaderNode(c, ""))
+	}
+	store := &boundedOwnerLoaderStore{Store: base}
+	require.Len(t, ownerLoaderAll(store, "repo"), 257)
+	assert.Equal(t, 3, store.incomingCalls, "one bounded incoming query per 128 legacy candidate IDs")
+	assert.LessOrEqual(t, store.largestIncoming, 128)
+}
+
+func TestContractOwnerLoaderPreservesConcreteNumericMetadata(t *testing.T) {
+	for _, backend := range []string{"memory", "sqlite"} {
+		t.Run(backend, func(t *testing.T) {
+			var store graph.Store = graph.New()
+			var durable *store_sqlite.Store
+			var databasePath string
+			if backend == "sqlite" {
+				databasePath = filepath.Join(t.TempDir(), "graph.sqlite")
+				var err error
+				durable, err = store_sqlite.Open(databasePath)
+				require.NoError(t, err)
+				store = durable
+				t.Cleanup(func() {
+					if durable != nil {
+						require.NoError(t, durable.Close())
+					}
+				})
+			}
+			left := ownerLoaderRecord("repo", "workspace", "provider", "repo/shared.env", "")
+			left.Meta = map[string]any{"var": "OWNER_ROUNDTRIP", "numeric": int(7)}
+			right := left
+			right.Meta = map[string]any{"var": "OWNER_ROUNDTRIP", "numeric": float64(7)}
+			want := []contracts.Contract{left, right}
+			leftJSON, err := json.Marshal(left)
+			require.NoError(t, err)
+			rightJSON, err := json.Marshal(right)
+			require.NoError(t, err)
+			require.Equal(t, string(leftJSON), string(rightJSON), "the proposed JSON-only record key must actually collide")
+			require.False(t, reflect.DeepEqual(left, right), "the complete contracts retain a real concrete-type distinction")
+			leftSource, leftEdge := ownerLoaderSourceAndEdge(left, true)
+			rightSource, rightEdge := ownerLoaderSourceAndEdge(right, true)
+			// Two genuine same-repo KindFile sources make the ownership edges
+			// structurally distinct. Their record path/line and explicit empty
+			// symbol ID remain identical; the scoped reader admits both.
+			leftSource.ID, leftSource.FilePath = "repo/left.env", "repo/left.env"
+			rightSource.ID, rightSource.FilePath = "repo/right.env", "repo/right.env"
+			leftEdge.From, rightEdge.From = leftSource.ID, rightSource.ID
+			store.AddBatch([]*graph.Node{leftSource, rightSource, ownerLoaderNode(left, "contract_owner_record")}, []*graph.Edge{leftEdge, rightEdge})
+			verifyStored := func(t *testing.T) {
+				t.Helper()
+				for _, source := range []*graph.Node{leftSource, rightSource} {
+					actual := store.GetNode(source.ID)
+					require.NotNil(t, actual)
+					require.Equal(t, graph.KindFile, actual.Kind)
+					require.Equal(t, "repo", actual.RepoPrefix)
+				}
+				rows := graph.ReadRepoEdgesByKinds(store, []string{"repo"}, []graph.EdgeKind{graph.EdgeProvides})
+				require.Len(t, rows, 2, "both persisted rows must be admitted by the actual repository projection")
+				edges := store.GetInEdges(left.ID)
+				require.Len(t, edges, 2)
+				seen := make(map[string]bool)
+				for _, edge := range edges {
+					require.Equal(t, left.FilePath, edge.FilePath)
+					require.Equal(t, left.Line, edge.Line)
+					symbol, present := edge.Meta["contract_owner_symbol_id"].(string)
+					require.True(t, present)
+					require.Empty(t, symbol)
+					metadata, ok := edge.Meta["contract_owner_meta"].(map[string]any)
+					require.True(t, ok)
+					switch edge.From {
+					case leftSource.ID:
+						require.IsType(t, int(0), metadata["numeric"], "native store codec must preserve int, not normalize it to float64")
+						require.True(t, reflect.DeepEqual(left.Meta, metadata))
+					case rightSource.ID:
+						require.IsType(t, float64(0), metadata["numeric"])
+						require.True(t, reflect.DeepEqual(right.Meta, metadata))
+					default:
+						t.Fatalf("unexpected owner source %q", edge.From)
+					}
+					seen[edge.From] = true
+				}
+				require.Len(t, seen, 2)
+			}
+			if !t.Run("actual_storage_codec_prerequisites", func(t *testing.T) {
+				verifyStored(t)
+				if durable != nil {
+					require.NoError(t, durable.Close())
+					durable = nil
+					durable, err = store_sqlite.Open(databasePath)
+					require.NoError(t, err)
+					store = durable
+					verifyStored(t)
+				}
+			}) {
+				return // do not claim a loader regression from an invalid fixture
+			}
+			t.Run("public_loader_full_record_multiset", func(t *testing.T) {
+				registry := contracts.LoadRegistryFromGraph(store, "repo")
+				require.NotNil(t, registry)
+				actual := registry.ByID(left.ID)
+				require.Len(t, actual, 2, "exact-record dedup must not collapse JSON-equal concrete metadata types")
+				seen := make([]bool, len(want))
+				for _, record := range actual {
+					found := -1
+					for i, expected := range want {
+						if reflect.DeepEqual(record, expected) {
+							found = i
+							break
+						}
+					}
+					require.NotEqual(t, -1, found, "compare complete records with concrete Go types, never JSON-only multisets")
+					require.False(t, seen[found], "do not substitute a duplicate for the distinct numeric record")
+					seen[found] = true
+				}
+				// All deliberately coalesces ID/file/symbol/role; this test does
+				// not change Registry.All's separate established contract.
+				require.Len(t, registry.All(), 1)
+			})
+		})
+	}
+}
+
+// Preserve only the mandatory bounded deletion capability needed by the
+// compatibility writer. Native owner replacement and scalar invalidation remain
+// hidden, as do native read projections. A bare Store wrapper cannot delete.
+type opaqueOwnerLifecycleStore struct{ graph.Store }
+
+func (store opaqueOwnerLifecycleStore) RemoveEdgesExact(edges []*graph.Edge) int {
+	remover, ok := store.Store.(graph.ExactEdgeBatchRemover)
+	if !ok {
+		panic("lifecycle fixture requires exact edge batch removal")
+	}
+	return remover.RemoveEdgesExact(edges)
+}
+
+func (store opaqueOwnerLifecycleStore) EvictContractNodesByIDs(ids []string) (int, int) {
+	nodes, edges, supported := graph.EvictContractNodesByIDs(store.Store, ids)
+	if !supported {
+		panic("lifecycle fixture requires bounded contract-node eviction")
+	}
+	return nodes, edges
+}
+
+func TestContractOwnerOpaqueReplacementLifecycleDoesNotResurrect(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "graph.sqlite")
+	store, err := store_sqlite.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if store != nil {
+			require.NoError(t, store.Close())
+		}
+	})
+	provider := ownerLoaderRecord("repo-a", "workspace-a", "provider", "repo-a/.env", "")
+	consumer := ownerLoaderRecord("repo-b", "workspace-b", "consumer", "repo-b/use.go", "repo-b/use.go::Use")
+	consumer.Line, consumer.Confidence = 29, 0.5
+	consumer.Meta = map[string]any{"var": "OWNER_ROUNDTRIP", "nested": map[string]any{"values": []any{"only-b", "preserve"}}}
+	unrelated := ownerLoaderRecord("repo-c", "workspace-c", "provider", "repo-c/.env", "")
+	unrelated.ID = "env::OPAQUE_UNRELATED"
+	sourceB, edgeB := ownerLoaderSourceAndEdge(consumer, false)
+	store.AddBatch([]*graph.Node{
+		{ID: provider.FilePath, Kind: graph.KindFile, RepoPrefix: provider.RepoPrefix, FilePath: provider.FilePath},
+		sourceB, ownerLoaderNode(provider, ""), ownerLoaderNode(unrelated, ""),
+	}, []*graph.Edge{edgeB})
+	require.Len(t, store.GetOutEdges(sourceB.ID), 1, "fixture must persist the surviving legacy B owner")
+	opaque := opaqueOwnerLifecycleStore{store}
+	// Keep the same capability-erasing adapter after reopen. Switching to a
+	// native handle would change the deliberately conservative legacy policy.
+	reopen := func() {
+		t.Helper()
+		require.NoError(t, store.Close())
+		store = nil
+		store, err = store_sqlite.Open(path)
+		require.NoError(t, err)
+		opaque = opaqueOwnerLifecycleStore{store}
+	}
+	check := func(stage string, wantB bool) {
+		t.Helper()
+		assert.Empty(t, ownerLoaderAll(opaque, provider.RepoPrefix), "%s: ambiguous/removed A must not hydrate", stage)
+		var expectedB []contracts.Contract
+		if wantB {
+			expectedB = []contracts.Contract{consumer}
+		}
+		assert.Equal(t, ownerLoaderRecords(t, expectedB), ownerLoaderRecords(t, ownerLoaderAll(opaque, consumer.RepoPrefix)), "%s: retain B's entire record, not merely its ID", stage)
+		assert.Equal(t, ownerLoaderRecords(t, []contracts.Contract{unrelated}), ownerLoaderRecords(t, ownerLoaderAll(opaque, unrelated.RepoPrefix)), "%s: unrelated scalar-only compatibility survives", stage)
+	}
+	check("before removal", true)
+	_, err = graph.ReplaceContractOwners(opaque, graph.ContractOwnerReplacement{
+		RepoPrefix: provider.RepoPrefix, FilePaths: []string{provider.FilePath}, TouchedNodeIDs: []string{provider.ID},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, store.GetNode(provider.ID), "surviving B must retain the shared canonical node")
+	check("after A removal", true)
+	reopen()
+	check("after A removal and reopen", true)
+	// Refresh B through the same compatibility path without replacing the
+	// canonical scalar. This must neither resurrect A nor duplicate B's record.
+	_, err = graph.ReplaceContractOwners(opaque, graph.ContractOwnerReplacement{
+		RepoPrefix: consumer.RepoPrefix, FilePaths: []string{consumer.FilePath},
+		TouchedNodeIDs: []string{consumer.ID}, Edges: []*graph.Edge{edgeB},
+	})
+	require.NoError(t, err)
+	require.Len(t, store.GetOutEdges(sourceB.ID), 1)
+	check("after B refresh", true)
+	_, err = graph.ReplaceContractOwners(opaque, graph.ContractOwnerReplacement{
+		RepoPrefix: consumer.RepoPrefix, FilePaths: []string{consumer.FilePath}, TouchedNodeIDs: []string{consumer.ID},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, store.GetNode(provider.ID), "removing the last real owner prunes the shared canonical node")
+	assert.Empty(t, store.GetOutEdges(sourceB.ID))
+	check("after final B removal", false)
+	reopen()
+	assert.Nil(t, store.GetNode(provider.ID), "pruning survives reopen")
+	check("after final removal and reopen", false)
+}
+
+// Capture complete stored rows, including encoded metadata, as a multiset.
+// No schema-specific omitted columns or count-only comparison can hide damage.
+func ownerGenerationRowMultiset(t *testing.T, db *sql.DB, query string, args ...any) map[string]int {
+	t.Helper()
+	rows, err := db.Query(query, args...)
+	require.NoError(t, err)
+	defer rows.Close()
+	columns, err := rows.Columns()
+	require.NoError(t, err)
+	set := make(map[string]int)
+	for rows.Next() {
+		values := make([]any, len(columns))
+		pointers := make([]any, len(columns))
+		for i := range values {
+			pointers[i] = &values[i]
+		}
+		require.NoError(t, rows.Scan(pointers...))
+		for i, value := range values {
+			if blob, ok := value.([]byte); ok {
+				values[i] = append([]byte(nil), blob...)
+			}
+		}
+		encoded, err := json.Marshal(values)
+		require.NoError(t, err)
+		set[string(encoded)]++
+	}
+	require.NoError(t, rows.Err())
+	return set
+}
+
+func TestContractOwnerLoaderAndRemovalIsolateDistinctGenerationPayloads(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "graph.sqlite")
+	store, err := store_sqlite.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if store != nil {
+			require.NoError(t, store.Close())
+		}
+	})
+	const canonicalID = "env::DISTINCT_GENERATION_OWNER"
+	records := func(workspace, tag string, line int, confidence float64) (contracts.Contract, contracts.Contract) {
+		provider := ownerLoaderRecord("repo-a", workspace, "provider", "repo-a/.env", "")
+		provider.ID, provider.Line, provider.Confidence = canonicalID, line, confidence
+		provider.Meta = map[string]any{"var": "DISTINCT_GENERATION_OWNER", "generation": tag, "nested": map[string]any{"values": []any{tag, "provider"}}}
+		consumer := ownerLoaderRecord("repo-b", workspace+"-b", "consumer", "repo-b/use.go", "repo-b/use.go::Use")
+		consumer.ID, consumer.Line, consumer.Confidence = canonicalID, line+1, confidence/2
+		consumer.Meta = map[string]any{"var": "DISTINCT_GENERATION_OWNER", "generation": tag, "nested": map[string]any{"values": []any{tag, "consumer"}}}
+		return provider, consumer
+	}
+	seed := func(provider, consumer contracts.Contract) {
+		t.Helper()
+		aNode, aEdge := ownerLoaderSourceAndEdge(provider, true)
+		bNode, bEdge := ownerLoaderSourceAndEdge(consumer, true)
+		// Legacy scalar A exercises exact invalidation when A is removed while
+		// B retains the shared ID. Both generations use identical row identities.
+		store.AddBatch([]*graph.Node{aNode, bNode, ownerLoaderNode(provider, "")}, []*graph.Edge{aEdge, bEdge})
+		require.Len(t, store.GetOutEdges(aNode.ID), 1)
+		require.Len(t, store.GetOutEdges(bNode.ID), 1)
+	}
+	historicalA, historicalB := records("historical-workspace", "generation-7", 71, 0.875)
+	selectedA, selectedB := records("selected-workspace", "generation-0", 3, 0.25)
+	require.NotEqual(t, ownerLoaderRecords(t, []contracts.Contract{historicalA, historicalB}), ownerLoaderRecords(t, []contracts.Contract{selectedA, selectedB}), "fixture must distinguish metadata, line, confidence and ownership across generations")
+	seed(historicalA, historicalB)
+	require.NoError(t, store.Close())
+	store = nil
+	// Move only this disposable, stopped fixture to a sibling generation,
+	// following the existing generation regression pattern. Never a daemon store.
+	db, err := sql.Open("sqlite", path)
+	require.NoError(t, err)
+	_, err = db.Exec("UPDATE nodes SET view_gen = 7")
+	require.NoError(t, err)
+	_, err = db.Exec("UPDATE edges SET view_gen = 7")
+	require.NoError(t, err)
+	beforeNodes := ownerGenerationRowMultiset(t, db, "SELECT * FROM nodes WHERE view_gen = ?", 7)
+	beforeEdges := ownerGenerationRowMultiset(t, db, "SELECT * FROM edges WHERE view_gen = ?", 7)
+	require.Len(t, beforeNodes, 3)
+	require.Len(t, beforeEdges, 2, "both historical ownership payloads must be present")
+	require.NoError(t, db.Close())
+	store, err = store_sqlite.Open(path)
+	require.NoError(t, err)
+	seed(selectedA, selectedB)
+	checkSelected := func(stage string, wantA bool) {
+		t.Helper()
+		var expectedA []contracts.Contract
+		if wantA {
+			expectedA = []contracts.Contract{selectedA}
+		}
+		assert.Equal(t, ownerLoaderRecords(t, expectedA), ownerLoaderRecords(t, ownerLoaderAll(store, "repo-a")), "%s: only selected-generation A records may hydrate", stage)
+		assert.Equal(t, ownerLoaderRecords(t, []contracts.Contract{selectedB}), ownerLoaderRecords(t, ownerLoaderAll(store, "repo-b")), "%s: B must retain its selected-generation full record", stage)
+	}
+	checkSelected("before removal", true)
+	_, err = graph.ReplaceContractOwners(store, graph.ContractOwnerReplacement{
+		RepoPrefix: selectedA.RepoPrefix, FilePaths: []string{selectedA.FilePath}, TouchedNodeIDs: []string{canonicalID},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, store.GetNode(canonicalID), "selected B retains the shared canonical ID")
+	checkSelected("after selected A removal", false)
+	require.NoError(t, store.Close())
+	store = nil
+	store, err = store_sqlite.Open(path)
+	require.NoError(t, err)
+	checkSelected("after selected A removal and reopen", false)
+	require.NoError(t, store.Close())
+	store = nil
+	db, err = sql.Open("sqlite", path)
+	require.NoError(t, err)
+	defer db.Close()
+	assert.Equal(t, beforeNodes, ownerGenerationRowMultiset(t, db, "SELECT * FROM nodes WHERE view_gen = ?", 7), "every sibling node column remains unchanged")
+	assert.Equal(t, beforeEdges, ownerGenerationRowMultiset(t, db, "SELECT * FROM edges WHERE view_gen = ?", 7), "every sibling edge column, including exact encoded ownership metadata, remains unchanged")
+}
+
+// oldOwnerReplacerStore models an implementation exposing the old optional
+// replacement interface without the new conditional scalar invalidator.
+// Its exact replacement delegates to the supported compatibility writer;
+// this sequential test makes no stronger concurrent-atomicity claim.
+type oldOwnerReplacerStore struct{ opaqueOwnerLifecycleStore }
+
+func (store oldOwnerReplacerStore) ReplaceContractOwners(replacement graph.ContractOwnerReplacement) (graph.ContractOwnerReplaceResult, error) {
+	return graph.ReplaceContractOwners(store.opaqueOwnerLifecycleStore, replacement)
+}
+
+// A callable invalidator does not prove that a custom replacement invokes it.
+// This adapter exposes the correct native Graph operation but retains the old
+// replacement implementation above, which bypasses that operation entirely.
+type oldReplacerWithUnusedInvalidator struct {
+	oldOwnerReplacerStore
+	invalidator *graph.Graph
+}
+
+func (store oldReplacerWithUnusedInvalidator) InvalidateContractOwnerScalars(replacement graph.ContractOwnerReplacement) int {
+	return store.invalidator.InvalidateContractOwnerScalars(replacement)
+}
+
+type oldReplacerWithFalseGuarantee struct{ oldOwnerReplacerStore }
+
+func (store oldReplacerWithFalseGuarantee) ContractOwnerScalarLivenessGuaranteed() bool { return false }
+
+func TestContractOwnerLegacyReplacerDoesNotImplyScalarInvalidation(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		factory           func(*testing.T) graph.Store
+		exposeInvalidator bool
+		falseGuarantee    bool
+	}{
+		{name: "memory", factory: func(t *testing.T) graph.Store { return graph.New() }},
+		{name: "sqlite", factory: func(t *testing.T) graph.Store { return openContractLoaderSQLite(t) }},
+		{name: "memory_with_unused_invalidator", factory: func(t *testing.T) graph.Store { return graph.New() }, exposeInvalidator: true},
+		{name: "memory_with_false_guarantee", factory: func(t *testing.T) graph.Store { return graph.New() }, falseGuarantee: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := tc.factory(t)
+			oldReplacer := oldOwnerReplacerStore{opaqueOwnerLifecycleStore{raw}}
+			var store graph.Store = oldReplacer
+			if tc.exposeInvalidator {
+				memory, ok := raw.(*graph.Graph)
+				require.True(t, ok)
+				store = oldReplacerWithUnusedInvalidator{oldOwnerReplacerStore: oldReplacer, invalidator: memory}
+			}
+			if tc.falseGuarantee {
+				store = oldReplacerWithFalseGuarantee{oldReplacer}
+			}
+			if guarantee, ok := store.(interface{ ContractOwnerScalarLivenessGuaranteed() bool }); ok {
+				require.True(t, tc.falseGuarantee)
+				require.False(t, guarantee.ContractOwnerScalarLivenessGuaranteed())
+			} else {
+				require.False(t, tc.falseGuarantee)
+			}
+			_, replacementSupported := any(store).(graph.ContractOwnerReplacer)
+			require.True(t, replacementSupported, "fixture must expose the existing optional replacement interface")
+			_, scalarInvalidationSupported := any(store).(graph.ContractOwnerScalarInvalidator)
+			require.Equal(t, tc.exposeInvalidator, scalarInvalidationSupported, "fixture must expose only the requested callable capability")
+
+			provider := ownerLoaderRecord("repo-a", "workspace-a", "provider", "repo-a/.env", "")
+			consumer := ownerLoaderRecord("repo-b", "workspace-b", "consumer", "repo-b/use.go", "repo-b/use.go::Use")
+			consumer.Meta = map[string]any{"var": "OWNER_ROUNDTRIP", "nested": map[string]any{"survivor": "B"}}
+			sourceB, edgeB := ownerLoaderSourceAndEdge(consumer, false)
+			raw.AddBatch([]*graph.Node{sourceB, ownerLoaderNode(provider, "")}, []*graph.Edge{edgeB})
+			_, err := graph.ReplaceContractOwners(store, graph.ContractOwnerReplacement{
+				RepoPrefix: provider.RepoPrefix, FilePaths: []string{provider.FilePath}, TouchedNodeIDs: []string{provider.ID},
+			})
+			require.NoError(t, err)
+			canonical := raw.GetNode(provider.ID)
+			require.NotNil(t, canonical, "B still owns the shared canonical")
+			require.NotEqual(t, true, canonical.Meta["contract_owner_removed"], "old replacement did not add the new marker")
+			require.Len(t, raw.GetInEdges(provider.ID), 1, "B ownership survives")
+
+			// Optional atomic replacement alone says nothing about this new
+			// legacy marker. The loader must apply its conservative fallback
+			// policy instead of reviving A from the now-ambiguous scalar.
+			assert.Empty(t, ownerLoaderAll(store, provider.RepoPrefix), "old Replacer capability must not certify removed A")
+			assert.Equal(t, ownerLoaderRecords(t, []contracts.Contract{consumer}),
+				ownerLoaderRecords(t, ownerLoaderAll(store, consumer.RepoPrefix)), "full B owner payload remains recoverable")
+		})
+	}
+}
+
+func TestContractOwnerLoaderPreservesDistinctLinesAndOwnerPayload(t *testing.T) {
+	for backend, factory := range ownerLoaderFactories() {
+		t.Run(backend, func(t *testing.T) {
+			store := factory(t)
+			first := ownerLoaderRecord("repo", "workspace", "provider", "repo/use.go", "repo/use.go::Use")
+			second := first
+			second.Line = first.Line + 10
+			second.Confidence = 0.25
+			second.Meta = map[string]any{"var": "OWNER_ROUNDTRIP", "payload": "second occurrence"}
+			source, edgeA := ownerLoaderSourceAndEdge(first, true)
+			_, edgeB := ownerLoaderSourceAndEdge(second, true)
+			stale := first
+			stale.Confidence = 0.5
+			stale.Meta = map[string]any{"var": "OWNER_ROUNDTRIP", "payload": "obsolete scalar"}
+			store.AddBatch([]*graph.Node{source, ownerLoaderNode(stale, "")}, []*graph.Edge{edgeA, edgeB})
+			require.Len(t, store.GetOutEdges(source.ID), 2, "the existing store admits both line-distinct owners")
+			loaded := contracts.LoadRegistryFromGraph(store, "repo")
+			require.NotNil(t, loaded)
+			got := loaded.ByID(first.ID)
+			assert.Equal(t, ownerLoaderRecords(t, []contracts.Contract{first, second}), ownerLoaderRecords(t, got), "owner rows are complete records; an obsolete scalar for the first identity is not a third record")
+		})
+	}
+}
+
+func TestContractRegistryRetainsDistinctRecordPayloads(t *testing.T) {
+	first := ownerLoaderRecord("repo", "workspace", "provider", "repo/use.go", "repo/use.go::Use")
+	second := first
+	second.Line++
+	third := first
+	third.Confidence = 0.25
+	third.Meta = map[string]any{"different": "same-line payload"}
+	registry := contracts.NewRegistry()
+	registry.Add(first)
+	registry.Add(second)
+	registry.Add(third)
+	require.Equal(t, ownerLoaderRecords(t, []contracts.Contract{first, second, third}), ownerLoaderRecords(t, registry.ByID(first.ID)))
+	require.Equal(t, ownerLoaderRecords(t, []contracts.Contract{first, second, third}), ownerLoaderRecords(t, registry.ByWorkspace(first.WorkspaceID)))
+	require.Equal(t, ownerLoaderRecords(t, []contracts.Contract{first}), ownerLoaderRecords(t, registry.All()), "All intentionally keeps the first logical ID/file/symbol/role record")
+}
+
+func TestContractOwnerRemovalPreservesOtherFileLegacyScalar(t *testing.T) {
+	for _, backend := range []string{"memory", "sqlite"} {
+		t.Run(backend, func(t *testing.T) {
+			var store graph.Store = graph.New()
+			if backend == "sqlite" {
+				durable, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+				require.NoError(t, err)
+				t.Cleanup(func() { require.NoError(t, durable.Close()) })
+				store = durable
+			}
+			const id = "env::REVERSE_LEGACY"
+			const scalarFile = "repo-b/provider.env"
+			const edgeFile = "repo-a/consumer.go"
+			scalar := &graph.Node{ID: id, Name: id, Kind: graph.KindContract, FilePath: scalarFile, RepoPrefix: "repo-b", WorkspaceID: "workspace-b", ProjectID: "project-b", Meta: map[string]any{"type": "env", "role": "provider", "symbol_id": "", "line": 2, "confidence": 1.0, "contract_meta": map[string]any{"var": "REVERSE_LEGACY", "scalar_only": true}}}
+			source := &graph.Node{ID: edgeFile + "::Consume", Name: "Consume", Kind: graph.KindFunction, FilePath: edgeFile, RepoPrefix: "repo-a"}
+			store.AddBatch([]*graph.Node{scalar, source}, []*graph.Edge{{From: source.ID, To: id, Kind: graph.EdgeConsumes, FilePath: edgeFile, Line: 3, Meta: map[string]any{"contract_owner_repo_prefix": "repo-a", "contract_owner_type": "env", "contract_owner_symbol_id": source.ID, "contract_owner_meta": map[string]any{"var": "REVERSE_LEGACY"}}}})
+			before := contracts.LoadRegistryFromGraph(store, "repo-b")
+			require.NotNil(t, before, "the unmarked scalar-only sibling is a real recoverable legacy record")
+			require.Len(t, before.All(), 1)
+			result, err := graph.ReplaceContractOwners(store, graph.ContractOwnerReplacement{RepoPrefix: "repo-a", FilePaths: []string{edgeFile}, TouchedNodeIDs: []string{id}})
+			require.NoError(t, err)
+			assert.Equal(t, 1, result.EdgesRemoved)
+			assert.Zero(t, result.NodesRemoved, "removing A's record must not prune the intact legacy scalar B")
+			assert.NotNil(t, store.GetNode(id), "B is still a known record even though it has no owner edge")
+			if after := contracts.LoadRegistryFromGraph(store, "repo-b"); assert.NotNil(t, after) {
+				assert.Equal(t, before.All(), after.All(), "preserve the exact legacy scalar payload/scope")
+			}
+			_, err = graph.ReplaceContractOwners(store, graph.ContractOwnerReplacement{RepoPrefix: "repo-b", FilePaths: []string{scalarFile}, TouchedNodeIDs: []string{id}})
+			require.NoError(t, err)
+			assert.Nil(t, store.GetNode(id), "deleting B's own scalar file must still remove the last record")
+		})
+	}
+}
+
+func TestContractOwnerLegacyAdaptersReplacementLifecycleDoesNotResurrect(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		durable           bool
+		exposeInvalidator bool
+		falseGuarantee    bool
+	}{
+		{name: "memory"},
+		{name: "memory_with_unused_invalidator", exposeInvalidator: true},
+		{name: "memory_with_false_guarantee", falseGuarantee: true},
+		{name: "sqlite", durable: true},
+		{name: "sqlite_with_false_guarantee", durable: true, falseGuarantee: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var raw graph.Store = graph.New()
+			var durable *store_sqlite.Store
+			databasePath := filepath.Join(t.TempDir(), "graph.sqlite")
+			if tc.durable {
+				var err error
+				durable, err = store_sqlite.Open(databasePath)
+				require.NoError(t, err)
+				raw = durable
+				t.Cleanup(func() {
+					if durable != nil {
+						require.NoError(t, durable.Close())
+					}
+				})
+			}
+			makeAdapter := func() graph.Store {
+				t.Helper()
+				old := oldOwnerReplacerStore{opaqueOwnerLifecycleStore{raw}}
+				var adapter graph.Store = old
+				if tc.exposeInvalidator {
+					memory, ok := raw.(*graph.Graph)
+					require.True(t, ok)
+					adapter = oldReplacerWithUnusedInvalidator{oldOwnerReplacerStore: old, invalidator: memory}
+				}
+				if tc.falseGuarantee {
+					adapter = oldReplacerWithFalseGuarantee{old}
+				}
+				_, replacementSupported := adapter.(graph.ContractOwnerReplacer)
+				require.True(t, replacementSupported, "retain the old optional dispatch capability")
+				_, invalidationSupported := adapter.(graph.ContractOwnerScalarInvalidator)
+				require.Equal(t, tc.exposeInvalidator, invalidationSupported)
+				if guarantee, ok := adapter.(interface{ ContractOwnerScalarLivenessGuaranteed() bool }); ok {
+					require.True(t, tc.falseGuarantee)
+					require.False(t, guarantee.ContractOwnerScalarLivenessGuaranteed())
+				} else {
+					require.False(t, tc.falseGuarantee)
+				}
+				return adapter
+			}
+			adapter := makeAdapter()
+			provider := ownerLoaderRecord("repo-a", "workspace-a", "provider", "repo-a/.env", "")
+			consumer := ownerLoaderRecord("repo-b", "workspace-b", "consumer", "repo-b/use.go", "repo-b/use.go::Use")
+			consumer.Line, consumer.Confidence = 29, 0.5
+			consumer.Meta = map[string]any{"var": "OWNER_ROUNDTRIP", "nested": map[string]any{"values": []any{"only-b", "preserve"}}}
+			unrelated := ownerLoaderRecord("repo-c", "workspace-c", "provider", "repo-c/.env", "")
+			unrelated.ID = "env::OLD_REPLACER_UNRELATED"
+			sourceB, edgeB := ownerLoaderSourceAndEdge(consumer, false)
+			raw.AddBatch([]*graph.Node{
+				{ID: provider.FilePath, Kind: graph.KindFile, RepoPrefix: provider.RepoPrefix, FilePath: provider.FilePath},
+				sourceB, ownerLoaderNode(provider, ""), ownerLoaderNode(unrelated, ""),
+			}, []*graph.Edge{edgeB})
+			require.Len(t, raw.GetOutEdges(sourceB.ID), 1, "the real store must admit surviving legacy B")
+			check := func(stage string, wantB bool) {
+				t.Helper()
+				assert.Empty(t, ownerLoaderAll(adapter, provider.RepoPrefix), "%s: ambiguous/removed A must not hydrate", stage)
+				var expectedB []contracts.Contract
+				if wantB {
+					expectedB = []contracts.Contract{consumer}
+				}
+				assert.Equal(t, ownerLoaderRecords(t, expectedB), ownerLoaderRecords(t, ownerLoaderAll(adapter, consumer.RepoPrefix)), "%s: preserve B's complete record", stage)
+				assert.Equal(t, ownerLoaderRecords(t, []contracts.Contract{unrelated}), ownerLoaderRecords(t, ownerLoaderAll(adapter, unrelated.RepoPrefix)), "%s: unrelated unambiguous scalar survives", stage)
+			}
+			reopen := func() {
+				t.Helper()
+				require.True(t, tc.durable)
+				require.NoError(t, durable.Close())
+				durable = nil
+				var err error
+				durable, err = store_sqlite.Open(databasePath)
+				require.NoError(t, err)
+				raw = durable
+				adapter = makeAdapter() // preserve exactly the same erased capabilities
+			}
+			check("before removal", true)
+			_, err := graph.ReplaceContractOwners(adapter, graph.ContractOwnerReplacement{
+				RepoPrefix: provider.RepoPrefix, FilePaths: []string{provider.FilePath}, TouchedNodeIDs: []string{provider.ID},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, raw.GetNode(provider.ID), "B must retain the shared canonical after A removal")
+			check("after A removal", true)
+			if tc.durable {
+				reopen()
+				check("after A removal and reopen", true)
+			}
+			_, err = graph.ReplaceContractOwners(adapter, graph.ContractOwnerReplacement{
+				RepoPrefix: consumer.RepoPrefix, FilePaths: []string{consumer.FilePath},
+				TouchedNodeIDs: []string{consumer.ID}, Edges: []*graph.Edge{edgeB},
+			})
+			require.NoError(t, err)
+			require.Len(t, raw.GetOutEdges(sourceB.ID), 1, "B refresh must preserve one full owner record")
+			check("after B refresh", true)
+			_, err = graph.ReplaceContractOwners(adapter, graph.ContractOwnerReplacement{
+				RepoPrefix: consumer.RepoPrefix, FilePaths: []string{consumer.FilePath}, TouchedNodeIDs: []string{consumer.ID},
+			})
+			require.NoError(t, err)
+			assert.Nil(t, raw.GetNode(provider.ID), "removing final B must prune the shared canonical")
+			assert.Empty(t, raw.GetOutEdges(sourceB.ID))
+			check("after final B removal", false)
+			if tc.durable {
+				reopen()
+				assert.Nil(t, raw.GetNode(provider.ID), "final canonical pruning must survive reopen")
+				check("after final removal and reopen", false)
+			}
+		})
+	}
+}
+
+func TestContractOwnerLegacyAdaptersPreserveUntouchedScalarFrontier(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		factory           func(*testing.T) graph.Store
+		exposeInvalidator bool
+		falseGuarantee    bool
+	}{
+		{name: "memory", factory: func(t *testing.T) graph.Store { return graph.New() }},
+		{name: "memory_with_unused_invalidator", factory: func(t *testing.T) graph.Store { return graph.New() }, exposeInvalidator: true},
+		{name: "memory_with_false_guarantee", factory: func(t *testing.T) graph.Store { return graph.New() }, falseGuarantee: true},
+		{name: "sqlite", factory: func(t *testing.T) graph.Store { return openContractLoaderSQLite(t) }},
+		{name: "sqlite_with_false_guarantee", factory: func(t *testing.T) graph.Store { return openContractLoaderSQLite(t) }, falseGuarantee: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := tc.factory(t)
+			old := oldOwnerReplacerStore{opaqueOwnerLifecycleStore{raw}}
+			var adapter graph.Store = old
+			if tc.exposeInvalidator {
+				memory, ok := raw.(*graph.Graph)
+				require.True(t, ok)
+				adapter = oldReplacerWithUnusedInvalidator{oldOwnerReplacerStore: old, invalidator: memory}
+			}
+			if tc.falseGuarantee {
+				adapter = oldReplacerWithFalseGuarantee{old}
+			}
+			scalar := ownerLoaderRecord("repo-b", "workspace-b", "provider", "repo-b/untouched.env", "")
+			scalar.ID = "env::UNTOUCHED_SCALAR_FRONTIER"
+			expectedNode := ownerLoaderNode(ownerLoaderRecord("repo-b", "workspace-b", "provider", "repo-b/untouched.env", ""), "")
+			expectedNode.ID = scalar.ID // independently allocated expected metadata
+			const unrelatedFile = "repo-a/refresh.go"
+			raw.AddBatch([]*graph.Node{
+				{ID: unrelatedFile, Kind: graph.KindFile, RepoPrefix: "repo-a", FilePath: unrelatedFile},
+				ownerLoaderNode(scalar, ""),
+			}, nil)
+			require.Empty(t, raw.GetInEdges(scalar.ID), "this is genuinely scalar-only, not a hidden surviving ownership edge")
+			before := contracts.LoadRegistryFromGraph(adapter, scalar.RepoPrefix)
+			require.NotNil(t, before)
+			require.Equal(t, ownerLoaderRecords(t, []contracts.Contract{scalar}), ownerLoaderRecords(t, before.ByID(scalar.ID)))
+			result, err := graph.ReplaceContractOwners(adapter, graph.ContractOwnerReplacement{
+				RepoPrefix: "repo-a", FilePaths: []string{unrelatedFile}, TouchedNodeIDs: []string{scalar.ID},
+			})
+			require.NoError(t, err)
+			assert.Zero(t, result.EdgesRemoved, "no owner was removed in this operation")
+			assert.Zero(t, result.NodesRemoved, "a touched ID alone cannot invalidate an outside-frontier legacy scalar")
+			assert.Equal(t, expectedNode, raw.GetNode(scalar.ID), "preserve every node field and nested metadata value")
+			after := contracts.LoadRegistryFromGraph(adapter, scalar.RepoPrefix)
+			if assert.NotNil(t, after) {
+				assert.Equal(t, ownerLoaderRecords(t, before.ByID(scalar.ID)), ownerLoaderRecords(t, after.ByID(scalar.ID)), "preserve the complete untouched scalar record")
 			}
 		})
 	}

--- a/internal/contracts/load_from_graph_projection_test.go
+++ b/internal/contracts/load_from_graph_projection_test.go
@@ -110,6 +110,74 @@ type contractLoaderAdapter struct {
 	graph.Store
 }
 
+func TestLoadRegistrySparseScalarSymbolPresence(t *testing.T) {
+	factories := map[string]func(*testing.T) graph.Store{
+		"memory": func(t *testing.T) graph.Store { return graph.New() },
+		"sqlite": func(t *testing.T) graph.Store { return openContractLoaderSQLite(t) },
+	}
+	for backend, factory := range factories {
+		for _, explicitEmpty := range []bool{false, true} {
+			name := "absent"
+			if explicitEmpty {
+				name = "explicit_empty"
+			}
+			t.Run(backend+"/"+name, func(t *testing.T) {
+				g := factory(t)
+				owner := contracts.Contract{
+					ID: "sparse-contract", Type: contracts.ContractGRPC, Role: contracts.RoleConsumer,
+					SymbolID: "repo::client", FilePath: "repo/client.go", RepoPrefix: "repo",
+					WorkspaceID: "workspace", ProjectID: "project", Confidence: 0.9,
+					Meta: map[string]any{"service": "Users", "method": "Get"},
+				}
+				scalarMeta := map[string]any{
+					"type": string(owner.Type), "role": string(owner.Role),
+					"contract_meta": owner.Meta, "confidence": owner.Confidence,
+				}
+				if explicitEmpty {
+					scalarMeta["symbol_id"] = ""
+				}
+				g.AddBatch([]*graph.Node{
+					{ID: owner.SymbolID, Kind: graph.KindFunction, Name: "client", FilePath: owner.FilePath, RepoPrefix: owner.RepoPrefix},
+					{ID: owner.ID, Kind: graph.KindContract, Name: owner.ID, FilePath: owner.FilePath,
+						RepoPrefix: owner.RepoPrefix, WorkspaceID: owner.WorkspaceID, ProjectID: owner.ProjectID, Meta: scalarMeta},
+				}, []*graph.Edge{{
+					From: owner.SymbolID, To: owner.ID, Kind: graph.EdgeConsumes, FilePath: owner.FilePath,
+					Meta: map[string]any{
+						"contract_owner_repo_prefix": owner.RepoPrefix,
+						"contract_owner_workspace":   owner.WorkspaceID,
+						"contract_owner_project":     owner.ProjectID,
+						"contract_owner_type":        string(owner.Type),
+						"contract_owner_confidence":  owner.Confidence,
+						"contract_owner_meta":        owner.Meta,
+						"contract_owner_symbol_id":   owner.SymbolID,
+					},
+				}})
+				require.Len(t, g.GetInEdges(owner.ID), 1, "a genuine source owner must be persisted")
+				canonical := g.GetNodesByIDs([]string{owner.ID})[owner.ID]
+				require.NotNil(t, canonical)
+				_, symbolPresent := canonical.Meta["symbol_id"]
+				require.Equal(t, explicitEmpty, symbolPresent, "fixture must preserve absence versus explicit empty")
+				expected := []contracts.Contract{owner}
+				if explicitEmpty {
+					symbolLess := owner
+					symbolLess.SymbolID = ""
+					expected = append(expected, symbolLess)
+				}
+				for _, scoped := range []bool{false, true} {
+					var loaded *contracts.Registry
+					if scoped {
+						loaded = contracts.LoadRegistryFromGraphWithScope(g, "repo", "workspace", "project")
+					} else {
+						loaded = contracts.LoadRegistryFromGraph(g, "repo")
+					}
+					require.NotNil(t, loaded)
+					require.ElementsMatch(t, expected, loaded.ByID(owner.ID), "full records, scoped=%v", scoped)
+				}
+			})
+		}
+	}
+}
+
 func TestLoadRegistryFromGraphProjectionEquivalent(t *testing.T) {
 	factories := map[string]func(*testing.T) graph.Store{
 		"memory": func(t *testing.T) graph.Store { return graph.New() },

--- a/internal/graph/contract_owner_replace.go
+++ b/internal/graph/contract_owner_replace.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"errors"
+	"maps"
 	"sort"
 )
 
@@ -24,7 +25,9 @@ type ContractOwnerReplaceResult struct {
 	EdgesAdded   int
 }
 
-// ContractOwnerReplacer applies a replacement atomically when the backend can.
+// ContractOwnerReplacer applies a replacement atomically when the backend can,
+// including invalidation of an exact removed legacy scalar record when a
+// sibling owner requires the shared canonical node to remain.
 // SQLite implements one transaction; the in-memory compatibility path below is
 // still set-oriented and never removes another repository's shared-ID edges.
 type ContractOwnerReplacer interface {
@@ -81,21 +84,34 @@ func ReplaceContractOwners(store Store, replacement ContractOwnerReplacement) (C
 	}
 
 	result := ContractOwnerReplaceResult{}
+	if invalidator, ok := store.(ContractOwnerScalarInvalidator); ok {
+		result.NodesChanged = invalidator.InvalidateContractOwnerScalars(replacement)
+	}
 	if len(stale) > 0 {
 		result.EdgesRemoved = remover.RemoveEdgesExact(stale)
 	}
 	if len(replacement.Nodes) > 0 || len(replacement.Edges) > 0 {
 		store.AddBatch(replacement.Nodes, replacement.Edges)
-		result.NodesChanged = len(replacement.Nodes)
+		result.NodesChanged += len(replacement.Nodes)
 		result.EdgesAdded = len(replacement.Edges)
 	}
 	if len(pruneIDs) == 0 {
 		return result, nil
 	}
 
+	currentNodes := store.GetNodesByIDs(pruneIDs)
 	incoming := store.GetInEdgesByNodeIDs(pruneIDs)
 	orphanIDs := make([]string, 0, len(pruneIDs))
 	for _, id := range pruneIDs {
+		node := currentNodes[id]
+		if node != nil && node.Kind == KindContract {
+			removed, _ := node.Meta["contract_owner_removed"].(bool)
+			ownerBacked, _ := node.Meta["contract_owner_record"].(bool)
+			_, removedFile := files[node.FilePath]
+			if !removed && !ownerBacked && (node.RepoPrefix != replacement.RepoPrefix || !removedFile) {
+				continue // This exact legacy scalar belongs to a surviving frontier.
+			}
+		}
 		owned := false
 		for _, edge := range incoming[id] {
 			if edge != nil && (edge.Kind == EdgeProvides || edge.Kind == EdgeConsumes || edge.Kind == EdgeHandlesRoute) {
@@ -113,6 +129,83 @@ func ReplaceContractOwners(store Store, replacement ContractOwnerReplacement) (C
 		result.EdgesRemoved += edges
 	}
 	return result, nil
+}
+
+// ContractOwnerScalarInvalidator invalidates a removed scalar record only if
+// that record still belongs to the exact replacement repository/file frontier.
+// It is a conditional node mutation, not an atomic replacement of owner edges.
+type ContractOwnerScalarInvalidator interface {
+	InvalidateContractOwnerScalars(replacement ContractOwnerReplacement) int
+}
+
+// InvalidateContractOwnerScalars uses the same node lock, index accounting and
+// receipt boundaries as AddNode, but rechecks ownership under the lock before
+// copying metadata. A sibling that replaced the shared canonical ID wins: its
+// current record never gets replaced with a stale pre-lock snapshot.
+func (g *Graph) InvalidateContractOwnerScalars(replacement ContractOwnerReplacement) int {
+	files := make(map[string]struct{}, len(replacement.FilePaths))
+	for _, path := range replacement.FilePaths {
+		if path != "" {
+			files[path] = struct{}{}
+		}
+	}
+	ids := contractOwnerPruneIDs(replacement)
+	if len(files) == 0 || len(ids) == 0 {
+		return 0
+	}
+	receiptActive := g.beginReceiptMutation()
+	if receiptActive {
+		defer g.endReceiptMutation()
+	}
+	changed := 0
+	for _, id := range ids {
+		shard := g.shardFor(id)
+		shard.mu.Lock()
+		if g.invalidateContractOwnerScalarLocked(id, replacement.RepoPrefix, files) {
+			changed++
+		}
+		shard.mu.Unlock()
+	}
+	if changed > 0 {
+		g.nodeMutGen.Add(1)
+		// The removed scalar is no longer a usable contract record even though
+		// the shared canonical node and sibling edges remain. This is not an
+		// add-only frontier; do not leave an observation receipt complete.
+		g.markMutationReceiptsIncomplete()
+	}
+	return changed
+}
+
+func (g *Graph) invalidateContractOwnerScalarLocked(id, repo string, files map[string]struct{}) bool {
+	shard := g.shardFor(id)
+	current := shard.nodes[id]
+	if !contractOwnerScalarMatchesRemovedFrontier(current, repo, files) {
+		return false
+	}
+	updated := *current
+	updated.Meta = maps.Clone(current.Meta)
+	if updated.Meta == nil {
+		updated.Meta = make(map[string]any, 1)
+	}
+	updated.Meta["contract_owner_removed"] = true
+	g.addNodeLocked(shard, &updated)
+	return true
+}
+
+func contractOwnerScalarMatchesRemovedFrontier(node *Node, repo string, files map[string]struct{}) bool {
+	if node == nil || node.Kind != KindContract || node.RepoPrefix != repo {
+		return false
+	}
+	if _, removed := files[node.FilePath]; !removed {
+		return false
+	}
+	if removed, _ := node.Meta["contract_owner_removed"].(bool); removed {
+		return false
+	}
+	if ownerBacked, _ := node.Meta["contract_owner_record"].(bool); ownerBacked {
+		return false // fallback already requires the corresponding owner row
+	}
+	return true
 }
 
 func contractOwnerPruneIDs(replacement ContractOwnerReplacement) []string {

--- a/internal/graph/contract_owner_replace.go
+++ b/internal/graph/contract_owner_replace.go
@@ -131,6 +131,20 @@ func ReplaceContractOwners(store Store, replacement ContractOwnerReplacement) (C
 	return result, nil
 }
 
+// ContractOwnerScalarLiveness advertises a nonmutating guarantee about owner
+// replacement. A true result means removed legacy scalar records are invalidated
+// conditionally in the same protected replacement boundary. Merely implementing
+// ContractOwnerReplacer does not imply this stronger, newer guarantee.
+// Adapters overriding mutation methods must preserve this contract before
+// forwarding true, including methods promoted through concrete embedding.
+type ContractOwnerScalarLiveness interface {
+	ContractOwnerScalarLivenessGuaranteed() bool
+}
+
+// ContractOwnerScalarLivenessGuaranteed reports the conditional scalar
+// invalidation performed by Graph's protected owner-replacement lifecycle.
+func (g *Graph) ContractOwnerScalarLivenessGuaranteed() bool { return true }
+
 // ContractOwnerScalarInvalidator invalidates a removed scalar record only if
 // that record still belongs to the exact replacement repository/file frontier.
 // It is a conditional node mutation, not an atomic replacement of owner edges.

--- a/internal/graph/contract_owner_replace.go
+++ b/internal/graph/contract_owner_replace.go
@@ -99,12 +99,25 @@ func ReplaceContractOwners(store Store, replacement ContractOwnerReplacement) (C
 		return result, nil
 	}
 
+	scalarLivenessGuaranteed := false
+	if guarantee, ok := store.(ContractOwnerScalarLiveness); ok {
+		scalarLivenessGuaranteed = guarantee.ContractOwnerScalarLivenessGuaranteed()
+	}
+	removedOwnerIDs := make(map[string]struct{}, len(stale))
+	for _, edge := range stale {
+		removedOwnerIDs[edge.To] = struct{}{}
+	}
 	currentNodes := store.GetNodesByIDs(pruneIDs)
 	incoming := store.GetInEdgesByNodeIDs(pruneIDs)
 	orphanIDs := make([]string, 0, len(pruneIDs))
 	for _, id := range pruneIDs {
 		node := currentNodes[id]
-		if node != nil && node.Kind == KindContract {
+		_, removedOwner := removedOwnerIDs[id]
+		// Without a liveness guarantee, removing an actual owner makes an
+		// unmarked scalar ambiguous: it may belong to a previously removed
+		// owner. Preserve untouched scalar-only legacy records, but do not
+		// resurrect ambiguous records after their final owner disappears.
+		if node != nil && node.Kind == KindContract && (scalarLivenessGuaranteed || !removedOwner) {
 			removed, _ := node.Meta["contract_owner_removed"].(bool)
 			ownerBacked, _ := node.Meta["contract_owner_record"].(bool)
 			_, removedFile := files[node.FilePath]

--- a/internal/graph/contract_owner_scalar_invalidation_test.go
+++ b/internal/graph/contract_owner_scalar_invalidation_test.go
@@ -1,0 +1,87 @@
+package graph
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type scalarInvalidatorUnderTest interface {
+	InvalidateContractOwnerScalars(ContractOwnerReplacement) int
+}
+
+func TestContractOwnerScalarInvalidationPreservesIdentityAndReceipts(t *testing.T) {
+	g := New()
+	invalidator, ok := any(g).(scalarInvalidatorUnderTest)
+	require.True(t, ok, "native conditional invalidator must be installed")
+	const id = "env::REMOVED"
+	original := &Node{ID: id, Kind: KindContract, RepoPrefix: "a", FilePath: "a/.env", Meta: map[string]any{"role": "provider", "contract_meta": map[string]any{"var": "REMOVED"}}}
+	g.AddNode(original)
+	beforeRevision := g.nodeMutGen.Load()
+	beforeCount := g.NodeCount()
+	token := g.BeginMutationReceipt()
+	frontier := ContractOwnerReplacement{RepoPrefix: "a", FilePaths: []string{"a/.env"}, TouchedNodeIDs: []string{id, id}}
+	require.Equal(t, 1, invalidator.InvalidateContractOwnerScalars(frontier))
+	receipt := g.EndMutationReceipt(token)
+	assert.False(t, receipt.Complete)
+	assert.Equal(t, beforeCount, g.NodeCount())
+	assert.Equal(t, beforeRevision+1, g.nodeMutGen.Load())
+	updated := g.GetNode(id)
+	require.NotNil(t, updated)
+	assert.NotSame(t, original, updated, "replace under node lock rather than mutating an escaped old pointer")
+	assert.NotContains(t, original.Meta, "contract_owner_removed")
+	assert.Equal(t, true, updated.Meta["contract_owner_removed"])
+	assert.Equal(t, original.Meta["contract_meta"], updated.Meta["contract_meta"])
+	assert.Equal(t, updated, g.GetFileNodes("a/.env")[0], "secondary index points at updated node")
+	assert.Zero(t, invalidator.InvalidateContractOwnerScalars(frontier), "repeat invalidation is a no-op")
+	assert.Equal(t, beforeRevision+1, g.nodeMutGen.Load())
+}
+
+func TestContractOwnerScalarInvalidationDoesNotOverwriteSibling(t *testing.T) {
+	g := New()
+	invalidator, ok := any(g).(scalarInvalidatorUnderTest)
+	require.True(t, ok, "native conditional invalidator must be installed")
+	const id = "env::SHARED"
+	frontier := ContractOwnerReplacement{RepoPrefix: "a", FilePaths: []string{"a/.env"}, TouchedNodeIDs: []string{id}}
+	for range 256 {
+		g.AddNode(&Node{ID: id, Kind: KindContract, RepoPrefix: "a", FilePath: "a/.env", Meta: map[string]any{"role": "provider"}})
+		sibling := &Node{ID: id, Kind: KindContract, RepoPrefix: "b", FilePath: "b/.env", Meta: map[string]any{"role": "consumer", "sibling_payload": "must survive"}}
+		var workers sync.WaitGroup
+		workers.Add(2)
+		start := make(chan struct{})
+		go func() { defer workers.Done(); <-start; invalidator.InvalidateContractOwnerScalars(frontier) }()
+		go func() { defer workers.Done(); <-start; g.AddNode(sibling) }()
+		close(start)
+		workers.Wait()
+		current := g.GetNode(id)
+		require.Same(t, sibling, current, "regardless of ordering, A-only invalidation must never replace B")
+		require.NotContains(t, current.Meta, "contract_owner_removed")
+	}
+}
+
+func TestContractOwnerScalarInvalidationRejectsWrongFrontierAndCurrentRecords(t *testing.T) {
+	g := New()
+	invalidator, ok := any(g).(scalarInvalidatorUnderTest)
+	require.True(t, ok)
+	for _, tc := range []struct {
+		name        string
+		node        *Node
+		replacement ContractOwnerReplacement
+	}{
+		{"wrong_repo", &Node{ID: "c", Kind: KindContract, RepoPrefix: "b", FilePath: "a/.env"}, ContractOwnerReplacement{RepoPrefix: "a", FilePaths: []string{"a/.env"}, TouchedNodeIDs: []string{"c"}}},
+		{"wrong_file", &Node{ID: "c", Kind: KindContract, RepoPrefix: "a", FilePath: "a/other.env"}, ContractOwnerReplacement{RepoPrefix: "a", FilePaths: []string{"a/.env"}, TouchedNodeIDs: []string{"c"}}},
+		{"wrong_kind", &Node{ID: "c", Kind: KindFile, RepoPrefix: "a", FilePath: "a/.env"}, ContractOwnerReplacement{RepoPrefix: "a", FilePaths: []string{"a/.env"}, TouchedNodeIDs: []string{"c"}}},
+		{"already_owner_backed", &Node{ID: "c", Kind: KindContract, RepoPrefix: "a", FilePath: "a/.env", Meta: map[string]any{"contract_owner_record": true}}, ContractOwnerReplacement{RepoPrefix: "a", FilePaths: []string{"a/.env"}, TouchedNodeIDs: []string{"c"}}},
+		{"current_replacement", &Node{ID: "c", Kind: KindContract, RepoPrefix: "a", FilePath: "a/.env"}, ContractOwnerReplacement{RepoPrefix: "a", FilePaths: []string{"a/.env"}, TouchedNodeIDs: []string{"c"}, Nodes: []*Node{{ID: "c", Kind: KindContract}}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g.AddNode(tc.node)
+			before := g.nodeMutGen.Load()
+			assert.Zero(t, invalidator.InvalidateContractOwnerScalars(tc.replacement))
+			assert.Same(t, tc.node, g.GetNode("c"))
+			assert.Equal(t, before, g.nodeMutGen.Load())
+		})
+	}
+}

--- a/internal/graph/file_batch_evict.go
+++ b/internal/graph/file_batch_evict.go
@@ -14,69 +14,19 @@ func (g *Graph) EvictFiles(filePaths []string) (nodesRemoved, edgesRemoved int) 
 	if len(pathSet) == 0 {
 		return 0, 0
 	}
-
 	receiptActive := g.beginReceiptMutation()
 	if receiptActive {
 		defer g.endReceiptMutation()
 	}
 	g.lockAllWrite()
-	defer g.unlockAllWrite()
-
-	var nodes []*Node
-	for filePath := range pathSet {
-		for _, shard := range g.shards {
-			nodes = append(nodes, shard.byFile[filePath]...)
+	var scalarInvalidated bool
+	defer func() {
+		g.unlockAllWrite()
+		if scalarInvalidated {
+			g.markMutationReceiptsIncomplete()
 		}
-	}
-	if len(nodes) == 0 {
-		return 0, 0
-	}
-	evictedIDs := make(map[string]string, len(nodes))
-	for _, node := range nodes {
-		if node != nil {
-			evictedIDs[node.ID] = node.RepoPrefix
-		}
-	}
-	// This eviction deletes every edge touching a doomed node, including
-	// edges whose SOURCE survives. restubIncomingRefs parks the
-	// IsResolvableRefEdge kinds under a stub first, so those stay described
-	// by the name and file frontiers; the rest — accesses_field, arg_of,
-	// tests, imports, contains — are destroyed outright.
-	//
-	// An earlier revision failed the receipt closed over exactly that, which
-	// forces the whole-graph fallback resolve. The fallback cannot repair it:
-	// it retargets edges that still exist and are parked under a stub, and a
-	// deleted edge is neither, so both paths reach the same graph and the
-	// gate bought only the cost of the larger pass. On a real package it
-	// fired on nearly every reindex, a capability or structural edge from a
-	// neighbouring file being the common shape rather than the exceptional
-	// one. TestResolveAllDoesNotRestoreAnEvictionDestroyedCapabilityEdge in
-	// internal/resolver pins the premise.
-	//
-	// The eviction therefore still describes its RESOLUTION delta exactly,
-	// which is the only question a receipt answers. The destruction is a real
-	// pre-existing defect — those edges vanish when a neighbour is reindexed
-	// and nothing recreates them until the SOURCE file is reparsed — but it
-	// is not a receipt-exactness problem and is tracked separately.
-	g.recordEvictedNodesForReceipts(nodes)
-	for _, node := range nodes {
-		if node == nil {
-			continue
-		}
-		shard := g.shardFor(node.ID)
-		shard.repoNodeRemove(node)
-		delete(shard.nodes, node.ID)
-		if node.QualName != "" {
-			if current, ok := shard.byQual[node.QualName]; ok && current.ID == node.ID {
-				delete(shard.byQual, node.QualName)
-			}
-		}
-		removeNodeFromBucket(shard.byName, shard.byNameIdx, node.Name, node.ID)
-		removeNodeFromBucket(shard.byFile, shard.byFileIdx, node.FilePath, node.ID)
-		removeNodeFromBucket(shard.byRepo, shard.byRepoIdx, node.RepoPrefix, node.ID)
-	}
-	nodesRemoved = len(evictedIDs)
-	edgesRemoved = g.evictEdgesLocked(evictedIDs)
+	}()
+	nodesRemoved, edgesRemoved, scalarInvalidated = g.evictFileNodesLocked(pathSet, false)
 	return nodesRemoved, edgesRemoved
 }
 

--- a/internal/graph/file_contract_owner_evict.go
+++ b/internal/graph/file_contract_owner_evict.go
@@ -1,0 +1,225 @@
+package graph
+
+// evictFileNodesLocked retains the existing node-file eviction frontier. It
+// additionally follows ownership targets of doomed source nodes so a canonical
+// node whose scalar belongs to another file does not leak after its final owner
+// disappears. The caller holds every shard's write lock for the entire call.
+//
+// Deliberately do not scan edges by their own FilePath: an edge whose source and
+// target both lie outside this frontier was untouched by the old file eviction.
+// ReplaceContractOwners remains responsible for that file-record lifecycle.
+//
+// bumpDeletedNodeRevision preserves the existing public-path distinction:
+// EvictFile bumps nodeMutGen for deletion; EvictFiles currently does not. A new
+// legacy scalar mutation always bumps it, independently of that old difference.
+func (g *Graph) evictFileNodesLocked(paths map[string]struct{}, bumpDeletedNodeRevision bool) (nodesRemoved, edgesRemoved int, scalarInvalidated bool) {
+	original := make(map[string]*Node)
+	for path := range paths {
+		for _, shard := range g.shards {
+			for _, node := range shard.byFile[path] {
+				if node != nil {
+					original[node.ID] = node
+				}
+			}
+		}
+	}
+	if len(original) == 0 {
+		return 0, 0, false
+	}
+
+	doomed := make(map[string]*Node, len(original))
+	touched := make(map[string]*Node)
+	liveOwners := make(map[string]int)
+	legacySurvives := make(map[string]bool)
+	dependents := make(map[string][]string)
+	var queue []string
+	for id, node := range original {
+		if node.Kind != KindContract {
+			doomed[id] = node
+		}
+	}
+	touch := func(node *Node) {
+		if node == nil || node.Kind != KindContract {
+			return
+		}
+		if _, seen := touched[node.ID]; seen {
+			return
+		}
+		touched[node.ID] = node
+		legacySurvives[node.ID] = contractFileLegacyScalarSurvives(node, paths)
+		shard := g.shardFor(node.ID)
+		for _, edge := range shard.inEdges[node.ID] {
+			if edge == nil {
+				continue
+			}
+			sourceID := edge.From
+			if g.contractFileOwnerSurvivesLocked(edge, sourceID, paths, doomed) {
+				liveOwners[node.ID]++
+				dependents[sourceID] = append(dependents[sourceID], node.ID)
+			}
+		}
+		if liveOwners[node.ID] == 0 && !legacySurvives[node.ID] {
+			queue = append(queue, node.ID)
+		}
+	}
+	touchOwnerTargets := func(id string) {
+		shard := g.shardFor(id)
+		for _, edge := range shard.outEdges[id] {
+			if edge != nil && contractFileOwnerKind(edge.Kind) {
+				targetID := edge.To
+				touch(g.shardFor(targetID).nodes[targetID])
+			}
+		}
+	}
+	for id, node := range original {
+		touch(node)
+		// A source record in the removed file is not a surviving owner even
+		// when that source happens to be a retained shared canonical node.
+		touchOwnerTargets(id)
+	}
+	for next := 0; next < len(queue); next++ {
+		id := queue[next]
+		if _, removed := doomed[id]; removed {
+			continue
+		}
+		doomed[id] = touched[id]
+		// Each live incoming owner was counted once when its target was
+		// discovered. Decrement only those dependent targets, without
+		// rescanning their adjacency for every newly doomed source.
+		for _, targetID := range dependents[id] {
+			liveOwners[targetID]--
+			if liveOwners[targetID] == 0 && !legacySurvives[targetID] {
+				queue = append(queue, targetID)
+			}
+		}
+		// Follow only newly doomed ownership sources, not the entire graph.
+		// Newly discovered targets exclude already-doomed incoming owners.
+		touchOwnerTargets(id)
+	}
+
+	// A kept canonical may still describe the exact removed legacy scalar.
+	// Copy metadata under the held lock; do not overwrite a sibling snapshot or
+	// reenter the public invalidator's shard locks.
+	for id, node := range touched {
+		if _, removed := doomed[id]; removed {
+			continue
+		}
+		if g.invalidateContractOwnerScalarLocked(id, node.RepoPrefix, paths) {
+			scalarInvalidated = true
+		}
+	}
+
+	// Remove only affected owner records incident to kept touched canonicals.
+	// Their source can survive (for example, a bound handler in another file).
+	// Like existing eviction, endpoints must match their adjacency buckets.
+	// Snapshot insertion-time hashes before mutating either bucket; non-endpoint
+	// payload changes must not make removal recompute a different hash.
+	type ownerRemoval struct {
+		edge   *Edge
+		key    edgeHash
+		source string
+		target string
+	}
+	var ownerRemovals []ownerRemoval
+	for id := range touched {
+		if _, removed := doomed[id]; removed {
+			continue // normal endpoint eviction removes every incident edge
+		}
+		shard := g.shardFor(id)
+		for i, edge := range shard.inEdges[id] {
+			if edge == nil || !contractFileOwnerKind(edge.Kind) {
+				continue
+			}
+			key := shard.inEdgeKeys[id][i]
+			sourceID := edge.From
+			if _, removed := doomed[sourceID]; removed {
+				continue // normal source eviction removes this owner
+			}
+			if _, removed := paths[edge.FilePath]; removed {
+				ownerRemovals = append(ownerRemovals, ownerRemoval{edge, key, sourceID, id})
+			}
+		}
+	}
+	for _, removal := range ownerRemovals {
+		edge := removal.edge
+		from := g.shardFor(removal.source)
+		to := g.shardFor(removal.target)
+		var sourceRepo string
+		if source := from.nodes[removal.source]; source != nil {
+			sourceRepo = source.RepoPrefix
+		}
+		removeEdgeFromBucket(from.outEdges, from.outEdgeKeys, from.outEdgeIdx, removal.source, removal.key)
+		removeEdgeFromBucket(to.inEdges, to.inEdgeKeys, to.inEdgeIdx, removal.target, removal.key)
+		from.repoEdgeRemove(sourceRepo, edge)
+	}
+
+	nodes := make([]*Node, 0, len(doomed))
+	evictedIDs := make(map[string]string, len(doomed))
+	for id, node := range doomed {
+		nodes = append(nodes, node)
+		evictedIDs[id] = node.RepoPrefix
+	}
+	g.recordEvictedNodesForReceipts(nodes)
+	for _, node := range nodes {
+		shard := g.shardFor(node.ID)
+		shard.repoNodeRemove(node)
+		delete(shard.nodes, node.ID)
+		if node.QualName != "" {
+			if current, ok := shard.byQual[node.QualName]; ok && current.ID == node.ID {
+				delete(shard.byQual, node.QualName)
+			}
+		}
+		removeNodeFromBucket(shard.byName, shard.byNameIdx, node.Name, node.ID)
+		removeNodeFromBucket(shard.byFile, shard.byFileIdx, node.FilePath, node.ID)
+		removeNodeFromBucket(shard.byRepo, shard.byRepoIdx, node.RepoPrefix, node.ID)
+	}
+	nodesRemoved = len(evictedIDs)
+	if (bumpDeletedNodeRevision && nodesRemoved > 0) || scalarInvalidated {
+		g.nodeMutGen.Add(1)
+	}
+	edgesRemoved = g.evictEdgesLocked(evictedIDs)
+	if edgesRemoved == 0 && len(ownerRemovals) > 0 {
+		g.edgeMutGen.Add(1)
+	}
+	edgesRemoved += len(ownerRemovals)
+	return nodesRemoved, edgesRemoved, scalarInvalidated
+}
+
+func contractFileOwnerKind(kind EdgeKind) bool {
+	return kind == EdgeProvides || kind == EdgeConsumes || kind == EdgeHandlesRoute
+}
+
+func contractFileLegacyScalarSurvives(node *Node, paths map[string]struct{}) bool {
+	if node == nil || node.Kind != KindContract {
+		return false
+	}
+	if _, removed := paths[node.FilePath]; removed {
+		return false
+	}
+	removed, _ := node.Meta["contract_owner_removed"].(bool)
+	backed, _ := node.Meta["contract_owner_record"].(bool)
+	return !removed && !backed
+}
+
+func (g *Graph) contractFileOwnerSurvivesLocked(edge *Edge, sourceID string, paths map[string]struct{}, doomed map[string]*Node) bool {
+	if edge == nil || !contractFileOwnerKind(edge.Kind) {
+		return false
+	}
+	if _, removed := paths[edge.FilePath]; removed {
+		return false
+	}
+	if _, removed := doomed[sourceID]; removed {
+		return false
+	}
+	source := g.shardFor(sourceID).nodes[sourceID]
+	if source == nil {
+		return false
+	}
+	if _, removed := paths[source.FilePath]; removed {
+		return false
+	}
+	if ownerRepo, explicit := edge.Meta["contract_owner_repo_prefix"].(string); explicit && ownerRepo != source.RepoPrefix {
+		return false
+	}
+	return true
+}

--- a/internal/graph/file_contract_owner_evict_test.go
+++ b/internal/graph/file_contract_owner_evict_test.go
@@ -1,0 +1,330 @@
+package graph
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	fileOwnerA  = "a/provider.go"
+	fileOwnerB  = "b/consumer.go"
+	fileOwnerC  = "c/other.go"
+	fileOwnerID = "env::FILE_EVICTION_SHARED"
+)
+
+func fileOwnerEvict(g *Graph, batch bool, path string) (int, int) {
+	if batch {
+		return g.EvictFiles([]string{path, path})
+	}
+	return g.EvictFile(path)
+}
+
+func fileOwnerNode(id, repo, path string) *Node {
+	return &Node{ID: id, Name: id, Kind: KindFunction, RepoPrefix: repo, FilePath: path}
+}
+
+func fileOwnerCanonical(path, repo string, ownerBacked, removed bool) *Node {
+	return &Node{ID: fileOwnerID, Name: "SHARED", QualName: "SHARED", Kind: KindContract, FilePath: path, RepoPrefix: repo,
+		Meta: map[string]any{"type": "env", "role": "provider", "contract_meta": map[string]any{"var": "FILE_EVICTION_SHARED", "nested": map[string]any{"values": []any{"keep", "metadata"}}}, "contract_owner_record": ownerBacked, "contract_owner_removed": removed}}
+}
+
+func fileOwnerEdge(source *Node, path string, kind EdgeKind) *Edge {
+	return &Edge{From: source.ID, To: fileOwnerID, Kind: kind, FilePath: path, Line: 7,
+		Meta: map[string]any{"contract_owner_repo_prefix": source.RepoPrefix, "contract_owner_type": "env", "contract_owner_meta": map[string]any{"var": "FILE_EVICTION_SHARED", "source": source.ID}}}
+}
+
+func fileOwnerEdgeSnapshot(t *testing.T, edges []*Edge) string {
+	t.Helper()
+	var values []struct {
+		Edge *Edge          `json:"edge"`
+		Meta map[string]any `json:"meta"`
+	}
+	for _, edge := range edges {
+		values = append(values, struct {
+			Edge *Edge          `json:"edge"`
+			Meta map[string]any `json:"meta"`
+		}{edge, edge.Meta})
+	}
+	encoded, err := json.Marshal(values)
+	require.NoError(t, err)
+	return string(encoded)
+}
+
+func TestFileEvictionRetainsSharedContractAndPrunesLastOwner(t *testing.T) {
+	for _, batch := range []bool{false, true} {
+		for _, legacy := range []bool{false, true} {
+			name := "single/owner_backed"
+			if batch {
+				name = "batch/owner_backed"
+			}
+			if legacy {
+				name += "/legacy_scalar"
+			}
+			t.Run(name, func(t *testing.T) {
+				g := New()
+				a, b := fileOwnerNode("a::Provide", "a", fileOwnerA), fileOwnerNode("b::Consume", "b", fileOwnerB)
+				canonical := fileOwnerCanonical(fileOwnerA, "a", !legacy, false)
+				edgeA, edgeB := fileOwnerEdge(a, fileOwnerA, EdgeProvides), fileOwnerEdge(b, fileOwnerB, EdgeConsumes)
+				g.AddBatch([]*Node{a, b, canonical}, []*Edge{edgeA, edgeB})
+				beforeB := fileOwnerEdgeSnapshot(t, g.GetOutEdges(b.ID))
+				beforeRevision := g.nodeMutGen.Load()
+				token := g.BeginMutationReceipt()
+				nodes, edges := fileOwnerEvict(g, batch, fileOwnerA)
+				receipt := g.EndMutationReceipt(token)
+				assert.Equal(t, 1, nodes)
+				assert.Equal(t, 1, edges)
+				assert.Nil(t, g.GetNode(a.ID))
+				assert.Same(t, b, g.GetNode(b.ID))
+				current := g.GetNode(fileOwnerID)
+				assert.NotNil(t, current, "surviving cross-repository owner retains shared canonical ID")
+				assert.Equal(t, beforeB, fileOwnerEdgeSnapshot(t, g.GetOutEdges(b.ID)))
+				if current != nil && legacy {
+					assert.NotSame(t, canonical, current)
+					assert.Equal(t, false, canonical.Meta["contract_owner_removed"], "escaped old pointer is not mutated")
+					assert.Equal(t, true, current.Meta["contract_owner_removed"])
+					assert.Equal(t, canonical.Meta["contract_meta"], current.Meta["contract_meta"])
+					assert.Equal(t, []*Node{current}, g.GetFileNodes(fileOwnerA), "file index contains replacement pointer")
+					assert.Greater(t, g.nodeMutGen.Load(), beforeRevision)
+					assert.False(t, receipt.Complete, "removed scalar record is a semantic mutation")
+				}
+				// The canonical scalar still names A, not B: last-owner cleanup
+				// must follow B's outgoing ownership target outside the B bucket.
+				nodes, edges = fileOwnerEvict(g, batch, fileOwnerB)
+				assert.Equal(t, 2, nodes)
+				assert.Equal(t, 1, edges)
+				assert.Zero(t, g.NodeCount())
+				assert.Zero(t, g.EdgeCount())
+			})
+		}
+	}
+}
+
+func TestFileEvictionPreservesOffFrontierLegacyScalar(t *testing.T) {
+	for _, batch := range []bool{false, true} {
+		for _, tc := range []struct {
+			name                  string
+			backed, removed, keep bool
+		}{
+			{name: "genuine_legacy_scalar", keep: true},
+			{name: "already_removed_scalar", removed: true},
+			{name: "owner_backed_scalar", backed: true},
+		} {
+			name := "single/" + tc.name
+			if batch {
+				name = "batch/" + tc.name
+			}
+			t.Run(name, func(t *testing.T) {
+				g := New()
+				a, b := fileOwnerNode("a::Provide", "a", fileOwnerA), fileOwnerNode("b::Source", "b", fileOwnerB)
+				canonical := fileOwnerCanonical(fileOwnerB, "b", tc.backed, tc.removed)
+				g.AddBatch([]*Node{a, b, canonical}, []*Edge{fileOwnerEdge(a, fileOwnerA, EdgeProvides)})
+				fileOwnerEvict(g, batch, fileOwnerA)
+				if tc.keep {
+					assert.Same(t, canonical, g.GetNode(fileOwnerID), "A's final incoming owner removal does not delete B's recoverable scalar-only record")
+				} else {
+					assert.Nil(t, g.GetNode(fileOwnerID), "removed or owner-backed off-file scalar cannot keep an orphan alive")
+				}
+				assert.Empty(t, g.GetInEdges(fileOwnerID))
+				fileOwnerEvict(g, batch, fileOwnerB)
+				assert.Zero(t, g.NodeCount(), "deleting B itself removes its scalar-only record")
+				assert.Zero(t, g.EdgeCount())
+			})
+		}
+	}
+}
+
+func TestFileEvictionDoesNotCountInvalidOutsideOwner(t *testing.T) {
+	for _, batch := range []bool{false, true} {
+		for _, missing := range []bool{false, true} {
+			name := "single/wrong_owner_repo"
+			if batch {
+				name = "batch/wrong_owner_repo"
+			}
+			if missing {
+				name += "/missing_source"
+			}
+			t.Run(name, func(t *testing.T) {
+				g := New()
+				a, b := fileOwnerNode("a::Provide", "a", fileOwnerA), fileOwnerNode("b::Consume", "b", fileOwnerB)
+				edgeB := fileOwnerEdge(b, fileOwnerB, EdgeConsumes)
+				nodes := []*Node{a, fileOwnerCanonical(fileOwnerA, "a", true, false)}
+				if !missing {
+					nodes = append(nodes, b)
+					edgeB.Meta["contract_owner_repo_prefix"] = "wrong"
+				}
+				g.AddBatch(nodes, []*Edge{fileOwnerEdge(a, fileOwnerA, EdgeProvides), edgeB})
+				fileOwnerEvict(g, batch, fileOwnerA)
+				assert.Nil(t, g.GetNode(fileOwnerID))
+				assert.Zero(t, g.EdgeCount(), "unrecoverable owner row cannot retain the canonical")
+			})
+		}
+	}
+}
+
+func TestFileEvictionOnlyCleansRecordPathsOnTouchedCanonicals(t *testing.T) {
+	for _, batch := range []bool{false, true} {
+		for _, touched := range []bool{false, true} {
+			name := "single/outside_endpoints_unchanged"
+			if batch {
+				name = "batch/outside_endpoints_unchanged"
+			}
+			if touched {
+				name += "/canonical_in_frontier"
+			}
+			t.Run(name, func(t *testing.T) {
+				g := New()
+				a, b, c := fileOwnerNode("a::Source", "a", fileOwnerA), fileOwnerNode("a::BoundHandler", "a", "a/handler.go"), fileOwnerNode("c::Owner", "c", fileOwnerC)
+				canonicalPath := fileOwnerC
+				if touched {
+					canonicalPath = fileOwnerA
+				}
+				canonical := fileOwnerCanonical(canonicalPath, "a", true, false)
+				g.AddBatch([]*Node{a, b, c, canonical}, []*Edge{fileOwnerEdge(b, fileOwnerA, EdgeProvides), fileOwnerEdge(c, fileOwnerC, EdgeHandlesRoute)})
+				beforeB, beforeC := fileOwnerEdgeSnapshot(t, g.GetOutEdges(b.ID)), fileOwnerEdgeSnapshot(t, g.GetOutEdges(c.ID))
+				_, edges := fileOwnerEvict(g, batch, fileOwnerA)
+				assert.NotNil(t, g.GetNode(fileOwnerID))
+				assert.Equal(t, beforeC, fileOwnerEdgeSnapshot(t, g.GetOutEdges(c.ID)), "unaffected C keeps exact metadata")
+				if touched {
+					assert.Equal(t, 1, edges)
+					assert.Empty(t, g.GetOutEdges(b.ID), "incident A-owned record is removed even when its bound handler survives")
+				} else {
+					assert.Zero(t, edges)
+					assert.Equal(t, beforeB, fileOwnerEdgeSnapshot(t, g.GetOutEdges(b.ID)), "do not broaden file eviction into global edge.FilePath cleanup")
+				}
+			})
+		}
+	}
+}
+
+func TestFileEvictionPreservesEmptyPathAndOrdinaryRevisionBehavior(t *testing.T) {
+	for _, batch := range []bool{false, true} {
+		for _, path := range []string{"", "ordinary.go"} {
+			name := "single/" + path
+			if batch {
+				name = "batch/" + path
+			}
+			t.Run(name, func(t *testing.T) {
+				g := New()
+				g.AddNode(&Node{ID: "ordinary", Kind: KindFile, FilePath: path})
+				before := g.nodeMutGen.Load()
+				nodes, edges := fileOwnerEvict(g, batch, path)
+				assert.Zero(t, edges)
+				if batch && path == "" {
+					assert.Zero(t, nodes)
+					assert.NotNil(t, g.GetNode("ordinary"))
+				} else {
+					assert.Equal(t, 1, nodes)
+					assert.Nil(t, g.GetNode("ordinary"))
+				}
+				want := before
+				if !batch {
+					want++
+				}
+				assert.Equal(t, want, g.nodeMutGen.Load(), "preserve existing direct-versus-batch deletion revision behavior explicitly")
+			})
+		}
+	}
+}
+
+func TestFileEvictionSelectiveOwnerRemovalUsesStoredHashes(t *testing.T) {
+	for _, batch := range []bool{false, true} {
+		name := "single"
+		if batch {
+			name = "batch"
+		}
+		t.Run(name, func(t *testing.T) {
+			g := New()
+			a, b, c := fileOwnerNode("a::Source", "a", fileOwnerA), fileOwnerNode("a::Handler", "a", "a/handler.go"), fileOwnerNode("c::Owner", "c", fileOwnerC)
+			bound := fileOwnerEdge(b, fileOwnerA, EdgeProvides)
+			g.AddBatch([]*Node{a, b, c, fileOwnerCanonical(fileOwnerA, "a", true, false)}, []*Edge{bound, fileOwnerEdge(c, fileOwnerC, EdgeConsumes)})
+			require.Len(t, g.GetOutEdges(b.ID), 1)
+			require.Len(t, g.GetInEdges(fileOwnerID), 2)
+			sourceShard := g.shardFor(b.ID)
+			beforeRepoEdges := sourceShard.repoEdgeCount["a"]
+			require.Positive(t, beforeRepoEdges)
+			beforeC := fileOwnerEdgeSnapshot(t, g.GetOutEdges(c.ID))
+			// A non-endpoint identity field changes before the buckets are
+			// reindexed. Endpoints remain stable, as existing evictEdgesLocked
+			// requires; the insertion-time hash must still remove the entry.
+			bound.Line++
+			_, edges := fileOwnerEvict(g, batch, fileOwnerA)
+			assert.Equal(t, 1, edges)
+			assert.Empty(t, g.GetOutEdges(b.ID), "old indexed source bucket is cleared")
+			assert.Len(t, g.GetInEdges(fileOwnerID), 1, "old indexed target bucket retains only C")
+			assert.Equal(t, beforeRepoEdges-1, sourceShard.repoEdgeCount["a"], "debit the inserted source repository counter")
+			assert.Equal(t, beforeC, fileOwnerEdgeSnapshot(t, g.GetOutEdges(c.ID)))
+			assert.NotNil(t, g.GetNode(fileOwnerID))
+		})
+	}
+}
+
+func TestFileEvictionClosesOnlyNewlyDoomedOwnerChains(t *testing.T) {
+	for _, batch := range []bool{false, true} {
+		for _, directC := range []bool{false, true} {
+			for _, legacyC := range []bool{false, true} {
+				name := "single/chain"
+				if batch {
+					name = "batch/chain"
+				}
+				if directC {
+					name += "/A_also_owns_C"
+				}
+				if legacyC {
+					name += "/legacy_C"
+				}
+				t.Run(name, func(t *testing.T) {
+					g := New()
+					a := fileOwnerNode("a::Source", "a", fileOwnerA)
+					b := fileOwnerCanonical(fileOwnerB, "b", true, false)
+					b.ID, b.Name, b.QualName = "env::CHAIN_B", "CHAIN_B", "CHAIN_B"
+					c := fileOwnerCanonical(fileOwnerC, "c", !legacyC, false)
+					c.ID, c.Name, c.QualName = "env::CHAIN_C", "CHAIN_C", "CHAIN_C"
+					aToB := fileOwnerEdge(a, fileOwnerA, EdgeProvides)
+					aToB.To = b.ID
+					bToC := fileOwnerEdge(b, fileOwnerB, EdgeConsumes)
+					bToC.To = c.ID
+					edges := []*Edge{aToB, bToC}
+					if directC {
+						aToC := fileOwnerEdge(a, fileOwnerA, EdgeProvides)
+						aToC.To = c.ID
+						edges = append(edges, aToC)
+					}
+					g.AddBatch([]*Node{a, b, c}, edges)
+					require.Equal(t, 3, g.NodeCount())
+					require.Equal(t, len(edges), g.EdgeCount())
+					beforeC, err := json.Marshal(c)
+					require.NoError(t, err)
+					beforeMeta, err := json.Marshal(c.Meta)
+					require.NoError(t, err)
+					nodesRemoved, edgesRemoved := fileOwnerEvict(g, batch, fileOwnerA)
+					assert.Nil(t, g.GetNode(a.ID))
+					assert.Nil(t, g.GetNode(b.ID), "off-file B loses its final owner A")
+					if legacyC {
+						assert.Equal(t, 2, nodesRemoved)
+						assert.Same(t, c, g.GetNode(c.ID), "genuine off-frontier scalar C protects the record without incoming owners")
+						afterC, marshalErr := json.Marshal(g.GetNode(c.ID))
+						require.NoError(t, marshalErr)
+						assert.Equal(t, string(beforeC), string(afterC))
+						afterMeta, marshalErr := json.Marshal(c.Meta)
+						require.NoError(t, marshalErr)
+						assert.Equal(t, string(beforeMeta), string(afterMeta))
+					} else {
+						assert.Equal(t, 3, nodesRemoved)
+						assert.Nil(t, g.GetNode(c.ID), "newly doomed B cannot keep C alive, including when C was already touched by A")
+					}
+					assert.Equal(t, len(edges), edgesRemoved)
+					assert.Zero(t, g.EdgeCount())
+					assert.Empty(t, g.GetOutEdges(b.ID))
+					assert.Empty(t, g.GetInEdges(c.ID))
+					if legacyC {
+						fileOwnerEvict(g, batch, fileOwnerC)
+					}
+					assert.Zero(t, g.NodeCount())
+				})
+			}
+		}
+	}
+}

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -3223,46 +3223,15 @@ func (g *Graph) EvictFile(filePath string) (nodesRemoved, edgesRemoved int) {
 		defer g.endReceiptMutation()
 	}
 	g.lockAllWrite()
-	defer g.unlockAllWrite()
-
-	// Gather nodes across shards.
-	var nodes []*Node
-	for _, s := range g.shards {
-		nodes = append(nodes, s.byFile[filePath]...)
-	}
-	if len(nodes) == 0 {
-		return 0, 0
-	}
-	// id → source-repo captured BEFORE we delete the node from
-	// s.nodes; evictEdgesLocked needs the repo to debit per-repo
-	// edge counters and the live node would already be gone.
-	evictedIDs := make(map[string]string, len(nodes))
-	for _, n := range nodes {
-		evictedIDs[n.ID] = n.RepoPrefix
-	}
-	// See EvictFiles: the edges this eviction destroys from surviving
-	// sources are not reconstructible by any resolution pass, so failing the
-	// receipt closed over them would force a fallback that reaches the same
-	// graph. The RESOLUTION delta stays exactly describable.
-	g.recordEvictedNodesForReceipts(nodes)
-
-	for _, n := range nodes {
-		s := g.shardFor(n.ID)
-		s.repoNodeRemove(n)
-		delete(s.nodes, n.ID)
-		if n.QualName != "" {
-			if cur, ok := s.byQual[n.QualName]; ok && cur.ID == n.ID {
-				delete(s.byQual, n.QualName)
-			}
+	var scalarInvalidated bool
+	defer func() {
+		g.unlockAllWrite()
+		if scalarInvalidated {
+			g.markMutationReceiptsIncomplete()
 		}
-		removeNodeFromBucket(s.byName, s.byNameIdx, n.Name, n.ID)
-		removeNodeFromBucket(s.byFile, s.byFileIdx, filePath, n.ID)
-		removeNodeFromBucket(s.byRepo, s.byRepoIdx, n.RepoPrefix, n.ID)
-	}
-	nodesRemoved = len(nodes)
-	g.nodeMutGen.Add(1)
-
-	edgesRemoved = g.evictEdgesLocked(evictedIDs)
+	}()
+	// Direct eviction historically accepts the empty file-path bucket.
+	nodesRemoved, edgesRemoved, scalarInvalidated = g.evictFileNodesLocked(map[string]struct{}{filePath: {}}, true)
 	return nodesRemoved, edgesRemoved
 }
 

--- a/internal/graph/store_sqlite/bulk_load.go
+++ b/internal/graph/store_sqlite/bulk_load.go
@@ -102,18 +102,6 @@ var bulkDroppableIndexes = []bulkDroppableIndex{
 	{"nodes_by_kind", `CREATE INDEX IF NOT EXISTS nodes_by_kind ON nodes(kind)`},
 	{"nodes_by_file", `CREATE INDEX IF NOT EXISTS nodes_by_file ON nodes(file_path)`},
 	{"nodes_by_repo", `CREATE INDEX IF NOT EXISTS nodes_by_repo ON nodes(repo_prefix) WHERE repo_prefix <> ''`},
-	// Repo-first (repo_prefix, kind) probes for the repository projections:
-	// the flat kind index invites whole-kind-range scans that a repo filter
-	// then discards — measured on this workspace at 4.67s vs 0.82s (common
-	// kind) and 6.21s vs 0.02s (small repo) against repo-first plans.
-	// Deliberately NOT partial: the projections probe repo_prefix through a
-	// json_each CTE join, and SQLite cannot prove such a join implies
-	// repo_prefix <> '', so a partial index is structurally unusable there —
-	// which is precisely why the partial nodes_by_repo never served these
-	// queries and they fell back to kind-range scans. WITHOUT ROWID keys
-	// make each entry (repo_prefix, kind, id, view_gen), so ID projections
-	// are index-only.
-	{"nodes_by_repo_kind", `CREATE INDEX IF NOT EXISTS nodes_by_repo_kind ON nodes(repo_prefix, kind)`},
 	// Resolver warmup selects definitions by exact repository, compatible
 	// language family, and a bounded page of names. Keep the key minimal: kind
 	// is not a query predicate and WITHOUT ROWID secondary indexes already
@@ -162,10 +150,23 @@ const (
 	edgesByGenerationIndexDDL = `CREATE INDEX IF NOT EXISTS edges_by_generation ON edges(view_gen, id) WHERE view_gen > 0`
 )
 
-// bulkAlwaysLiveIndexes are sparse partial indexes. Their predicates keep
-// maintenance bounded, while leaving them live preserves resolver and
-// repository projections as soon as the first repository publishes.
+// bulkAlwaysLiveIndexes preserve bounded maintenance and resolver/repository
+// projections as soon as the first repository publishes. Most are sparse
+// partial indexes; the dense repo-leading index also stays live so per-repo
+// emptiness checks and exact recounts never scan the growing cold corpus.
 var bulkAlwaysLiveIndexes = []bulkDroppableIndex{
+	// Repo-first (repo_prefix, kind) probes for the repository projections:
+	// the flat kind index invites whole-kind-range scans that a repo filter
+	// then discards — measured on this workspace at 4.67s vs 0.82s (common
+	// kind) and 6.21s vs 0.02s (small repo) against repo-first plans.
+	// Deliberately NOT partial: the projections probe repo_prefix through a
+	// json_each CTE join, and SQLite cannot prove such a join implies
+	// repo_prefix <> '', so a partial index is structurally unusable there —
+	// which is precisely why the partial nodes_by_repo never served these
+	// queries and they fell back to kind-range scans. WITHOUT ROWID keys
+	// make each entry (repo_prefix, kind, id, view_gen), so ID projections
+	// are index-only.
+	{"nodes_by_repo_kind", `CREATE INDEX IF NOT EXISTS nodes_by_repo_kind ON nodes(repo_prefix, kind)`},
 	{nodesByGenerationIndexName, nodesByGenerationIndexDDL},
 	{edgesByGenerationIndexName, edgesByGenerationIndexDDL},
 	{"nodes_repo_files", `CREATE INDEX IF NOT EXISTS nodes_repo_files ON nodes(repo_prefix, workspace_id, language, file_path, id) WHERE kind = 'file'`},

--- a/internal/graph/store_sqlite/close_checkpoint_test.go
+++ b/internal/graph/store_sqlite/close_checkpoint_test.go
@@ -1,0 +1,165 @@
+package store_sqlite
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// The fake connection observes the real checkpoint call without slow disks or
+// sleeps. Both database/sql pools are opened before Close so cleanup assertions
+// cannot pass merely because no driver connection was created.
+type closeCheckpointProbe struct {
+	queryErr error
+	busy     int64
+	queries  atomic.Int32
+	closed   atomic.Int32
+	deadline atomic.Bool
+}
+
+type closeCheckpointConnector struct{ probe *closeCheckpointProbe }
+type closeCheckpointDriver struct{}
+type closeCheckpointConn struct{ probe *closeCheckpointProbe }
+type closeCheckpointRows struct {
+	busy int64
+	sent bool
+}
+
+func (c closeCheckpointConnector) Connect(context.Context) (driver.Conn, error) {
+	return &closeCheckpointConn{probe: c.probe}, nil
+}
+func (closeCheckpointConnector) Driver() driver.Driver { return closeCheckpointDriver{} }
+func (closeCheckpointDriver) Open(string) (driver.Conn, error) {
+	return nil, errors.New("checkpoint fixture requires its connector")
+}
+func (c *closeCheckpointConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("unexpected checkpoint fixture prepare")
+}
+func (c *closeCheckpointConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("unexpected checkpoint fixture transaction")
+}
+func (c *closeCheckpointConn) Close() error { c.probe.closed.Add(1); return nil }
+func (c *closeCheckpointConn) QueryContext(ctx context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
+	if !strings.Contains(strings.ToLower(query), "wal_checkpoint") {
+		return nil, fmt.Errorf("unexpected checkpoint fixture query: %s", query)
+	}
+	c.probe.queries.Add(1)
+	if _, ok := ctx.Deadline(); ok {
+		c.probe.deadline.Store(true)
+	}
+	if c.probe.queryErr != nil {
+		return nil, c.probe.queryErr
+	}
+	return &closeCheckpointRows{busy: c.probe.busy}, nil
+}
+func (*closeCheckpointRows) Columns() []string { return []string{"busy", "log", "checkpointed"} }
+func (*closeCheckpointRows) Close() error      { return nil }
+func (r *closeCheckpointRows) Next(values []driver.Value) error {
+	if r.sent {
+		return io.EOF
+	}
+	r.sent = true
+	values[0], values[1], values[2] = r.busy, int64(0), int64(0)
+	return nil
+}
+
+func newCloseCheckpointFixture(t *testing.T, checkpointErr error, busy int64) (*Store, *closeCheckpointProbe, *closeCheckpointProbe) {
+	t.Helper()
+	s, err := Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// This source-verified idempotent join leaves no background checkpoint
+	// using the original pools while the fixture replaces them.
+	s.stopCheckpointLoop()
+	if err := closeSQLitePools(s.db, s.writerDB); err != nil {
+		t.Fatal(err)
+	}
+	reader := &closeCheckpointProbe{}
+	writer := &closeCheckpointProbe{queryErr: checkpointErr, busy: busy}
+	s.db = sql.OpenDB(closeCheckpointConnector{probe: reader})
+	s.writerDB = sql.OpenDB(closeCheckpointConnector{probe: writer})
+	t.Cleanup(func() { _ = closeSQLitePools(s.db, s.writerDB) })
+	for _, db := range []*sql.DB{s.db, s.writerDB} {
+		if err := db.PingContext(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return s, reader, writer
+}
+
+func assertCloseCheckpointPoolsClosed(t *testing.T, s *Store, reader, writer *closeCheckpointProbe) {
+	t.Helper()
+	for name, db := range map[string]*sql.DB{"reader": s.db, "writer": s.writerDB} {
+		if err := db.PingContext(context.Background()); err == nil {
+			t.Errorf("%s pool remains usable after Close", name)
+		}
+		if open := db.Stats().OpenConnections; open != 0 {
+			t.Errorf("%s pool retains %d connections", name, open)
+		}
+	}
+	if reader.closed.Load() != 1 || writer.closed.Load() != 1 {
+		t.Errorf("driver closes: reader=%d writer=%d, want one each", reader.closed.Load(), writer.closed.Load())
+	}
+}
+
+func TestCloseCheckpointDoesNotUseInteractiveDeadline(t *testing.T) {
+	s, reader, writer := newCloseCheckpointFixture(t, nil, 0)
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if writer.queries.Load() != 1 || reader.queries.Load() != 0 {
+		t.Fatalf("checkpoint queries: writer=%d reader=%d", writer.queries.Load(), reader.queries.Load())
+	}
+	if writer.deadline.Load() {
+		t.Error("ordinary Close imposed the interactive checkpoint deadline on successful shutdown I/O")
+	}
+	assertCloseCheckpointPoolsClosed(t, s, reader, writer)
+}
+
+func TestExplicitCheckpointWALKeepsInteractiveDeadline(t *testing.T) {
+	s, reader, writer := newCloseCheckpointFixture(t, nil, 0)
+	if err := s.CheckpointWAL(); err != nil {
+		t.Fatal(err)
+	}
+	if writer.queries.Load() != 1 || reader.queries.Load() != 0 {
+		t.Fatalf("checkpoint queries: writer=%d reader=%d", writer.queries.Load(), reader.queries.Load())
+	}
+	if !writer.deadline.Load() {
+		t.Error("explicit CheckpointWAL lost its interactive deadline")
+	}
+}
+
+func TestCloseCheckpointErrorStillClosesBothPools(t *testing.T) {
+	want := errors.New("checkpoint driver failure")
+	s, reader, writer := newCloseCheckpointFixture(t, want, 0)
+	if err := s.Close(); !errors.Is(err, want) {
+		t.Fatalf("Close error = %v, want original checkpoint failure", err)
+	}
+	if writer.queries.Load() != 1 {
+		t.Fatalf("checkpoint queries=%d, want one non-retryable failure", writer.queries.Load())
+	}
+	assertCloseCheckpointPoolsClosed(t, s, reader, writer)
+}
+
+func TestCloseCheckpointRetainsContentionRetryBudget(t *testing.T) {
+	s, reader, writer := newCloseCheckpointFixture(t, nil, 1)
+	// This expires the existing contention repetition budget deterministically;
+	// it does not sleep or impose a deadline on a single successful I/O call.
+	s.busyRetryTimeout = time.Nanosecond
+	if err := s.Close(); !errors.Is(err, errSQLiteBusyRetryExhausted) {
+		t.Fatalf("Close error = %v, want bounded contention exhaustion", err)
+	}
+	if writer.queries.Load() == 0 {
+		t.Fatal("contention prerequisite: the checkpoint driver was not called")
+	}
+	assertCloseCheckpointPoolsClosed(t, s, reader, writer)
+}

--- a/internal/graph/store_sqlite/cold_maintenance_test.go
+++ b/internal/graph/store_sqlite/cold_maintenance_test.go
@@ -1,0 +1,414 @@
+package store_sqlite
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func newColdMaintenanceStore(t testing.TB) *Store {
+	t.Helper()
+	s, err := Open(filepath.Join(t.TempDir(), "store.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := s.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	return s
+}
+
+// The active writer helper is essential during coordinated bulk loading: the
+// only writer connection is pinned, so acquiring writerDB.Conn would deadlock.
+func coldMaintenanceExec(t testing.TB, s *Store, query string, args ...any) {
+	t.Helper()
+	s.writeMu.Lock()
+	_, err := s.execActiveWriteLocked(context.Background(), query, args...)
+	s.writeMu.Unlock()
+	if err != nil {
+		t.Fatalf("fixture SQL: %v", err)
+	}
+}
+
+func coldMaintenanceCount(t testing.TB, s *Store, want int, query string, args ...any) {
+	t.Helper()
+	var got int
+	if err := s.db.QueryRow(query, args...).Scan(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("count = %d, want %d; query %s", got, want, query)
+	}
+}
+
+func coldMaintenanceNode(t testing.TB, s *Store, repo, id string, gen int) {
+	t.Helper()
+	coldMaintenanceExec(t, s, `INSERT INTO nodes (id, kind, name, file_path, repo_prefix, view_gen)
+		VALUES (?, 'function', ?, ?, ?, ?)`, id, id, repo+"/fixture.go", repo, gen)
+}
+
+func coldMaintenanceEdge(t testing.TB, s *Store, from, to string, gen int) {
+	t.Helper()
+	coldMaintenanceExec(t, s, `INSERT INTO edges (from_id, to_id, kind, view_gen)
+		VALUES (?, ?, 'calls', ?)`, from, to, gen)
+}
+
+func coldMaintenanceSidecars(t testing.TB, s *Store, repo string, gen int) {
+	t.Helper()
+	coldMaintenanceExec(t, s, `INSERT INTO semantic_binding_types
+		(view_gen, repo_prefix, file_path, line, name, type_name)
+		VALUES (?, ?, ?, 1, 'binding', 'Type')`, gen, repo, repo+"/fixture.go")
+	coldMaintenanceExec(t, s, `INSERT INTO file_index_failures
+		(view_gen, repo_prefix, file_path, error) VALUES (?, ?, ?, 'fixture failure')`,
+		gen, repo, repo+"/fixture.go")
+}
+
+func coldMaintenanceEvict(t testing.TB, s *Store, predicate string, arg any, scope evictScope, wantNodes, wantEdges int) {
+	t.Helper()
+	nodes, edges, err := s.evictByPredicateResult(predicate, arg, scope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nodes != wantNodes || edges != wantEdges {
+		t.Fatalf("removed (%d nodes, %d edges), want (%d, %d)", nodes, edges, wantNodes, wantEdges)
+	}
+}
+
+func TestColdMaintenanceEmptyGenerationCleansOnlySelectedSidecars(t *testing.T) {
+	s := newColdMaintenanceStore(t)
+	coldMaintenanceNode(t, s, "target", "target::a", 7)
+	coldMaintenanceNode(t, s, "target", "target::b", 7)
+	coldMaintenanceEdge(t, s, "target::a", "target::b", 7)
+	coldMaintenanceNode(t, s, "other", "other::a", 0)
+	coldMaintenanceNode(t, s, "other", "other::b", 0)
+	coldMaintenanceEdge(t, s, "other::a", "other::b", 0)
+	coldMaintenanceSidecars(t, s, "target", 0)
+	coldMaintenanceSidecars(t, s, "target", 7)
+	coldMaintenanceSidecars(t, s, "other", 0)
+
+	coldMaintenanceEvict(t, s, evictNonEmptyRepoPredicate, "target", evictThisGeneration, 0, 0)
+	coldMaintenanceCount(t, s, 4, `SELECT COUNT(*) FROM nodes`)
+	coldMaintenanceCount(t, s, 2, `SELECT COUNT(*) FROM edges`)
+	for _, table := range []string{"semantic_binding_types", "file_index_failures"} {
+		coldMaintenanceCount(t, s, 0, `SELECT COUNT(*) FROM `+table+` WHERE repo_prefix = 'target' AND view_gen = 0`)
+		coldMaintenanceCount(t, s, 1, `SELECT COUNT(*) FROM `+table+` WHERE repo_prefix = 'target' AND view_gen = 7`)
+		coldMaintenanceCount(t, s, 1, `SELECT COUNT(*) FROM `+table+` WHERE repo_prefix = 'other' AND view_gen = 0`)
+	}
+}
+
+func TestColdMaintenanceEmptyScopeDoesNotPrepareGraphDeletes(t *testing.T) {
+	s := newColdMaintenanceStore(t)
+	coldMaintenanceSidecars(t, s, "target", 0)
+	// Deliberate query-path fault injection, not a supported database layout.
+	// With no candidate node, the old implementation still prepares DELETE FROM
+	// edges and errors. Restore the table before Store.Close and other cleanup.
+	coldMaintenanceExec(t, s, `ALTER TABLE edges RENAME TO cold_test_hidden_edges`)
+	defer coldMaintenanceExec(t, s, `ALTER TABLE cold_test_hidden_edges RENAME TO edges`)
+	coldMaintenanceEvict(t, s, evictNonEmptyRepoPredicate, "target", evictThisGeneration, 0, 0)
+	coldMaintenanceCount(t, s, 0, `SELECT COUNT(*) FROM semantic_binding_types`)
+	coldMaintenanceCount(t, s, 0, `SELECT COUNT(*) FROM file_index_failures`)
+}
+
+func TestColdMaintenanceExistingRepoIgnoresStaleLedger(t *testing.T) {
+	for _, tc := range []struct {
+		name                                  string
+		scope                                 evictScope
+		wantNodes, wantEdges, remainingTarget int
+	}{
+		{"current_generation", evictThisGeneration, 2, 3, 2},
+		{"all_generations", evictAllGenerations, 4, 6, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newColdMaintenanceStore(t)
+			for _, gen := range []int{0, 7} {
+				coldMaintenanceNode(t, s, "target", "target::a", gen)
+				coldMaintenanceNode(t, s, "target", "target::b", gen)
+				coldMaintenanceNode(t, s, "other", "other::a", gen)
+				coldMaintenanceEdge(t, s, "target::a", "target::b", gen)
+				coldMaintenanceEdge(t, s, "target::a", "other::a", gen)
+				coldMaintenanceEdge(t, s, "other::a", "target::a", gen)
+				coldMaintenanceEdge(t, s, "other::a", "other::a", gen)
+				coldMaintenanceSidecars(t, s, "target", gen)
+				coldMaintenanceSidecars(t, s, "other", gen)
+				// Deliberately false metadata: graph truth must determine eviction.
+				coldMaintenanceExec(t, s, `INSERT INTO repo_index_state
+					(view_gen, repo_prefix, node_count, edge_count) VALUES (?, 'target', 0, 0)`, gen)
+			}
+			coldMaintenanceEvict(t, s, evictNonEmptyRepoPredicate, "target", tc.scope, tc.wantNodes, tc.wantEdges)
+			coldMaintenanceCount(t, s, tc.remainingTarget, `SELECT COUNT(*) FROM nodes WHERE repo_prefix = 'target'`)
+			coldMaintenanceCount(t, s, 2, `SELECT COUNT(*) FROM nodes WHERE repo_prefix = 'other'`)
+			coldMaintenanceCount(t, s, 8-tc.wantEdges, `SELECT COUNT(*) FROM edges`)
+			for _, table := range []string{"semantic_binding_types", "file_index_failures"} {
+				coldMaintenanceCount(t, s, 0, `SELECT COUNT(*) FROM `+table+` WHERE repo_prefix = 'target' AND view_gen = 0`)
+				coldMaintenanceCount(t, s, tc.remainingTarget/2, `SELECT COUNT(*) FROM `+table+` WHERE repo_prefix = 'target' AND view_gen = 7`)
+				coldMaintenanceCount(t, s, 2, `SELECT COUNT(*) FROM `+table+` WHERE repo_prefix = 'other'`)
+			}
+		})
+	}
+}
+
+func TestColdMaintenanceEmptyPrefixIsNotAllRepositories(t *testing.T) {
+	s := newColdMaintenanceStore(t)
+	coldMaintenanceNode(t, s, "", "global::a", 0)
+	coldMaintenanceNode(t, s, "other", "other::a", 0)
+	coldMaintenanceSidecars(t, s, "", 0)
+	coldMaintenanceSidecars(t, s, "other", 0)
+	coldMaintenanceEvict(t, s, evictRepoPredicate, "", evictThisGeneration, 1, 0)
+	coldMaintenanceCount(t, s, 1, `SELECT COUNT(*) FROM nodes WHERE repo_prefix = 'other'`)
+	for _, table := range []string{"semantic_binding_types", "file_index_failures"} {
+		coldMaintenanceCount(t, s, 0, `SELECT COUNT(*) FROM `+table+` WHERE repo_prefix = ''`)
+		coldMaintenanceCount(t, s, 1, `SELECT COUNT(*) FROM `+table+` WHERE repo_prefix = 'other'`)
+	}
+}
+
+func TestColdMaintenanceEmptyFilePreservesFailureLedger(t *testing.T) {
+	s := newColdMaintenanceStore(t)
+	coldMaintenanceSidecars(t, s, "target", 0)
+	coldMaintenanceEvict(t, s, evictFilePredicate, "target/fixture.go", evictThisGeneration, 0, 0)
+	coldMaintenanceCount(t, s, 0, `SELECT COUNT(*) FROM semantic_binding_types WHERE repo_prefix = 'target'`)
+	// File eviction is not successful reindexing or confirmed deletion. The
+	// existing failure ledger must survive even when the node scope is empty.
+	coldMaintenanceCount(t, s, 1, `SELECT COUNT(*) FROM file_index_failures WHERE repo_prefix = 'target'`)
+}
+
+func TestColdMaintenanceProbeFailureRollsBackSidecars(t *testing.T) {
+	s := newColdMaintenanceStore(t)
+	coldMaintenanceSidecars(t, s, "target", 0)
+	// Fault-inject the existence query after sidecar cleanup. Restoring the
+	// table in a defer also protects teardown when the expected error is absent.
+	coldMaintenanceExec(t, s, `ALTER TABLE nodes RENAME TO cold_test_hidden_nodes`)
+	defer coldMaintenanceExec(t, s, `ALTER TABLE cold_test_hidden_nodes RENAME TO nodes`)
+	_, _, err := s.evictByPredicateResult(evictNonEmptyRepoPredicate, "target", evictThisGeneration)
+	if err == nil {
+		t.Fatal("expected missing-node-table error")
+	}
+	coldMaintenanceCount(t, s, 1, `SELECT COUNT(*) FROM semantic_binding_types WHERE repo_prefix = 'target'`)
+	coldMaintenanceCount(t, s, 1, `SELECT COUNT(*) FROM file_index_failures WHERE repo_prefix = 'target'`)
+}
+
+func coldMaintenanceCorpus(t testing.TB, s *Store, nodes, edges int) {
+	t.Helper()
+	coldMaintenanceExec(t, s, `WITH RECURSIVE seq(n) AS (
+		VALUES(0) UNION ALL SELECT n + 1 FROM seq WHERE n + 1 < ?)
+		INSERT INTO nodes (id, kind, name, file_path, repo_prefix, view_gen, workspace_id, project_id)
+		SELECT printf('large::%d', n), 'function', printf('fn%d', n), 'large/fixture.go', 'large', 0, 'large', 'large' FROM seq`, nodes)
+	coldMaintenanceExec(t, s, `WITH RECURSIVE seq(n) AS (
+		VALUES(0) UNION ALL SELECT n + 1 FROM seq WHERE n + 1 < ?)
+		INSERT INTO edges (from_id, to_id, kind, view_gen)
+		SELECT printf('large::%d', n % ?), printf('large::%d', (n % ? + n / ? + 1) % ?), 'calls', 0 FROM seq`,
+		edges, nodes, nodes, nodes, nodes)
+}
+
+func coldMaintenancePlan(t testing.TB, s *Store, query string, args ...any) string {
+	t.Helper()
+	rows, err := s.db.Query("EXPLAIN QUERY PLAN "+query, args...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	var plan strings.Builder
+	for rows.Next() {
+		var id, parent, unused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+			t.Fatal(err)
+		}
+		fmt.Fprintln(&plan, detail)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return plan.String()
+}
+
+func TestColdMaintenanceRepoIndexAvailableDuringBulk(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "store.sqlite")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if s != nil {
+			if err := s.Close(); err != nil {
+				t.Error(err)
+			}
+		}
+	})
+	if !s.BeginCoordinatedBulkLoad() {
+		t.Fatal("fresh disk store did not enter coordinated bulk loading")
+	}
+	coldMaintenanceCount(t, s, 1, `SELECT COUNT(*) FROM sqlite_schema WHERE type = 'index' AND name = 'nodes_by_repo_kind'`)
+	coldMaintenanceCount(t, s, 1, `SELECT COUNT(*) FROM sqlite_schema WHERE type = 'index' AND name = 'nodes_missing_workspace_slugs'`)
+	for _, index := range bulkDroppableIndexes {
+		coldMaintenanceCount(t, s, 0, `SELECT COUNT(*) FROM sqlite_schema WHERE type = 'index' AND name = ?`, index.name)
+	}
+	coldMaintenanceCorpus(t, s, 1000, 5000)
+	coldMaintenanceNode(t, s, "target", "target::a", 0)
+	coldMaintenanceEdge(t, s, "target::a", "large::0", 0)
+	for _, query := range []string{
+		`SELECT EXISTS(SELECT 1 FROM nodes WHERE repo_prefix = ? AND repo_prefix <> '' AND view_gen = ? LIMIT 1)`,
+		`SELECT COUNT(*) FROM nodes WHERE repo_prefix = ? AND view_gen = ?`,
+		`SELECT COUNT(*) FROM edges e JOIN nodes n ON n.id = e.from_id AND n.view_gen = e.view_gen WHERE n.repo_prefix = ? AND e.view_gen = ?`,
+	} {
+		plan := coldMaintenancePlan(t, s, query, "target", 0)
+		repoSeek := false
+		for _, line := range strings.Split(plan, "\n") {
+			fields := strings.Fields(line)
+			if len(fields) < 2 {
+				continue
+			}
+			isNode := fields[1] == "n" || fields[1] == "nodes"
+			isEdge := fields[1] == "e" || fields[1] == "edges"
+			if fields[0] == "SEARCH" && isNode && strings.Contains(line, "nodes_by_repo_kind") {
+				repoSeek = true
+			}
+			if fields[0] == "SCAN" && (isNode || isEdge) {
+				t.Fatalf("unexpected whole-graph-table scan for %s; plan:\n%s", query, plan)
+			}
+		}
+		if !repoSeek {
+			t.Fatalf("expected repository-indexed node seek for %s; plan:\n%s", query, plan)
+		}
+	}
+	if err := s.EndCoordinatedBulkLoad(); err != nil {
+		t.Fatal(err)
+	}
+	coldMaintenanceCount(t, s, 1, `SELECT COUNT(*) FROM sqlite_schema WHERE type = 'index' AND name = 'nodes_by_repo_kind'`)
+	coldMaintenanceCount(t, s, 1, `SELECT COUNT(*) FROM sqlite_schema WHERE type = 'index' AND name = 'nodes_missing_workspace_slugs'`)
+	for _, index := range bulkDroppableIndexes {
+		coldMaintenanceCount(t, s, 1, `SELECT COUNT(*) FROM sqlite_schema WHERE type = 'index' AND name = ?`, index.name)
+	}
+	if err := s.EndCoordinatedBulkLoad(); err != nil {
+		t.Fatalf("idempotent bulk completion: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatal(err)
+	}
+	s = nil
+	s, err = Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	coldMaintenanceCount(t, s, 1, `SELECT COUNT(*) FROM sqlite_schema WHERE type = 'index' AND name = 'nodes_by_repo_kind'`)
+	coldMaintenanceCount(t, s, 1, `SELECT COUNT(*) FROM sqlite_schema WHERE type = 'index' AND name = 'nodes_missing_workspace_slugs'`)
+	coldMaintenanceCount(t, s, 1, `SELECT COUNT(*) FROM nodes WHERE repo_prefix = 'target' AND view_gen = 0`)
+}
+
+func coldMaintenanceBenchmarkStore(b *testing.B, indexes string) *Store {
+	b.Helper()
+	s := newColdMaintenanceStore(b)
+	if !s.BeginCoordinatedBulkLoad() {
+		b.Fatal("fresh disk store did not enter bulk loading")
+	}
+	switch indexes {
+	case "legacy_deferred":
+		// Reproduce the original deferred-index set after the proposed move.
+		coldMaintenanceExec(b, s, `DROP INDEX IF EXISTS nodes_by_repo_kind`)
+	case "retained_repo":
+		// Preserve only the proposed always-live repository index.
+	case "sealed_access_paths":
+		// Restore access paths while retaining the same bulk connection/cache
+		// PRAGMAs. This is deliberately NOT a normal sealed connection profile.
+		for _, index := range bulkDroppableIndexes {
+			coldMaintenanceExec(b, s, index.ddl)
+		}
+	default:
+		b.Fatalf("unknown fixture %q", indexes)
+	}
+	coldMaintenanceCorpus(b, s, 100000, 500000)
+	return s
+}
+
+func BenchmarkColdBulkRepoMaintenance(b *testing.B) {
+	for _, indexes := range []string{"legacy_deferred", "retained_repo", "sealed_access_paths"} {
+		b.Run(indexes, func(b *testing.B) {
+			b.Run("absent_eviction", func(b *testing.B) {
+				s := coldMaintenanceBenchmarkStore(b, indexes)
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					coldMaintenanceEvict(b, s, evictNonEmptyRepoPredicate, "absent", evictThisGeneration, 0, 0)
+				}
+				b.StopTimer()
+			})
+			b.Run("existing_tiny_eviction", func(b *testing.B) {
+				s := coldMaintenanceBenchmarkStore(b, indexes)
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					b.StopTimer()
+					coldMaintenanceNode(b, s, "target", "target::a", 0)
+					coldMaintenanceNode(b, s, "target", "target::b", 0)
+					coldMaintenanceEdge(b, s, "target::a", "target::b", 0)
+					coldMaintenanceEdge(b, s, "target::a", "large::0", 0)
+					coldMaintenanceEdge(b, s, "large::0", "target::a", 0)
+					b.StartTimer()
+					coldMaintenanceEvict(b, s, evictNonEmptyRepoPredicate, "target", evictThisGeneration, 2, 3)
+				}
+				b.StopTimer()
+			})
+			b.Run("exact_tiny_recount", func(b *testing.B) {
+				s := coldMaintenanceBenchmarkStore(b, indexes)
+				coldMaintenanceNode(b, s, "target", "target::a", 0)
+				coldMaintenanceEdge(b, s, "target::a", "large::0", 0)
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					coldMaintenanceCount(b, s, 1, `SELECT COUNT(*) FROM nodes WHERE repo_prefix = ? AND view_gen = ?`, "target", 0)
+					coldMaintenanceCount(b, s, 1, `SELECT COUNT(*) FROM edges e JOIN nodes n ON n.id = e.from_id AND n.view_gen = e.view_gen WHERE n.repo_prefix = ? AND e.view_gen = ?`, "target", 0)
+				}
+				b.StopTimer()
+			})
+		})
+	}
+}
+
+func BenchmarkColdBulkRepoIndexInsertCost(b *testing.B) {
+	// Each iteration gets a fresh disk store. Setup/close are untimed, and only
+	// Store.AddBatch is charged. This measures the real node insertion path,
+	// but not parsing or complete multi-repository ingest. Compare multiple
+	// runs: there is no OS cache flush, and these synthetic nodes have no edges.
+	for _, retained := range []bool{false, true} {
+		name := "legacy_deferred"
+		if retained {
+			name = "retained_repo"
+		}
+		b.Run(name, func(b *testing.B) {
+			b.StopTimer()
+			nodes := make([]*graph.Node, 100000)
+			for i := range nodes {
+				id := fmt.Sprintf("large::%d", i)
+				nodes[i] = &graph.Node{ID: id, Kind: graph.KindFunction, Name: id, RepoPrefix: "large"}
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				s, err := Open(b.TempDir() + "/store.sqlite")
+				if err != nil {
+					b.Fatal(err)
+				}
+				if !s.BeginCoordinatedBulkLoad() {
+					_ = s.Close()
+					b.Fatal("fresh disk store did not enter bulk loading")
+				}
+				if !retained {
+					coldMaintenanceExec(b, s, `DROP INDEX IF EXISTS nodes_by_repo_kind`)
+				}
+				b.StartTimer()
+				s.AddBatch(nodes, nil)
+				b.StopTimer()
+				if err := s.Close(); err != nil {
+					b.Fatal(err)
+				}
+			}
+			b.ReportMetric(float64(len(nodes)), "nodes/op")
+		})
+	}
+}

--- a/internal/graph/store_sqlite/contract_owner_fts_test.go
+++ b/internal/graph/store_sqlite/contract_owner_fts_test.go
@@ -1,0 +1,534 @@
+package store_sqlite_test
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+)
+
+const (
+	backendFTSCanonical = "env::BACKEND_FTS_SHARED"
+	backendFTSFileA     = "repo-a/provider.go"
+	backendFTSFileB     = "repo-b/consumer.go"
+	backendFTSSourceA   = backendFTSFileA + "::Provide"
+	backendFTSSourceB   = backendFTSFileB + "::Consume"
+	backendFTSUnrelated = "repo-c/other.go::Unrelated"
+)
+
+// Compare complete stored rows, including encoded metadata and FTS rowids.
+func backendFTSRows(t *testing.T, db *sql.DB, query string, args ...any) map[string]int {
+	t.Helper()
+	rows, err := db.Query(query, args...)
+	require.NoError(t, err)
+	defer rows.Close()
+	columns, err := rows.Columns()
+	require.NoError(t, err)
+	result := make(map[string]int)
+	for rows.Next() {
+		values := make([]any, len(columns))
+		pointers := make([]any, len(columns))
+		for i := range values {
+			pointers[i] = &values[i]
+		}
+		require.NoError(t, rows.Scan(pointers...))
+		for i, value := range values {
+			if blob, ok := value.([]byte); ok {
+				// Preserve the SQL value type and distinguish an empty BLOB
+				// from NULL or a text cell with the same base64 representation.
+				values[i] = struct{ Blob []byte }{Blob: append([]byte{}, blob...)}
+			}
+		}
+		encoded, err := json.Marshal(values)
+		require.NoError(t, err)
+		result[string(encoded)]++
+	}
+	require.NoError(t, rows.Err())
+	return result
+}
+
+type backendFTSState struct {
+	mapping map[string]int
+	virtual map[string]int
+	rowIDs  []int64
+}
+
+func backendFTSForNode(t *testing.T, db *sql.DB, generation int64, id string) backendFTSState {
+	t.Helper()
+	state := backendFTSState{
+		mapping: backendFTSRows(t, db, "SELECT * FROM symbol_fts_rowid WHERE view_gen = ? AND node_id = ?", generation, id),
+		virtual: backendFTSRows(t, db, "SELECT f.rowid, f.* FROM symbol_fts f JOIN symbol_fts_rowid m ON f.rowid = m.fts_rowid WHERE m.view_gen = ? AND m.node_id = ?", generation, id),
+	}
+	rows, err := db.Query("SELECT fts_rowid FROM symbol_fts_rowid WHERE view_gen = ? AND node_id = ?", generation, id)
+	require.NoError(t, err)
+	defer rows.Close()
+	for rows.Next() {
+		var rowID int64
+		require.NoError(t, rows.Scan(&rowID))
+		state.rowIDs = append(state.rowIDs, rowID)
+	}
+	require.NoError(t, rows.Err())
+	return state
+}
+
+func backendFTSAssertGone(t *testing.T, db *sql.DB, generation int64, id string, before backendFTSState) {
+	t.Helper()
+	assert.Empty(t, backendFTSForNode(t, db, generation, id).mapping, "deleted canonical must have no rowid mapping")
+	// Do not check only the join: deleting a mapping while leaking its virtual
+	// row would make a joined absence assertion falsely pass.
+	for _, rowID := range before.rowIDs {
+		assert.Empty(t, backendFTSRows(t, db, "SELECT rowid, * FROM symbol_fts WHERE rowid = ?", rowID), "deleted canonical must have no orphaned virtual FTS row")
+	}
+}
+
+type backendFTSFixture struct {
+	path  string
+	store *store_sqlite.Store
+	db    *sql.DB
+}
+
+func newBackendFTSFixture(t *testing.T) *backendFTSFixture {
+	t.Helper()
+	f := &backendFTSFixture{path: filepath.Join(t.TempDir(), "graph.sqlite")}
+	f.open(t)
+	t.Cleanup(func() { f.close(t) })
+	return f
+}
+
+func (f *backendFTSFixture) open(t *testing.T) {
+	t.Helper()
+	var err error
+	f.store, err = store_sqlite.Open(f.path)
+	require.NoError(t, err)
+	f.db, err = sql.Open("sqlite", f.path)
+	require.NoError(t, err)
+}
+
+func (f *backendFTSFixture) close(t *testing.T) {
+	t.Helper()
+	if f.db != nil {
+		require.NoError(t, f.db.Close())
+		f.db = nil
+	}
+	if f.store != nil {
+		require.NoError(t, f.store.Close())
+		f.store = nil
+	}
+}
+
+func (f *backendFTSFixture) reopen(t *testing.T) {
+	t.Helper()
+	f.close(t)
+	f.open(t)
+}
+
+func (f *backendFTSFixture) seed(t *testing.T, tag string, canonicalFTS bool) {
+	t.Helper()
+	f.store.AddBatch([]*graph.Node{
+		{ID: backendFTSSourceA, Name: "Provide", Kind: graph.KindFunction, Language: "go", RepoPrefix: "repo-a", FilePath: backendFTSFileA, WorkspaceID: tag + "-wa", ProjectID: tag + "-pa", Meta: map[string]any{"fixture": tag, "nested": map[string]any{"role": "provider"}}},
+		{ID: backendFTSSourceB, Name: "Consume", Kind: graph.KindFunction, Language: "go", RepoPrefix: "repo-b", FilePath: backendFTSFileB, WorkspaceID: tag + "-wb", ProjectID: tag + "-pb", Meta: map[string]any{"fixture": tag, "nested": map[string]any{"role": "consumer"}}},
+		{ID: backendFTSUnrelated, Name: "Unrelated", Kind: graph.KindFunction, Language: "go", RepoPrefix: "repo-c", FilePath: "repo-c/other.go", Meta: map[string]any{"fixture": tag, "unrelated": true}},
+		{ID: backendFTSCanonical, Name: backendFTSCanonical, Kind: graph.KindContract, Language: "contract", RepoPrefix: "repo-a", FilePath: backendFTSFileA, WorkspaceID: tag + "-wa", ProjectID: tag + "-pa", Meta: map[string]any{"type": "env", "role": "provider", "contract_owner_record": true, "fixture": tag, "contract_meta": map[string]any{"var": "BACKEND_FTS_SHARED", "tag": tag}}},
+	}, []*graph.Edge{
+		{From: backendFTSSourceA, To: backendFTSCanonical, Kind: graph.EdgeProvides, FilePath: backendFTSFileA, Line: 11, Meta: map[string]any{"contract_owner_repo_prefix": "repo-a", "contract_owner_workspace": tag + "-wa", "contract_owner_project": tag + "-pa", "contract_owner_type": "env", "contract_owner_meta": map[string]any{"tag": tag, "role": "provider"}}},
+		{From: backendFTSSourceB, To: backendFTSCanonical, Kind: graph.EdgeConsumes, FilePath: backendFTSFileB, Line: 23, Meta: map[string]any{"contract_owner_repo_prefix": "repo-b", "contract_owner_workspace": tag + "-wb", "contract_owner_project": tag + "-pb", "contract_owner_type": "env", "contract_owner_meta": map[string]any{"tag": tag, "role": "consumer"}}},
+	})
+	items := []graph.SymbolFTSItem{
+		{NodeID: backendFTSSourceA, Tokens: tag + " ordinary provider"},
+		{NodeID: backendFTSSourceB, Tokens: tag + " ordinary consumer"},
+		{NodeID: backendFTSUnrelated, Tokens: tag + " ordinary unrelated"},
+	}
+	if canonicalFTS {
+		items = append(items, graph.SymbolFTSItem{NodeID: backendFTSCanonical, Tokens: tag + " canonical shared env"})
+	}
+	// A separate actual indexer.populateSymbolFTS regression proves contract
+	// admission. Here the public writer sets up positive backend rows directly.
+	batcher, ok := any(f.store).(graph.SymbolFTSBatchUpserter)
+	require.True(t, ok)
+	require.NoError(t, batcher.BatchUpsertSymbolFTS(items))
+	require.Len(t, backendFTSForNode(t, f.db, 0, backendFTSSourceA).virtual, 1)
+	require.Len(t, backendFTSForNode(t, f.db, 0, backendFTSSourceB).virtual, 1)
+	canonical := backendFTSForNode(t, f.db, 0, backendFTSCanonical)
+	if canonicalFTS {
+		require.Len(t, canonical.virtual, 1)
+		require.Len(t, canonical.mapping, 1)
+	} else {
+		require.Empty(t, canonical.virtual)
+		require.Empty(t, canonical.mapping)
+	}
+	require.Len(t, f.store.GetInEdges(backendFTSCanonical), 2)
+}
+
+func (f *backendFTSFixture) remove(t *testing.T, mode, repo, file string) {
+	t.Helper()
+	switch mode {
+	case "raw_file_eviction":
+		f.store.EvictFiles([]string{file})
+	case "owner_replacement":
+		_, err := graph.ReplaceContractOwners(f.store, graph.ContractOwnerReplacement{RepoPrefix: repo, FilePaths: []string{file}, TouchedNodeIDs: []string{backendFTSCanonical}})
+		require.NoError(t, err)
+	default:
+		t.Fatalf("unknown fixture operation %q", mode)
+	}
+}
+
+func TestContractFTSBackendSharedOwnerLifecycle(t *testing.T) {
+	for _, mode := range []string{"raw_file_eviction", "owner_replacement"} {
+		for _, withFTS := range []bool{true, false} {
+			name := mode + "/positive_fts"
+			if !withFTS {
+				name = mode + "/missing_fts"
+			}
+			t.Run(name, func(t *testing.T) {
+				f := newBackendFTSFixture(t)
+				f.seed(t, "selected", withFTS)
+				canonical := backendFTSForNode(t, f.db, 0, backendFTSCanonical)
+				ordinary := map[string]backendFTSState{}
+				for _, id := range []string{backendFTSSourceA, backendFTSSourceB, backendFTSUnrelated} {
+					ordinary[id] = backendFTSForNode(t, f.db, 0, id)
+				}
+				bNode := backendFTSRows(t, f.db, "SELECT * FROM nodes WHERE view_gen = 0 AND id = ?", backendFTSSourceB)
+				bEdges := backendFTSRows(t, f.db, "SELECT * FROM edges WHERE view_gen = 0 AND from_id = ?", backendFTSSourceB)
+				require.Len(t, bNode, 1)
+				require.Len(t, bEdges, 1)
+				f.remove(t, mode, "repo-a", backendFTSFileA)
+				if mode == "raw_file_eviction" {
+					assert.Nil(t, f.store.GetNode(backendFTSSourceA), "the raw source-file mutation actually ran")
+				} else {
+					assert.NotNil(t, f.store.GetNode(backendFTSSourceA), "owner replacement does not evict ordinary source nodes")
+				}
+				assert.NotNil(t, f.store.GetNode(backendFTSCanonical), "B keeps the shared canonical alive")
+				assert.Equal(t, canonical, backendFTSForNode(t, f.db, 0, backendFTSCanonical), "retained canonical FTS payload and rowid must be untouched")
+				assert.Equal(t, bNode, backendFTSRows(t, f.db, "SELECT * FROM nodes WHERE view_gen = 0 AND id = ?", backendFTSSourceB))
+				assert.Equal(t, bEdges, backendFTSRows(t, f.db, "SELECT * FROM edges WHERE view_gen = 0 AND from_id = ?", backendFTSSourceB), "B ownership metadata must not be rewritten")
+				assert.Empty(t, backendFTSRows(t, f.db, "SELECT * FROM edges WHERE view_gen = 0 AND from_id = ? AND to_id = ?", backendFTSSourceA, backendFTSCanonical))
+				f.reopen(t)
+				assert.NotNil(t, f.store.GetNode(backendFTSCanonical), "retention must be durable")
+				assert.Equal(t, canonical, backendFTSForNode(t, f.db, 0, backendFTSCanonical))
+				f.remove(t, mode, "repo-b", backendFTSFileB)
+				if mode == "raw_file_eviction" {
+					assert.Nil(t, f.store.GetNode(backendFTSSourceB))
+				} else {
+					assert.NotNil(t, f.store.GetNode(backendFTSSourceB))
+				}
+				assert.Nil(t, f.store.GetNode(backendFTSCanonical), "final owner removal prunes the off-file canonical")
+				assert.Empty(t, backendFTSRows(t, f.db, "SELECT * FROM edges WHERE view_gen = 0 AND (from_id = ? OR to_id = ?)", backendFTSCanonical, backendFTSCanonical))
+				backendFTSAssertGone(t, f.db, 0, backendFTSCanonical, canonical)
+				for id, before := range ordinary {
+					assert.Equal(t, before, backendFTSForNode(t, f.db, 0, id), "raw backend operations must preserve preexisting ordinary FTS behavior for %s", id)
+				}
+				assert.NotNil(t, f.store.GetNode(backendFTSUnrelated))
+				f.reopen(t)
+				assert.Nil(t, f.store.GetNode(backendFTSCanonical))
+				backendFTSAssertGone(t, f.db, 0, backendFTSCanonical, canonical)
+			})
+		}
+	}
+}
+
+func TestContractFTSBackendOutsideEndpointRecordFileScope(t *testing.T) {
+	f := newBackendFTSFixture(t)
+	const id = "env::BACKEND_FTS_RECORD_ONLY"
+	const source = "repo-b/live.go::Owner"
+	const recordFile = "repo-b/removed-record.env"
+	f.store.AddBatch([]*graph.Node{
+		{ID: source, Name: "Owner", Kind: graph.KindFunction, RepoPrefix: "repo-b", FilePath: "repo-b/live.go"},
+		{ID: id, Name: id, Kind: graph.KindContract, RepoPrefix: "repo-c", FilePath: "repo-c/canonical.go", Meta: map[string]any{"contract_owner_record": true, "type": "env", "role": "provider"}},
+	}, []*graph.Edge{{From: source, To: id, Kind: graph.EdgeProvides, FilePath: recordFile, Line: 31, Meta: map[string]any{"contract_owner_repo_prefix": "repo-b", "contract_owner_type": "env", "contract_owner_meta": map[string]any{"fixture": "outside-endpoints"}}}})
+	batcher, ok := any(f.store).(graph.SymbolFTSBatchUpserter)
+	require.True(t, ok)
+	require.NoError(t, batcher.BatchUpsertSymbolFTS([]graph.SymbolFTSItem{{NodeID: id, Tokens: "canonical record only"}, {NodeID: source, Tokens: "ordinary outside source"}}))
+	canonical := backendFTSForNode(t, f.db, 0, id)
+	ordinary := backendFTSForNode(t, f.db, 0, source)
+	require.Len(t, canonical.virtual, 1)
+	require.Len(t, ordinary.virtual, 1)
+	nodes := backendFTSRows(t, f.db, "SELECT * FROM nodes WHERE view_gen = 0")
+	edges := backendFTSRows(t, f.db, "SELECT * FROM edges WHERE view_gen = 0")
+	require.Len(t, nodes, 2)
+	require.Len(t, edges, 1)
+	removedNodes, removedEdges := f.store.EvictFiles([]string{recordFile})
+	assert.Zero(t, removedNodes)
+	assert.Zero(t, removedEdges)
+	assert.Equal(t, nodes, backendFTSRows(t, f.db, "SELECT * FROM nodes WHERE view_gen = 0"), "raw node-file frontier must not expand to record-file-only endpoints")
+	assert.Equal(t, edges, backendFTSRows(t, f.db, "SELECT * FROM edges WHERE view_gen = 0"))
+	assert.Equal(t, canonical, backendFTSForNode(t, f.db, 0, id))
+	_, err := graph.ReplaceContractOwners(f.store, graph.ContractOwnerReplacement{RepoPrefix: "repo-b", FilePaths: []string{recordFile}, TouchedNodeIDs: []string{id}})
+	require.NoError(t, err)
+	assert.Nil(t, f.store.GetNode(id), "record lifecycle can prune the final owner-backed scalar even when both endpoints are off-file")
+	backendFTSAssertGone(t, f.db, 0, id, canonical)
+	assert.NotNil(t, f.store.GetNode(source))
+	assert.Equal(t, ordinary, backendFTSForNode(t, f.db, 0, source))
+	f.reopen(t)
+	assert.Nil(t, f.store.GetNode(id))
+	backendFTSAssertGone(t, f.db, 0, id, canonical)
+}
+
+type backendFTSGenerationState struct {
+	nodes, edges, mapping, virtual map[string]int
+}
+
+func backendFTSGeneration(t *testing.T, db *sql.DB, generation int64) backendFTSGenerationState {
+	t.Helper()
+	return backendFTSGenerationState{
+		nodes:   backendFTSRows(t, db, "SELECT * FROM nodes WHERE view_gen = ?", generation),
+		edges:   backendFTSRows(t, db, "SELECT * FROM edges WHERE view_gen = ?", generation),
+		mapping: backendFTSRows(t, db, "SELECT * FROM symbol_fts_rowid WHERE view_gen = ?", generation),
+		virtual: backendFTSRows(t, db, "SELECT f.rowid, f.* FROM symbol_fts f JOIN symbol_fts_rowid m ON f.rowid = m.fts_rowid WHERE m.view_gen = ?", generation),
+	}
+}
+
+func TestContractFTSBackendLifecyclePreservesSiblingGeneration(t *testing.T) {
+	for _, mode := range []string{"raw_file_eviction", "owner_replacement"} {
+		t.Run(mode, func(t *testing.T) {
+			f := newBackendFTSFixture(t)
+			f.seed(t, "historical-seven", true)
+			f.close(t)
+			// Only this closed disposable fixture is modified. Keep virtual rowids
+			// fixed; ownership lives in symbol_fts_rowid, not a virtual-table gen column.
+			db, err := sql.Open("sqlite", f.path)
+			require.NoError(t, err)
+			tx, err := db.Begin()
+			require.NoError(t, err)
+			for _, query := range []string{"UPDATE nodes SET view_gen = 7", "UPDATE edges SET view_gen = 7", "UPDATE symbol_fts_rowid SET view_gen = 7"} {
+				_, err = tx.Exec(query)
+				require.NoError(t, err)
+			}
+			require.NoError(t, tx.Commit())
+			historical := backendFTSGeneration(t, db, 7)
+			require.Len(t, historical.nodes, 4)
+			require.Len(t, historical.edges, 2)
+			require.Len(t, historical.mapping, 4)
+			require.Len(t, historical.virtual, 4)
+			require.NoError(t, db.Close())
+			f.open(t)
+			f.seed(t, "selected-zero", true)
+			assert.Equal(t, historical, backendFTSGeneration(t, f.db, 7), "seeding identical selected IDs must preserve distinct historical payloads")
+			selected := backendFTSForNode(t, f.db, 0, backendFTSCanonical)
+			historicalCanonical := backendFTSForNode(t, f.db, 7, backendFTSCanonical)
+			require.NotEqual(t, selected.virtual, historicalCanonical.virtual, "generation fixture must distinguish exact FTS payloads and rowids")
+			f.remove(t, mode, "repo-a", backendFTSFileA)
+			assert.NotNil(t, f.store.GetNode(backendFTSCanonical))
+			assert.Equal(t, selected, backendFTSForNode(t, f.db, 0, backendFTSCanonical))
+			assert.Equal(t, historical, backendFTSGeneration(t, f.db, 7), "retained phase must not mutate any sibling node/edge/FTS/map column")
+			f.reopen(t)
+			f.remove(t, mode, "repo-b", backendFTSFileB)
+			assert.Nil(t, f.store.GetNode(backendFTSCanonical))
+			backendFTSAssertGone(t, f.db, 0, backendFTSCanonical, selected)
+			assert.Equal(t, historical, backendFTSGeneration(t, f.db, 7), "final selected prune must not delete same-ID sibling FTS or graph rows")
+			f.reopen(t)
+			backendFTSAssertGone(t, f.db, 0, backendFTSCanonical, selected)
+			assert.Equal(t, historical, backendFTSGeneration(t, f.db, 7), "generation isolation must survive reopen")
+		})
+	}
+}
+
+func TestContractFTSBackendMutationRollsBackOnFixtureAbort(t *testing.T) {
+	for _, mode := range []string{"raw_file_eviction", "owner_replacement"} {
+		for _, boundary := range []string{"canonical_node", "fts_mapping"} {
+			t.Run(mode+"/"+boundary, func(t *testing.T) {
+				f := newBackendFTSFixture(t)
+				f.seed(t, "rollback", true)
+				// Use the public owner API to leave exactly A as the final owner.
+				// B's ordinary source/FTS remain positive unaffected controls.
+				_, err := graph.ReplaceContractOwners(f.store, graph.ContractOwnerReplacement{
+					RepoPrefix: "repo-b", FilePaths: []string{backendFTSFileB}, TouchedNodeIDs: []string{backendFTSCanonical},
+				})
+				require.NoError(t, err)
+				require.NotNil(t, f.store.GetNode(backendFTSCanonical))
+				require.Len(t, f.store.GetInEdges(backendFTSCanonical), 1)
+				f.close(t)
+				db, err := sql.Open("sqlite", f.path)
+				require.NoError(t, err)
+				// Fault injection is a fixture-only SQLite trigger, not a new
+				// production hook/private API. FTS virtual tables cannot have
+				// triggers; the ordinary rowid map is a supported later boundary
+				// after virtual-row deletion in the shared cleanup helper.
+				trigger := `CREATE TRIGGER contract_fts_fixture_abort BEFORE DELETE ON nodes
+WHEN OLD.id = 'env::BACKEND_FTS_SHARED' AND OLD.view_gen = 0
+BEGIN SELECT RAISE(ABORT, 'contract_fts_fixture_abort'); END`
+				if boundary == "fts_mapping" {
+					trigger = `CREATE TRIGGER contract_fts_fixture_abort BEFORE DELETE ON symbol_fts_rowid
+WHEN OLD.node_id = 'env::BACKEND_FTS_SHARED' AND OLD.view_gen = 0
+BEGIN SELECT RAISE(ABORT, 'contract_fts_fixture_abort'); END`
+				}
+				_, err = db.Exec(trigger)
+				require.NoError(t, err)
+				require.NoError(t, db.Close())
+				f.open(t)
+				before := backendFTSGeneration(t, f.db, 0)
+				virtualBefore := backendFTSRows(t, f.db, "SELECT rowid, * FROM symbol_fts")
+				canonicalBefore := backendFTSForNode(t, f.db, 0, backendFTSCanonical)
+				require.Len(t, before.nodes, 4)
+				require.Len(t, before.edges, 1)
+				require.Len(t, canonicalBefore.mapping, 1)
+				require.Len(t, canonicalBefore.virtual, 1)
+				if mode == "raw_file_eviction" {
+					// Actual public EvictFiles routes this SQLite failure through
+					// panicOnFatal. Preserve that existing error surface; recover
+					// only to inspect durable rollback, not to mask another panic.
+					var recovered any
+					func() {
+						defer func() { recovered = recover() }()
+						f.store.EvictFiles([]string{backendFTSFileA})
+					}()
+					require.NotNil(t, recovered, "the installed failure boundary must actually be reached")
+					require.Contains(t, fmt.Sprint(recovered), "contract_fts_fixture_abort")
+				} else {
+					_, err = graph.ReplaceContractOwners(f.store, graph.ContractOwnerReplacement{
+						RepoPrefix: "repo-a", FilePaths: []string{backendFTSFileA}, TouchedNodeIDs: []string{backendFTSCanonical},
+					})
+					require.ErrorContains(t, err, "contract_fts_fixture_abort", "the installed failure boundary must actually be reached")
+				}
+				require.Equal(t, before, backendFTSGeneration(t, f.db, 0), "failed mutation must roll back every selected node/edge/FTS/map column")
+				require.Equal(t, virtualBefore, backendFTSRows(t, f.db, "SELECT rowid, * FROM symbol_fts"), "rollback must restore deleted virtual rows, not merely their mappings")
+				require.NotNil(t, f.store.GetNode(backendFTSCanonical))
+				f.reopen(t)
+				require.Equal(t, before, backendFTSGeneration(t, f.db, 0), "rollback must remain intact after reopen")
+				require.Equal(t, virtualBefore, backendFTSRows(t, f.db, "SELECT rowid, * FROM symbol_fts"))
+				_, err = f.db.Exec("DROP TRIGGER contract_fts_fixture_abort")
+				require.NoError(t, err)
+				// Positive retry rules out an empty frontier/no-op masquerading
+				// as rollback after the expected public error/panic surface.
+				f.remove(t, mode, "repo-a", backendFTSFileA)
+				assert.Nil(t, f.store.GetNode(backendFTSCanonical))
+				backendFTSAssertGone(t, f.db, 0, backendFTSCanonical, canonicalBefore)
+				assert.NotNil(t, f.store.GetNode(backendFTSSourceB))
+				assert.NotNil(t, f.store.GetNode(backendFTSUnrelated))
+			})
+		}
+	}
+}
+
+const (
+	ownerFTSOrderF     = "repo/f.go::FTSOrderF"
+	ownerFTSOrderA     = "env::FTS_OWNER_PRUNE_A"
+	ownerFTSOrderB     = "env::FTS_OWNER_PRUNE_B"
+	ownerFTSOrderFileF = "repo/f.go"
+)
+
+func seedOwnerFTSPruneOrder(t *testing.T, f *backendFTSFixture, tag string) {
+	t.Helper()
+	f.store.AddBatch([]*graph.Node{
+		{ID: ownerFTSOrderF, Name: "F", Kind: graph.KindFunction, RepoPrefix: "repo", FilePath: ownerFTSOrderFileF, Meta: map[string]any{"fixture": tag}},
+		{ID: ownerFTSOrderA, Name: "A", Kind: graph.KindContract, RepoPrefix: "repo", FilePath: "repo/a.go", WorkspaceID: tag + "-wa", ProjectID: tag + "-pa", Meta: map[string]any{"contract_owner_record": true, "type": "env", "role": "provider", "contract_meta": map[string]any{"var": "FTS_OWNER_PRUNE_A", "fixture": tag}}},
+		{ID: ownerFTSOrderB, Name: "B", Kind: graph.KindContract, RepoPrefix: "repo", FilePath: "repo/b.go", WorkspaceID: tag + "-wb", ProjectID: tag + "-pb", Meta: map[string]any{"contract_owner_record": true, "type": "env", "role": "consumer", "contract_meta": map[string]any{"var": "FTS_OWNER_PRUNE_B", "fixture": tag}}},
+	}, []*graph.Edge{
+		{From: ownerFTSOrderF, To: ownerFTSOrderA, Kind: graph.EdgeProvides, FilePath: ownerFTSOrderFileF, Line: 11, Meta: map[string]any{"contract_owner_repo_prefix": "repo", "contract_owner_type": "env", "contract_owner_meta": map[string]any{"record": "F owns A", "fixture": tag}}},
+		{From: ownerFTSOrderA, To: ownerFTSOrderB, Kind: graph.EdgeConsumes, FilePath: "repo/b.go", Line: 23, Meta: map[string]any{"contract_owner_repo_prefix": "repo", "contract_owner_type": "env", "contract_owner_meta": map[string]any{"record": "A owns B", "fixture": tag}}},
+	})
+	batcher, ok := any(f.store).(graph.SymbolFTSBatchUpserter)
+	require.True(t, ok)
+	require.NoError(t, batcher.BatchUpsertSymbolFTS([]graph.SymbolFTSItem{
+		{NodeID: ownerFTSOrderF, Tokens: tag + " ordinary F"},
+		{NodeID: ownerFTSOrderA, Tokens: tag + " canonical A"},
+		{NodeID: ownerFTSOrderB, Tokens: tag + " canonical B"},
+	}))
+	require.Equal(t, 3, f.store.NodeCount())
+	require.Equal(t, 2, f.store.EdgeCount())
+	require.Len(t, f.store.GetInEdges(ownerFTSOrderA), 1)
+	require.Len(t, f.store.GetInEdges(ownerFTSOrderB), 1)
+	for _, id := range []string{ownerFTSOrderF, ownerFTSOrderA, ownerFTSOrderB} {
+		state := backendFTSForNode(t, f.db, 0, id)
+		require.Len(t, state.mapping, 1)
+		require.Len(t, state.virtual, 1)
+	}
+}
+
+func TestContractFTSOwnerPruningPreservesFinalNodeSet(t *testing.T) {
+	for _, boundary := range []string{"success", "final_B_node_abort", "final_B_fts_mapping_abort"} {
+		t.Run(boundary, func(t *testing.T) {
+			f := newBackendFTSFixture(t)
+			seedOwnerFTSPruneOrder(t, f, "sibling-seven")
+			f.close(t)
+			// Fixture-only generation setup on a closed disposable Store, using
+			// the already-established exact-column generation move. FTS virtual
+			// rowids stay fixed; the generation belongs to their rowid mapping.
+			db, err := sql.Open("sqlite", f.path)
+			require.NoError(t, err)
+			tx, err := db.Begin()
+			require.NoError(t, err)
+			for _, query := range []string{"UPDATE nodes SET view_gen = 7", "UPDATE edges SET view_gen = 7", "UPDATE symbol_fts_rowid SET view_gen = 7"} {
+				_, err = tx.Exec(query)
+				require.NoError(t, err)
+			}
+			require.NoError(t, tx.Commit())
+			historical := backendFTSGeneration(t, db, 7)
+			require.Len(t, historical.nodes, 3)
+			require.Len(t, historical.edges, 2)
+			require.Len(t, historical.mapping, 3)
+			require.Len(t, historical.virtual, 3)
+			require.NoError(t, db.Close())
+			f.open(t)
+			seedOwnerFTSPruneOrder(t, f, "selected-zero")
+			require.Equal(t, historical, backendFTSGeneration(t, f.db, 7))
+			before := backendFTSGeneration(t, f.db, 0)
+			virtualBefore := backendFTSRows(t, f.db, "SELECT rowid, * FROM symbol_fts")
+			ordinaryNode := backendFTSRows(t, f.db, "SELECT * FROM nodes WHERE id = ? AND view_gen = 0", ownerFTSOrderF)
+			ordinaryFTS := backendFTSForNode(t, f.db, 0, ownerFTSOrderF)
+			canonicalFTS := make(map[string]backendFTSState)
+			for _, id := range []string{ownerFTSOrderA, ownerFTSOrderB} {
+				canonicalFTS[id] = backendFTSForNode(t, f.db, 0, id)
+				require.NotEqual(t, canonicalFTS[id].virtual, backendFTSForNode(t, f.db, 7, id).virtual, "same-ID generations must have distinct positive FTS payloads and rowids")
+			}
+			replace := func() (graph.ContractOwnerReplaceResult, error) {
+				return graph.ReplaceContractOwners(f.store, graph.ContractOwnerReplacement{
+					RepoPrefix: "repo", FilePaths: []string{ownerFTSOrderFileF}, TouchedNodeIDs: []string{ownerFTSOrderA, ownerFTSOrderB},
+				})
+			}
+			if boundary != "success" {
+				f.close(t)
+				db, err = sql.Open("sqlite", f.path)
+				require.NoError(t, err)
+				trigger := `CREATE TRIGGER owner_fts_prune_order_abort BEFORE DELETE ON nodes
+WHEN OLD.id = 'env::FTS_OWNER_PRUNE_B' AND OLD.view_gen = 0
+BEGIN SELECT RAISE(ABORT, 'owner_fts_prune_order_abort'); END`
+				if boundary == "final_B_fts_mapping_abort" {
+					trigger = `CREATE TRIGGER owner_fts_prune_order_abort BEFORE DELETE ON symbol_fts_rowid
+WHEN OLD.node_id = 'env::FTS_OWNER_PRUNE_B' AND OLD.view_gen = 0
+BEGIN SELECT RAISE(ABORT, 'owner_fts_prune_order_abort'); END`
+				}
+				_, err = db.Exec(trigger)
+				require.NoError(t, err)
+				require.NoError(t, db.Close())
+				f.open(t)
+				_, err = replace()
+				require.ErrorContains(t, err, "owner_fts_prune_order_abort", "the final B boundary must actually be reached; initial-A-only pruning is not equivalent")
+				require.Equal(t, before, backendFTSGeneration(t, f.db, 0), "both contract/FTS rows and earlier owner-edge deletion must roll back")
+				require.Equal(t, virtualBefore, backendFTSRows(t, f.db, "SELECT rowid, * FROM symbol_fts"), "rollback restores exact virtual rows, not only their maps")
+				require.Equal(t, historical, backendFTSGeneration(t, f.db, 7))
+				f.reopen(t)
+				require.Equal(t, before, backendFTSGeneration(t, f.db, 0))
+				require.Equal(t, virtualBefore, backendFTSRows(t, f.db, "SELECT rowid, * FROM symbol_fts"))
+				require.Equal(t, historical, backendFTSGeneration(t, f.db, 7))
+				_, err = f.db.Exec("DROP TRIGGER owner_fts_prune_order_abort")
+				require.NoError(t, err)
+			}
+			result, err := replace()
+			require.NoError(t, err)
+			require.Equal(t, 2, result.NodesRemoved, "preserve SQLite's existing final orphan re-evaluation: remove A AND B")
+			require.Equal(t, 2, result.EdgesRemoved)
+			require.Equal(t, 1, f.store.NodeCount())
+			require.Zero(t, f.store.EdgeCount())
+			for _, id := range []string{ownerFTSOrderA, ownerFTSOrderB} {
+				require.Nil(t, f.store.GetNode(id))
+				backendFTSAssertGone(t, f.db, 0, id, canonicalFTS[id])
+			}
+			assert.Equal(t, ordinaryNode, backendFTSRows(t, f.db, "SELECT * FROM nodes WHERE id = ? AND view_gen = 0", ownerFTSOrderF))
+			assert.Equal(t, ordinaryFTS, backendFTSForNode(t, f.db, 0, ownerFTSOrderF))
+			assert.Equal(t, historical, backendFTSGeneration(t, f.db, 7), "every sibling node/edge/map/virtual column and rowid remains unchanged")
+			f.reopen(t)
+			for _, id := range []string{ownerFTSOrderA, ownerFTSOrderB} {
+				require.Nil(t, f.store.GetNode(id))
+				backendFTSAssertGone(t, f.db, 0, id, canonicalFTS[id])
+			}
+			assert.Equal(t, ordinaryFTS, backendFTSForNode(t, f.db, 0, ownerFTSOrderF))
+			assert.Equal(t, historical, backendFTSGeneration(t, f.db, 7))
+		})
+	}
+}

--- a/internal/graph/store_sqlite/contract_owner_replace.go
+++ b/internal/graph/store_sqlite/contract_owner_replace.go
@@ -1,6 +1,7 @@
 package store_sqlite
 
 import (
+	"database/sql"
 	"errors"
 
 	"github.com/zzet/gortex/internal/graph"
@@ -43,6 +44,14 @@ func (s *Store) ReplaceContractOwners(replacement graph.ContractOwnerReplacement
 	}()
 
 	result := graph.ContractOwnerReplaceResult{}
+	if hasFiles && hasTouched {
+		invalidated, invalidationErr := s.invalidateContractOwnerScalarsTx(
+			tx, replacement.RepoPrefix, filesJSON, touchedJSON)
+		if invalidationErr != nil {
+			return graph.ContractOwnerReplaceResult{}, invalidationErr
+		}
+		result.NodesChanged = invalidated
+	}
 	if hasFiles {
 		removed, execErr := tx.Exec(`
 WITH owner_files(file_path) AS (
@@ -77,7 +86,7 @@ WHERE kind IN (?, ?, ?)
 	if err != nil {
 		return graph.ContractOwnerReplaceResult{}, err
 	}
-	result.NodesChanged = nodesChanged
+	result.NodesChanged += nodesChanged
 	edgesAdded, _, _, err := insertEdgeChunksTx(tx, s.viewGen, replacement.Edges, false)
 	if err != nil {
 		return graph.ContractOwnerReplaceResult{}, err
@@ -85,6 +94,13 @@ WHERE kind IN (?, ?, ?)
 	result.EdgesAdded = edgesAdded
 
 	if hasTouched {
+		// Exact invalidation above retired only removed scalar records. A
+		// recoverable scalar from another file/repository remains a live owner
+		// even if this replacement removed the final incoming owner edge.
+		prunableJSON, err := s.prunableContractOwnerIDsTx(tx, touchedJSON)
+		if err != nil {
+			return graph.ContractOwnerReplaceResult{}, err
+		}
 		const orphanContractIDs = `
 WITH touched(id) AS (
     SELECT CAST(value AS TEXT) FROM json_each(?)
@@ -104,7 +120,7 @@ DELETE FROM edges
 WHERE (from_id IN (SELECT id FROM orphan)
     OR to_id IN (SELECT id FROM orphan))
   AND view_gen = ?`,
-			touchedJSON, s.viewGen, string(graph.KindContract),
+			prunableJSON, s.viewGen, string(graph.KindContract),
 			string(graph.EdgeProvides), string(graph.EdgeConsumes), string(graph.EdgeHandlesRoute),
 			s.viewGen, s.viewGen)
 		if execErr != nil {
@@ -118,7 +134,7 @@ WHERE (from_id IN (SELECT id FROM orphan)
 
 		removed, execErr = tx.Exec(orphanContractIDs+`
 DELETE FROM nodes WHERE id IN (SELECT id FROM orphan) AND view_gen = ?`,
-			touchedJSON, s.viewGen, string(graph.KindContract),
+			prunableJSON, s.viewGen, string(graph.KindContract),
 			string(graph.EdgeProvides), string(graph.EdgeConsumes), string(graph.EdgeHandlesRoute),
 			s.viewGen, s.viewGen)
 		if execErr != nil {
@@ -143,6 +159,82 @@ DELETE FROM nodes WHERE id IN (SELECT id FROM orphan) AND view_gen = ?`,
 	return result, nil
 }
 
+// invalidateContractOwnerScalarsTx runs only while the caller holds writeMu
+// and its existing replacement transaction. It reads bounded candidate rows
+// from the exact handle generation; no read-pool snapshot is blindly upserted.
+func (s *Store) invalidateContractOwnerScalarsTx(tx *sql.Tx, repo, filesJSON, touchedJSON string) (int, error) {
+	rows, err := tx.Query(`SELECT `+lookupNodeCols+` FROM nodes
+WHERE view_gen = ? AND kind = ? AND repo_prefix = ?
+  AND id IN (SELECT CAST(value AS TEXT) FROM json_each(?))
+  AND file_path IN (SELECT CAST(value AS TEXT) FROM json_each(?))`,
+		s.viewGen, string(graph.KindContract), repo, touchedJSON, filesJSON)
+	if err != nil {
+		return 0, err
+	}
+	var updates []*graph.Node
+	for rows.Next() {
+		node, scanErr := scanNodeCursor(rows)
+		if scanErr != nil {
+			_ = rows.Close()
+			return 0, scanErr
+		}
+		removed, _ := node.Meta["contract_owner_removed"].(bool)
+		ownerBacked, _ := node.Meta["contract_owner_record"].(bool)
+		if removed || ownerBacked {
+			continue
+		}
+		if node.Meta == nil {
+			node.Meta = make(map[string]any, 1)
+		}
+		node.Meta["contract_owner_removed"] = true
+		updates = append(updates, node)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return 0, err
+	}
+	if err := rows.Close(); err != nil {
+		return 0, err
+	}
+	changed, _, _, err := insertNodeChunksTx(tx, s.viewGen, updates, false)
+	return changed, err
+}
+
+func (s *Store) prunableContractOwnerIDsTx(tx *sql.Tx, touchedJSON string) (string, error) {
+	rows, err := tx.Query(`SELECT `+lookupNodeCols+` FROM nodes
+WHERE view_gen = ? AND kind = ?
+  AND id IN (SELECT CAST(value AS TEXT) FROM json_each(?))`,
+		s.viewGen, string(graph.KindContract), touchedJSON)
+	if err != nil {
+		return "", err
+	}
+	var ids []string
+	for rows.Next() {
+		node, scanErr := scanNodeCursor(rows)
+		if scanErr != nil {
+			_ = rows.Close()
+			return "", scanErr
+		}
+		removed, _ := node.Meta["contract_owner_removed"].(bool)
+		ownerBacked, _ := node.Meta["contract_owner_record"].(bool)
+		if removed || ownerBacked {
+			ids = append(ids, node.ID)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return "", err
+	}
+	if err := rows.Close(); err != nil {
+		return "", err
+	}
+	encoded, _ := projectionJSON(ids)
+	if encoded == "" {
+		encoded = "[]"
+	}
+	return encoded, nil
+}
+
 func nonEmptyProjectionJSON(values []string) (string, bool) {
 	filtered := make([]string, 0, len(values))
 	for _, value := range values {
@@ -154,8 +246,8 @@ func nonEmptyProjectionJSON(values []string) (string, bool) {
 }
 
 // contractOwnerPruneIDs omits current replacement nodes. A current contract
-// without a symbol has no provides/consumes edge but remains a valid extracted
-// contract; only IDs absent from the new file frontier are orphan candidates.
+// without an admitted source owner remains a valid extracted scalar; only IDs
+// absent from the new file frontier are orphan candidates.
 func contractOwnerPruneIDs(replacement graph.ContractOwnerReplacement) []string {
 	current := make(map[string]struct{}, len(replacement.Nodes))
 	for _, node := range replacement.Nodes {

--- a/internal/graph/store_sqlite/contract_owner_replace.go
+++ b/internal/graph/store_sqlite/contract_owner_replace.go
@@ -9,6 +9,10 @@ import (
 
 var _ graph.ContractOwnerReplacer = (*Store)(nil)
 
+// ContractOwnerScalarLivenessGuaranteed reports the conditional legacy scalar
+// invalidation performed inside ReplaceContractOwners' existing transaction.
+func (s *Store) ContractOwnerScalarLivenessGuaranteed() bool { return true }
+
 // ReplaceContractOwners atomically replaces only the contract-ownership rows
 // emitted by an exact repository/file frontier. Canonical contract IDs may be
 // shared by several repositories, so stale edge deletion is guarded by both
@@ -132,11 +136,41 @@ WHERE (from_id IN (SELECT id FROM orphan)
 		}
 		result.EdgesRemoved += int(rows)
 
-		removed, execErr = tx.Exec(orphanContractIDs+`
-DELETE FROM nodes WHERE id IN (SELECT id FROM orphan) AND view_gen = ?`,
+		orphanRows, err := tx.Query(orphanContractIDs+`SELECT id FROM orphan`,
 			prunableJSON, s.viewGen, string(graph.KindContract),
 			string(graph.EdgeProvides), string(graph.EdgeConsumes), string(graph.EdgeHandlesRoute),
-			s.viewGen, s.viewGen)
+			s.viewGen)
+		if err != nil {
+			return graph.ContractOwnerReplaceResult{}, err
+		}
+		var orphanIDs []string
+		for orphanRows.Next() {
+			var id string
+			if err := orphanRows.Scan(&id); err != nil {
+				_ = orphanRows.Close()
+				return graph.ContractOwnerReplaceResult{}, err
+			}
+			orphanIDs = append(orphanIDs, id)
+		}
+		if err := orphanRows.Err(); err != nil {
+			_ = orphanRows.Close()
+			return graph.ContractOwnerReplaceResult{}, err
+		}
+		if err := orphanRows.Close(); err != nil {
+			return graph.ContractOwnerReplaceResult{}, err
+		}
+		// Preserve the existing edge-delete then orphan-reevaluation order.
+		// Freeze the final node-deletion set so FTS and node cleanup agree
+		// within this transaction and selected payload generation.
+		if err := s.deleteSymbolFTSTx(tx, orphanIDs); err != nil {
+			return graph.ContractOwnerReplaceResult{}, err
+		}
+		frozenJSON, _ := projectionJSON(orphanIDs)
+		if frozenJSON == "" {
+			frozenJSON = "[]"
+		}
+		removed, execErr = tx.Exec(`DELETE FROM nodes
+WHERE id IN (SELECT CAST(value AS TEXT) FROM json_each(?)) AND view_gen = ?`, frozenJSON, s.viewGen)
 		if execErr != nil {
 			return graph.ContractOwnerReplaceResult{}, execErr
 		}

--- a/internal/graph/store_sqlite/contract_owner_scalar_backend_test.go
+++ b/internal/graph/store_sqlite/contract_owner_scalar_backend_test.go
@@ -1,0 +1,120 @@
+package store_sqlite_test
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+)
+
+func scalarBackendFixture(t *testing.T, backend string) graph.Store {
+	t.Helper()
+	if backend == "memory" {
+		return graph.New()
+	}
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	return store
+}
+
+func scalarBackendSnapshot(t *testing.T, value any) string {
+	t.Helper()
+	if node, ok := value.(*graph.Node); ok && node != nil {
+		value = struct {
+			Node *graph.Node
+			Meta map[string]any
+		}{node, node.Meta}
+	}
+	encoded, err := json.Marshal(value)
+	require.NoError(t, err)
+	return string(encoded)
+}
+
+func TestContractOwnerReplacementRetiresOnlyRemovedScalar(t *testing.T) {
+	for _, backend := range []string{"memory", "sqlite"} {
+		for _, sameRepo := range []bool{false, true} {
+			name := "cross_repository"
+			if sameRepo {
+				name = "same_repository"
+			}
+			t.Run(backend+"/"+name, func(t *testing.T) {
+				store := scalarBackendFixture(t, backend)
+				repoA, repoB := "a", "b"
+				if sameRepo {
+					repoB = repoA
+				}
+				const id = "env::SHARED"
+				fileA, fileB := repoA+"/provider.env", repoB+"/consumer.go"
+				sourceA := &graph.Node{ID: "source-a", Kind: graph.KindFile, RepoPrefix: repoA, FilePath: fileA}
+				sourceB := &graph.Node{ID: "source-b", Kind: graph.KindFunction, RepoPrefix: repoB, FilePath: fileB}
+				canonical := &graph.Node{ID: id, Kind: graph.KindContract, RepoPrefix: repoA, FilePath: fileA, WorkspaceID: "workspace-a", ProjectID: "project-a", Meta: map[string]any{"type": "env", "role": "provider", "symbol_id": "", "contract_meta": map[string]any{"var": "SHARED", "nested": []any{"a", true}}}}
+				edgeA := &graph.Edge{From: sourceA.ID, To: id, Kind: graph.EdgeProvides, FilePath: fileA, Line: 1}
+				edgeB := &graph.Edge{From: sourceB.ID, To: id, Kind: graph.EdgeConsumes, FilePath: fileB, Line: 7, Meta: map[string]any{"contract_owner_repo_prefix": repoB, "contract_owner_workspace_id": "workspace-b", "contract_owner_meta": map[string]any{"var": "SHARED", "payload": []any{"b", true}}}}
+				store.AddBatch([]*graph.Node{sourceA, sourceB, canonical}, []*graph.Edge{edgeA, edgeB})
+				rows := graph.ReadRepoEdgesByKinds(store, []string{repoB}, []graph.EdgeKind{graph.EdgeConsumes})
+				require.Len(t, rows, 1)
+				beforeB := scalarBackendSnapshot(t, struct {
+					Edge *graph.Edge
+					Meta map[string]any
+				}{rows[0].Edge, rows[0].Edge.Meta})
+				beforeMeta := store.GetNode(id).Meta
+				frontierA := graph.ContractOwnerReplacement{RepoPrefix: repoA, FilePaths: []string{fileA}, TouchedNodeIDs: []string{id, id}}
+				result, err := graph.ReplaceContractOwners(store, frontierA)
+				require.NoError(t, err)
+				assert.Equal(t, 1, result.NodesChanged)
+				assert.Equal(t, 1, result.EdgesRemoved)
+				assert.Zero(t, result.NodesRemoved)
+				remaining := store.GetNode(id)
+				require.NotNil(t, remaining)
+				assert.Equal(t, true, remaining.Meta["contract_owner_removed"], "retained canonical must not resurrect removed scalar A")
+				assert.Equal(t, scalarBackendSnapshot(t, beforeMeta["contract_meta"]), scalarBackendSnapshot(t, remaining.Meta["contract_meta"]))
+				rows = graph.ReadRepoEdgesByKinds(store, []string{repoB}, []graph.EdgeKind{graph.EdgeConsumes})
+				require.Len(t, rows, 1)
+				assert.Equal(t, beforeB, scalarBackendSnapshot(t, struct {
+					Edge *graph.Edge
+					Meta map[string]any
+				}{rows[0].Edge, rows[0].Edge.Meta}), "sibling owner payload must survive unchanged")
+				repeated, err := graph.ReplaceContractOwners(store, frontierA)
+				require.NoError(t, err)
+				assert.Equal(t, graph.ContractOwnerReplaceResult{}, repeated, "repeat replacement is mutation-free")
+				last, err := graph.ReplaceContractOwners(store, graph.ContractOwnerReplacement{RepoPrefix: repoB, FilePaths: []string{fileB}, TouchedNodeIDs: []string{id}})
+				require.NoError(t, err)
+				assert.Equal(t, 1, last.NodesRemoved)
+				assert.Nil(t, store.GetNode(id))
+				assert.Empty(t, store.GetInEdges(id))
+				assert.Empty(t, store.GetOutEdges(id))
+				assert.NotNil(t, store.GetNode(sourceB.ID), "contract replacement does not evict source declarations")
+			})
+		}
+	}
+}
+
+func TestContractOwnerReplacementPreservesUnremovedLegacyScalar(t *testing.T) {
+	for _, backend := range []string{"memory", "sqlite"} {
+		t.Run(backend, func(t *testing.T) {
+			store := scalarBackendFixture(t, backend)
+			const id = "env::SCALAR_ONLY_SIBLING"
+			const fileA, fileB = "a/consumer.go", "b/provider.env"
+			source := &graph.Node{ID: "source-a", Kind: graph.KindFunction, RepoPrefix: "a", FilePath: fileA}
+			canonical := &graph.Node{ID: id, Kind: graph.KindContract, RepoPrefix: "b", FilePath: fileB, WorkspaceID: "workspace-b", ProjectID: "project-b", Meta: map[string]any{"type": "env", "role": "provider", "symbol_id": "", "contract_meta": map[string]any{"var": "SCALAR_ONLY_SIBLING", "nested": []any{"b", true}}}}
+			store.AddBatch([]*graph.Node{source, canonical}, []*graph.Edge{{From: source.ID, To: id, Kind: graph.EdgeConsumes, FilePath: fileA}})
+			before := scalarBackendSnapshot(t, store.GetNode(id))
+			result, err := graph.ReplaceContractOwners(store, graph.ContractOwnerReplacement{RepoPrefix: "a", FilePaths: []string{fileA}, TouchedNodeIDs: []string{id}})
+			require.NoError(t, err)
+			assert.Equal(t, 1, result.EdgesRemoved)
+			assert.Zero(t, result.NodesChanged)
+			assert.Zero(t, result.NodesRemoved)
+			require.NotNil(t, store.GetNode(id), "B's scalar is a live legacy record without an owner edge")
+			assert.Equal(t, before, scalarBackendSnapshot(t, store.GetNode(id)))
+			last, err := graph.ReplaceContractOwners(store, graph.ContractOwnerReplacement{RepoPrefix: "b", FilePaths: []string{fileB}, TouchedNodeIDs: []string{id}})
+			require.NoError(t, err)
+			assert.Equal(t, 1, last.NodesRemoved)
+			assert.Nil(t, store.GetNode(id))
+		})
+	}
+}

--- a/internal/graph/store_sqlite/file_batch_evict.go
+++ b/internal/graph/store_sqlite/file_batch_evict.go
@@ -161,6 +161,24 @@ func (s *Store) evictByPredicateResult(predicate string, arg any, scope evictSco
 			return 0, 0, err
 		}
 	}
+	// A repository's first cold drain has no existing nodes, but the incoming
+	// edge DELETE can still scan the growing edge table while its index is
+	// deferred. Prove emptiness in the same writer transaction and generation
+	// as the deletes: persisted repository counters are not a freshness proof.
+	// Sidecar cleanup stays above this guard because bindings and failures can
+	// outlive every candidate node.
+	var hasCandidates bool
+	if err := tx.QueryRowContext(ctx, `SELECT EXISTS(SELECT 1 FROM nodes WHERE `+scoped+` LIMIT 1)`, scopeArgs...).Scan(&hasCandidates); err != nil {
+		return 0, 0, err
+	}
+	if !hasCandidates {
+		if err := tx.Commit(); err != nil {
+			return 0, 0, err
+		}
+		s.finishAnalysisMutationLocked(false)
+		return 0, 0, nil
+	}
+
 	scopedNodes := `SELECT id FROM nodes WHERE ` + scoped
 	for _, column := range []string{"from_id", "to_id"} {
 		result, err := tx.ExecContext(ctx, `DELETE FROM edges WHERE `+column+` IN (`+scopedNodes+`)`+edgeScope, edgeArgs...)

--- a/internal/graph/store_sqlite/file_batch_evict.go
+++ b/internal/graph/store_sqlite/file_batch_evict.go
@@ -2,6 +2,9 @@ package store_sqlite
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
 
 	"github.com/zzet/gortex/internal/graph"
 )
@@ -26,8 +29,8 @@ const (
 
 // EvictFiles removes a bounded file replacement set in one transaction. The
 // two edge deletes deliberately use indexed from_id/to_id predicates instead
-// of an OR expression, and keep the candidate node set inside SQLite rather
-// than materialising every node ID in Go.
+// of an OR expression. Ordinary node frontiers stay in SQLite; only affected
+// shared contract records are read to preserve surviving owners.
 func (s *Store) EvictFiles(filePaths []string) (nodesRemoved, edgesRemoved int) {
 	paths := make([]string, 0, len(filePaths))
 	seen := make(map[string]struct{}, len(filePaths))
@@ -67,10 +70,10 @@ func (s *Store) evictByPredicate(predicate string, arg any, scope evictScope) (n
 }
 
 // evictByPredicateResult keeps the entire binding/edge/node change in one
-// IMMEDIATE transaction. Candidate node IDs remain in SQLite: the two indexed
-// edge deletes consume the same predicate subquery directly, so scope size
-// never creates a Go ID frontier or a DELETE-per-node loop. The one exception
-// is the exact-receipt path: while a mutation receipt is active, a bounded
+// IMMEDIATE transaction. Ordinary node IDs remain in SQLite; the bounded
+// contract-only plan freezes shared canonical retention before the two indexed
+// edge deletes. Active observation receipts additionally read doomed identities:
+// the exact-receipt path while a mutation receipt is active, a bounded
 // this-generation file eviction reads the doomed nodes' identities first (same
 // pattern as mutationNodeIdentitiesTx — paid only while receipts observe) so
 // the receipt can stay complete instead of forcing the whole-graph fallback
@@ -95,58 +98,11 @@ func (s *Store) evictByPredicateResult(predicate string, arg any, scope evictSco
 	// subquery and once on the edge row itself, so an edge cannot be dragged out
 	// of another generation by a node id this one also uses.
 	scoped, scopeArgs := predicate, []any{arg}
-	edgeScope, edgeArgs := "", []any{arg}
+	edgeScope := ""
 	if scope == evictThisGeneration {
 		scoped += ` AND view_gen = ?`
 		scopeArgs = append(scopeArgs, s.viewGen)
 		edgeScope = ` AND view_gen = ?`
-		edgeArgs = append(edgeArgs, s.viewGen, s.viewGen)
-	}
-	// A failure in this receipt-only read degrades the receipt to incomplete
-	// (receiptDelta stays nil, the post-commit branch marks the fallback)
-	// rather than blocking the eviction itself - the same choice
-	// prepareSQLiteReindexReceiptTx makes for its identity read.
-	//
-	// The read is bound to the same generation scope as the eviction itself
-	// (scoped/scopeArgs), so it describes exactly the rows this handle will
-	// delete and never another generation's copy of the same path. Only a
-	// this-generation file eviction is bounded enough to describe exactly; an
-	// all-generations repo sweep never takes this path.
-	var receiptDelta *sqliteMutationReceiptAccumulator
-	if scope == evictThisGeneration && s.hasActiveMutationReceiptsLocked() {
-		// The DELETEs below remove every edge touching a doomed node,
-		// including edges whose SOURCE survives. restubIncomingRefs parks the
-		// IsResolvableRefEdge kinds under a stub first, so those stay
-		// described by the name and file frontiers; the rest -
-		// accesses_field, arg_of, tests, imports, contains - are destroyed.
-		//
-		// An earlier revision probed for exactly that and failed the receipt
-		// closed, forcing the whole-graph fallback resolve. The fallback
-		// cannot repair it: it retargets edges that still exist and are
-		// parked under a stub, and a deleted edge is neither. Both paths
-		// reach the same graph, so the probe bought only the cost of the
-		// larger pass, and on a real package it fired on nearly every
-		// reindex. The eviction still describes its RESOLUTION delta
-		// exactly, which is the only question a receipt answers; the
-		// destruction is a real pre-existing defect tracked separately.
-		delta := newSQLiteMutationReceiptAccumulator()
-		rows, err := tx.QueryContext(ctx, `SELECT id, kind, name, qual_name, file_path FROM nodes WHERE `+scoped, scopeArgs...)
-		if err == nil {
-			for rows.Next() {
-				var id, kind, name, qualName, filePath string
-				if err = rows.Scan(&id, &kind, &name, &qualName, &filePath); err != nil {
-					break
-				}
-				recordSQLiteEvictedNode(delta, id, kind, name, qualName, filePath)
-			}
-			if err == nil {
-				err = rows.Err()
-			}
-			_ = rows.Close()
-		}
-		if err == nil {
-			receiptDelta = delta
-		}
 	}
 	// The binding sidecar follows the node/edge scope: an unscoped sweep would
 	// strand bindings against nodes that no longer exist, and a scoped one must
@@ -179,7 +135,78 @@ func (s *Store) evictByPredicateResult(predicate string, arg any, scope evictSco
 		return 0, 0, nil
 	}
 
-	scopedNodes := `SELECT id FROM nodes WHERE ` + scoped
+	// File eviction may retain shared canonicals or retire off-file targets
+	// whose final source owner is removed. Repository eviction is unchanged.
+	nodeScoped, nodeArgs := scoped, append([]any(nil), scopeArgs...)
+	plan := contractFileEvictionPlan{}
+	if scope == evictThisGeneration && (predicate == evictFilePredicate || predicate == evictFilesPredicate) {
+		plan, err = s.planContractFileEvictionTx(tx, predicate, arg, scoped, scopeArgs)
+		if err != nil {
+			return 0, 0, err
+		}
+		if plan.affectedJSON != "" {
+			nodeScoped = `((` + scoped + `) AND kind <> ?) OR (id IN (SELECT CAST(value AS TEXT) FROM json_each(?)) AND kind = ? AND view_gen = ?)`
+			nodeArgs = append(nodeArgs, string(graph.KindContract), plan.orphanJSON, string(graph.KindContract), s.viewGen)
+		}
+	}
+	// Node subqueries and their edge-generation residual bind independently.
+	edgeArgs := append(append([]any(nil), nodeArgs...), s.viewGen)
+	if scope != evictThisGeneration {
+		edgeArgs = append([]any(nil), nodeArgs...)
+	}
+	// A failure in this receipt-only read degrades the receipt to incomplete
+	// (receiptDelta stays nil, the post-commit branch marks the fallback)
+	// rather than blocking the eviction itself - the same choice
+	// prepareSQLiteReindexReceiptTx makes for its identity read.
+	//
+	// The read is bound to the same generation scope as the eviction itself
+	// (scoped/scopeArgs), so it describes exactly the rows this handle will
+	// delete and never another generation's copy of the same path. Only a
+	// this-generation file eviction is bounded enough to describe exactly; an
+	// all-generations repo sweep never takes this path.
+	var receiptDelta *sqliteMutationReceiptAccumulator
+	if scope == evictThisGeneration && s.hasActiveMutationReceiptsLocked() {
+		// The DELETEs below remove every edge touching a doomed node,
+		// including edges whose SOURCE survives. restubIncomingRefs parks the
+		// IsResolvableRefEdge kinds under a stub first, so those stay
+		// described by the name and file frontiers; the rest -
+		// accesses_field, arg_of, tests, imports, contains - are destroyed.
+		//
+		// An earlier revision probed for exactly that and failed the receipt
+		// closed, forcing the whole-graph fallback resolve. The fallback
+		// cannot repair it: it retargets edges that still exist and are
+		// parked under a stub, and a deleted edge is neither. Both paths
+		// reach the same graph, so the probe bought only the cost of the
+		// larger pass, and on a real package it fired on nearly every
+		// reindex. The eviction still describes its RESOLUTION delta
+		// exactly, which is the only question a receipt answers; the
+		// destruction is a real pre-existing defect tracked separately.
+		delta := newSQLiteMutationReceiptAccumulator()
+		rows, err := tx.QueryContext(ctx, `SELECT id, kind, name, qual_name, file_path FROM nodes WHERE `+nodeScoped, nodeArgs...)
+		if err == nil {
+			for rows.Next() {
+				var id, kind, name, qualName, filePath string
+				if err = rows.Scan(&id, &kind, &name, &qualName, &filePath); err != nil {
+					break
+				}
+				recordSQLiteEvictedNode(delta, id, kind, name, qualName, filePath)
+			}
+			if err == nil {
+				err = rows.Err()
+			}
+			_ = rows.Close()
+		}
+		if err == nil {
+			receiptDelta = delta
+		}
+	}
+	scalarChanges, ownerEdgesRemoved, err := s.applyContractFileEvictionTx(tx, plan)
+	if err != nil {
+		return 0, 0, err
+	}
+	edgesRemoved += ownerEdgesRemoved
+
+	scopedNodes := `SELECT id FROM nodes WHERE ` + nodeScoped
 	for _, column := range []string{"from_id", "to_id"} {
 		result, err := tx.ExecContext(ctx, `DELETE FROM edges WHERE `+column+` IN (`+scopedNodes+`)`+edgeScope, edgeArgs...)
 		if err != nil {
@@ -191,7 +218,7 @@ func (s *Store) evictByPredicateResult(predicate string, arg any, scope evictSco
 		}
 		edgesRemoved += int(removed)
 	}
-	result, err := tx.ExecContext(ctx, `DELETE FROM nodes WHERE `+scoped, scopeArgs...)
+	result, err := tx.ExecContext(ctx, `DELETE FROM nodes WHERE `+nodeScoped, nodeArgs...)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -200,7 +227,7 @@ func (s *Store) evictByPredicateResult(predicate string, arg any, scope evictSco
 		return 0, 0, err
 	}
 	nodesRemoved = int(removed)
-	changed := nodesRemoved > 0 || edgesRemoved > 0
+	changed := nodesRemoved > 0 || edgesRemoved > 0 || scalarChanges > 0
 	invalidatedAnalysis := false
 	if changed && s.analysisGenerationPresent {
 		if err := invalidateAnalysisGenerationTx(tx); err != nil {
@@ -217,7 +244,7 @@ func (s *Store) evictByPredicateResult(predicate string, arg any, scope evictSco
 	}
 	s.finishAnalysisMutationLocked(changed)
 	if changed {
-		if receiptDelta != nil {
+		if receiptDelta != nil && scalarChanges == 0 {
 			s.mergeMutationReceiptLocked(receiptDelta)
 		} else {
 			s.markMutationReceiptsIncompleteLocked()
@@ -275,3 +302,277 @@ var (
 	_ graph.AllGenerationsRepoEvicter        = (*Store)(nil)
 	_ graph.CheckedAllGenerationsRepoEvicter = (*Store)(nil)
 )
+
+// contractFileEvictionPlan freezes the bounded canonical frontier before any
+// owner edge is deleted. Ordinary node rows stay in SQL; only endangered
+// contract records and their incoming owner payloads are hydrated.
+type contractFileEvictionPlan struct {
+	affectedJSON  string
+	orphanJSON    string
+	orphanIDs     []string
+	filesJSON     string
+	scalarUpdates []*graph.Node
+}
+
+func (s *Store) planContractFileEvictionTx(tx *sql.Tx, predicate string, arg any, scoped string, scopeArgs []any) (contractFileEvictionPlan, error) {
+	var plan contractFileEvictionPlan
+	if predicate != evictFilePredicate && predicate != evictFilesPredicate {
+		return plan, nil
+	}
+	value, ok := arg.(string)
+	if !ok {
+		return plan, errors.New("invalid file eviction argument")
+	}
+	var files []string
+	if predicate == evictFilePredicate {
+		files = []string{value} // Direct EvictFile retains its empty-path semantics.
+		plan.filesJSON, _ = projectionJSON(files)
+	} else {
+		plan.filesJSON = value
+		if err := json.Unmarshal([]byte(value), &files); err != nil {
+			return plan, err
+		}
+	}
+	fileSet := make(map[string]struct{}, len(files))
+	for _, path := range files {
+		fileSet[path] = struct{}{}
+	}
+	// The second arm follows only outgoing owners of doomed source nodes.
+	// An owner whose file matches but whose two endpoints both survive was
+	// outside EvictFiles' old frontier and remains outside it here.
+	affected := `SELECT id FROM nodes WHERE ` + scoped + `
+UNION
+SELECT to_id FROM edges WHERE from_id IN (SELECT id FROM nodes WHERE ` + scoped + `)
+  AND view_gen = ? AND kind IN (?, ?, ?)`
+	args := []any{s.viewGen, string(graph.KindContract)}
+	args = append(args, scopeArgs...)
+	args = append(args, scopeArgs...)
+	args = append(args, s.viewGen, string(graph.EdgeProvides), string(graph.EdgeConsumes), string(graph.EdgeHandlesRoute))
+	//nolint:rowserrcheck // readNodes checks Err and closes every result below.
+	rows, err := tx.Query(`SELECT `+lookupNodeCols+` FROM nodes
+WHERE view_gen = ? AND kind = ? AND id IN (`+affected+`)`, args...)
+	if err != nil {
+		return plan, err
+	}
+	nodes := make(map[string]*graph.Node)
+	var ids []string
+	readNodes := func(rows *sql.Rows) ([]string, error) {
+		var added []string
+		for rows.Next() {
+			node, scanErr := scanNodeCursor(rows)
+			if scanErr != nil {
+				_ = rows.Close()
+				return nil, scanErr
+			}
+			if nodes[node.ID] != nil {
+				continue
+			}
+			nodes[node.ID] = node
+			ids = append(ids, node.ID)
+			added = append(added, node.ID)
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		return added, rows.Close()
+	}
+	pending, err := readNodes(rows)
+	if err != nil {
+		return plan, err
+	}
+	if len(pending) == 0 {
+		return plan, nil
+	}
+	liveOwners := make(map[string]int)
+	dependents := make(map[string][]string)
+	doomed := make(map[string]bool)
+	var orphanIDs []string
+	discovered := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		discovered[id] = true
+	}
+	// Every canonical is hydrated and has incoming owners read once. Every
+	// newly doomed canonical's outgoing owners are followed once, in fixed
+	// batches. This is an incident closure, never a scan of all ownership rows.
+	// Doomed membership is monotone and fixed before any edge DELETE.
+	for len(pending) > 0 {
+		for start := 0; start < len(pending); start += 128 {
+			chunkJSON, _ := projectionJSON(pending[start:min(start+128, len(pending))])
+			rows, err = tx.Query(`SELECT owner.to_id, owner.from_id, source.repo_prefix, owner.meta
+FROM edges AS owner
+JOIN nodes AS source ON source.id = owner.from_id AND source.view_gen = ?
+WHERE owner.to_id IN (SELECT CAST(value AS TEXT) FROM json_each(?))
+  AND owner.view_gen = ? AND owner.kind IN (?, ?, ?)
+  AND source.file_path NOT IN (SELECT CAST(value AS TEXT) FROM json_each(?))
+  AND owner.file_path NOT IN (SELECT CAST(value AS TEXT) FROM json_each(?))`,
+				s.viewGen, chunkJSON, s.viewGen,
+				string(graph.EdgeProvides), string(graph.EdgeConsumes), string(graph.EdgeHandlesRoute),
+				plan.filesJSON, plan.filesJSON)
+			if err != nil {
+				return plan, err
+			}
+			for rows.Next() {
+				var id, source, repo string
+				var blob []byte
+				if err := rows.Scan(&id, &source, &repo, &blob); err != nil {
+					_ = rows.Close()
+					return plan, err
+				}
+				if len(blob) > 0 {
+					meta, err := decodeMeta(blob)
+					if err != nil {
+						_ = rows.Close()
+						return plan, err
+					}
+					if claimed, explicit := meta["contract_owner_repo_prefix"].(string); explicit && claimed != repo {
+						continue
+					}
+				}
+				if !doomed[source] {
+					liveOwners[id]++
+				}
+				dependents[source] = append(dependents[source], id)
+			}
+			if err := rows.Err(); err != nil {
+				_ = rows.Close()
+				return plan, err
+			}
+			if err := rows.Close(); err != nil {
+				return plan, err
+			}
+		}
+		queue := append([]string(nil), pending...)
+		var newlyDoomed []string
+		for head := 0; head < len(queue); head++ {
+			id := queue[head]
+			if doomed[id] {
+				continue
+			}
+			node := nodes[id]
+			_, fileRemoved := fileSet[node.FilePath]
+			removed, _ := node.Meta["contract_owner_removed"].(bool)
+			ownerBacked, _ := node.Meta["contract_owner_record"].(bool)
+			if !fileRemoved && !removed && !ownerBacked {
+				continue // A genuine outside-frontier legacy record survives.
+			}
+			if liveOwners[id] > 0 {
+				continue
+			}
+			doomed[id] = true
+			orphanIDs = append(orphanIDs, id)
+			newlyDoomed = append(newlyDoomed, id)
+			// A newly doomed off-file canonical is no longer a live source
+			// owner for another already-loaded candidate.
+			for _, dependent := range dependents[id] {
+				liveOwners[dependent]--
+				if liveOwners[dependent] == 0 {
+					queue = append(queue, dependent)
+				}
+			}
+		}
+		pending = nil
+		for start := 0; start < len(newlyDoomed); start += 128 {
+			chunkJSON, _ := projectionJSON(newlyDoomed[start:min(start+128, len(newlyDoomed))])
+			// Discover target IDs first so a high-fan-in canonical is not
+			// repeatedly decoded when many doomed owners name it.
+			rows, err = tx.Query(`SELECT DISTINCT to_id FROM edges
+WHERE from_id IN (SELECT CAST(value AS TEXT) FROM json_each(?))
+  AND view_gen = ? AND kind IN (?, ?, ?)`, chunkJSON, s.viewGen,
+				string(graph.EdgeProvides), string(graph.EdgeConsumes), string(graph.EdgeHandlesRoute))
+			if err != nil {
+				return plan, err
+			}
+			var unseen []string
+			for rows.Next() {
+				var id string
+				if err := rows.Scan(&id); err != nil {
+					_ = rows.Close()
+					return plan, err
+				}
+				if !discovered[id] {
+					discovered[id] = true
+					unseen = append(unseen, id)
+				}
+			}
+			if err := rows.Err(); err != nil {
+				_ = rows.Close()
+				return plan, err
+			}
+			if err := rows.Close(); err != nil {
+				return plan, err
+			}
+			for offset := 0; offset < len(unseen); offset += 128 {
+				targetJSON, _ := projectionJSON(unseen[offset:min(offset+128, len(unseen))])
+				//nolint:rowserrcheck // readNodes checks Err and closes every result below.
+				rows, err = tx.Query(`SELECT `+lookupNodeCols+` FROM nodes
+WHERE view_gen = ? AND kind = ?
+  AND id IN (SELECT CAST(value AS TEXT) FROM json_each(?))`,
+					s.viewGen, string(graph.KindContract), targetJSON)
+				if err != nil {
+					return plan, err
+				}
+				added, err := readNodes(rows)
+				if err != nil {
+					return plan, err
+				}
+				pending = append(pending, added...)
+			}
+		}
+	}
+	for _, id := range ids {
+		if doomed[id] {
+			continue
+		}
+		node := nodes[id]
+		_, fileRemoved := fileSet[node.FilePath]
+		removed, _ := node.Meta["contract_owner_removed"].(bool)
+		ownerBacked, _ := node.Meta["contract_owner_record"].(bool)
+		if fileRemoved && !removed && !ownerBacked {
+			if node.Meta == nil {
+				node.Meta = make(map[string]any, 1)
+			}
+			node.Meta["contract_owner_removed"] = true
+			plan.scalarUpdates = append(plan.scalarUpdates, node)
+		}
+	}
+	plan.affectedJSON, _ = projectionJSON(ids)
+	// JSON projection binds a single parameter regardless of contract count.
+	// Keep this frozen: deleting owner edges must not change orphan identity
+	// between the outgoing/incoming edge deletes and the node delete.
+	plan.orphanIDs = orphanIDs
+	plan.orphanJSON, _ = projectionJSON(orphanIDs)
+	if plan.orphanJSON == "" {
+		plan.orphanJSON = "[]"
+	}
+	return plan, nil
+}
+
+func (s *Store) applyContractFileEvictionTx(tx *sql.Tx, plan contractFileEvictionPlan) (nodesChanged, edgesRemoved int, err error) {
+	if plan.affectedJSON == "" {
+		return 0, 0, nil
+	}
+	// Only frozen actually-doomed canonical IDs are removed from FTS. Ordinary
+	// raw file-eviction FTS accounting remains the caller's responsibility.
+	if err = s.deleteSymbolFTSTx(tx, plan.orphanIDs); err != nil {
+		return 0, 0, err
+	}
+	nodesChanged, _, _, err = insertNodeChunksTx(tx, s.viewGen, plan.scalarUpdates, false)
+	if err != nil {
+		return 0, 0, err
+	}
+	// A retained canonical used to be deleted wholesale. Retire its removed
+	// file's incident owner rows even when their symbolic source survives.
+	// Do not discover unrelated FilePath-only edges outside affectedJSON.
+	result, err := tx.Exec(`DELETE FROM edges
+WHERE to_id IN (SELECT CAST(value AS TEXT) FROM json_each(?))
+  AND file_path IN (SELECT CAST(value AS TEXT) FROM json_each(?))
+  AND view_gen = ? AND kind IN (?, ?, ?)`,
+		plan.affectedJSON, plan.filesJSON, s.viewGen,
+		string(graph.EdgeProvides), string(graph.EdgeConsumes), string(graph.EdgeHandlesRoute))
+	if err != nil {
+		return 0, 0, err
+	}
+	count, err := result.RowsAffected()
+	return nodesChanged, int(count), err
+}

--- a/internal/graph/store_sqlite/file_contract_owner_evict_test.go
+++ b/internal/graph/store_sqlite/file_contract_owner_evict_test.go
@@ -1,0 +1,416 @@
+package store_sqlite_test
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+)
+
+func sqliteContractFileStore(t *testing.T) *store_sqlite.Store {
+	t.Helper()
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	return store
+}
+
+func sqliteContractFileNode(id, path, repo string) *graph.Node {
+	return &graph.Node{ID: id, Name: id, Kind: graph.KindFunction, FilePath: path, RepoPrefix: repo}
+}
+
+func sqliteContractFileCanonical(id, path, repo string, backed, removed bool) *graph.Node {
+	return &graph.Node{ID: id, Name: id, Kind: graph.KindContract, FilePath: path, RepoPrefix: repo, Meta: map[string]any{
+		"type": "env", "role": "provider", "contract_owner_record": backed, "contract_owner_removed": removed,
+		"contract_meta": map[string]any{"nested": map[string]any{"values": []any{"preserve", "payload"}}},
+	}}
+}
+
+func sqliteContractFileEdge(source *graph.Node, id, path string) *graph.Edge {
+	return &graph.Edge{From: source.ID, To: id, Kind: graph.EdgeProvides, FilePath: path, Line: 7, Meta: map[string]any{
+		"contract_owner_repo_prefix": source.RepoPrefix, "contract_owner_type": "env",
+		"contract_owner_meta": map[string]any{"source": source.ID, "nested": []any{"exact", "payload"}},
+	}}
+}
+
+func sqliteContractFileEdges(t *testing.T, store graph.Store, source string) string {
+	t.Helper()
+	var rows []struct {
+		Edge *graph.Edge
+		Meta map[string]any
+	}
+	for _, edge := range store.GetOutEdges(source) {
+		rows = append(rows, struct {
+			Edge *graph.Edge
+			Meta map[string]any
+		}{edge, edge.Meta})
+	}
+	encoded, err := json.Marshal(rows)
+	require.NoError(t, err)
+	return string(encoded)
+}
+
+func TestSQLiteFileEvictionRetainsSharedContractAndPrunesLastOwner(t *testing.T) {
+	for _, batch := range []bool{false, true} {
+		for _, legacy := range []bool{false, true} {
+			t.Run(fmt.Sprintf("batch=%t/legacy=%t", batch, legacy), func(t *testing.T) {
+				store := sqliteContractFileStore(t)
+				const id, fileA, fileB = "env::FILE_RETAIN", "a/owner.go", "b/owner.go"
+				a, b := sqliteContractFileNode("a::Owner", fileA, "a"), sqliteContractFileNode("b::Owner", fileB, "b")
+				canonical := sqliteContractFileCanonical(id, fileA, "a", !legacy, false)
+				store.AddBatch([]*graph.Node{a, b, canonical}, []*graph.Edge{sqliteContractFileEdge(a, id, fileA), sqliteContractFileEdge(b, id, fileB)})
+				before := sqliteContractFileEdges(t, store, b.ID)
+				evict := func(path string) (int, int) {
+					if batch {
+						return store.EvictFiles([]string{path, path})
+					}
+					return store.EvictFile(path)
+				}
+				token := store.BeginMutationReceipt()
+				nodes, edges := evict(fileA)
+				receipt := store.EndMutationReceipt(token)
+				assert.Equal(t, 1, nodes)
+				assert.Equal(t, 1, edges)
+				assert.Nil(t, store.GetNode(a.ID))
+				assert.NotNil(t, store.GetNode(b.ID))
+				current := store.GetNode(id)
+				if assert.NotNil(t, current) {
+					assert.Equal(t, canonical.Meta["contract_meta"], current.Meta["contract_meta"])
+					if legacy {
+						assert.Equal(t, true, current.Meta["contract_owner_removed"])
+						assert.False(t, receipt.Complete)
+					}
+				}
+				assert.Equal(t, before, sqliteContractFileEdges(t, store, b.ID))
+				nodes, edges = evict(fileB)
+				assert.Equal(t, 2, nodes, "last owner pruning follows canonical ID outside B's file bucket")
+				assert.Equal(t, 1, edges)
+				assert.Nil(t, store.GetNode(id))
+				assert.Empty(t, store.GetInEdges(id))
+				assert.Empty(t, store.GetOutEdges(id))
+			})
+		}
+	}
+}
+
+func TestSQLiteFileEvictionPreservesOnlyLiveOffFrontierLegacyScalar(t *testing.T) {
+	for _, tc := range []struct {
+		name                  string
+		backed, removed, keep bool
+	}{
+		{name: "legacy", keep: true},
+		{name: "owner_backed", backed: true},
+		{name: "already_removed", removed: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := sqliteContractFileStore(t)
+			const id, fileA, fileB = "env::OFF_FILE", "a/owner.go", "b/scalar.env"
+			a := sqliteContractFileNode("a::Owner", fileA, "a")
+			canonical := sqliteContractFileCanonical(id, fileB, "b", tc.backed, tc.removed)
+			store.AddBatch([]*graph.Node{a, canonical}, []*graph.Edge{sqliteContractFileEdge(a, id, fileA)})
+			store.EvictFiles([]string{fileA})
+			if tc.keep {
+				assert.NotNil(t, store.GetNode(id))
+			} else {
+				assert.Nil(t, store.GetNode(id), "a removed or owner-backed scalar cannot keep an orphan alive")
+			}
+			store.EvictFiles([]string{fileB})
+			assert.Nil(t, store.GetNode(id))
+			assert.Empty(t, store.GetInEdges(id))
+		})
+	}
+}
+
+func TestSQLiteFileEvictionKeepsFileOnlyOwnershipOutsideNodeFrontier(t *testing.T) {
+	for _, touched := range []bool{false, true} {
+		t.Run(fmt.Sprintf("touched=%t", touched), func(t *testing.T) {
+			store := sqliteContractFileStore(t)
+			const id, fileA, fileC = "env::BOUNDED_FRONTIER", "a/routes.go", "c/owner.go"
+			a := sqliteContractFileNode("a::Source", fileA, "a")
+			b := sqliteContractFileNode("a::Handler", "a/handler.go", "a")
+			c := sqliteContractFileNode("c::Owner", fileC, "c")
+			path := fileC
+			if touched {
+				path = fileA
+			}
+			store.AddBatch([]*graph.Node{a, b, c, sqliteContractFileCanonical(id, path, "a", true, false)}, []*graph.Edge{sqliteContractFileEdge(b, id, fileA), sqliteContractFileEdge(c, id, fileC)})
+			beforeB, beforeC := sqliteContractFileEdges(t, store, b.ID), sqliteContractFileEdges(t, store, c.ID)
+			store.EvictFiles([]string{fileA})
+			assert.NotNil(t, store.GetNode(id))
+			assert.Equal(t, beforeC, sqliteContractFileEdges(t, store, c.ID))
+			if touched {
+				assert.Empty(t, store.GetOutEdges(b.ID), "removed file's incident owner must not survive a retained canonical")
+			} else {
+				assert.Equal(t, beforeB, sqliteContractFileEdges(t, store, b.ID), "both endpoints were outside old raw eviction; replacement owns later cleanup")
+			}
+		})
+	}
+}
+
+func TestSQLiteFileEvictionLargeContractFrontierUsesBoundedBindings(t *testing.T) {
+	store := sqliteContractFileStore(t)
+	const count, fileA, fileB = 2049, "a/many.go", "b/many.go"
+	a, b := sqliteContractFileNode("a::Many", fileA, "a"), sqliteContractFileNode("b::Many", fileB, "b")
+	nodes := []*graph.Node{a, b}
+	edges := make([]*graph.Edge, 0, count*2)
+	ids := make([]string, 0, count)
+	for i := range count {
+		id := fmt.Sprintf("env::MANY_%04d", i)
+		ids = append(ids, id)
+		nodes = append(nodes, sqliteContractFileCanonical(id, fileA, "a", true, false))
+		edges = append(edges, sqliteContractFileEdge(a, id, fileA), sqliteContractFileEdge(b, id, fileB))
+	}
+	store.AddBatch(nodes, edges)
+	require.Len(t, store.GetOutEdges(a.ID), count)
+	require.Len(t, store.GetOutEdges(b.ID), count)
+	removedNodes, removedEdges := store.EvictFiles([]string{fileA})
+	assert.Equal(t, 1, removedNodes)
+	assert.Equal(t, count, removedEdges)
+	assert.Len(t, store.GetNodesByIDs(ids), count)
+	assert.Len(t, store.GetOutEdges(b.ID), count)
+	removedNodes, removedEdges = store.EvictFiles([]string{fileB})
+	assert.Equal(t, count+1, removedNodes)
+	assert.Equal(t, count, removedEdges)
+	assert.Empty(t, store.GetNodesByIDs(ids))
+}
+
+func TestSQLiteFileEvictionContractOwnerClosure(t *testing.T) {
+	for _, initial := range []bool{false, true} {
+		for _, legacyC := range []bool{false, true} {
+			t.Run(fmt.Sprintf("initial_target=%t/legacy_c=%t", initial, legacyC), func(t *testing.T) {
+				store := sqliteContractFileStore(t)
+				a := sqliteContractFileNode("a::Owner", "a/owner.go", "a")
+				b := sqliteContractFileCanonical("env::CHAIN_B", "b/record.env", "b", true, false)
+				c := sqliteContractFileCanonical("env::CHAIN_C", "c/record.env", "c", !legacyC, false)
+				edges := []*graph.Edge{sqliteContractFileEdge(a, b.ID, a.FilePath), sqliteContractFileEdge(b, c.ID, b.FilePath)}
+				if initial {
+					edges = append(edges, sqliteContractFileEdge(a, c.ID, a.FilePath))
+				}
+				store.AddBatch([]*graph.Node{a, b, c}, edges)
+				require.Len(t, store.GetOutEdges(b.ID), 1, "legacy canonical-source ownership is durably admitted")
+				store.EvictFiles([]string{a.FilePath})
+				assert.Nil(t, store.GetNode(b.ID))
+				if legacyC {
+					assert.NotNil(t, store.GetNode(c.ID), "independent recoverable scalar C survives")
+				} else {
+					assert.Nil(t, store.GetNode(c.ID), "doomed B cannot count as a live source owner for C")
+				}
+				assert.Empty(t, store.GetInEdges(c.ID))
+				assert.Empty(t, store.GetOutEdges(b.ID))
+			})
+		}
+	}
+}
+
+func TestSQLiteFileEvictionOwnerRepoMetadataMatchesDecoder(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value any
+		keep  bool
+	}{
+		{name: "non_string_falls_back", value: 42, keep: true},
+		{name: "explicit_empty_is_authoritative", value: "", keep: false},
+		{name: "wrong_repo_is_authoritative", value: "wrong", keep: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := sqliteContractFileStore(t)
+			const id = "env::REPO_METADATA"
+			a := sqliteContractFileNode("a::Owner", "a/owner.go", "a")
+			b := sqliteContractFileNode("b::Owner", "b/owner.go", "b")
+			edgeB := sqliteContractFileEdge(b, id, b.FilePath)
+			edgeB.Meta["contract_owner_repo_prefix"] = tc.value
+			store.AddBatch([]*graph.Node{a, b, sqliteContractFileCanonical(id, a.FilePath, "a", true, false)}, []*graph.Edge{sqliteContractFileEdge(a, id, a.FilePath), edgeB})
+			require.Len(t, store.GetOutEdges(b.ID), 1)
+			store.EvictFiles([]string{a.FilePath})
+			if tc.keep {
+				assert.NotNil(t, store.GetNode(id))
+			} else {
+				assert.Nil(t, store.GetNode(id))
+			}
+		})
+	}
+}
+
+func sqliteContractFileHistoricalRows(t *testing.T, db *sql.DB) map[string][]string {
+	t.Helper()
+	result := make(map[string][]string)
+	for _, query := range []struct{ table, order string }{
+		{"nodes", "id"},
+		{"edges", "from_id, to_id, kind, file_path, line"},
+	} {
+		rows, err := db.Query("SELECT * FROM " + query.table + " WHERE view_gen = 7 ORDER BY " + query.order)
+		require.NoError(t, err)
+		columns, err := rows.Columns()
+		require.NoError(t, err)
+		for rows.Next() {
+			values := make([]any, len(columns))
+			pointers := make([]any, len(columns))
+			for i := range values {
+				pointers[i] = &values[i]
+			}
+			require.NoError(t, rows.Scan(pointers...))
+			encoded, err := json.Marshal(values)
+			require.NoError(t, err)
+			result[query.table] = append(result[query.table], string(encoded))
+		}
+		require.NoError(t, rows.Err())
+		require.NoError(t, rows.Close())
+	}
+	return result
+}
+
+func TestSQLiteFileEvictionPreservesExactSiblingGenerationRows(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "graph.sqlite")
+	store, err := store_sqlite.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if store != nil {
+			require.NoError(t, store.Close())
+		}
+	})
+	const id, fileA, fileB = "env::FILE_GENERATION", "a/owner.go", "b/owner.go"
+	seed := func(version string) {
+		a, b := sqliteContractFileNode("a::Owner", fileA, "a"), sqliteContractFileNode("b::Owner", fileB, "b")
+		canonical := sqliteContractFileCanonical(id, fileA, "a", false, false)
+		canonical.Meta["fixture_version"] = version
+		aEdge, bEdge := sqliteContractFileEdge(a, id, fileA), sqliteContractFileEdge(b, id, fileB)
+		aEdge.Meta["fixture_version"], bEdge.Meta["fixture_version"] = version, version
+		store.AddBatch([]*graph.Node{a, b, canonical}, []*graph.Edge{aEdge, bEdge})
+	}
+	seed("historical-seven")
+	require.NoError(t, store.Close())
+	store = nil
+	db, err := sql.Open("sqlite", path)
+	require.NoError(t, err)
+	_, err = db.Exec("UPDATE nodes SET view_gen = 7")
+	require.NoError(t, err)
+	_, err = db.Exec("UPDATE edges SET view_gen = 7")
+	require.NoError(t, err)
+	before := sqliteContractFileHistoricalRows(t, db)
+	require.Len(t, before["nodes"], 3)
+	require.Len(t, before["edges"], 2)
+	require.NoError(t, db.Close())
+	store, err = store_sqlite.Open(path)
+	require.NoError(t, err)
+	seed("current-zero")
+	store.EvictFiles([]string{fileA})
+	if current := store.GetNode(id); assert.NotNil(t, current) {
+		assert.Equal(t, "current-zero", current.Meta["fixture_version"])
+		assert.Equal(t, true, current.Meta["contract_owner_removed"])
+	}
+	assert.Len(t, store.GetOutEdges("b::Owner"), 1)
+	require.NoError(t, store.Close())
+	store = nil
+	db, err = sql.Open("sqlite", path)
+	require.NoError(t, err)
+	assert.Equal(t, before, sqliteContractFileHistoricalRows(t, db), "all historical columns and full binary node/edge payloads remain unchanged")
+	require.NoError(t, db.Close())
+	store, err = store_sqlite.Open(path)
+	require.NoError(t, err)
+	store.EvictFiles([]string{fileB})
+	assert.Nil(t, store.GetNode(id))
+	assert.Empty(t, store.GetInEdges(id))
+}
+
+func TestSQLiteContractFileEvictionQueryPlans(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "graph.sqlite")
+	store, err := store_sqlite.Open(path)
+	require.NoError(t, err)
+	const id, fileA, fileB = "env::QUERY_PLAN", "a/owner.go", "b/owner.go"
+	a, b := sqliteContractFileNode("a::Owner", fileA, "a"), sqliteContractFileNode("b::Owner", fileB, "b")
+	store.AddBatch([]*graph.Node{a, b, sqliteContractFileCanonical(id, fileA, "a", true, false)}, []*graph.Edge{sqliteContractFileEdge(a, id, fileA), sqliteContractFileEdge(b, id, fileB)})
+	// Exercise the installed implementation, not only copied query text. The
+	// access shapes below match its guarded, source-reviewed SQL; they are not
+	// a claim that EXPLAIN captures statements dynamically from the operation.
+	removed, _ := store.EvictFiles([]string{fileA})
+	require.Equal(t, 1, removed)
+	require.Nil(t, store.GetNode(a.ID))
+	require.NotNil(t, store.GetNode(b.ID))
+	require.NotNil(t, store.GetNode(id))
+	require.Len(t, store.GetInEdges(id), 1)
+	require.NoError(t, store.Close())
+	db, err := sql.Open("sqlite", path)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, db.Close()) }()
+	files, err := json.Marshal([]string{fileA})
+	require.NoError(t, err)
+	ids, err := json.Marshal([]string{id})
+	require.NoError(t, err)
+	queries := []struct {
+		name, sql  string
+		args       []any
+		mustSearch []string
+	}{
+		{"affected_contracts", `SELECT * FROM nodes WHERE view_gen = ? AND kind = ? AND id IN (
+SELECT id FROM nodes WHERE file_path IN (SELECT CAST(value AS TEXT) FROM json_each(?)) AND view_gen = ?
+UNION
+SELECT to_id FROM edges WHERE from_id IN (SELECT id FROM nodes WHERE file_path IN (SELECT CAST(value AS TEXT) FROM json_each(?)) AND view_gen = ?)
+AND view_gen = ? AND kind IN (?, ?, ?))`,
+			[]any{int64(0), string(graph.KindContract), string(files), int64(0), string(files), int64(0), int64(0), string(graph.EdgeProvides), string(graph.EdgeConsumes), string(graph.EdgeHandlesRoute)},
+			[]string{"nodes", "edges"}},
+		{"surviving_owners", `SELECT owner.to_id, owner.from_id, source.repo_prefix, owner.meta FROM edges AS owner
+JOIN nodes AS source ON source.id = owner.from_id AND source.view_gen = ?
+WHERE owner.to_id IN (SELECT CAST(value AS TEXT) FROM json_each(?))
+AND owner.view_gen = ? AND owner.kind IN (?, ?, ?)
+AND source.file_path NOT IN (SELECT CAST(value AS TEXT) FROM json_each(?))
+AND owner.file_path NOT IN (SELECT CAST(value AS TEXT) FROM json_each(?))`,
+			[]any{int64(0), string(ids), int64(0), string(graph.EdgeProvides), string(graph.EdgeConsumes), string(graph.EdgeHandlesRoute), string(files), string(files)},
+			[]string{"owner", "source"}},
+		{"incident_closure_ids", `SELECT DISTINCT to_id FROM edges
+WHERE from_id IN (SELECT CAST(value AS TEXT) FROM json_each(?))
+AND view_gen = ? AND kind IN (?, ?, ?)`,
+			[]any{string(ids), int64(0), string(graph.EdgeProvides), string(graph.EdgeConsumes), string(graph.EdgeHandlesRoute)},
+			[]string{"edges"}},
+		{"unseen_contract_payloads", `SELECT * FROM nodes WHERE view_gen = ? AND kind = ?
+AND id IN (SELECT CAST(value AS TEXT) FROM json_each(?))`,
+			[]any{int64(0), string(graph.KindContract), string(ids)},
+			[]string{"nodes"}},
+	}
+	nodeScoped := `((file_path IN (SELECT CAST(value AS TEXT) FROM json_each(?)) AND view_gen = ?) AND kind <> ?) OR (id IN (SELECT CAST(value AS TEXT) FROM json_each(?)) AND kind = ? AND view_gen = ?)`
+	for _, column := range []string{"from_id", "to_id"} {
+		queries = append(queries, struct {
+			name, sql  string
+			args       []any
+			mustSearch []string
+		}{
+			"delete_" + column,
+			`DELETE FROM edges WHERE ` + column + ` IN (SELECT id FROM nodes WHERE ` + nodeScoped + `) AND view_gen = ?`,
+			[]any{string(files), int64(0), string(graph.KindContract), string(ids), string(graph.KindContract), int64(0), int64(0)},
+			[]string{"edges", "nodes"},
+		})
+	}
+	for _, query := range queries {
+		t.Run(query.name, func(t *testing.T) {
+			rows, err := db.Query("EXPLAIN QUERY PLAN "+query.sql, query.args...)
+			require.NoError(t, err)
+			searches := map[string]bool{}
+			for rows.Next() {
+				var id, parent, unused int
+				var detail string
+				require.NoError(t, rows.Scan(&id, &parent, &unused, &detail))
+				t.Log(detail)
+				fields := strings.Fields(detail)
+				if len(fields) >= 2 {
+					if fields[0] == "SEARCH" {
+						searches[fields[1]] = true
+					}
+					if fields[0] == "SCAN" {
+						require.NotContains(t, []string{"nodes", "edges", "owner", "source"}, fields[1], "no whole ordinary-node/edge scan")
+					}
+				}
+			}
+			require.NoError(t, rows.Err())
+			require.NoError(t, rows.Close())
+			for _, table := range query.mustSearch {
+				require.True(t, searches[table], "expected indexed lookup for "+table)
+			}
+		})
+	}
+}

--- a/internal/graph/store_sqlite/schema.go
+++ b/internal/graph/store_sqlite/schema.go
@@ -909,7 +909,14 @@ func createGraphCoreIndexes(db schemaColumnDB) error {
 			return fmt.Errorf("%s: %w", idx.name, err)
 		}
 	}
-	for _, ddl := range []string{nodesByQualIndexSQL, edgesExternalIndexSQL} {
+	for _, ddl := range []string{
+		nodesByQualIndexSQL,
+		edgesExternalIndexSQL,
+		// Keep this sparse frontier live during bulk loading. It must also be
+		// buildable before the view-generation migration adds view_gen.
+		`CREATE INDEX IF NOT EXISTS nodes_missing_workspace_slugs ON nodes(repo_prefix)
+			WHERE workspace_id = '' OR project_id = ''`,
+	} {
 		if _, err := db.Exec(ddl); err != nil {
 			return err
 		}

--- a/internal/graph/store_sqlite/store.go
+++ b/internal/graph/store_sqlite/store.go
@@ -733,9 +733,9 @@ func hasGraphStoreTables(db *sql.DB) (bool, error) {
 // not shrink the file; explicit/final checkpoints use TRUNCATE instead.
 const (
 	walCheckpointInterval = 5 * time.Minute
-	// walCheckpointTimeout bounds explicit/final pool acquisition, contention
-	// retry, and SQLite execution. A caller gets an error instead of an
-	// unbounded shutdown or operator-command wait.
+	// walCheckpointTimeout bounds explicit maintenance pool acquisition,
+	// contention retry, and SQLite execution. Ordinary Close allows slow
+	// checkpoint I/O to finish before closing the connection pools.
 	walCheckpointTimeout = 10 * time.Second
 	// The periodic path is best-effort and one-shot. Its gate acquisition is a
 	// non-blocking TryLock; this context only protects an unexpected writer-pool
@@ -1024,7 +1024,11 @@ func (s *Store) Close() error {
 		if hadBulk {
 			checkpointErr = s.checkpointBulkWAL()
 		} else {
-			checkpointErr = s.CheckpointWAL()
+			// Close is a durability boundary, not an interactive checkpoint.
+			// A successful filesystem sync can exceed CheckpointWAL's deadline
+			// on a busy disk. Let it finish; withSQLiteBusyRetry still bounds
+			// repeated lock contention, and checkpoint errors remain fatal.
+			checkpointErr = s.checkpointWALWithContext(context.Background())
 		}
 	}
 	stmts := []*sql.Stmt{

--- a/internal/graph/store_sqlite/store_fts.go
+++ b/internal/graph/store_sqlite/store_fts.go
@@ -167,6 +167,16 @@ func (s *Store) BatchDeleteSymbolFTS(nodeIDs []string) error {
 	}
 	defer tx.Rollback() //nolint:errcheck // rollback after Commit is a no-op
 
+	if err := s.deleteSymbolFTSTx(tx, ids); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// deleteSymbolFTSTx deletes only the supplied IDs in the caller's existing
+// transaction and payload generation. Mapping rows must outlive virtual-row
+// deletion; this helper never locks, begins, commits or rolls back a transaction.
+func (s *Store) deleteSymbolFTSTx(tx *sql.Tx, ids []string) error {
 	for start := 0; start < len(ids); start += ftsInsertChunkRows {
 		end := minInt(start+ftsInsertChunkRows, len(ids))
 		chunk := ids[start:end]
@@ -185,7 +195,7 @@ SELECT fts_rowid FROM symbol_fts_rowid WHERE view_gen = ? AND node_id IN (`+plac
 			return err
 		}
 	}
-	return tx.Commit()
+	return nil
 }
 
 // dedupeSymbolFTSItems drops empty IDs and collapses repeats with last-write-

--- a/internal/graph/store_sqlite/store_generation_write_test.go
+++ b/internal/graph/store_sqlite/store_generation_write_test.go
@@ -912,9 +912,12 @@ func generationWriteCases() []generationWriteCase {
 // generationWriteContractMaterial is the contract node plus the owner edge both
 // the contract evicter and the owner replacer select on.
 func generationWriteContractMaterial() ([]*graph.Node, []*graph.Edge) {
+	// This canonical belongs only to the owner edge below. Its different
+	// file path must not imply a separate, surviving legacy scalar record.
 	return []*graph.Node{{
 		ID: genWriteContract, Kind: graph.KindContract, Name: "Contract",
 		FilePath: "repo::pkg/contract.go", RepoPrefix: genWriteRepo,
+		Meta: map[string]any{"contract_owner_record": true},
 	}}, []*graph.Edge{{
 		From: genWriteCaller, To: genWriteContract, Kind: graph.EdgeProvides,
 		FilePath: genWriteCallerFile, Line: 5,

--- a/internal/graph/store_sqlite/store_generation_write_test.go
+++ b/internal/graph/store_sqlite/store_generation_write_test.go
@@ -674,12 +674,12 @@ func generationWriteCases() []generationWriteCase {
 			seed: func(t *testing.T, base, derived *Store) {
 				addToBothGenerations(base, derived, func() ([]*graph.Node, []*graph.Edge) {
 					return []*graph.Node{{
-						ID: genWriteConfigKey, Kind: graph.KindConfigKey, Name: "server.port",
-						FilePath: "repo::pkg/app.yaml", RepoPrefix: genWriteRepo,
-					}}, []*graph.Edge{{
-						From: genWriteCaller, To: genWriteConfigKey, Kind: graph.EdgeReads,
-						FilePath: genWriteCallerFile, Line: 8,
-					}}
+							ID: genWriteConfigKey, Kind: graph.KindConfigKey, Name: "server.port",
+							FilePath: "repo::pkg/app.yaml", RepoPrefix: genWriteRepo,
+						}}, []*graph.Edge{{
+							From: genWriteCaller, To: genWriteConfigKey, Kind: graph.EdgeReads,
+							FilePath: genWriteCallerFile, Line: 8,
+						}}
 				})
 			},
 			disturb: func(t *testing.T, s *Store) {
@@ -725,24 +725,24 @@ func generationWriteCases() []generationWriteCase {
 			seed: func(t *testing.T, base, derived *Store) {
 				addToBothGenerations(base, derived, func() ([]*graph.Node, []*graph.Edge) {
 					return []*graph.Node{
-						{
-							ID: genWriteBridge, Kind: graph.KindContractBridge, Name: "Bridge",
-							FilePath: "repo::pkg/bridge.go", RepoPrefix: genWriteRepo,
-						},
-						{
-							ID: genWriteTopic, Kind: graph.KindTopic, Name: "Topic",
-							FilePath: "repo::pkg/topic.go", RepoPrefix: genWriteRepo,
-						},
-					}, []*graph.Edge{
-						{
-							From: genWriteCaller, To: genWriteBridge, Kind: graph.EdgeReferences,
-							FilePath: genWriteCallerFile, Line: 6,
-						},
-						{
-							From: genWriteCaller, To: genWriteTopic, Kind: graph.EdgeProducesTopic,
-							FilePath: genWriteCallerFile, Line: 7,
-						},
-					}
+							{
+								ID: genWriteBridge, Kind: graph.KindContractBridge, Name: "Bridge",
+								FilePath: "repo::pkg/bridge.go", RepoPrefix: genWriteRepo,
+							},
+							{
+								ID: genWriteTopic, Kind: graph.KindTopic, Name: "Topic",
+								FilePath: "repo::pkg/topic.go", RepoPrefix: genWriteRepo,
+							},
+						}, []*graph.Edge{
+							{
+								From: genWriteCaller, To: genWriteBridge, Kind: graph.EdgeReferences,
+								FilePath: genWriteCallerFile, Line: 6,
+							},
+							{
+								From: genWriteCaller, To: genWriteTopic, Kind: graph.EdgeProducesTopic,
+								FilePath: genWriteCallerFile, Line: 7,
+							},
+						}
 				})
 			},
 			disturb: func(t *testing.T, s *Store) {
@@ -915,13 +915,13 @@ func generationWriteContractMaterial() ([]*graph.Node, []*graph.Edge) {
 	// This canonical belongs only to the owner edge below. Its different
 	// file path must not imply a separate, surviving legacy scalar record.
 	return []*graph.Node{{
-		ID: genWriteContract, Kind: graph.KindContract, Name: "Contract",
-		FilePath: "repo::pkg/contract.go", RepoPrefix: genWriteRepo,
-		Meta: map[string]any{"contract_owner_record": true},
-	}}, []*graph.Edge{{
-		From: genWriteCaller, To: genWriteContract, Kind: graph.EdgeProvides,
-		FilePath: genWriteCallerFile, Line: 5,
-	}}
+			ID: genWriteContract, Kind: graph.KindContract, Name: "Contract",
+			FilePath: "repo::pkg/contract.go", RepoPrefix: genWriteRepo,
+			Meta: map[string]any{"contract_owner_record": true},
+		}}, []*graph.Edge{{
+			From: genWriteCaller, To: genWriteContract, Kind: graph.EdgeProvides,
+			FilePath: genWriteCallerFile, Line: 5,
+		}}
 }
 
 // TestGenerationScopedWriterFamilies drives every remaining scoped writer

--- a/internal/graph/store_sqlite/workspace_slugs.go
+++ b/internal/graph/store_sqlite/workspace_slugs.go
@@ -48,6 +48,16 @@ func (s *Store) BackfillWorkspaceSlugsWithImpact(slugs []graph.WorkspaceSlug) gr
 	for start := 0; start < len(updates); start += workspaceSlugChunkSize {
 		end := minInt(start+workspaceSlugChunkSize, len(updates))
 		chunk := updates[start:end]
+		candidateQuery, candidateArgs := workspaceSlugCandidates(s.viewGen, chunk)
+		var hasCandidates bool
+		if scanErr := tx.QueryRow(candidateQuery, candidateArgs...).Scan(&hasCandidates); scanErr != nil {
+			_ = tx.Rollback()
+			panicOnFatal(scanErr)
+			return graph.WorkspaceSlugBackfillResult{}
+		}
+		if !hasCandidates {
+			continue
+		}
 		impactQuery, impactArgs := workspaceSlugResolutionImpact(s.viewGen, chunk)
 		var resolutionAffected int
 		if scanErr := tx.QueryRow(impactQuery, impactArgs...).Scan(&resolutionAffected); scanErr != nil {
@@ -90,6 +100,24 @@ func (s *Store) BackfillWorkspaceSlugsWithImpact(slugs []graph.WorkspaceSlug) gr
 	}
 	s.finishAnalysisMutationLocked(backfill.Changed > 0)
 	return backfill
+}
+
+// Probe the database-maintained missing-ownership frontier, not every node in
+// a repository. Reevaluate supplied configuration on each call; project-only
+// and builtin fills remain eligible even when resolution impact is zero.
+func workspaceSlugCandidates(viewGen int64, slugs []graph.WorkspaceSlug) (string, []any) {
+	values, args := workspaceSlugValues(slugs)
+	args = append(args, viewGen)
+	query := `WITH updates(repo_prefix, workspace_id, project_id) AS (VALUES ` + values + `)
+	SELECT EXISTS (
+		SELECT 1 FROM updates AS u
+		CROSS JOIN nodes AS n INDEXED BY nodes_missing_workspace_slugs ON n.repo_prefix = u.repo_prefix
+		WHERE n.view_gen = ?
+			AND (n.workspace_id = '' OR n.project_id = '')
+			AND ((n.workspace_id = '' AND u.workspace_id <> '')
+				OR (n.project_id = '' AND u.project_id <> ''))
+	)`
+	return query, args
 }
 
 func workspaceSlugValues(slugs []graph.WorkspaceSlug) (string, []any) {

--- a/internal/graph/store_sqlite/workspace_slugs_frontier_test.go
+++ b/internal/graph/store_sqlite/workspace_slugs_frontier_test.go
@@ -105,7 +105,7 @@ func TestWorkspaceSlugFrontierIsGenerationScopedAndIndexed(t *testing.T) {
 	query, args := workspaceSlugCandidates(0, slugs)
 	tx, err = s.beginWrite()
 	require.NoError(t, err)
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 	rows, err := tx.Query("EXPLAIN QUERY PLAN "+query, args...)
 	require.NoError(t, err)
 	var plan []string
@@ -126,7 +126,7 @@ func workspaceFrontierHasCandidates(t *testing.T, s *Store, generation int64, sl
 	t.Helper()
 	tx, err := s.beginWrite()
 	require.NoError(t, err)
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 	query, args := workspaceSlugCandidates(generation, slugs)
 	var found bool
 	require.NoError(t, tx.QueryRow(query, args...).Scan(&found))
@@ -192,7 +192,7 @@ func BenchmarkWorkspaceSlugNoopBackfill(b *testing.B) {
 				if err != nil {
 					return err
 				}
-				defer tx.Rollback()
+				defer func() { _ = tx.Rollback() }()
 				impactQuery, impactArgs := workspaceSlugResolutionImpact(0, slugs)
 				updateQuery, updateArgs := workspaceSlugUpdate(0, slugs)
 				var affected int

--- a/internal/graph/store_sqlite/workspace_slugs_frontier_test.go
+++ b/internal/graph/store_sqlite/workspace_slugs_frontier_test.go
@@ -1,0 +1,224 @@
+package store_sqlite
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func TestWorkspaceSlugFrontierPreservesNeutralFills(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		node      graph.Node
+		slug      graph.WorkspaceSlug
+		workspace string
+		project   string
+	}{
+		{
+			name:      "builtin only",
+			node:      graph.Node{ID: "repo::builtin", Kind: graph.KindBuiltin, RepoPrefix: "repo"},
+			slug:      graph.WorkspaceSlug{RepoPrefix: "repo", Workspace: "shared", Project: "project"},
+			workspace: "shared", project: "project",
+		},
+		{
+			name:      "project only configuration",
+			node:      graph.Node{ID: "repo::fn", Kind: graph.KindFunction, RepoPrefix: "repo"},
+			slug:      graph.WorkspaceSlug{RepoPrefix: "repo", Project: "project"},
+			workspace: "", project: "project",
+		},
+		{
+			name:      "existing workspace",
+			node:      graph.Node{ID: "repo::fn", Kind: graph.KindFunction, RepoPrefix: "repo", WorkspaceID: "existing"},
+			slug:      graph.WorkspaceSlug{RepoPrefix: "repo", Workspace: "different", Project: "project"},
+			workspace: "existing", project: "project",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, err := Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, s.Close()) })
+			s.AddBatch([]*graph.Node{&tc.node}, nil)
+			before := s.AnalysisMutationRevision()
+			require.Equal(t, graph.WorkspaceSlugBackfillResult{Changed: 1}, s.BackfillWorkspaceSlugsWithImpact([]graph.WorkspaceSlug{tc.slug}))
+			require.Equal(t, before+1, s.AnalysisMutationRevision())
+			node := s.GetNode(tc.node.ID)
+			require.NotNil(t, node)
+			require.Equal(t, tc.workspace, node.WorkspaceID)
+			require.Equal(t, tc.project, node.ProjectID)
+			require.Equal(t, graph.WorkspaceSlugBackfillResult{}, s.BackfillWorkspaceSlugsWithImpact([]graph.WorkspaceSlug{tc.slug}))
+			require.Equal(t, before+1, s.AnalysisMutationRevision())
+		})
+	}
+}
+
+func TestWorkspaceSlugFrontierTracksConfigurationAndMutations(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	s.AddBatch([]*graph.Node{{ID: "repo::first", Kind: graph.KindFunction, RepoPrefix: "repo"}}, nil)
+	empty := []graph.WorkspaceSlug{{RepoPrefix: "repo"}}
+	before := s.AnalysisMutationRevision()
+	require.Equal(t, graph.WorkspaceSlugBackfillResult{}, s.BackfillWorkspaceSlugsWithImpact(empty))
+	require.Equal(t, before, s.AnalysisMutationRevision())
+	slugs := []graph.WorkspaceSlug{{RepoPrefix: "repo", Workspace: "shared", Project: "project"}}
+	require.Equal(t, graph.WorkspaceSlugBackfillResult{Changed: 1, ResolutionAffected: 1}, s.BackfillWorkspaceSlugsWithImpact(slugs))
+	require.False(t, workspaceFrontierHasCandidates(t, s, 0, slugs))
+	s.AddBatch([]*graph.Node{{ID: "repo::later", Kind: graph.KindBuiltin, RepoPrefix: "repo"}}, nil)
+	require.True(t, workspaceFrontierHasCandidates(t, s, 0, slugs))
+	require.Equal(t, graph.WorkspaceSlugBackfillResult{Changed: 1}, s.BackfillWorkspaceSlugsWithImpact(slugs))
+	// Any writer that reintroduces a missing column must reopen eligibility;
+	// a separately maintained Boolean would miss this mutation.
+	tx, err := s.beginWrite()
+	require.NoError(t, err)
+	_, err = tx.Exec(`UPDATE nodes SET project_id = '' WHERE view_gen = 0 AND id = ?`, "repo::first")
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	require.True(t, workspaceFrontierHasCandidates(t, s, 0, slugs))
+	require.Equal(t, graph.WorkspaceSlugBackfillResult{Changed: 1}, s.BackfillWorkspaceSlugsWithImpact(slugs))
+	require.False(t, workspaceFrontierHasCandidates(t, s, 0, slugs))
+}
+
+func TestWorkspaceSlugFrontierIsGenerationScopedAndIndexed(t *testing.T) {
+	s, err := Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	s.AddBatch([]*graph.Node{
+		{ID: "repo::complete", Kind: graph.KindFunction, RepoPrefix: "repo", WorkspaceID: "shared", ProjectID: "project"},
+		{ID: "repo::other-generation", Kind: graph.KindFunction, RepoPrefix: "repo"},
+		{ID: "sibling::missing", Kind: graph.KindFunction, RepoPrefix: "sibling"},
+	}, nil)
+	tx, err := s.beginWrite()
+	require.NoError(t, err)
+	_, err = tx.Exec(`UPDATE nodes SET view_gen = 7 WHERE view_gen = 0 AND id = ?`, "repo::other-generation")
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+	slugs := []graph.WorkspaceSlug{{RepoPrefix: "repo", Workspace: "shared", Project: "project"}}
+	require.False(t, workspaceFrontierHasCandidates(t, s, 0, slugs))
+	require.True(t, workspaceFrontierHasCandidates(t, s, 7, slugs))
+	require.Equal(t, graph.WorkspaceSlugBackfillResult{}, s.BackfillWorkspaceSlugsWithImpact(slugs))
+	require.Equal(t, "", s.GetNode("sibling::missing").WorkspaceID)
+	query, args := workspaceSlugCandidates(0, slugs)
+	tx, err = s.beginWrite()
+	require.NoError(t, err)
+	defer tx.Rollback()
+	rows, err := tx.Query("EXPLAIN QUERY PLAN "+query, args...)
+	require.NoError(t, err)
+	var plan []string
+	for rows.Next() {
+		var id, parent, unused int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &unused, &detail))
+		plan = append(plan, detail)
+	}
+	require.NoError(t, rows.Err())
+	require.NoError(t, rows.Close())
+	joined := strings.Join(plan, "\n")
+	require.Contains(t, joined, "SEARCH n USING INDEX nodes_missing_workspace_slugs")
+	require.NotContains(t, joined, "SCAN n ")
+}
+
+func workspaceFrontierHasCandidates(t *testing.T, s *Store, generation int64, slugs []graph.WorkspaceSlug) bool {
+	t.Helper()
+	tx, err := s.beginWrite()
+	require.NoError(t, err)
+	defer tx.Rollback()
+	query, args := workspaceSlugCandidates(generation, slugs)
+	var found bool
+	require.NoError(t, tx.QueryRow(query, args...).Scan(&found))
+	return found
+}
+
+func TestWorkspaceSlugFrontierSurvivesBulkAndReopen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "graph.sqlite")
+	s, err := Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// Open may return nil on a failed reopen after the first store closed.
+		if s != nil {
+			require.NoError(t, s.Close())
+		}
+	})
+	slugs := []graph.WorkspaceSlug{{RepoPrefix: "repo", Workspace: "shared", Project: "project"}}
+	require.True(t, s.BeginCoordinatedBulkLoad())
+	s.AddBatch([]*graph.Node{{ID: "repo::fn", Kind: graph.KindFunction, RepoPrefix: "repo"}}, nil)
+	require.True(t, workspaceFrontierHasCandidates(t, s, 0, slugs))
+	require.Equal(t, graph.WorkspaceSlugBackfillResult{Changed: 1, ResolutionAffected: 1}, s.BackfillWorkspaceSlugsWithImpact(slugs))
+	require.False(t, workspaceFrontierHasCandidates(t, s, 0, slugs))
+	require.NoError(t, s.EndCoordinatedBulkLoad())
+	require.NoError(t, s.Close())
+	s, err = Open(path)
+	require.NoError(t, err)
+	require.False(t, workspaceFrontierHasCandidates(t, s, 0, slugs))
+	s.AddBatch([]*graph.Node{{ID: "repo::later", Kind: graph.KindFunction, RepoPrefix: "repo"}}, nil)
+	require.True(t, workspaceFrontierHasCandidates(t, s, 0, slugs))
+}
+
+func BenchmarkWorkspaceSlugNoopBackfill(b *testing.B) {
+	s, err := Open(filepath.Join(b.TempDir(), "graph.sqlite"))
+	require.NoError(b, err)
+	b.Cleanup(func() { require.NoError(b, s.Close()) })
+	var nodes []*graph.Node
+	var slugs []graph.WorkspaceSlug
+	for repo := 0; repo < 10; repo++ {
+		prefix := fmt.Sprintf("repo%d", repo)
+		slugs = append(slugs, graph.WorkspaceSlug{RepoPrefix: prefix, Workspace: "shared", Project: "project"})
+		for n := 0; n < 1000; n++ {
+			nodes = append(nodes, &graph.Node{ID: fmt.Sprintf("%s::%d", prefix, n), Kind: graph.KindFunction, RepoPrefix: prefix, WorkspaceID: "shared", ProjectID: "project"})
+		}
+	}
+	s.AddBatch(nodes, nil)
+	b.Run("frontier", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			if got := s.BackfillWorkspaceSlugsWithImpact(slugs); got != (graph.WorkspaceSlugBackfillResult{}) {
+				b.Fatalf("unexpected mutation: %+v", got)
+			}
+		}
+	})
+	// Retain both historical queries on the same indexed store, so this
+	// isolates the gate's savings rather than attributing index gains twice.
+	b.Run("legacy_count_and_update", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			legacy := func() error {
+				s.writeMu.Lock()
+				defer s.writeMu.Unlock()
+				tx, err := s.beginWrite()
+				if err != nil {
+					return err
+				}
+				defer tx.Rollback()
+				impactQuery, impactArgs := workspaceSlugResolutionImpact(0, slugs)
+				updateQuery, updateArgs := workspaceSlugUpdate(0, slugs)
+				var affected int
+				if err := tx.QueryRow(impactQuery, impactArgs...).Scan(&affected); err != nil {
+					return err
+				}
+				result, err := tx.Exec(updateQuery, updateArgs...)
+				if err != nil {
+					return err
+				}
+				changed, err := result.RowsAffected()
+				if err != nil {
+					return err
+				}
+				if affected != 0 || changed != 0 {
+					return fmt.Errorf("unexpected mutation: affected=%d changed=%d", affected, changed)
+				}
+				if err := tx.Commit(); err != nil {
+					return err
+				}
+				s.finishAnalysisMutationLocked(false)
+				return nil
+			}
+			if err := legacy(); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/internal/indexer/cold_manifest_census.go
+++ b/internal/indexer/cold_manifest_census.go
@@ -1,0 +1,310 @@
+package indexer
+
+import (
+	"context"
+	"errors"
+
+	"github.com/zzet/gortex/internal/contracts"
+	"github.com/zzet/gortex/internal/graph"
+	"go.uber.org/zap"
+)
+
+var errColdManifestIncomplete = errors.New("cold manifest processing did not complete")
+
+// A durable backend must be able to invalidate a previously successful
+// receipt. Unsupported writer-only backends keep the old manifest behavior;
+// do not introduce receipts that they cannot later invalidate safely.
+func supportsColdManifestReceipts(store graph.Store) bool {
+	_, writer := store.(graph.FileMtimeWriter)
+	_, replacer := store.(graph.FileMtimeReplacer)
+	if !writer && !replacer {
+		return true
+	}
+	_, ok := store.(graph.FileMtimeDeleter)
+	return ok
+}
+
+// Caller has already applied root-manifest admission and ignore/security
+// gates. This runs during the existing filesystem walk, before any shadow.
+func (idx *Indexer) captureColdManifest(census **coldManifestCensus, ctx context.Context, path string, priorErr error) {
+	if !supportsColdManifestReceipts(idx.graph) {
+		return
+	}
+	if *census == nil {
+		*census = &coldManifestCensus{ctx: ctx, manifests: make(map[string]*coldManifestRead, 2)}
+		idx.pendingColdManifests = *census
+	}
+	key := idx.relKey(path)
+	if prior := (*census).manifests[key]; prior != nil && prior.err != nil {
+		return
+	}
+	var src []byte
+	var version fileReadVersion
+	err := priorErr
+	if err == nil {
+		src, version, err = idx.readFileWithVersion(path)
+	}
+	if err == nil && !version.valid {
+		err = errFileVersionChanged
+	}
+	manifest := &coldManifestRead{
+		source: src, err: err,
+		receipt:         fileReadReceipt{absPath: path, mtimeKey: key, readVersion: version},
+		modulesRequired: key == "go.mod" && idx.config.Coverage.IsEnabled("modules"),
+	}
+	if key == "go.work" {
+		manifest.source = nil // no cold byte consumer; keep only the version
+	}
+	(*census).manifests[key] = manifest
+	if err != nil {
+		(*census).failed = true
+		idx.noteFileIndexFailure(path, err)
+	}
+}
+
+func (idx *Indexer) coldManifestsForRegistry(reg *contracts.Registry) *coldManifestCensus {
+	b := idx.pendingColdManifests
+	if b == nil || reg == nil || b.registry != reg {
+		return nil
+	}
+	return b
+}
+
+// Both cold module consumers use the one captured go.mod version. Generic
+// callers pass nil and retain their existing read/extraction behavior.
+func (idx *Indexer) extractExternalModulesForCensus(reg *contracts.Registry) {
+	if !idx.config.Coverage.IsEnabled("modules") {
+		return
+	}
+	b := idx.coldManifestsForRegistry(reg)
+	if b == nil {
+		idx.extractExternalModules()
+		return
+	}
+	for _, spec := range rootManifests() {
+		var manifest *coldManifestRead
+		if b != nil {
+			manifest = b.manifests[spec.path]
+		}
+		if manifest == nil {
+			idx.extractOneModuleManifest(spec.path, spec.parse, spec.ownPathFromSrc)
+		} else if manifest.err == nil {
+			idx.extractOneModuleManifestSource(spec.path, manifest.source, spec.parse, spec.ownPathFromSrc)
+			manifest.modulesDone = true
+		}
+	}
+	idx.extractPackageWorkspace()
+}
+
+// Called after final graph/FTS/vector publication, and after actual contract
+// commit. Either order is valid, but neither boundary alone may certify a
+// manifest or authoritatively prune the previous census.
+func (idx *Indexer) finishColdManifests(b *coldManifestCensus) {
+	if b == nil || idx.pendingColdManifests != b || !b.graphReady {
+		return
+	}
+	if b.ctx.Err() != nil {
+		paths := make([]string, 0, len(b.manifests))
+		for path := range b.manifests {
+			paths = append(paths, path)
+		}
+		idx.invalidateColdFileMtimes(paths)
+		idx.pendingColdManifests = nil
+		return
+	}
+	if !b.contractsReady {
+		// Preserve early parser progress throughout long enrichment. Old
+		// manifest receipts cannot certify the newly published graph yet.
+		idx.publishColdFileMtimes(b.census, false)
+		paths := make([]string, 0, len(b.manifests))
+		for path := range b.manifests {
+			paths = append(paths, path)
+		}
+		idx.invalidateColdFileMtimes(paths)
+		return
+	}
+	var receipts []fileReadReceipt
+	var failedPaths []string
+	for path, manifest := range b.manifests {
+		if manifest.err == nil && path == "go.mod" &&
+			(!manifest.dependencyDone || (manifest.modulesRequired && !manifest.modulesDone)) {
+			manifest.err = errColdManifestIncomplete
+		}
+		if manifest.err != nil {
+			b.failed = true
+			failedPaths = append(failedPaths, path)
+			idx.noteFileIndexFailure(manifest.receipt.absPath, manifest.err)
+			continue
+		}
+		receipts = append(receipts, manifest.receipt)
+	}
+	// Existing helper revalidates identity/size/mtime and publishes only
+	// successful versions. Never pass a latched failed receipt to it.
+	fresh, stale := idx.recordFileReadVersionsBatched(receipts)
+	for _, path := range fresh {
+		key := idx.relKey(path)
+		b.census[key] = b.manifests[key].receipt.readVersion.mtime
+	}
+	for _, path := range stale {
+		failedPaths = append(failedPaths, idx.relKey(path))
+		b.failed = true
+	}
+	idx.invalidateColdFileMtimes(failedPaths)
+	idx.publishColdFileMtimes(b.census, !b.failed && b.ctx.Err() == nil)
+	idx.flushFileIndexFailures()
+	idx.pendingColdManifests = nil
+}
+
+// Remove only specifically failed/pending receipts; never prune unrelated
+// old keys on failure. Replacement cannot safely emulate deletion: empty
+// input is a no-op and the local map may omit durable peers.
+func (idx *Indexer) invalidateColdFileMtimes(paths []string) {
+	if len(paths) == 0 {
+		return
+	}
+	idx.mtimeMu.Lock()
+	idx.ensureFileMtimesWritableLocked()
+	for _, path := range paths {
+		delete(idx.fileMtimes, path)
+	}
+	idx.mtimeMu.Unlock()
+	if _, ok := idx.graph.(graph.FileMtimeDeleter); ok {
+		idx.pruneDeletedFileMtimes(paths)
+	} else {
+		_, writer := idx.graph.(graph.FileMtimeWriter)
+		_, replacer := idx.graph.(graph.FileMtimeReplacer)
+		if writer || replacer {
+			idx.markFileMtimePersistenceDirty()
+			idx.logger.Warn("cannot invalidate cold file receipts without deletion support",
+				zap.String("repo", idx.repoPrefix), zap.Int("count", len(paths)))
+		}
+	}
+}
+
+// The previous full-index persistence block, shared by early progress and
+// final replacement. Existing COW ownership and dirty-state APIs are reused.
+func (idx *Indexer) publishColdFileMtimes(mtimes map[string]int64, authoritative bool) {
+	if !authoritative && len(mtimes) == 0 {
+		return
+	}
+	// A durable write failure marks retry state; it must not hide already
+	// committed parser progress from the current process or its watchers.
+	if authoritative {
+		idx.SetFileMtimes(mtimes)
+	} else {
+		idx.mtimeMu.Lock()
+		idx.ensureFileMtimesWritableLocked()
+		for path, mtime := range mtimes {
+			idx.fileMtimes[path] = mtime
+		}
+		idx.mtimeMu.Unlock()
+	}
+	var err error
+	persisted, replaced := false, false
+	if authoritative && len(mtimes) == 0 {
+		// ReplaceFileMtimes deliberately treats empty input as a no-op.
+		// This boundary proves a complete successful census, so explicitly
+		// delete the persisted roster, not merely this Indexer's old map.
+		reader, canRead := idx.graph.(graph.FileMtimeReader)
+		deleter, canDelete := idx.graph.(graph.FileMtimeDeleter)
+		if canRead && canDelete {
+			stored := reader.LoadFileMtimes(idx.repoPrefix)
+			paths := make([]string, 0, len(stored))
+			for path := range stored {
+				paths = append(paths, path)
+			}
+			err = deleter.DeleteFileMtimes(idx.repoPrefix, paths)
+			persisted, replaced = true, true
+			if err == nil {
+				idx.fileMtimePersistenceDirty.Store(false)
+			}
+		} else {
+			_, writer := idx.graph.(graph.FileMtimeWriter)
+			_, replacer := idx.graph.(graph.FileMtimeReplacer)
+			if writer || replacer {
+				err = errors.New("store cannot clear a completed empty file census")
+			}
+		}
+	} else if replacer, ok := idx.graph.(graph.FileMtimeReplacer); authoritative && ok {
+		err = replacer.ReplaceFileMtimes(idx.repoPrefix, mtimes)
+		persisted, replaced = true, true
+		if err == nil {
+			idx.fileMtimePersistenceDirty.Store(false)
+		}
+	} else if writer, ok := idx.graph.(graph.FileMtimeWriter); ok {
+		err = writer.BulkSetFileMtimes(idx.repoPrefix, mtimes)
+		persisted = true
+	}
+	if err != nil {
+		idx.markFileMtimePersistenceDirty()
+		idx.logger.Warn("persist file mtimes failed", zap.String("repo", idx.repoPrefix), zap.Error(err))
+	} else if persisted {
+		idx.logger.Info("persisted file mtimes", zap.String("repo", idx.repoPrefix),
+			zap.Int("count", len(mtimes)), zap.Bool("authoritative", replaced))
+	}
+}
+
+func (mi *MultiIndexer) refreshColdCensusMetadata(idx *Indexer) {
+	mtimes := idx.publishFileMtimes()
+	mi.mu.Lock()
+	defer mi.mu.Unlock()
+	meta := mi.repos[idx.repoPrefix]
+	if meta == nil || mi.indexers[idx.repoPrefix] != idx {
+		return
+	}
+	next := *meta
+	next.FileMtimes = mtimes
+	mi.repos[idx.repoPrefix] = &next
+}
+
+// Called by indexCtxRaw's post-publication defer. The existing successfulFiles
+// map supplies parser candidates; the existing failure ledger supplies exact
+// invalidations. No parallel per-file outcome state is introduced.
+func (idx *Indexer) finishColdIndexCensus(ctx context.Context, result *IndexResult, indexErr error,
+	mtimes map[string]int64, b *coldManifestCensus, failed bool) {
+	if b != nil && idx.pendingColdManifests != b {
+		return
+	}
+	if idx.contentSource() != nil {
+		if indexErr == nil && result != nil && mtimes != nil {
+			idx.SetFileMtimes(nil)
+		}
+		return // immutable sources never write filesystem receipts
+	}
+	var paths []string
+	for _, path := range idx.fileIndexFailurePaths() {
+		if rel, ok := idx.graphPathRelKey(path); ok {
+			paths = append(paths, rel)
+		}
+	}
+	idx.invalidateColdFileMtimes(paths)
+	if indexErr != nil || result == nil || mtimes == nil {
+		// Graph publication can succeed before a later FTS/vector boundary
+		// fails. Old receipts must not certify that incomplete replacement.
+		// Invalidate only this attempt's captured manifests, not prior peers.
+		if b != nil {
+			paths = paths[:0]
+			for path := range b.manifests {
+				paths = append(paths, path)
+			}
+			idx.invalidateColdFileMtimes(paths)
+		}
+		idx.pendingColdManifests = nil
+		return
+	}
+	if b != nil {
+		b.graphReady = true
+		b.census = mtimes
+		b.failed = b.failed || failed
+	}
+	if ctx.Err() != nil {
+		idx.finishColdManifests(b) // invalidate only pending manifest receipts
+		return
+	}
+	if b == nil {
+		idx.publishColdFileMtimes(mtimes, !failed && ctx.Err() == nil)
+	} else {
+		b.failed = b.failed || failed
+		idx.finishColdManifests(b)
+	}
+}

--- a/internal/indexer/cold_manifest_census_test.go
+++ b/internal/indexer/cold_manifest_census_test.go
@@ -1,0 +1,794 @@
+package indexer
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/contracts"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/search"
+	"go.uber.org/zap"
+)
+
+func coldReceiptFixture(t *testing.T) (*Indexer, *store_sqlite.Store, string) {
+	t.Helper()
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+	require.NoError(t, err)
+	idx := New(store, newTestRegistry(), config.IndexConfig{}, zap.NewNop())
+	idx.SetRepoPrefix("repo")
+	root := t.TempDir()
+	idx.storeRootPath(root)
+	t.Cleanup(func() { idx.Close(); require.NoError(t, store.Close()) })
+	return idx, store, root
+}
+
+func writeColdReceiptFile(t *testing.T, root, name, body string) (string, int64) {
+	t.Helper()
+	path := filepath.Join(root, name)
+	require.NoError(t, os.WriteFile(path, []byte(body), 0600))
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	return path, info.ModTime().UnixNano()
+}
+
+func completeColdReceiptContracts(idx *Indexer, b *coldManifestCensus) {
+	idx.extractGoModContracts(b.registry)
+	idx.extractExternalModulesForCensus(b.registry)
+	idx.commitContracts(b.registry)
+	b.contractsReady = true
+	idx.finishColdManifests(b)
+}
+
+func TestColdManifestFailedReadCannotHideUnchangedMtimeRetry(t *testing.T) {
+	idx, store, root := coldReceiptFixture(t)
+	body := "module example.test/app\n\ngo 1.24\n"
+	path, mtime := writeColdReceiptFile(t, root, "go.mod", body)
+	prior := map[string]int64{"untouched.go": 101, "go.mod": mtime}
+	idx.SetFileMtimes(prior)
+	require.NoError(t, store.BulkSetFileMtimes("repo", prior))
+	require.NoError(t, os.Remove(path))
+	var b *coldManifestCensus
+	idx.captureColdManifest(&b, context.Background(), path, nil) // real read failure
+	require.Error(t, b.manifests["go.mod"].err)
+	_, _ = writeColdReceiptFile(t, root, "go.mod", body)
+	require.NoError(t, os.Chtimes(path, time.Unix(0, mtime), time.Unix(0, mtime)))
+	idx.captureColdManifest(&b, context.Background(), path, nil)
+	require.Error(t, b.manifests["go.mod"].err) // same-attempt error stays latched
+	b.registry = contracts.NewRegistry()
+	idx.finishColdIndexCensus(context.Background(), &IndexResult{}, nil, map[string]int64{}, b, false)
+	completeColdReceiptContracts(idx, b)
+	require.Equal(t, map[string]int64{"untouched.go": 101}, store.LoadFileMtimes("repo"))
+	require.Contains(t, idx.fileIndexFailurePaths(), "repo/go.mod")
+
+	warm := New(store, newTestRegistry(), config.IndexConfig{}, zap.NewNop())
+	warm.SetRepoPrefix("repo")
+	warm.storeRootPath(root)
+	warm.SetFileMtimes(store.LoadFileMtimes("repo"))
+	warm.loadFileIndexFailures()
+	t.Cleanup(func() { warm.Close() })
+	changed, _, _, err := warm.changedSinceMtimesCensus(root)
+	require.NoError(t, err)
+	require.Contains(t, changed, "go.mod")
+	b = nil
+	warm.captureColdManifest(&b, context.Background(), path, nil)
+	b.registry = contracts.NewRegistry()
+	warm.finishColdIndexCensus(context.Background(), &IndexResult{}, nil, map[string]int64{}, b, false)
+	completeColdReceiptContracts(warm, b)
+	require.Equal(t, map[string]int64{"go.mod": mtime}, store.LoadFileMtimes("repo"))
+	require.NotContains(t, warm.fileIndexFailurePaths(), "repo/go.mod")
+}
+
+func TestColdManifestChangedVersionsAreNotCertified(t *testing.T) {
+	for _, name := range []string{"go.mod", "go.work"} {
+		t.Run(name, func(t *testing.T) {
+			idx, store, root := coldReceiptFixture(t)
+			body := "module example.test/app\n\ngo 1.24\nrequire example.test/old v1.0.0\n"
+			if name == "go.work" {
+				body = "go 1.24\nuse .\n"
+			}
+			path, mtime := writeColdReceiptFile(t, root, name, body)
+			prior := map[string]int64{"untouched.go": 101, name: mtime}
+			idx.SetFileMtimes(prior)
+			require.NoError(t, store.BulkSetFileMtimes("repo", prior))
+			var b *coldManifestCensus
+			idx.captureColdManifest(&b, context.Background(), path, nil)
+			b.registry = contracts.NewRegistry()
+			idx.extractGoModContracts(b.registry)
+			require.NoError(t, os.WriteFile(path, []byte(strings.ReplaceAll(body, "example.test/old", "example.test/new")), 0600))
+			newTime := time.Unix(0, mtime).Add(time.Second)
+			require.NoError(t, os.Chtimes(path, newTime, newTime))
+			idx.extractExternalModulesForCensus(b.registry)
+			if name == "go.mod" {
+				rows, err := json.Marshal(coldReceiptGraphRows(t, store))
+				require.NoError(t, err)
+				require.Contains(t, string(rows), "example.test/old")
+				require.NotContains(t, string(rows), "example.test/new")
+			}
+			idx.commitContracts(b.registry)
+			b.contractsReady = true
+			idx.finishColdIndexCensus(context.Background(), &IndexResult{}, nil, map[string]int64{}, b, false)
+			require.Equal(t, map[string]int64{"untouched.go": 101}, store.LoadFileMtimes("repo"))
+			require.Contains(t, idx.fileIndexFailurePaths(), "repo/"+name)
+		})
+	}
+}
+
+func TestColdCensusFailureAndCancellationPreservePriorKeys(t *testing.T) {
+	for _, stage := range []string{"parse", "graph_error", "deferred", "after_contracts", "parser_error"} {
+		t.Run(stage, func(t *testing.T) {
+			idx, store, root := coldReceiptFixture(t)
+			mainPath, mainMtime := writeColdReceiptFile(t, root, "main.go", "package app\n")
+			modPath, modMtime := writeColdReceiptFile(t, root, "go.mod", "module example.test/app\n")
+			prior := map[string]int64{"untouched.go": 101, "go.mod": modMtime}
+			idx.SetFileMtimes(prior)
+			require.NoError(t, store.BulkSetFileMtimes("repo", prior))
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			var b *coldManifestCensus
+			idx.captureColdManifest(&b, ctx, modPath, nil)
+			b.registry = contracts.NewRegistry()
+			candidate := map[string]int64{"main.go": mainMtime}
+			if stage == "deferred" {
+				idx.finishColdIndexCensus(ctx, &IndexResult{}, nil, candidate, b, false)
+				require.EqualValues(t, mainMtime, store.LoadFileMtimes("repo")["main.go"])
+			}
+			if stage == "after_contracts" {
+				completeColdReceiptContracts(idx, b)
+			}
+			switch stage {
+			case "parser_error":
+				idx.noteFileIndexFailure(mainPath, errors.New("extract failed"))
+				idx.finishColdIndexCensus(ctx, &IndexResult{}, nil, map[string]int64{}, b, true)
+				completeColdReceiptContracts(idx, b)
+			case "graph_error":
+				idx.finishColdIndexCensus(ctx, nil, errors.New("graph publish failed"), candidate, b, false)
+			default:
+				cancel()
+				if stage == "deferred" {
+					idx.finishColdManifests(b)
+				} else {
+					idx.finishColdIndexCensus(ctx, &IndexResult{}, nil, candidate, b, false)
+				}
+			}
+			persisted := store.LoadFileMtimes("repo")
+			require.EqualValues(t, 101, persisted["untouched.go"])
+			if stage != "deferred" {
+				require.NotContains(t, persisted, "main.go")
+			}
+			if stage != "parser_error" {
+				require.NotContains(t, persisted, "go.mod", "failed or cancelled publication cannot retain an old clean receipt")
+			}
+			require.Nil(t, idx.pendingColdManifests)
+		})
+	}
+}
+
+type coldReceiptWriteFailureStore struct{ *store_sqlite.Store }
+
+func (s *coldReceiptWriteFailureStore) BulkSetFileMtimes(string, map[string]int64) error {
+	return errors.New("mtime write failed")
+}
+func (s *coldReceiptWriteFailureStore) ReplaceFileMtimes(string, map[string]int64) error {
+	return errors.New("mtime replace failed")
+}
+
+func TestColdCensusWriteFailureKeepsVisibleProgressAndMarksDirty(t *testing.T) {
+	_, store, _ := coldReceiptFixture(t)
+	idx := New(&coldReceiptWriteFailureStore{store}, newTestRegistry(), config.IndexConfig{}, zap.NewNop())
+	idx.SetRepoPrefix("repo")
+	t.Cleanup(func() { idx.Close() })
+	idx.publishColdFileMtimes(map[string]int64{"main.go": 101}, false)
+	require.Equal(t, map[string]int64{"main.go": 101}, idx.publishFileMtimes())
+	require.True(t, idx.fileMtimePersistenceDirty.Load())
+	require.Empty(t, store.LoadFileMtimes("repo"))
+}
+
+func TestColdCensusEmptySuccessAndOldAttemptFence(t *testing.T) {
+	idx, store, root := coldReceiptFixture(t)
+	idx.SetFileMtimes(map[string]int64{"deleted.go": 101})
+	require.NoError(t, store.BulkSetFileMtimes("repo", idx.publishFileMtimes()))
+	idx.finishColdIndexCensus(context.Background(), &IndexResult{}, nil, map[string]int64{}, nil, false)
+	require.Empty(t, store.LoadFileMtimes("repo"))
+	path, _ := writeColdReceiptFile(t, root, "go.mod", "module example.test/app\n")
+	var old, current *coldManifestCensus
+	idx.captureColdManifest(&old, context.Background(), path, nil)
+	old.registry = contracts.NewRegistry()
+	idx.captureColdManifest(&current, context.Background(), path, nil)
+	current.registry = contracts.NewRegistry()
+	idx.finishColdIndexCensus(context.Background(), &IndexResult{}, nil, map[string]int64{"old.go": 101}, old, false)
+	old.graphReady, old.contractsReady = true, true
+	idx.finishColdManifests(old)
+	require.Same(t, current, idx.pendingColdManifests)
+	require.Empty(t, store.LoadFileMtimes("repo"))
+}
+
+func TestColdCensusEmptySuccessUsesPersistedRoster(t *testing.T) {
+	for _, mtimes := range []map[string]int64{nil, {}} {
+		t.Run(map[bool]string{true: "nil", false: "empty"}[mtimes == nil], func(t *testing.T) {
+			idx, store, _ := coldReceiptFixture(t)
+			// This Indexer has no prior map: only the durable roster can tell
+			// the successful empty census which old receipts to remove.
+			require.Empty(t, idx.publishFileMtimes())
+			require.NoError(t, store.BulkSetFileMtimes("repo", map[string]int64{"durable-only.go": 101}))
+			require.NoError(t, store.BulkSetFileMtimes("sibling", map[string]int64{"keep.go": 202}))
+			idx.markFileMtimePersistenceDirty()
+			idx.publishColdFileMtimes(mtimes, true)
+			require.Empty(t, store.LoadFileMtimes("repo"))
+			require.Empty(t, idx.publishFileMtimes())
+			require.Equal(t, map[string]int64{"keep.go": 202}, store.LoadFileMtimes("sibling"))
+			require.False(t, idx.fileMtimePersistenceDirty.Load())
+		})
+	}
+}
+
+func TestColdCensusEmptySuccessPreservesSiblingGeneration(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "graph.sqlite")
+	store, err := store_sqlite.Open(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, store.BulkSetFileMtimes("repo", map[string]int64{"old.go": 101, "foreign.go": 202}))
+	require.NoError(t, store.Close())
+	// Move only the fixture's foreign receipt into a sibling generation.
+	// The production store is closed while the fixture row is prepared.
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	update, err := db.Exec(`UPDATE file_mtimes SET view_gen = 7 WHERE repo_prefix = ? AND file_path = ?`, "repo", "foreign.go")
+	require.NoError(t, err)
+	rows, err := update.RowsAffected()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rows)
+	store, err = store_sqlite.Open(dbPath)
+	require.NoError(t, err)
+	idx := New(store, newTestRegistry(), config.IndexConfig{}, zap.NewNop())
+	idx.SetRepoPrefix("repo")
+	t.Cleanup(func() { idx.Close(); require.NoError(t, store.Close()) })
+	idx.publishColdFileMtimes(nil, true)
+	require.Empty(t, store.LoadFileMtimes("repo"))
+	var mtime int64
+	require.NoError(t, db.QueryRow(`SELECT mtime_ns FROM file_mtimes WHERE view_gen = 7 AND repo_prefix = ? AND file_path = ?`, "repo", "foreign.go").Scan(&mtime))
+	require.EqualValues(t, 202, mtime)
+}
+
+// Hide optional reader/deleter capabilities while preserving a durable
+// writer/replacer adapter's established empty-replacement no-op contract.
+type coldReceiptNoClearStore struct{ graph.Store }
+
+func (s *coldReceiptNoClearStore) BulkSetFileMtimes(string, map[string]int64) error {
+	return nil
+}
+func (s *coldReceiptNoClearStore) ReplaceFileMtimes(string, map[string]int64) error {
+	return nil
+}
+
+func TestColdCensusUnsupportedEmptyClearPreservesDurableData(t *testing.T) {
+	_, store, _ := coldReceiptFixture(t)
+	require.NoError(t, store.BulkSetFileMtimes("repo", map[string]int64{"keep.go": 101}))
+	idx := New(&coldReceiptNoClearStore{store}, newTestRegistry(), config.IndexConfig{}, zap.NewNop())
+	idx.SetRepoPrefix("repo")
+	t.Cleanup(func() { idx.Close() })
+	idx.publishColdFileMtimes(map[string]int64{}, true)
+	require.Empty(t, idx.publishFileMtimes())
+	require.True(t, idx.fileMtimePersistenceDirty.Load())
+	require.Equal(t, map[string]int64{"keep.go": 101}, store.LoadFileMtimes("repo"))
+}
+
+func TestColdCensusMetadataRefreshIsImmutableAndIndexerBound(t *testing.T) {
+	idx, store, root := coldReceiptFixture(t)
+	idx.SetFileMtimes(map[string]int64{"main.go": 101})
+	prior := &RepoMetadata{RepoPrefix: "repo", RootPath: root, FileMtimes: idx.publishFileMtimes()}
+	mi := &MultiIndexer{repos: map[string]*RepoMetadata{"repo": prior}, indexers: map[string]*Indexer{"repo": idx}}
+	idx.publishColdFileMtimes(map[string]int64{"go.mod": 202}, false)
+	mi.refreshColdCensusMetadata(idx)
+	require.Equal(t, map[string]int64{"main.go": 101}, prior.FileMtimes)
+	require.Equal(t, map[string]int64{"main.go": 101, "go.mod": 202}, mi.FileMtimes("repo"))
+	replacement := New(store, newTestRegistry(), config.IndexConfig{}, zap.NewNop())
+	t.Cleanup(func() { replacement.Close() })
+	mi.indexers["repo"] = replacement
+	before := mi.repos["repo"]
+	idx.publishColdFileMtimes(map[string]int64{"old.go": 303}, false)
+	mi.refreshColdCensusMetadata(idx)
+	require.Same(t, before, mi.repos["repo"])
+}
+
+func TestColdManifestInlineIndexPublishesReceipts(t *testing.T) {
+	idx, store, root := coldReceiptFixture(t)
+	expected := make(map[string]int64)
+	for name, body := range map[string]string{
+		"main.go": "package app\nfunc Main() {}\n",
+		"go.mod":  "module example.test/app\n\ngo 1.24\nrequire example.test/dependency v1.0.0\n",
+		"go.work": "go 1.24\nuse .\n",
+	} {
+		_, expected[name] = writeColdReceiptFile(t, root, name, body)
+	}
+	// No deferral flags: exercise the normal inline contract/module ordering,
+	// then the final shadow/FTS/vector publication and census callback.
+	_, err := idx.IndexCtx(context.Background(), root)
+	require.NoError(t, err)
+	require.NotNil(t, store.GetNodesByIDs([]string{"dep::example.test/dependency"})["dep::example.test/dependency"])
+	require.Equal(t, expected, store.LoadFileMtimes("repo"))
+	require.Equal(t, expected, idx.publishFileMtimes())
+	require.Nil(t, idx.pendingColdManifests)
+}
+
+func TestColdIndexFirstRestartPreservesManifestGraph(t *testing.T) {
+	root := t.TempDir()
+	files := map[string]string{
+		"main.go": "package app\nfunc Main() {}\n",
+		"go.mod":  "module example.test/app\n\ngo 1.24\nrequire example.test/dependency v1.0.0\n",
+		"go.work": "go 1.24\nuse .\n",
+	}
+	expected := make(map[string]int64)
+	var paths []string
+	for path, body := range files {
+		_, expected[path] = writeColdReceiptFile(t, root, path, body)
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	dbPath := filepath.Join(t.TempDir(), "graph.sqlite")
+	store, err := store_sqlite.Open(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if store != nil {
+			_ = store.Close()
+		}
+	})
+	registry := newTestRegistry()
+	cfg := config.IndexConfig{MaxFileSize: 128}
+	cold := New(store, registry, cfg, zap.NewNop())
+	closed := false
+	t.Cleanup(func() {
+		if !closed {
+			cold.Close()
+		}
+	})
+	cold.SetRepoPrefix("repo")
+	cold.SetDeferResolve(true)
+	cold.SetDeferGlobalPasses(true)
+	_, err = cold.IndexCtx(context.Background(), root)
+	require.NoError(t, err)
+	// Parser progress is visible before deferred contracts; the go.mod
+	// receipt must still be withheld until those contracts commit.
+	require.EqualValues(t, expected["main.go"], store.LoadFileMtimes("repo")["main.go"])
+	require.NotContains(t, store.LoadFileMtimes("repo"), "go.mod")
+	cold.RunDeferredPasses(context.Background())
+	require.Equal(t, expected, store.LoadFileMtimes("repo"))
+	for _, id := range []string{"repo/main.go", "repo/go.mod", "dep::example.test/dependency"} {
+		require.NotNil(t, store.GetNodesByIDs([]string{id})[id], "seed endpoint %s must exist", id)
+	}
+	// Match the exact populations lost by the measured false manifest refresh.
+	// Bridge synthesis is outside this fixture's scope; do not claim a
+	// synthetic bridge preservation assertion from node/edge totals alone.
+	seeded := []*graph.Edge{
+		{From: "repo/main.go", To: "dep::example.test/dependency", Kind: "imports", FilePath: "repo/main.go", Line: 2},
+		{From: "repo/main.go", To: "repo/go.mod", Kind: "co_change", FilePath: "repo/main.go"},
+		{From: "repo/go.mod", To: "repo/main.go", Kind: "co_change", FilePath: "repo/go.mod"},
+	}
+	store.AddBatch(nil, seeded)
+	storedEdges := store.GetOutEdgesByNodeIDs([]string{"repo/main.go", "repo/go.mod"})
+	for _, want := range seeded {
+		found := 0
+		for _, got := range storedEdges[want.From] {
+			if got.From == want.From && got.To == want.To && got.Kind == want.Kind {
+				found++
+			}
+		}
+		require.Equal(t, 1, found, "stored %s edge %s -> %s", want.Kind, want.From, want.To)
+	}
+	before := coldReceiptGraphRows(t, store)
+	cold.Close()
+	closed = true
+	require.NoError(t, store.Close())
+	store, err = store_sqlite.Open(dbPath)
+	require.NoError(t, err)
+	warm := New(store, registry, cfg, zap.NewNop())
+	t.Cleanup(func() { warm.Close() })
+	warm.SetRepoPrefix("repo")
+	warm.storeRootPath(root)
+	warm.SetFileMtimes(store.LoadFileMtimes("repo"))
+	changed, deleted, detected, err := warm.changedSinceMtimesCensus(root)
+	require.NoError(t, err)
+	require.Empty(t, changed)
+	require.Empty(t, deleted)
+	require.Equal(t, len(files), detected)
+	result, err := warm.incrementalReindexPathsMode(root, paths, incrementalPathMode{})
+	require.NoError(t, err)
+	require.Zero(t, result.StaleFileCount)
+	require.Equal(t, expected, store.LoadFileMtimes("repo"))
+	require.Equal(t, before, coldReceiptGraphRows(t, store))
+}
+
+func TestMultiIndexerColdManifestReceiptsSurviveDeferredTail(t *testing.T) {
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	var entries []config.RepoEntry
+	expected := make(map[string]map[string]int64)
+	for _, prefix := range []string{"repo-a", "repo-b"} {
+		root := t.TempDir()
+		mtimes := make(map[string]int64)
+		for name, body := range map[string]string{
+			"main.go": "package app\nfunc Main() {}\n",
+			"go.mod":  "module example.test/" + prefix + "\n\ngo 1.24\nrequire example.test/dependency v1.0.0\n",
+			"go.work": "go 1.24\nuse .\n",
+		} {
+			_, mtimes[name] = writeColdReceiptFile(t, root, name, body)
+		}
+		expected[prefix] = mtimes
+		entries = append(entries, config.RepoEntry{Path: root, Name: prefix})
+	}
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	global := &config.GlobalConfig{Repos: entries}
+	global.SetConfigPath(configPath)
+	require.NoError(t, global.Save())
+	manager, err := config.NewConfigManager(configPath)
+	require.NoError(t, err)
+	mi := NewMultiIndexer(store, newTestRegistry(), search.NewNull(), manager, zap.NewNop())
+	t.Cleanup(func() {
+		for _, idx := range mi.indexers {
+			idx.Close()
+		}
+	})
+
+	// Exercise actual raw-worker publication and the coordinated deferred
+	// tail. A parse-only context cancelled by ordinary worker cleanup must
+	// not prevent this successful tail from publishing manifest receipts.
+	results, err := mi.IndexAll()
+	require.NoError(t, err)
+	require.Len(t, results, len(entries))
+	for prefix, mtimes := range expected {
+		require.Equal(t, mtimes, store.LoadFileMtimes(prefix), prefix)
+		require.Equal(t, mtimes, mi.FileMtimes(prefix), "late metadata refresh for %s", prefix)
+		idx := mi.indexers[prefix]
+		require.NotNil(t, idx)
+		require.Nil(t, idx.pendingColdManifests, "deferred receipt bundle drained for %s", prefix)
+		changed, deleted, _, err := idx.changedSinceMtimesCensus(mi.GetMetadata(prefix).RootPath)
+		require.NoError(t, err)
+		require.Empty(t, changed, prefix)
+		require.Empty(t, deleted, prefix)
+	}
+}
+
+func TestColdDeferredCohortRetainsRegisteredUniverseScope(t *testing.T) {
+	mi, idx, store, root := deferredOverlapFixture(t)
+	indexDeferredOverlapAttempt(t, idx, root, "scoped", time.Now().Add(-time.Minute))
+	mi.mu.Lock()
+	for _, prefix := range []string{"other-a", "other-b"} {
+		other := New(store, newTestRegistry(), config.IndexConfig{}, zap.NewNop())
+		other.SetRepoPrefix(prefix)
+		mi.indexers[prefix] = other
+	}
+	mi.mu.Unlock()
+	// The explicit cold route is valid only while this cohort's lane is
+	// held. The two other registered Indexers are not admitted as work.
+	err := idx.coordinateRepositoryMutation(context.Background(), func() error {
+		run := mi.beginDeferredPasses(context.Background(), nil, []*Indexer{idx}, true)
+		defer run.FinishTailResult()
+		require.Len(t, run.workIndexers, 1)
+		require.Equal(t, 3, run.indexerCount)
+		require.Equal(t, map[string]struct{}{"overlap": {}},
+			normalizeDeferredCatchupScope(run.catchupScope, run.catchupKnown, run.indexerCount))
+		return nil
+	})
+	require.NoError(t, err)
+	require.Nil(t, normalizeDeferredCatchupScope(map[string]struct{}{"overlap": {}}, false, 3))
+	require.Nil(t, normalizeDeferredCatchupScope(map[string]struct{}{
+		"overlap": {}, "other-a": {}, "other-b": {},
+	}, true, 3))
+}
+
+func coldReceiptGraphRows(t *testing.T, store graph.Store) map[string]string {
+	t.Helper()
+	rows := make(map[string]string)
+	var ids []string
+	for _, node := range store.AllNodes() {
+		encoded, err := json.Marshal(node)
+		require.NoError(t, err)
+		rows["node:"+node.ID] = string(encoded)
+		ids = append(ids, node.ID)
+	}
+	for _, edges := range store.GetOutEdgesByNodeIDs(ids) {
+		for _, edge := range edges {
+			encoded, err := json.Marshal(edge)
+			require.NoError(t, err)
+			rows["edge:"+string(encoded)] = string(encoded)
+		}
+	}
+	return rows
+}
+
+// Embed only the base Store method set: the real SQLite backend supplies
+// graph behavior but cannot accidentally promote its optional Deleter.
+type manifestReplacerWithoutDelete struct {
+	graph.Store
+	graph.FileMtimeReader
+	replacer     graph.FileMtimeReplacer
+	replaceCalls int
+}
+
+func (s *manifestReplacerWithoutDelete) ReplaceFileMtimes(repo string, mtimes map[string]int64) error {
+	s.replaceCalls++
+	// Delegate to the real contract: empty input is deliberately a no-op,
+	// while nonempty replacement prunes omitted keys for this repository.
+	return s.replacer.ReplaceFileMtimes(repo, mtimes)
+}
+
+type manifestWriterReplacerWithoutDelete struct {
+	*manifestReplacerWithoutDelete
+	graph.FileMtimeWriter
+}
+
+var _ graph.FileMtimeReplacer = (*manifestReplacerWithoutDelete)(nil)
+var _ graph.FileMtimeWriter = (*manifestWriterReplacerWithoutDelete)(nil)
+
+func manifestCapabilityFixture(t *testing.T, withWriter bool) (*Indexer, *store_sqlite.Store, *manifestReplacerWithoutDelete) {
+	t.Helper()
+	backend, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, backend.Close()) })
+	adapter := &manifestReplacerWithoutDelete{
+		Store: backend, FileMtimeReader: backend, replacer: backend,
+	}
+	var store graph.Store = adapter
+	if withWriter {
+		store = &manifestWriterReplacerWithoutDelete{manifestReplacerWithoutDelete: adapter, FileMtimeWriter: backend}
+	}
+	_, canWrite := store.(graph.FileMtimeWriter)
+	require.Equal(t, withWriter, canWrite)
+	_, canReplace := store.(graph.FileMtimeReplacer)
+	require.True(t, canReplace)
+	_, canDelete := store.(graph.FileMtimeDeleter)
+	require.False(t, canDelete, "fixture must not inherit SQLite's deletion capability")
+	idx := New(store, newTestRegistry(), config.IndexConfig{}, zap.NewNop())
+	idx.SetRepoPrefix("repo")
+	idx.storeRootPath(t.TempDir())
+	t.Cleanup(idx.Close)
+	return idx, backend, adapter
+}
+
+func TestColdManifestCapabilitiesRejectDurableReplacerWithoutDelete(t *testing.T) {
+	for _, withWriter := range []bool{false, true} {
+		name := "replacer_only"
+		if withWriter {
+			name = "writer_and_replacer"
+		}
+		t.Run(name, func(t *testing.T) {
+			idx, backend, adapter := manifestCapabilityFixture(t, withWriter)
+			assert.False(t, supportsColdManifestReceipts(idx.graph))
+			path := filepath.Join(t.TempDir(), "go.work")
+			idx.storeRootPath(filepath.Dir(path))
+			require.NoError(t, os.WriteFile(path, []byte("go 1.24\nuse .\n"), 0600))
+			var bundle *coldManifestCensus
+			idx.captureColdManifest(&bundle, context.Background(), path, nil)
+			assert.Nil(t, bundle, "unsupported durable backend must not capture new receipts")
+			// If the broken gate captures anyway, complete the ordinary go.work
+			// receipt path to expose actual new durable rows, not just a bool.
+			if bundle != nil {
+				bundle.graphReady = true
+				bundle.contractsReady = true
+				bundle.census = make(map[string]int64)
+				idx.finishColdManifests(bundle)
+			}
+			assert.Empty(t, backend.LoadFileMtimes("repo"), "unsupported backend must not acquire an unrevocable new receipt")
+			assert.Zero(t, adapter.replaceCalls)
+		})
+	}
+}
+
+func TestColdManifestCapabilitiesUnsupportedInvalidationIsLocalAndDirty(t *testing.T) {
+	for _, withWriter := range []bool{false, true} {
+		capability := "replacer_only"
+		if withWriter {
+			capability = "writer_and_replacer"
+		}
+		for _, includePeers := range []bool{false, true} {
+			shape := "sole_manifest"
+			if includePeers {
+				shape = "persisted_only_peer"
+			}
+			t.Run(capability+"/"+shape, func(t *testing.T) {
+				idx, backend, adapter := manifestCapabilityFixture(t, withWriter)
+				durable := map[string]int64{"go.mod": 101}
+				local := map[string]int64{"go.mod": 101}
+				wantLocal := map[string]int64{}
+				if includePeers {
+					durable["disk-only.go"] = 202
+					durable["visible.go"] = 303
+					local["visible.go"] = 303
+					wantLocal["visible.go"] = 303
+				}
+				require.NoError(t, backend.BulkSetFileMtimes("repo", durable))
+				sibling := map[string]int64{"go.mod": 404}
+				require.NoError(t, backend.BulkSetFileMtimes("sibling", sibling))
+				idx.SetFileMtimes(local)
+				require.False(t, idx.fileMtimePersistenceDirty.Load())
+				idx.invalidateColdFileMtimes([]string{"go.mod"})
+				assert.Equal(t, wantLocal, idx.publishFileMtimes(), "invalidate only the exact local key")
+				assert.Equal(t, durable, backend.LoadFileMtimes("repo"), "without a deleter do not claim durable deletion or prune unknown peers")
+				assert.Equal(t, sibling, backend.LoadFileMtimes("sibling"))
+				assert.True(t, idx.fileMtimePersistenceDirty.Load(), "unsupported durable invalidation needs retry state")
+				assert.Zero(t, adapter.replaceCalls, "ReplaceFileMtimes is not an invalidation fallback")
+			})
+		}
+	}
+}
+
+func TestColdManifestCapabilitiesMemoryOnlyRemainsSupported(t *testing.T) {
+	// These helpers inspect capabilities and own the Indexer's mtime map;
+	// they do not invoke graph operations, so no graph fixture is required.
+	memory := &graph.Graph{}
+	_, writer := any(memory).(graph.FileMtimeWriter)
+	_, replacer := any(memory).(graph.FileMtimeReplacer)
+	require.False(t, writer)
+	require.False(t, replacer)
+	require.True(t, supportsColdManifestReceipts(memory))
+	idx := &Indexer{graph: memory, logger: zap.NewNop()}
+	idx.publishColdFileMtimes(map[string]int64{"go.work": 101, "keep.go": 202}, true)
+	require.Equal(t, map[string]int64{"go.work": 101, "keep.go": 202}, idx.publishFileMtimes())
+	idx.invalidateColdFileMtimes([]string{"go.work"})
+	require.Equal(t, map[string]int64{"keep.go": 202}, idx.publishFileMtimes())
+	require.False(t, idx.fileMtimePersistenceDirty.Load())
+}
+
+// Register the repository through real public orchestration, then retain its
+// actual Indexer. Every attempt below calls public IndexCtx on this same object;
+// no pending registry, census bundle, or completion flag is manufactured.
+func deferredOverlapFixture(t *testing.T) (*MultiIndexer, *Indexer, *store_sqlite.Store, string) {
+	t.Helper()
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "main.go"), []byte("package app\nfunc Main() {}\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.test/base\n\ngo 1.24\n"), 0600))
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	global := &config.GlobalConfig{Repos: []config.RepoEntry{{Path: root, Name: "overlap"}}}
+	global.SetConfigPath(configPath)
+	require.NoError(t, global.Save())
+	manager, err := config.NewConfigManager(configPath)
+	require.NoError(t, err)
+	mi := NewMultiIndexer(store, newTestRegistry(), search.NewNull(), manager, zap.NewNop())
+	t.Cleanup(func() {
+		for _, idx := range mi.indexers {
+			idx.Close()
+		}
+	})
+	_, err = mi.IndexAll()
+	require.NoError(t, err)
+	idx := mi.indexers["overlap"]
+	require.NotNil(t, idx)
+	idx.SetDeferResolve(true)
+	idx.SetDeferGlobalPasses(true)
+	return mi, idx, store, root
+}
+
+func indexDeferredOverlapAttempt(t *testing.T, idx *Indexer, root, name string, mtime time.Time) int64 {
+	t.Helper()
+	path := filepath.Join(root, "go.mod")
+	body := "module example.test/" + name + "\n\ngo 1.24\nrequire example.test/dependency v1.0.0\n"
+	require.NoError(t, os.WriteFile(path, []byte(body), 0600))
+	require.NoError(t, os.Chtimes(path, mtime, mtime))
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	_, err = idx.IndexCtx(context.Background(), root)
+	require.NoError(t, err)
+	require.NotNil(t, idx.pendingContractReg, "public IndexCtx must leave this attempt's contracts deferred")
+	return info.ModTime().UnixNano()
+}
+
+// Waiting for the enrichment pool creates a deterministic public-API gap:
+// no goroutine scheduling, sleeps, provider internals, or source hooks needed.
+// Cleanup drains each run exactly once, including after a failed prerequisite.
+func beginDeferredOverlapRun(t *testing.T, mi *MultiIndexer) func() {
+	t.Helper()
+	run := mi.BeginDeferredPasses(context.Background(), nil)
+	run.Wait()
+	finished := false
+	finish := func() {
+		if !finished {
+			finished = true
+			run.FinishTailResult()
+		}
+	}
+	t.Cleanup(finish)
+	return finish
+}
+
+func TestDeferredOlderTailDoesNotConsumeNewerRegistry(t *testing.T) {
+	mi, idx, _, root := deferredOverlapFixture(t)
+	start := time.Now().Add(-time.Minute)
+	indexDeferredOverlapAttempt(t, idx, root, "attempt-a", start)
+	registryA := idx.pendingContractReg
+	finishA := beginDeferredOverlapRun(t, mi)
+
+	indexDeferredOverlapAttempt(t, idx, root, "attempt-b", start.Add(time.Second))
+	registryB := idx.pendingContractReg
+	require.NotSame(t, registryA, registryB, "the public reindex must actually create a newer attempt")
+	finishA()
+	assert.Same(t, registryB, idx.pendingContractReg,
+		"A's deferred tail must not consume or clear B's newer pending registry")
+
+	// B owns its own tail. This is a separate run, not a second finish of A.
+	finishB := beginDeferredOverlapRun(t, mi)
+	finishB()
+}
+
+func TestDeferredOlderTailDoesNotCertifyNewerManifest(t *testing.T) {
+	mi, idx, store, root := deferredOverlapFixture(t)
+	start := time.Now().Add(-time.Minute)
+	indexDeferredOverlapAttempt(t, idx, root, "attempt-a", start)
+	registryA := idx.pendingContractReg
+	finishA := beginDeferredOverlapRun(t, mi)
+
+	mtimeB := indexDeferredOverlapAttempt(t, idx, root, "attempt-b", start.Add(time.Second))
+	registryB := idx.pendingContractReg
+	require.NotSame(t, registryA, registryB)
+	bundleB := idx.pendingColdManifests
+	require.NotNil(t, bundleB, "receipt integration prerequisite: B must own a real captured manifest bundle")
+	require.Same(t, registryB, bundleB.registry, "receipt integration prerequisite: raw indexing must bind B's registry")
+	require.True(t, bundleB.graphReady, "receipt integration prerequisite: B's graph publication must finish")
+	require.Contains(t, bundleB.manifests, "go.mod")
+	require.NotContains(t, store.LoadFileMtimes("overlap"), "go.mod", "B has not finished its contract tail")
+
+	// Begin B's real dependency phase before old A finishes. Otherwise the
+	// dependencyDone=false guard would withhold the receipt and mask whether
+	// an old tail can wrongly certify a newer, fully prepared bundle.
+	finishB := beginDeferredOverlapRun(t, mi)
+	require.True(t, bundleB.manifests["go.mod"].dependencyDone,
+		"receipt integration prerequisite: B's actual deferred go.mod phase must run")
+	require.False(t, bundleB.contractsReady, "B's own tail has not run")
+	finishA()
+	assert.Same(t, registryB, idx.pendingContractReg,
+		"registry ownership: A must not consume B")
+	assert.Same(t, bundleB, idx.pendingColdManifests,
+		"receipt ownership: A must not finalize B's census bundle")
+	assert.False(t, bundleB.contractsReady,
+		"receipt ownership: A must not mark B's contracts complete")
+	assert.NotContains(t, store.LoadFileMtimes("overlap"), "go.mod",
+		"A must not publish B's durable success receipt before B's own tail")
+
+	finishB()
+	require.Nil(t, idx.pendingContractReg)
+	require.Nil(t, idx.pendingColdManifests)
+	require.EqualValues(t, mtimeB, store.LoadFileMtimes("overlap")["go.mod"],
+		"B's legitimate tail must eventually publish its own manifest version")
+}
+
+func TestColdScopedDeferredTailPreservesUnselectedAttempt(t *testing.T) {
+	mi, unselected, _, root := deferredOverlapFixture(t)
+	indexDeferredOverlapAttempt(t, unselected, root, "unselected-pending", time.Now().Add(-time.Minute))
+	registry := unselected.pendingContractReg
+	bundle := unselected.pendingColdManifests
+
+	selectedRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(selectedRoot, "main.go"), []byte("package selected\nfunc Main() {}\n"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(selectedRoot, "go.mod"), []byte("module example.test/selected\n\ngo 1.24\n"), 0600))
+	// This is the actual cold orchestration entry whose sorted lane set only
+	// contains "selected". The previously registered "overlap" repository's
+	// lane is not part of this batch, despite its pending deferred contracts.
+	results, err := mi.indexMultiRepo([]config.RepoEntry{{Path: selectedRoot, Name: "selected"}})
+	require.NoError(t, err)
+	require.Contains(t, results, "selected")
+	assert.Same(t, registry, unselected.pendingContractReg,
+		"a selected cold batch must not drain an unrelated, unheld repository")
+	assert.Same(t, bundle, unselected.pendingColdManifests,
+		"the unrelated attempt's pending census must remain owned by that attempt")
+	selected := mi.indexers["selected"]
+	require.NotNil(t, selected)
+	require.Nil(t, selected.pendingContractReg, "the selected batch's own tail must complete")
+
+	// Drain any still-pending unselected work via the legitimate public path.
+	finishUnselected := beginDeferredOverlapRun(t, mi)
+	finishUnselected()
+}

--- a/internal/indexer/content_skip_census.go
+++ b/internal/indexer/content_skip_census.go
@@ -1,0 +1,78 @@
+package indexer
+
+import (
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser"
+)
+
+// Candidates have already passed the ordinary walk, exclusion, global-size,
+// and mtime checks. Keep only asset classes, including currently admitted
+// assets whose old content-policy stub may need to become parsed graph.
+type contentPolicyCensusCandidate struct {
+	relPath string
+	lang    string
+	size    int64
+}
+
+func contentPolicyCensusAsset(gate *contentAdmissionGate, lang string) bool {
+	if gate == nil {
+		return false
+	}
+	switch gate.classes[lang] {
+	case parser.AssetDocument, parser.AssetData, parser.AssetImage:
+		return true
+	default:
+		return false
+	}
+}
+
+// Read only deterministic asset file-node IDs from the selected store. This
+// adds neither a whole-repository scan nor hydration of ordinary source files.
+func (idx *Indexer) staleContentPolicyFiles(gate *contentAdmissionGate, candidates []contentPolicyCensusCandidate) []string {
+	const batchSize = 128
+	var stale []string
+	for start := 0; start < len(candidates); start += batchSize {
+		end := min(start+batchSize, len(candidates))
+		batch := candidates[start:end]
+		ids := make([]string, len(batch))
+		for i, candidate := range batch {
+			ids[i] = idx.prefixPath(candidate.relPath)
+		}
+		nodes := idx.graph.GetNodesByIDs(ids)
+		for i, candidate := range batch {
+			node := nodes[ids[i]]
+			var reason string
+			var validStub bool
+			if node != nil {
+				rel, scoped := idx.graphPathRelKey(node.FilePath)
+				size, sizeOK := sizeSkipMetaInt64(node.Meta["file_size_bytes"])
+				reason, _ = node.Meta["skip_reason"].(string)
+				validStub = node.Kind == graph.KindFile && node.ID == ids[i] &&
+					node.RepoPrefix == idx.repoPrefix && scoped && rel == candidate.relPath &&
+					node.Meta["skipped_due_to_content"] == true && sizeOK && size == candidate.size
+			}
+			// The cold untracked gate has precedence over content admission.
+			// Leave its valid stub alone even when content policy also rejects
+			// the asset; this change does not certify untracked-file receipts.
+			if validStub && reason == skipReasonUntrackedAsset {
+				continue
+			}
+			wantedReason, skip := gate.skip(candidate.lang, candidate.size)
+			if !skip {
+				if node != nil {
+					if _, marked := node.Meta["skipped_due_to_content"]; marked {
+						stale = append(stale, candidate.relPath)
+					}
+				}
+				continue
+			}
+			// Matching reason and size are the complete persisted policy
+			// evidence: changing a cap while the same rejection still holds
+			// does not require a refresh. There is no stored cap field.
+			if !validStub || reason != wantedReason {
+				stale = append(stale, candidate.relPath)
+			}
+		}
+	}
+	return stale
+}

--- a/internal/indexer/content_skip_census_test.go
+++ b/internal/indexer/content_skip_census_test.go
@@ -2,14 +2,27 @@ package indexer
 
 import (
 	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zzet/gortex/internal/config"
 	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/parser"
+	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/search"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"gopkg.in/yaml.v3"
 )
 
 func newContentCensusFixture(t *testing.T, imageLimit int64) *sizeCensusFixture {
@@ -114,6 +127,452 @@ func TestContentSkipCensusEqualMtimePolicyChanges(t *testing.T) {
 			}
 			reopenContentCensusFixture(f, tc.after)
 			f.census(nil, nil, 2)
+		})
+	}
+}
+
+type contentCensusReadSpy struct {
+	graph.Store
+	nodes   map[string]*graph.Node
+	batches [][]string
+}
+
+func (s *contentCensusReadSpy) GetNodesByIDs(ids []string) map[string]*graph.Node {
+	s.batches = append(s.batches, append([]string(nil), ids...))
+	result := make(map[string]*graph.Node)
+	for _, id := range ids {
+		if node := s.nodes[id]; node != nil {
+			result[id] = node
+		}
+	}
+	return result
+}
+
+func TestContentSkipHelperScopeAndUntrackedPrecedence(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		alter func(*graph.Node)
+		stale bool
+	}{
+		{"valid", func(*graph.Node) {}, false},
+		{"untracked_precedes_content_rejection", func(n *graph.Node) { n.Meta["skip_reason"] = skipReasonUntrackedAsset }, false},
+		{"wrong_repo", func(n *graph.Node) { n.RepoPrefix = "sibling" }, true},
+		{"wrong_id", func(n *graph.Node) { n.ID = "sibling/demo.gif" }, true},
+		{"wrong_path", func(n *graph.Node) { n.FilePath = "repo/other.gif" }, true},
+		{"wrong_kind", func(n *graph.Node) { n.Kind = graph.KindFunction }, true},
+		{"wrong_reason", func(n *graph.Node) { n.Meta["skip_reason"] = skipReasonLargeData }, true},
+		{"wrong_size", func(n *graph.Node) { n.Meta["file_size_bytes"] = int64(511) }, true},
+		{"false_marker", func(n *graph.Node) { n.Meta["skipped_due_to_content"] = false }, true},
+		{"string_marker", func(n *graph.Node) { n.Meta["skipped_due_to_content"] = "true" }, true},
+		{"foreign_untracked_not_exempt", func(n *graph.Node) { n.RepoPrefix = "sibling"; n.Meta["skip_reason"] = skipReasonUntrackedAsset }, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newContentCensusFixture(t, 128)
+			node := *f.fileNode()
+			node.Meta = map[string]any{"skipped_due_to_content": true, "skip_reason": skipReasonLargeImage, "file_size_bytes": int64(512)}
+			tc.alter(&node)
+			spy := &contentCensusReadSpy{Store: f.store, nodes: map[string]*graph.Node{"repo/demo.gif": &node}}
+			f.idx.graph = spy
+			got := f.idx.staleContentPolicyFiles(f.idx.newContentAdmissionGate(), []contentPolicyCensusCandidate{{"demo.gif", node.Language, 512}})
+			if tc.stale {
+				require.Equal(t, []string{"demo.gif"}, got)
+			} else {
+				require.Empty(t, got)
+			}
+			require.Equal(t, [][]string{{"repo/demo.gif"}}, spy.batches)
+		})
+	}
+}
+
+func TestContentSkipHelperAssetClassesAndPolicyToggle(t *testing.T) {
+	f := newContentCensusFixture(t, 128)
+	for _, tc := range []struct {
+		name   string
+		class  parser.AssetClass
+		reason string
+		after  *contentAdmissionGate
+		stale  bool
+	}{
+		{"document_cap_increase", parser.AssetDocument, skipReasonLargeDocument, &contentAdmissionGate{docLimit: 1024, docCapped: true}, true},
+		{"data_enabled", parser.AssetData, skipReasonVectorData, &contentAdmissionGate{indexData: true}, true},
+		{"data_same_disabled", parser.AssetData, skipReasonVectorData, &contentAdmissionGate{}, false},
+		{"data_rejection_reason_changes", parser.AssetData, skipReasonVectorData, &contentAdmissionGate{indexData: true, dataLimit: 128, dataCapped: true}, true},
+		{"image_same_rejection", parser.AssetImage, skipReasonLargeImage, &contentAdmissionGate{imageLimit: 256, imageCapped: true}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gate := tc.after
+			gate.classes = map[string]parser.AssetClass{"asset": tc.class}
+			require.True(t, contentPolicyCensusAsset(gate, "asset"))
+			require.False(t, contentPolicyCensusAsset(gate, "go"))
+			node := &graph.Node{ID: "repo/demo.gif", Kind: graph.KindFile, FilePath: "repo/demo.gif", RepoPrefix: "repo", Meta: map[string]any{"skipped_due_to_content": true, "skip_reason": tc.reason, "file_size_bytes": int64(512)}}
+			f.idx.graph = &contentCensusReadSpy{Store: f.store, nodes: map[string]*graph.Node{node.ID: node}}
+			got := f.idx.staleContentPolicyFiles(gate, []contentPolicyCensusCandidate{{"demo.gif", "asset", 512}})
+			if tc.stale {
+				require.Equal(t, []string{"demo.gif"}, got)
+			} else {
+				require.Empty(t, got)
+			}
+		})
+	}
+	require.False(t, contentPolicyCensusAsset(nil, "asset"))
+}
+
+func TestContentSkipHelperEmptyRepoAndSelectedGeneration(t *testing.T) {
+	t.Run("empty_repo", func(t *testing.T) {
+		f := newContentCensusFixture(t, 128)
+		lang := f.fileNode().Language
+		f.idx.SetRepoPrefix("")
+		node := &graph.Node{ID: "demo.gif", Kind: graph.KindFile, FilePath: "demo.gif", Meta: map[string]any{"skipped_due_to_content": true, "skip_reason": skipReasonLargeImage, "file_size_bytes": int64(512)}}
+		spy := &contentCensusReadSpy{Store: f.store, nodes: map[string]*graph.Node{node.ID: node}}
+		f.idx.graph = spy
+		require.Empty(t, f.idx.staleContentPolicyFiles(f.idx.newContentAdmissionGate(), []contentPolicyCensusCandidate{{"demo.gif", lang, 512}}))
+		require.Equal(t, [][]string{{"demo.gif"}}, spy.batches)
+	})
+	t.Run("other_generation", func(t *testing.T) {
+		f := newContentCensusFixture(t, 128)
+		require.Equal(t, true, f.fileNode().Meta["skipped_due_to_content"])
+		lang := f.fileNode().Language
+		f.close()
+		db, err := sql.Open("sqlite", f.dbPath)
+		require.NoError(t, err)
+		result, err := db.Exec(`UPDATE nodes SET view_gen = 7 WHERE id = ?`, "repo/demo.gif")
+		require.NoError(t, err)
+		rows, err := result.RowsAffected()
+		require.NoError(t, err)
+		require.EqualValues(t, 1, rows)
+		require.NoError(t, db.Close())
+		reopenContentCensusFixture(f, 128)
+		require.Nil(t, f.store.GetNodesByIDs([]string{"repo/demo.gif"})["repo/demo.gif"])
+		require.Equal(t, []string{"demo.gif"}, f.idx.staleContentPolicyFiles(f.idx.newContentAdmissionGate(), []contentPolicyCensusCandidate{{"demo.gif", lang, 512}}))
+	})
+}
+
+func TestContentSkipCensusReadsOnlyAssetsInBoundedBatches(t *testing.T) {
+	f := newContentCensusFixture(t, 128)
+	nodes := make(map[string]*graph.Node)
+	mtimes := f.store.LoadFileMtimes("repo")
+	for i := 0; i < 257; i++ {
+		rel := fmt.Sprintf("asset-%03d.gif", i)
+		path := filepath.Join(f.root, rel)
+		require.NoError(t, os.WriteFile(path, make([]byte, 512), 0600))
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		mtimes[rel] = info.ModTime().UnixNano()
+		id := "repo/" + rel
+		nodes[id] = &graph.Node{ID: id, Kind: graph.KindFile, FilePath: id, RepoPrefix: "repo", Meta: map[string]any{"skipped_due_to_content": true, "skip_reason": skipReasonLargeImage, "file_size_bytes": int64(512)}}
+	}
+	// Keep the existing real demo GIF out of this exact 257-candidate frontier.
+	require.NoError(t, os.Remove(filepath.Join(f.root, "demo.gif")))
+	delete(mtimes, "demo.gif")
+	f.idx.SetFileMtimes(mtimes)
+	spy := &contentCensusReadSpy{Store: f.store, nodes: nodes}
+	f.idx.graph = spy
+	changed, deleted, detected, err := f.idx.changedSinceMtimesCensus(f.root)
+	require.NoError(t, err)
+	require.Empty(t, changed)
+	require.Empty(t, deleted)
+	require.Equal(t, 258, detected)
+	require.Len(t, spy.batches, 3)
+	seen := make(map[string]bool)
+	for _, batch := range spy.batches {
+		require.LessOrEqual(t, len(batch), 128)
+		for _, id := range batch {
+			require.NotEqual(t, "repo/main.go", id)
+			require.False(t, seen[id])
+			seen[id] = true
+		}
+	}
+	require.Len(t, seen, 257)
+}
+
+// Keep the actual SIZE publication/version fixture's seam and durable retry
+// assertions, but select content policy: a valid 512B GIF exceeds the128B image
+// policy while remaining below4096B MaxFileSize. The active graph at the real
+// IndexCtx log seam must prove content=true/reason=large_image_asset and no
+// skipped_due_to_size field before cancellation or same-mtime size mutation.
+func TestContentSkipFailureBoundaryIndexCtxWiring(t *testing.T) {
+	for _, scenario := range []string{"cancel_after_capture", "same_mtime_size_change_after_capture"} {
+		t.Run(scenario, func(t *testing.T) {
+			root := t.TempDir()
+			gifPath := filepath.Join(root, "demo.gif")
+			const oldSize = 512
+			const limit = 128
+			const maxFileSize = 4096
+			require.Greater(t, oldSize, limit)
+			require.Less(t, oldSize, maxFileSize, "fixture must select content policy rather than SIZE")
+			sizeFailureBoundaryWriteGIF(t, gifPath, oldSize)
+			capturedInfo, err := os.Stat(gifPath)
+			require.NoError(t, err)
+			oldMtime := capturedInfo.ModTime().UnixNano()
+			peerPath := filepath.Join(root, "durable-only.go")
+			require.NoError(t, os.WriteFile(peerPath, []byte("package fixture\n"), 0600))
+			peerInfo, err := os.Stat(peerPath)
+			require.NoError(t, err)
+			peerMtime := peerInfo.ModTime().UnixNano()
+			dbPath := filepath.Join(t.TempDir(), "graph.sqlite")
+			var idx *Indexer
+			var store *store_sqlite.Store
+			t.Cleanup(func() {
+				if idx != nil {
+					idx.Close()
+				}
+				if store != nil {
+					require.NoError(t, store.Close())
+				}
+			})
+			store, err = store_sqlite.Open(dbPath)
+			require.NoError(t, err)
+			newIndexer := func(logger *zap.Logger) *Indexer {
+				registry := newTestRegistry()
+				registry.Register(languages.NewImageAssetExtractor())
+				cfg := config.IndexConfig{MaxFileSize: maxFileSize}
+				cfg.Content.MaxImageBytes = limit
+				result := New(store, registry, cfg, logger)
+				result.SetRepoPrefix("repo")
+				result.SetDeferResolve(true)
+				result.SetDeferGlobalPasses(true)
+				result.storeRootPath(root)
+				return result
+			}
+			// Establish a real previous graph, not only a synthetic file row.
+			// Seed the old receipt explicitly so this fixture also works before
+			// the separate missing-cold-receipt fix has landed.
+			idx = newIndexer(zap.NewNop())
+			_, err = idx.IndexCtx(context.Background(), root)
+			require.NoError(t, err)
+			idx.Close()
+			idx = nil
+			require.NotNil(t, store.GetNodesByIDs([]string{"repo/demo.gif"})["repo/demo.gif"])
+			require.NoError(t, store.BulkSetFileMtimes("repo", map[string]int64{
+				"demo.gif": oldMtime, "durable-only.go": peerMtime,
+			}))
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			var callbackHits atomic.Int32
+			var callbackErr error
+			var observedKind graph.NodeKind
+			var observedSkip, observedReason, observedSize any
+			var observedSizeFlagPresent bool
+			core := zapcore.NewCore(zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()), zapcore.AddSync(io.Discard), zap.InfoLevel)
+			logger := zap.New(core, zap.Hooks(func(entry zapcore.Entry) error {
+				if entry.Message != "indexer: parse subphases" {
+					return nil
+				}
+				if callbackHits.Add(1) != 1 {
+					callbackErr = errors.New("publication callback unexpectedly ran more than once")
+					return nil
+				}
+				if ctx.Err() != nil {
+					callbackErr = errors.New("context was cancelled before the intended publication seam")
+					return nil
+				}
+				// Read the active graph: on a shadow path it has not drained
+				// to the durable Store yet. This proves content-node emission has
+				// occurred without assuming a specific publication backend.
+				stub := idx.graph.GetNodesByIDs([]string{"repo/demo.gif"})["repo/demo.gif"]
+				if stub == nil {
+					callbackErr = errors.New("content skip node absent at the publication callback")
+					return nil
+				}
+				observedKind = stub.Kind
+				observedSkip = stub.Meta["skipped_due_to_content"]
+				observedSize = stub.Meta["file_size_bytes"]
+				observedReason = stub.Meta["skip_reason"]
+				_, observedSizeFlagPresent = stub.Meta["skipped_due_to_size"]
+				if scenario == "cancel_after_capture" {
+					cancel()
+					return nil
+				}
+				// Preserve a valid GIF and its mtime while invalidating the
+				// captured size version. The synchronous hook finishes before
+				// IndexCtx can execute either receipt finalizer.
+				data, err := os.ReadFile(gifPath)
+				if err == nil {
+					err = os.WriteFile(gifPath, append(data, make([]byte, 256)...), 0600)
+				}
+				if err == nil {
+					err = os.Chtimes(gifPath, capturedInfo.ModTime(), capturedInfo.ModTime())
+				}
+				callbackErr = err
+				return nil
+			}))
+			idx = newIndexer(logger)
+			// The peer is durable-only at entry, so receipt publication must
+			// not reconstruct an authoritative old roster from this map.
+			idx.SetFileMtimes(map[string]int64{"demo.gif": oldMtime})
+			result, indexErr := idx.IndexCtx(ctx, root)
+			require.EqualValues(t, 1, callbackHits.Load(), "the source-verified publication seam must actually execute")
+			require.NoError(t, callbackErr)
+			require.Equal(t, graph.KindFile, observedKind)
+			require.Equal(t, true, observedSkip)
+			require.EqualValues(t, oldSize, observedSize, "the stub must describe the pre-callback version")
+			require.Equal(t, "large_image_asset", observedReason)
+			require.False(t, observedSizeFlagPresent, "content-policy control must not be a SIZE skip")
+			if scenario == "cancel_after_capture" {
+				require.ErrorIs(t, ctx.Err(), context.Canceled)
+				// Some publication backends acknowledge this late cancellation
+				// with an error, while others have already produced a result.
+				// Both must withhold the cancelled attempt's receipt.
+				if indexErr != nil {
+					require.ErrorIs(t, indexErr, context.Canceled)
+				} else {
+					require.NotNil(t, result)
+				}
+			} else {
+				require.NoError(t, indexErr)
+				require.NotNil(t, result)
+				currentInfo, err := os.Stat(gifPath)
+				require.NoError(t, err)
+				require.EqualValues(t, oldSize+256, currentInfo.Size())
+				require.Equal(t, oldMtime, currentInfo.ModTime().UnixNano())
+			}
+			assert.NotContains(t, idx.publishFileMtimes(), "demo.gif", "the actual IndexCtx must invalidate the old local receipt")
+			assert.NotContains(t, store.LoadFileMtimes("repo"), "demo.gif", "the actual IndexCtx must invalidate the old durable receipt")
+			assert.Equal(t, peerMtime, store.LoadFileMtimes("repo")["durable-only.go"])
+			idx.Close()
+			idx = nil
+			require.NoError(t, store.Close())
+			store = nil
+			store, err = store_sqlite.Open(dbPath)
+			require.NoError(t, err)
+			idx = newIndexer(zap.NewNop())
+			idx.SetFileMtimes(store.LoadFileMtimes("repo"))
+			idx.loadFileIndexFailures()
+			assert.NotContains(t, store.LoadFileMtimes("repo"), "demo.gif")
+			assert.Equal(t, peerMtime, store.LoadFileMtimes("repo")["durable-only.go"])
+			changed, deleted, detected, err := idx.changedSinceMtimesCensus(root)
+			require.NoError(t, err)
+			assert.Equal(t, []string{"demo.gif"}, changed)
+			require.Empty(t, deleted)
+			require.Equal(t, 2, detected)
+		})
+	}
+}
+
+func TestContentSkipReconcileUsesExplicitPolicyFrontier(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		name := "mtime"
+		if enabled {
+			name = "merkle"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("GORTEX_MERKLE", "")
+			f := newSizeCensusFixture(t, 4096)
+			// Keep one asset policy transition below the full-retrack threshold.
+			// The sentinel below proves unchanged files are not reindexed.
+			for i := 1; i <= 3; i++ {
+				body := fmt.Sprintf("package fixture\nfunc Stable%d() {}\n", i)
+				require.NoError(t, os.WriteFile(filepath.Join(f.root, fmt.Sprintf("stable%d.go", i)), []byte(body), 0600))
+			}
+			writeConfig := func(imageLimit int64) {
+				cfg := config.Default()
+				cfg.Index.MaxFileSize = 4096
+				cfg.Index.Merkle = enabled
+				cfg.Index.Content.MaxImageBytes = imageLimit
+				encoded, err := yaml.Marshal(cfg)
+				require.NoError(t, err)
+				require.NoError(t, os.WriteFile(filepath.Join(f.root, ".gortex.yaml"), encoded, 0600))
+			}
+			writeConfig(1024)
+			f.idx.config.Merkle = enabled
+			f.idx.config.Content.MaxImageBytes = 1024
+			require.Equal(t, enabled, f.idx.merkleEnabled())
+			_, err := f.idx.IndexCtx(context.Background(), f.root)
+			require.NoError(t, err)
+			f.idx.RunDeferredPasses(context.Background())
+			f.establishKnownReceipt()
+			if enabled {
+				encoded, err := os.ReadFile(merkleTreeFile(f.root))
+				require.NoError(t, err)
+				var baseline map[string]any
+				require.NoError(t, json.Unmarshal(encoded, &baseline))
+				files, ok := baseline["files"].(map[string]any)
+				require.True(t, ok, "test-created baseline must contain its files map")
+				leaf, ok := files["demo.gif"].(map[string]any)
+				require.True(t, ok, "cold eligible GIF must have an actual leaf before content cap decrease")
+				hash, ok := leaf["hash"].(string)
+				require.True(t, ok)
+				require.Len(t, hash, 64)
+			}
+			require.GreaterOrEqual(t, len(f.store.LoadFileMtimes("repo")), 5)
+			assertPolicyOutcome := func(imageLimit int64) {
+				node := f.fileNode()
+				require.NotEqual(t, true, node.Meta["skipped_due_to_size"], "global size cap remains above the unchanged 512-byte GIF")
+				nodes := f.store.GetFileNodesByPaths([]string{"repo/demo.gif"})["repo/demo.gif"]
+				assetNodes := 0
+				for _, candidate := range nodes {
+					if candidate != nil && candidate.Kind != graph.KindFile {
+						assetNodes++
+					}
+				}
+				if imageLimit < 512 {
+					require.Equal(t, true, node.Meta["skipped_due_to_content"])
+					require.Equal(t, "large_image_asset", node.Meta["skip_reason"])
+					require.EqualValues(t, 512, node.Meta["file_size_bytes"])
+					require.Zero(t, assetNodes, "content-ineligible GIF must retain only its file stub")
+				} else {
+					require.NotEqual(t, true, node.Meta["skipped_due_to_content"])
+					require.NotEqual(t, "large_image_asset", node.Meta["skip_reason"])
+					require.Positive(t, assetNodes, "eligible GIF must have an actually parsed non-file image asset node")
+				}
+				require.Equal(t, f.mtime.UnixNano(), f.store.LoadFileMtimes("repo")["demo.gif"])
+			}
+			assertPolicyOutcome(1024)
+
+			unchanged := &graph.Edge{From: "repo/stable1.go", To: "repo/stable2.go",
+				Kind: "co_change", FilePath: "repo/stable1.go", Line: 777}
+			f.store.AddBatch(nil, []*graph.Edge{unchanged})
+			assertUnchangedEdge := func() {
+				edges := f.store.GetOutEdgesByNodeIDs([]string{unchanged.From})[unchanged.From]
+				found := 0
+				for _, edge := range edges {
+					if edge.From == unchanged.From && edge.To == unchanged.To && edge.Kind == unchanged.Kind && edge.Line == unchanged.Line {
+						found++
+					}
+				}
+				require.Equal(t, 1, found, "scoped content policy refresh must retain unchanged-file edge")
+			}
+			assertUnchangedEdge()
+
+			entry := config.RepoEntry{Path: f.root, Name: "repo"}
+			configPath := filepath.Join(t.TempDir(), "config.yaml")
+			global := &config.GlobalConfig{Repos: []config.RepoEntry{entry}}
+			global.SetConfigPath(configPath)
+			require.NoError(t, global.Save())
+			reconcile := func(imageLimit int64, wantStale bool) {
+				f.reopen(4096)
+				f.idx.config.Content.MaxImageBytes = imageLimit
+				f.idx.Close()
+				f.idx = nil
+				manager, err := config.NewConfigManager(configPath)
+				require.NoError(t, err)
+				registry := newTestRegistry()
+				registry.Register(languages.NewImageAssetExtractor())
+				mi := NewMultiIndexer(f.store, registry, search.NewNull(), manager, zap.NewNop())
+				// A fresh MI must load real repo config and reconcile persisted state.
+				result, err := mi.ReconcileRepoCtx(context.Background(), entry, f.store.LoadFileMtimes("repo"))
+				f.idx = mi.indexers["repo"]
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				require.NotNil(t, f.idx)
+				require.EqualValues(t, 4096, f.idx.config.MaxFileSize)
+				require.EqualValues(t, imageLimit, f.idx.config.Content.MaxImageBytes, "real repo content policy override must have loaded")
+				require.Equal(t, enabled, f.idx.merkleEnabled())
+				if wantStale {
+					require.Positive(t, result.StaleFileCount)
+				} else {
+					require.Zero(t, result.StaleFileCount)
+				}
+				assertPolicyOutcome(imageLimit)
+				assertUnchangedEdge()
+			}
+			writeConfig(128)
+			reconcile(128, true)
+			reconcile(128, false)
+			writeConfig(1024)
+			reconcile(1024, true)
+			reconcile(1024, false)
 		})
 	}
 }

--- a/internal/indexer/content_skip_census_test.go
+++ b/internal/indexer/content_skip_census_test.go
@@ -1,0 +1,119 @@
+package indexer
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func newContentCensusFixture(t *testing.T, imageLimit int64) *sizeCensusFixture {
+	t.Helper()
+	f := &sizeCensusFixture{t: t, root: t.TempDir(), dbPath: filepath.Join(t.TempDir(), "graph.sqlite")}
+	t.Cleanup(f.close)
+	require.NoError(t, os.WriteFile(filepath.Join(f.root, "main.go"), []byte("package fixture\nfunc Main() {}\n"), 0600))
+	writeSizeCensusGIF(t, filepath.Join(f.root, "demo.gif"), 512)
+	info, err := os.Stat(filepath.Join(f.root, "demo.gif"))
+	require.NoError(t, err)
+	f.mtime = info.ModTime()
+	f.open(4096) // the content cap, never MaxFileSize, rejects this GIF
+	f.idx.config.Content = config.ContentAdmissionConfig{MaxImageBytes: imageLimit}
+	_, err = f.idx.IndexCtx(context.Background(), f.root)
+	require.NoError(t, err)
+	f.idx.RunDeferredPasses(context.Background())
+	return f
+}
+
+func reopenContentCensusFixture(f *sizeCensusFixture, imageLimit int64) {
+	f.reopen(4096)
+	f.idx.config.Content = config.ContentAdmissionConfig{MaxImageBytes: imageLimit}
+}
+
+func TestContentSkipCensusColdGIFRepeatedRestartNoop(t *testing.T) {
+	f := newContentCensusFixture(t, 128)
+	stub := f.fileNode()
+	require.Equal(t, true, stub.Meta["skipped_due_to_content"])
+	require.Equal(t, skipReasonLargeImage, stub.Meta["skip_reason"])
+	require.EqualValues(t, 512, stub.Meta["file_size_bytes"])
+	require.NotEqual(t, true, stub.Meta["skipped_due_to_size"])
+	require.Less(t, int64(512), f.idx.config.MaxFileSize)
+	seeded := []*graph.Edge{
+		{From: "repo/main.go", To: "repo/demo.gif", Kind: "co_change", FilePath: "repo/main.go"},
+		{From: "repo/demo.gif", To: "repo/main.go", Kind: "co_change", FilePath: "repo/demo.gif"},
+	}
+	f.store.AddBatch(nil, seeded)
+	edges := f.store.GetOutEdgesByNodeIDs([]string{"repo/main.go", "repo/demo.gif"})
+	for _, want := range seeded {
+		found := 0
+		for _, got := range edges[want.From] {
+			if got.From == want.From && got.To == want.To && got.Kind == want.Kind {
+				found++
+			}
+		}
+		require.Equal(t, 1, found, "incoming/outgoing co_change prerequisite")
+	}
+	before := sizeCensusGraphRows(t, f.store)
+	assert.Equal(t, f.mtime.UnixNano(), f.store.LoadFileMtimes("repo")["demo.gif"], "cold content stub needs a published version receipt")
+	for restart := 0; restart < 2; restart++ {
+		reopenContentCensusFixture(f, 128)
+		changed, deleted, detected, err := f.idx.changedSinceMtimesCensus(f.root)
+		require.NoError(t, err)
+		assert.Empty(t, changed)
+		require.Empty(t, deleted)
+		require.Equal(t, 2, detected)
+		result, err := f.idx.incrementalReindexPathsMode(f.root, []string{"main.go", "demo.gif"}, incrementalPathMode{})
+		require.NoError(t, err)
+		assert.Zero(t, result.StaleFileCount)
+		assert.Equal(t, before, sizeCensusGraphRows(t, f.store), "unchanged content-policy asset must not lose co_change edges")
+	}
+}
+
+func TestContentSkipCensusEqualMtimePolicyChanges(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		before, after int64
+		stale, skip   bool
+	}{
+		{"cap_increase_admits", 128, 1024, true, false},
+		{"strict_boundary_admits", 128, 512, true, false},
+		{"cap_decrease_skips", 1024, 128, true, true},
+		{"same_rejection_no_work", 128, 256, false, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newContentCensusFixture(t, tc.before)
+			f.establishKnownReceipt() // isolate policy comparison from missing cold receipt
+			reopenContentCensusFixture(f, tc.after)
+			changed, deleted, detected, err := f.idx.changedSinceMtimesCensus(f.root)
+			require.NoError(t, err)
+			require.Empty(t, deleted)
+			require.Equal(t, 2, detected)
+			if tc.stale {
+				require.Equal(t, []string{"demo.gif"}, changed)
+				f.applyCensus(changed)
+			} else {
+				require.Empty(t, changed)
+			}
+			node := f.fileNode()
+			if tc.skip {
+				require.Equal(t, true, node.Meta["skipped_due_to_content"])
+				require.Equal(t, skipReasonLargeImage, node.Meta["skip_reason"])
+			} else {
+				require.NotEqual(t, true, node.Meta["skipped_due_to_content"])
+				found := false
+				for _, candidate := range f.store.GetRepoNodes("repo") {
+					if candidate.FilePath == "repo/demo.gif" && candidate.Kind != graph.KindFile {
+						found = true
+					}
+				}
+				require.True(t, found, "eligible real GIF must be parsed, not merely lose a flag")
+			}
+			reopenContentCensusFixture(f, tc.after)
+			f.census(nil, nil, 2)
+		})
+	}
+}

--- a/internal/indexer/contract_owner_frontier_test.go
+++ b/internal/indexer/contract_owner_frontier_test.go
@@ -1,0 +1,723 @@
+package indexer
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/contracts"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/search"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestContractRegistryPreloadSkipsEmptyIncrementalWork(t *testing.T) {
+	idx := New(graph.New(), newTestRegistry(), config.IndexConfig{}, zap.NewNop())
+	t.Cleanup(idx.Close)
+	idx.SetRepoPrefix("fixture")
+	idx.storeRootPath(t.TempDir())
+	require.Nil(t, idx.contractRegistry)
+	require.NoError(t, idx.coordinateRepositoryMutation(context.Background(), func() error {
+		plan, reparsed, failed, raced := idx.reindexIncrementalFilesBatched(nil, nil, &reparsePendingEnrichmentBatch{}, false)
+		assert.Empty(t, plan.Files)
+		assert.Empty(t, reparsed)
+		assert.Empty(t, failed)
+		assert.Empty(t, raced)
+		assert.Nil(t, idx.contractRegistry, "a zero-input batch must not materialize the scoped registry")
+		result := idx.evictFileIncrementalRaw("")
+		assert.NotNil(t, result.result)
+		assert.Nil(t, idx.contractRegistry, "invalid/empty explicit deletion must return before registry hydration")
+		return nil
+	}))
+}
+
+func bridgeDeletionOwnerSnapshot(t *testing.T, store graph.Store, consumer contracts.Contract) string {
+	t.Helper()
+	var snapshots []struct {
+		Edge *graph.Edge    `json:"edge"`
+		Meta map[string]any `json:"meta"`
+	}
+	for _, row := range graph.ReadRepoEdgesByKinds(store, []string{consumer.RepoPrefix}, []graph.EdgeKind{graph.EdgeConsumes}) {
+		if row.Edge.From == consumer.SymbolID && row.Edge.To == consumer.ID {
+			snapshots = append(snapshots, struct {
+				Edge *graph.Edge    `json:"edge"`
+				Meta map[string]any `json:"meta"`
+			}{row.Edge, row.Edge.Meta})
+		}
+	}
+	encoded, err := json.Marshal(snapshots)
+	require.NoError(t, err)
+	return string(encoded)
+}
+
+func TestBridgeRegistryRestartFileDeletionRetainsOtherRepositoryOwner(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		sameRepo bool
+	}{
+		{name: "cross_repository"},
+		{name: "same_repository", sameRepo: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testBridgeRegistryRestartFileDeletion(t, tc.sameRepo)
+		})
+	}
+}
+
+func testBridgeRegistryRestartFileDeletion(t *testing.T, sameRepo bool) {
+	t.Helper()
+	rootA, rootB := t.TempDir(), t.TempDir()
+	if sameRepo {
+		rootB = rootA
+	}
+	const relativeA = "provider.go"
+	fileA := filepath.Join(rootA, relativeA)
+	require.NoError(t, os.WriteFile(fileA, []byte("package fixture\nfunc Provide() {}\n"), 0o600))
+	fileB := filepath.Join(rootB, "consumer.go")
+	require.NoError(t, os.WriteFile(fileB, []byte("package fixture\nfunc Consume() {}\n"), 0o600))
+	storePath := filepath.Join(t.TempDir(), "graph.sqlite")
+	store, err := store_sqlite.Open(storePath)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if store != nil {
+			require.NoError(t, store.Close())
+		}
+	})
+	provider := contracts.Contract{
+		ID: "env::FILE_DELETE_SHARED", Type: contracts.ContractType("env"), Role: contracts.RoleProvider,
+		RepoPrefix: "repo-a", WorkspaceID: "workspace-a", ProjectID: "project-a",
+		FilePath: "repo-a/provider.go", SymbolID: "repo-a/provider.go::Provide", Line: 2, Confidence: 1,
+		Meta: map[string]any{"var": "FILE_DELETE_SHARED", "owner": "a"},
+	}
+	consumer := contracts.Contract{
+		ID: provider.ID, Type: contracts.ContractType("env"), Role: contracts.RoleConsumer,
+		RepoPrefix: "repo-b", WorkspaceID: "workspace-b", ProjectID: "project-b",
+		FilePath: "repo-b/consumer.go", SymbolID: "repo-b/consumer.go::Consume", Line: 2, Confidence: 0.75,
+		Meta: map[string]any{"var": "FILE_DELETE_SHARED", "owner": "b", "nested": map[string]any{"values": []any{"survives", "deletion"}}},
+	}
+	if sameRepo {
+		consumer.RepoPrefix, consumer.WorkspaceID, consumer.ProjectID = provider.RepoPrefix, provider.WorkspaceID, provider.ProjectID
+		consumer.FilePath = "repo-a/consumer.go"
+		consumer.SymbolID = consumer.FilePath + "::Consume"
+	}
+	sourceA := &graph.Node{ID: provider.SymbolID, Kind: graph.KindFunction, FilePath: provider.FilePath, RepoPrefix: provider.RepoPrefix, WorkspaceID: provider.WorkspaceID, ProjectID: provider.ProjectID}
+	sourceB := &graph.Node{ID: consumer.SymbolID, Kind: graph.KindFunction, FilePath: consumer.FilePath, RepoPrefix: consumer.RepoPrefix, WorkspaceID: consumer.WorkspaceID, ProjectID: consumer.ProjectID}
+	canonical := &graph.Node{ID: provider.ID, Kind: graph.KindContract, FilePath: provider.FilePath, RepoPrefix: provider.RepoPrefix, WorkspaceID: provider.WorkspaceID, ProjectID: provider.ProjectID,
+		Meta: map[string]any{"type": string(provider.Type), "role": string(provider.Role), "symbol_id": provider.SymbolID, "line": provider.Line, "confidence": provider.Confidence, "contract_meta": provider.Meta}}
+	edgeA := &graph.Edge{From: provider.SymbolID, To: provider.ID, Kind: graph.EdgeProvides, FilePath: provider.FilePath, Line: provider.Line, Meta: contractOwnerEdgeMeta(provider)}
+	edgeB := &graph.Edge{From: consumer.SymbolID, To: consumer.ID, Kind: graph.EdgeConsumes, FilePath: consumer.FilePath, Line: consumer.Line, Meta: contractOwnerEdgeMeta(consumer)}
+	store.AddBatch([]*graph.Node{
+		{ID: provider.FilePath, Kind: graph.KindFile, FilePath: provider.FilePath, RepoPrefix: provider.RepoPrefix},
+		{ID: consumer.FilePath, Kind: graph.KindFile, FilePath: consumer.FilePath, RepoPrefix: consumer.RepoPrefix},
+		sourceA, sourceB, canonical,
+	}, []*graph.Edge{edgeA, edgeB})
+	require.Len(t, store.GetInEdges(provider.ID), 2, "persist both actual ownership edges before simulating restart")
+	require.Equal(t, provider.FilePath, store.GetNode(provider.ID).FilePath, "canonical scalar must be attributed to the file being deleted")
+	ownerRowsB := graph.ReadRepoEdgesByKinds(store, []string{consumer.RepoPrefix}, []graph.EdgeKind{graph.EdgeConsumes})
+	require.Len(t, ownerRowsB, 1)
+	require.Equal(t, consumer.Meta, ownerRowsB[0].Edge.Meta["contract_owner_meta"], "fixture comparison must include real hydrated owner metadata")
+	beforeB := bridgeDeletionOwnerSnapshot(t, store, consumer)
+	require.NoError(t, store.Close())
+	store = nil
+	store, err = store_sqlite.Open(storePath)
+	require.NoError(t, err)
+	idx := New(store, newTestRegistry(), config.IndexConfig{}, zap.NewNop())
+	idx.SetRepoPrefix(provider.RepoPrefix)
+	idx.SetWorkspaceID(provider.WorkspaceID)
+	idx.SetProjectID(provider.ProjectID)
+	idx.storeRootPath(rootA)
+	t.Cleanup(func() {
+		if idx != nil {
+			idx.Close()
+		}
+	})
+	require.Nil(t, idx.contractRegistry, "restart fixture must not hide lost durable records behind an in-memory registry")
+	require.Len(t, store.GetOutEdges(sourceB.ID), 1, "B must still have its persisted owner after reopen")
+	require.NoError(t, os.Remove(fileA))
+	require.NoError(t, idx.coordinateRepositoryMutation(context.Background(), func() error {
+		idx.evictFileIncrementalRaw(relativeA)
+		return nil
+	}))
+	assert.Nil(t, store.GetNode(provider.SymbolID), "real raw deletion removes A's source symbol")
+	assert.Nil(t, store.GetNode(provider.FilePath), "real raw deletion removes A's file node")
+	assert.NotNil(t, store.GetNode(consumer.SymbolID), "unrelated B source remains")
+	assert.NotNil(t, store.GetNode(provider.ID), "B still requires the shared canonical contract node")
+	afterB := bridgeDeletionOwnerSnapshot(t, store, consumer)
+	assert.Equal(t, beforeB, afterB, "deleting A must retain B's complete persisted ownership edge, including metadata")
+	checkRegistryB := func(stage string) {
+		t.Helper()
+		var got []contracts.Contract
+		if registry := contracts.LoadRegistryFromGraph(store, consumer.RepoPrefix); registry != nil {
+			got = registry.All()
+		}
+		assert.Equal(t, bridgeRoundtripRecordMultiset(t, []contracts.Contract{consumer}), bridgeRoundtripRecordMultiset(t, got), "%s: surviving B must hydrate without another repository reparse", stage)
+	}
+	checkRegistryB("after deletion")
+	idx.Close()
+	idx = nil
+	require.NoError(t, store.Close())
+	store = nil
+	store, err = store_sqlite.Open(storePath)
+	require.NoError(t, err)
+	assert.NotNil(t, store.GetNode(provider.ID), "shared canonical preservation is durable")
+	afterReopenB := bridgeDeletionOwnerSnapshot(t, store, consumer)
+	assert.Equal(t, beforeB, afterReopenB, "B ownership preservation is durable")
+	checkRegistryB("after deletion and second reopen")
+	_, err = os.Stat(fileB)
+	require.NoError(t, err, "B's physical source is outside the deletion scope")
+
+	// A preservation fix must not keep every contract forever. Delete the last
+	// actual owner through another fresh, nil-registry indexer and audit durable
+	// node/edge rows, not only endpoint-filtered graph projections.
+	idx = New(store, newTestRegistry(), config.IndexConfig{}, zap.NewNop())
+	idx.SetRepoPrefix(consumer.RepoPrefix)
+	idx.SetWorkspaceID(consumer.WorkspaceID)
+	idx.SetProjectID(consumer.ProjectID)
+	idx.storeRootPath(rootB)
+	require.Nil(t, idx.contractRegistry, "last-owner deletion also models restart")
+	require.NoError(t, os.Remove(fileB))
+	require.NoError(t, idx.coordinateRepositoryMutation(context.Background(), func() error {
+		idx.evictFileIncrementalRaw("consumer.go")
+		return nil
+	}))
+	assert.Nil(t, store.GetNode(consumer.SymbolID), "last owner's source symbol is removed")
+	assert.Nil(t, store.GetNode(consumer.FilePath), "last owner's file node is removed")
+	assert.Nil(t, store.GetNode(consumer.ID), "canonical node must not leak after final owner removal")
+	assert.Empty(t, store.GetInEdges(consumer.ID))
+	assert.Empty(t, store.GetOutEdges(consumer.ID))
+	idx.Close()
+	idx = nil
+	require.NoError(t, store.Close())
+	store = nil
+	db, err := sql.Open("sqlite", storePath)
+	require.NoError(t, err)
+	defer db.Close()
+	var canonicalNodes, incidentEdges int
+	require.NoError(t, db.QueryRow("SELECT count(*) FROM nodes WHERE view_gen = 0 AND id = ?", consumer.ID).Scan(&canonicalNodes))
+	require.NoError(t, db.QueryRow("SELECT count(*) FROM edges WHERE view_gen = 0 AND (from_id = ? OR to_id = ?)", consumer.ID, consumer.ID).Scan(&incidentEdges))
+	assert.Zero(t, canonicalNodes, "last-owner canonical pruning is durable")
+	assert.Zero(t, incidentEdges, "no orphan incident rows remain after last-owner pruning")
+}
+
+func TestBridgeRegistryRestartOffFileCanonicalDeletionPlansContractReconcile(t *testing.T) {
+	root := t.TempDir()
+	const relativeA = "provider.go"
+	require.NoError(t, os.WriteFile(filepath.Join(root, relativeA), []byte("package fixture\nfunc Provide() {}\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "consumer.go"), []byte("package fixture\nfunc Consume() {}\n"), 0o600))
+	storePath := filepath.Join(t.TempDir(), "graph.sqlite")
+	store, err := store_sqlite.Open(storePath)
+	require.NoError(t, err)
+	var idx *Indexer
+	t.Cleanup(func() {
+		if idx != nil {
+			idx.Close()
+		}
+		if store != nil {
+			require.NoError(t, store.Close())
+		}
+	})
+	provider := contracts.Contract{
+		ID: "env::OFF_FILE_DELETE_PLAN", Type: contracts.ContractType("env"), Role: contracts.RoleProvider,
+		RepoPrefix: "fixture", WorkspaceID: "workspace", ProjectID: "project",
+		FilePath: "fixture/provider.go", SymbolID: "fixture/provider.go::Provide", Line: 2, Confidence: 1,
+		Meta: map[string]any{"var": "OFF_FILE_DELETE_PLAN"},
+	}
+	consumer := provider
+	consumer.Role = contracts.RoleConsumer
+	consumer.FilePath, consumer.SymbolID = "fixture/consumer.go", "fixture/consumer.go::Consume"
+	// The stored contract is complete by the actual production predicate. Seed
+	// deterministic fingerprints explicitly; no parser probe is being tested.
+	fileA := &graph.Node{ID: provider.FilePath, Kind: graph.KindFile, FilePath: provider.FilePath, RepoPrefix: provider.RepoPrefix,
+		Meta: map[string]any{
+			sourceDerivedDeclFingerprintMeta:     "fixture-declarations",
+			sourceDerivedImportFingerprintMeta:   "fixture-imports",
+			sourceDerivedRuntimeFingerprintMeta:  "fixture-runtime",
+			sourceDerivedArtifactFingerprintMeta: "fixture-artifacts",
+		}}
+	store.AddBatch([]*graph.Node{
+		fileA,
+		{ID: consumer.FilePath, Kind: graph.KindFile, FilePath: consumer.FilePath, RepoPrefix: consumer.RepoPrefix},
+		{ID: provider.SymbolID, Name: "Provide", Kind: graph.KindFunction, FilePath: provider.FilePath, RepoPrefix: provider.RepoPrefix, WorkspaceID: provider.WorkspaceID, ProjectID: provider.ProjectID},
+		{ID: consumer.SymbolID, Name: "Consume", Kind: graph.KindFunction, FilePath: consumer.FilePath, RepoPrefix: consumer.RepoPrefix, WorkspaceID: consumer.WorkspaceID, ProjectID: consumer.ProjectID},
+	}, nil)
+	idx = New(store, newTestRegistry(), config.IndexConfig{}, zap.NewNop())
+	idx.SetRepoPrefix(provider.RepoPrefix)
+	idx.SetWorkspaceID(provider.WorkspaceID)
+	idx.SetProjectID(provider.ProjectID)
+	idx.storeRootPath(root)
+	registry := contracts.NewRegistry()
+	registry.Add(provider)
+	registry.Add(consumer)
+	matched := contracts.Match(registry)
+	require.Len(t, matched.Matched, 1, "fixture must produce a real matched provider/consumer pair")
+	idx.commitContracts(registry)
+	canonical := store.GetNode(provider.ID)
+	require.NotNil(t, canonical)
+	require.Equal(t, consumer.FilePath, canonical.FilePath, "shared canonical scalar must belong to surviving B, outside deleted A")
+	require.Equal(t, 1, MaterializeContractBridges(store, matched.Matched), "fixture must materialize a real bridge")
+	var bridgeID string
+	for _, node := range store.GetFileNodes(ContractBridgeFilePath) {
+		if node.Kind == graph.KindContractBridge {
+			require.Empty(t, bridgeID, "fixture has exactly one bridge")
+			bridgeID = node.ID
+		}
+	}
+	require.NotEmpty(t, bridgeID)
+	var bridgeEdges int
+	for _, edge := range store.GetInEdges(provider.ID) {
+		if edge.Kind == graph.EdgeBridges && edge.From == bridgeID {
+			bridgeEdges++
+		}
+	}
+	require.Equal(t, 1, bridgeEdges, "shared-ID bridge must have its actual canonical attachment")
+	idx.Close()
+	idx = nil
+	require.NoError(t, store.Close())
+	store = nil
+	store, err = store_sqlite.Open(storePath)
+	require.NoError(t, err)
+	idx = New(store, newTestRegistry(), config.IndexConfig{}, zap.NewNop())
+	idx.SetRepoPrefix(provider.RepoPrefix)
+	idx.SetWorkspaceID(provider.WorkspaceID)
+	idx.SetProjectID(provider.ProjectID)
+	idx.storeRootPath(root)
+	require.Nil(t, idx.contractRegistry, "restarted indexer must not use the cold in-memory registry")
+	prior := store.GetFileNodes(provider.FilePath)
+	require.True(t, storedDerivedFingerprints(prior).complete(), "durable complete fingerprints disable broad legacy fallback")
+	for _, node := range prior {
+		require.NotEqual(t, graph.KindContract, node.Kind, "A's by-file node set deliberately excludes the off-file canonical")
+	}
+	require.NotNil(t, store.GetNode(bridgeID), "matched bridge survives the fixture restart")
+	require.Equal(t, consumer.FilePath, store.GetNode(provider.ID).FilePath)
+	require.NoError(t, os.Remove(filepath.Join(root, relativeA)))
+	var eviction forcedFileEviction
+	require.NoError(t, idx.coordinateRepositoryMutation(context.Background(), func() error {
+		eviction = idx.evictFileIncrementalRaw(relativeA)
+		return nil
+	}))
+	require.NotNil(t, eviction.result, "actual raw path must return its IndexResult before inspecting the plan")
+	invalidation := eviction.result.DerivedInvalidation
+	require.False(t, invalidation.LegacyFallback, "complete fingerprints must not accidentally make this regression pass through broad fallback")
+	assert.Nil(t, store.GetNode(provider.SymbolID), "A's source was physically and structurally removed")
+	assert.NotNil(t, store.GetNode(consumer.SymbolID), "B's source remains outside deletion scope")
+	assert.NotNil(t, store.GetNode(provider.ID), "B still owns the shared canonical")
+	assert.True(t, invalidation.Flags.Has(DerivedInvalidatesContracts), "deleting A's ownership must schedule contract reconciliation even though its canonical scalar is off-file")
+	assert.Contains(t, invalidation.ContractGroups, ContractGroupFrontier{WorkspaceID: provider.WorkspaceID, ProjectID: provider.ProjectID, ContractID: provider.ID})
+	assert.Contains(t, invalidation.ContractSymbolIDs, provider.SymbolID)
+	// Explicit bridge IDs are optional: the actual frontier consumer derives
+	// bridge cleanup from scoped contract groups and incoming bridge edges.
+	t.Logf("complete_fingerprints=true initial_matches=%d initial_bridges=1 contract_flag=%t groups=%d symbols=%d bridge_ids=%d legacy_fallback=%t",
+		len(matched.Matched), invalidation.Flags.Has(DerivedInvalidatesContracts), len(invalidation.ContractGroups), len(invalidation.ContractSymbolIDs), len(invalidation.ContractBridgeNodeIDs), invalidation.LegacyFallback)
+}
+
+func registeredBridgeNodeSnapshot(t *testing.T, store graph.Store, id string) string {
+	t.Helper()
+	node := store.GetNode(id)
+	require.NotNil(t, node)
+	encoded, err := json.Marshal(struct {
+		Node *graph.Node
+		Meta map[string]any
+	}{node, node.Meta})
+	require.NoError(t, err)
+	return string(encoded)
+}
+
+func registeredBridgeOwnerSnapshot(t *testing.T, store graph.Store, source string) []string {
+	t.Helper()
+	var rows []string
+	for _, edge := range store.GetOutEdges(source) {
+		if edge.Kind != graph.EdgeProvides && edge.Kind != graph.EdgeConsumes {
+			continue
+		}
+		encoded, err := json.Marshal(struct {
+			Edge *graph.Edge
+			Meta map[string]any
+		}{edge, edge.Meta})
+		require.NoError(t, err)
+		rows = append(rows, string(encoded))
+	}
+	sort.Strings(rows)
+	return rows
+}
+
+func registeredBridgeAttachment(t *testing.T, store graph.Store, contractID string) string {
+	t.Helper()
+	var id string
+	for _, edge := range store.GetInEdges(contractID) {
+		if edge.Kind != graph.EdgeBridges {
+			continue
+		}
+		require.Empty(t, id, "one canonical attachment per fixture bridge")
+		id = edge.From
+	}
+	require.NotEmpty(t, id)
+	return id
+}
+
+func registeredBridgeMatchSnapshot(t *testing.T, store graph.Store, ids ...string) map[string]struct{} {
+	t.Helper()
+	rows := make(map[string]struct{})
+	for _, id := range ids {
+		edges := append([]*graph.Edge(nil), store.GetInEdges(id)...)
+		edges = append(edges, store.GetOutEdges(id)...)
+		for _, edge := range edges {
+			if edge.Kind != graph.EdgeMatches {
+				continue
+			}
+			encoded, err := json.Marshal(struct {
+				Edge *graph.Edge
+				Meta map[string]any
+			}{edge, edge.Meta})
+			require.NoError(t, err)
+			rows[string(encoded)] = struct{}{}
+		}
+	}
+	return rows
+}
+
+func TestBridgeRegistryRegisteredRestartDispatchPreservesSurvivors(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	for _, name := range []string{"provider.go", "consumer.go", "other_provider.go", "other_consumer.go"} {
+		require.NoError(t, os.WriteFile(filepath.Join(root, name), []byte("package fixture\nfunc "+map[string]string{"provider.go": "Provide", "consumer.go": "Consume", "other_provider.go": "OtherProvide", "other_consumer.go": "OtherConsume"}[name]+"() {}\n"), 0o600))
+	}
+	entry := config.RepoEntry{Path: root, Name: "fixture"}
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	global := &config.GlobalConfig{Repos: []config.RepoEntry{entry}}
+	global.SetConfigPath(configPath)
+	require.NoError(t, global.Save())
+	manager, err := config.NewConfigManager(configPath)
+	require.NoError(t, err)
+	dbPath := filepath.Join(t.TempDir(), "graph.sqlite")
+	store, err := store_sqlite.Open(dbPath)
+	require.NoError(t, err)
+	var idx *Indexer
+	t.Cleanup(func() {
+		if idx != nil {
+			idx.Close()
+		}
+		if store != nil {
+			require.NoError(t, store.Close())
+		}
+	})
+	mi := NewMultiIndexer(store, newTestRegistry(), search.NewNull(), manager, zap.NewNop())
+	_, err = mi.ReconcileRepoCtx(ctx, entry, nil)
+	require.NoError(t, err)
+	idx = mi.indexers["fixture"]
+	require.NotNil(t, idx, "real registration must create the Indexer and metadata")
+	idx.SetWorkspaceID("workspace")
+	idx.SetProjectID("project")
+	record := func(id, file, symbol string, role contracts.Role) contracts.Contract {
+		return contracts.Contract{ID: id, Type: contracts.ContractType("env"), Role: role, RepoPrefix: "fixture", WorkspaceID: "workspace", ProjectID: "project",
+			FilePath: "fixture/" + file, SymbolID: "fixture/" + file + "::" + symbol, Line: 2, Confidence: 1,
+			Meta: map[string]any{"var": id, "payload": map[string]any{"source": file}}}
+	}
+	provider := record("env::REGISTERED_DELETE", "provider.go", "Provide", contracts.RoleProvider)
+	consumer := record(provider.ID, "consumer.go", "Consume", contracts.RoleConsumer)
+	otherProvider := record("env::REGISTERED_UNRELATED", "other_provider.go", "OtherProvide", contracts.RoleProvider)
+	otherConsumer := record(otherProvider.ID, "other_consumer.go", "OtherConsume", contracts.RoleConsumer)
+	records := []contracts.Contract{provider, consumer, otherProvider, otherConsumer}
+	var sources []*graph.Node
+	for _, c := range records {
+		sources = append(sources, &graph.Node{ID: c.SymbolID, Name: c.SymbolID, Kind: graph.KindFunction, FilePath: c.FilePath, RepoPrefix: c.RepoPrefix, WorkspaceID: c.WorkspaceID, ProjectID: c.ProjectID})
+	}
+	// Complete real deletion predicate, independent of the parser's own
+	// graph ID convention. Persisted mtimes come from actual registration.
+	sources = append(sources, &graph.Node{ID: provider.FilePath, Kind: graph.KindFile, FilePath: provider.FilePath, RepoPrefix: provider.RepoPrefix,
+		Meta: map[string]any{sourceDerivedDeclFingerprintMeta: "decl", sourceDerivedImportFingerprintMeta: "imports", sourceDerivedRuntimeFingerprintMeta: "runtime", sourceDerivedArtifactFingerprintMeta: "artifacts"}})
+	store.AddBatch(sources, nil)
+	registry := contracts.NewRegistry()
+	for _, c := range records {
+		registry.Add(c)
+	}
+	idx.commitContracts(registry)
+	matched := contracts.Match(registry)
+	require.Len(t, matched.Matched, 2)
+	require.Equal(t, 2, MaterializeContractBridges(store, matched.Matched))
+	// Model the cold complete extraction registry, then persist match edges
+	// through the actual public derived dispatcher, not synthetic edge rows.
+	idx.contractRegistry = registry
+	initialPlan := DerivedInvalidationPlan{Files: []string{provider.FilePath, consumer.FilePath, otherProvider.FilePath, otherConsumer.FilePath}}
+	initialPlan.Flags |= DerivedInvalidatesContracts
+	initialPlan.ContractGroups = []ContractGroupFrontier{
+		{WorkspaceID: provider.WorkspaceID, ProjectID: provider.ProjectID, ContractID: provider.ID},
+		{WorkspaceID: otherProvider.WorkspaceID, ProjectID: otherProvider.ProjectID, ContractID: otherProvider.ID},
+	}
+	initialReport := mi.RunIncrementalDerivedPasses(ctx, map[string]DerivedInvalidationPlan{"fixture": initialPlan})
+	require.Positive(t, initialReport.Contracts, "actual initial contract dispatcher must process the real matches")
+	require.NotEmpty(t, registeredBridgeMatchSnapshot(t, store, provider.ID, provider.SymbolID, consumer.SymbolID), "fixture persists a real match edge")
+	require.Equal(t, consumer.FilePath, store.GetNode(provider.ID).FilePath)
+	staleBridge := registeredBridgeAttachment(t, store, provider.ID)
+	unrelatedBridge := registeredBridgeAttachment(t, store, otherProvider.ID)
+	require.NotEqual(t, staleBridge, unrelatedBridge)
+	require.Len(t, store.LoadFileMtimes("fixture"), 4, "real registration persisted the unchanged restart census")
+	idx.Close()
+	idx = nil
+	require.NoError(t, store.Close())
+	store = nil
+	store, err = store_sqlite.Open(dbPath)
+	require.NoError(t, err)
+	mi = NewMultiIndexer(store, newTestRegistry(), search.NewNull(), manager, zap.NewNop())
+	_, err = mi.ReconcileRepoCtx(ctx, entry, store.LoadFileMtimes("fixture"))
+	require.NoError(t, err)
+	idx = mi.indexers["fixture"]
+	require.NotNil(t, idx)
+	idx.SetWorkspaceID("workspace")
+	idx.SetProjectID("project")
+	t.Logf("natural registered restart contract_registry_nil=%t", idx.contractRegistry == nil)
+	require.NotNil(t, store.GetNode(staleBridge), "registration must not erase the positive bridge fixture")
+	require.True(t, storedDerivedFingerprints(store.GetFileNodes(provider.FilePath)).complete())
+	require.Equal(t, consumer.FilePath, store.GetNode(provider.ID).FilePath)
+	beforeConsumer := registeredBridgeNodeSnapshot(t, store, provider.ID)
+	beforeOwner := registeredBridgeOwnerSnapshot(t, store, consumer.SymbolID)
+	require.Len(t, beforeOwner, 1)
+	beforeUnrelated := registeredBridgeNodeSnapshot(t, store, unrelatedBridge)
+	beforeUnrelatedOwner := registeredBridgeOwnerSnapshot(t, store, otherConsumer.SymbolID)
+	beforeUnrelatedMatches := registeredBridgeMatchSnapshot(t, store, otherProvider.ID, otherProvider.SymbolID, otherConsumer.SymbolID)
+	require.NotEmpty(t, beforeUnrelatedMatches, "unrelated persisted matches survive registration")
+	require.NotEmpty(t, registeredBridgeMatchSnapshot(t, store, provider.ID, provider.SymbolID, consumer.SymbolID), "deleted pair has a positive persisted match before eviction")
+	require.NoError(t, os.Remove(filepath.Join(root, "provider.go")))
+	var eviction forcedFileEviction
+	require.NoError(t, idx.coordinateRepositoryMutation(ctx, func() error { eviction = idx.evictFileIncrementalRaw("provider.go"); return nil }))
+	require.NotNil(t, eviction.result)
+	plan := eviction.result.DerivedInvalidation
+	require.False(t, plan.LegacyFallback)
+	assert.True(t, plan.Flags.Has(DerivedInvalidatesContracts))
+	assert.Contains(t, plan.ContractGroups, ContractGroupFrontier{WorkspaceID: provider.WorkspaceID, ProjectID: provider.ProjectID, ContractID: provider.ID})
+	assert.Contains(t, plan.ContractSymbolIDs, provider.SymbolID)
+	// Actual public dispatcher enforces the flag gate and reconciles groups.
+	// The group itself derives/discovers bridge IDs; an explicit ID list is
+	// not required and is intentionally not asserted here.
+	report := mi.RunIncrementalDerivedPasses(ctx, map[string]DerivedInvalidationPlan{"fixture": plan})
+	t.Logf("derived_contracts=%d repos=%d files=%d", report.Contracts, report.Repos, report.Files)
+	assert.Nil(t, store.GetNode(staleBridge), "the stale matched bridge must disappear through actual gated dispatch")
+	assert.Equal(t, beforeConsumer, registeredBridgeNodeSnapshot(t, store, provider.ID), "surviving B canonical metadata stays exact")
+	assert.Equal(t, beforeOwner, registeredBridgeOwnerSnapshot(t, store, consumer.SymbolID))
+	assert.Equal(t, beforeUnrelated, registeredBridgeNodeSnapshot(t, store, unrelatedBridge), "unrelated bridge group remains exact")
+	assert.Equal(t, beforeUnrelatedOwner, registeredBridgeOwnerSnapshot(t, store, otherConsumer.SymbolID))
+	assert.Equal(t, unrelatedBridge, registeredBridgeAttachment(t, store, otherProvider.ID))
+	assert.Equal(t, beforeUnrelatedMatches, registeredBridgeMatchSnapshot(t, store, otherProvider.ID, otherProvider.SymbolID, otherConsumer.SymbolID))
+	assert.Empty(t, registeredBridgeMatchSnapshot(t, store, provider.ID, provider.SymbolID, consumer.SymbolID), "deleted pair has no stale match")
+	for _, edge := range store.GetInEdges(provider.ID) {
+		assert.NotEqual(t, graph.EdgeBridges, edge.Kind, "deleted pair has no surviving bridge attachment")
+		assert.NotEqual(t, graph.EdgeMatches, edge.Kind, "deleted pair has no stale match")
+	}
+}
+
+// Inspect the actual temp-store FTS row schema without assuming a column name.
+// The fixture IDs are unique and matched exactly, never against token substrings.
+func contractFTSRowsForID(t *testing.T, db *sql.DB, id string) []string {
+	t.Helper()
+	rows, err := db.Query("SELECT * FROM symbol_fts")
+	require.NoError(t, err)
+	defer rows.Close()
+	columns, err := rows.Columns()
+	require.NoError(t, err)
+	var found []string
+	for rows.Next() {
+		values := make([]any, len(columns))
+		pointers := make([]any, len(columns))
+		for i := range values {
+			pointers[i] = &values[i]
+		}
+		require.NoError(t, rows.Scan(pointers...))
+		match := false
+		for i, value := range values {
+			if raw, ok := value.([]byte); ok {
+				value = string(raw)
+				values[i] = value
+			}
+			if value == id {
+				match = true
+			}
+		}
+		if match {
+			encoded, marshalErr := json.Marshal(values)
+			require.NoError(t, marshalErr)
+			found = append(found, string(encoded))
+		}
+	}
+	require.NoError(t, rows.Err())
+	return found
+}
+
+type contractFTSEvictionFixture struct {
+	store              *store_sqlite.Store
+	db                 *sql.DB
+	idx                *Indexer
+	root               string
+	provider, consumer contracts.Contract
+}
+
+func newContractFTSEvictionFixture(t *testing.T) contractFTSEvictionFixture {
+	t.Helper()
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "provider.go"), []byte("package fixture\nfunc Provide() {}\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "consumer.go"), []byte("package fixture\nfunc Consume() {}\n"), 0o600))
+	storePath := filepath.Join(t.TempDir(), "graph.sqlite")
+	store, err := store_sqlite.Open(storePath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	db, err := sql.Open("sqlite", storePath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	idx := New(store, newTestRegistry(), config.IndexConfig{}, zap.NewNop())
+	t.Cleanup(idx.Close)
+	idx.SetRepoPrefix("fixture")
+	idx.SetWorkspaceID("workspace")
+	idx.SetProjectID("project")
+	idx.storeRootPath(root)
+	provider := contracts.Contract{
+		ID: "env::FTS_FILE_EVICTION", Type: contracts.ContractType("env"), Role: contracts.RoleProvider,
+		RepoPrefix: "fixture", WorkspaceID: "workspace", ProjectID: "project",
+		FilePath: "fixture/provider.go", SymbolID: "fixture/provider.go::Provide", Line: 2, Confidence: 1,
+		Meta: map[string]any{"var": "FTS_FILE_EVICTION"},
+	}
+	consumer := provider
+	consumer.Role = contracts.RoleConsumer
+	consumer.FilePath, consumer.SymbolID = "fixture/consumer.go", "fixture/consumer.go::Consume"
+	store.AddBatch([]*graph.Node{
+		{ID: provider.FilePath, Kind: graph.KindFile, FilePath: provider.FilePath, RepoPrefix: provider.RepoPrefix},
+		{ID: consumer.FilePath, Kind: graph.KindFile, FilePath: consumer.FilePath, RepoPrefix: consumer.RepoPrefix},
+		{ID: provider.SymbolID, Name: "Provide", Kind: graph.KindFunction, FilePath: provider.FilePath, RepoPrefix: provider.RepoPrefix, Language: "go"},
+		{ID: consumer.SymbolID, Name: "Consume", Kind: graph.KindFunction, FilePath: consumer.FilePath, RepoPrefix: consumer.RepoPrefix, Language: "go"},
+	}, nil)
+	registry := contracts.NewRegistry()
+	registry.Add(consumer)
+	registry.Add(provider)
+	idx.commitContracts(registry)
+	canonical := store.GetNode(provider.ID)
+	require.NotNil(t, canonical)
+	require.Equal(t, provider.FilePath, canonical.FilePath, "canonical is in A's node-file eviction frontier")
+	require.Len(t, store.GetInEdges(provider.ID), 2, "surviving B owner must exist")
+	require.Empty(t, contractFTSRowsForID(t, db, provider.ID), "cold contract writer alone does not seed the FTS control")
+	require.Empty(t, contractFTSRowsForID(t, db, consumer.SymbolID), "ordinary positive control starts without synthetic FTS rows")
+	require.NoError(t, idx.populateSymbolFTS(nil), "invoke the actual supported store rebuild, not a direct FTS upsert")
+	require.Len(t, contractFTSRowsForID(t, db, consumer.SymbolID), 1, "actual ordinary-symbol rebuild proves the path is non-vacuous")
+	require.Len(t, contractFTSRowsForID(t, db, provider.ID), 1, "actual rebuild legitimately indexes the persisted contract")
+	return contractFTSEvictionFixture{store: store, db: db, idx: idx, root: root, provider: provider, consumer: consumer}
+}
+
+func TestContractFTSRebuildLegitimatelyIndexesPersistedContract(t *testing.T) {
+	fixture := newContractFTSEvictionFixture(t)
+	t.Logf("actual_rebuild ordinary_rows=%d contract_rows=%d", len(contractFTSRowsForID(t, fixture.db, fixture.consumer.SymbolID)), len(contractFTSRowsForID(t, fixture.db, fixture.provider.ID)))
+}
+
+func TestContractFTSRemoveFromSearchActualBackend(t *testing.T) {
+	f := newContractFTSEvictionFixture(t)
+	beforeB := contractFTSRowsForID(t, f.db, f.consumer.SymbolID)
+	require.Len(t, contractFTSRowsForID(t, f.db, f.provider.ID), 1)
+	f.idx.removeFromSearch(f.store.GetNode(f.provider.ID))
+	after := contractFTSRowsForID(t, f.db, f.provider.ID)
+	assert.Equal(t, beforeB, contractFTSRowsForID(t, f.db, f.consumer.SymbolID), "targeted search removal must leave B's ordinary document unchanged")
+	assert.NotNil(t, f.store.GetNode(f.provider.ID), "search removal is not graph-node removal")
+	_, churn := any(f.store).(graph.ChurnEnrichmentWriter)
+	_, coverage := any(f.store).(graph.CoverageEnrichmentWriter)
+	_, releases := any(f.store).(graph.ReleaseEnrichmentWriter)
+	_, blame := any(f.store).(graph.BlameEnrichmentWriter)
+	t.Logf("backend=%T before_contract_fts=1 after_remove_from_search=%d churn_writer=%t coverage_writer=%t release_writer=%t blame_writer=%t",
+		f.idx.search, len(after), churn, coverage, releases, blame)
+}
+
+func TestContractFTSFileEvictionPreservesRetainedCanonicalRows(t *testing.T) {
+	for _, rawIndexer := range []bool{false, true} {
+		name := "store_batch"
+		if rawIndexer {
+			name = "indexer_raw"
+		}
+		t.Run(name, func(t *testing.T) {
+			f := newContractFTSEvictionFixture(t)
+			beforeCanonical := contractFTSRowsForID(t, f.db, f.provider.ID)
+			beforeB := contractFTSRowsForID(t, f.db, f.consumer.SymbolID)
+			beforeA := contractFTSRowsForID(t, f.db, f.provider.SymbolID)
+			require.Len(t, beforeA, 1, "deleted ordinary A symbol also starts indexed")
+			require.NoError(t, os.Remove(filepath.Join(f.root, "provider.go")))
+			if rawIndexer {
+				// This fixture isolates sidecar accounting; reset the registry so
+				// a cold in-memory registry cannot hide the deletion boundary.
+				f.idx.contractRegistry = nil
+				require.NoError(t, f.idx.coordinateRepositoryMutation(context.Background(), func() error {
+					f.idx.evictFileIncrementalRaw("provider.go")
+					return nil
+				}))
+			} else {
+				f.store.EvictFiles([]string{f.provider.FilePath})
+			}
+			assert.Nil(t, f.store.GetNode(f.provider.SymbolID))
+			if rawIndexer {
+				assert.Empty(t, contractFTSRowsForID(t, f.db, f.provider.SymbolID), "indexer removes A's ordinary-symbol FTS row")
+			} else {
+				assert.Equal(t, beforeA, contractFTSRowsForID(t, f.db, f.provider.SymbolID), "raw graph primitive leaves FTS accounting with its caller, as before")
+			}
+			assert.NotNil(t, f.store.GetNode(f.provider.ID), "surviving B still requires the canonical")
+			assert.Equal(t, beforeCanonical, contractFTSRowsForID(t, f.db, f.provider.ID), "retain the exact legitimately rebuilt canonical search row")
+			assert.Equal(t, beforeB, contractFTSRowsForID(t, f.db, f.consumer.SymbolID), "B ordinary symbol search row is outside deletion scope")
+			if rawIndexer {
+				// On final-owner deletion the canonical still names the old A
+				// scalar path. Its now-orphaned FTS row must not leak just because
+				// B's initial by-file node set does not include the canonical.
+				f.idx.contractRegistry = nil
+				require.NoError(t, os.Remove(filepath.Join(f.root, "consumer.go")))
+				require.NoError(t, f.idx.coordinateRepositoryMutation(context.Background(), func() error {
+					f.idx.evictFileIncrementalRaw("consumer.go")
+					return nil
+				}))
+				assert.Nil(t, f.store.GetNode(f.provider.ID))
+				assert.Empty(t, contractFTSRowsForID(t, f.db, f.provider.ID), "final-owner removal cleans actually orphaned off-file canonical FTS")
+				assert.Empty(t, contractFTSRowsForID(t, f.db, f.consumer.SymbolID))
+			}
+		})
+	}
+}
+
+func TestContractFTSStructuralReparsePreservesRetainedCanonicalRows(t *testing.T) {
+	f := newContractFTSEvictionFixture(t)
+	beforeCanonical := contractFTSRowsForID(t, f.db, f.provider.ID)
+	beforeB := contractFTSRowsForID(t, f.db, f.consumer.SymbolID)
+	require.Len(t, beforeCanonical, 1)
+	require.Len(t, beforeB, 1)
+	require.NotNil(t, f.store.GetNode(f.provider.SymbolID))
+	require.NoError(t, os.WriteFile(filepath.Join(f.root, "provider.go"),
+		[]byte("package fixture\nfunc ReparsedProvider() {}\n"), 0o600))
+
+	core, observed := observer.New(zap.DebugLevel)
+	f.idx.logger = zap.New(core)
+	f.idx.contractRegistry = nil
+	// Reuse the receipt-aware entry and relative-path convention exercised by
+	// SIZE's applyCensus; do not add another mutation-coordinator wrapper.
+	_, _, _, err := f.idx.incrementalReindexPathsWithReceiptMode(f.root,
+		[]string{"provider.go"}, incrementalPathMode{forceExplicitFiles: true, detectDeletions: true})
+	require.NoError(t, err)
+
+	var structuralFiles int64
+	for _, entry := range observed.All() {
+		for _, field := range entry.Context {
+			if field.Key == "structural_files" {
+				structuralFiles += field.Integer
+			}
+		}
+	}
+	require.Positive(t, structuralFiles, "actual chunk graph apply must enter its nonempty structural branch")
+	assert.Nil(t, f.store.GetNode(f.provider.SymbolID), "the replaced A declaration must leave the graph")
+	var reparsedDeclaration bool
+	for _, node := range f.store.GetFileNodes(f.provider.FilePath) {
+		if node != nil && node.Kind == graph.KindFunction && node.Name == "ReparsedProvider" {
+			reparsedDeclaration = true
+		}
+	}
+	require.True(t, reparsedDeclaration, "the new A declaration must be parsed and committed")
+	require.NotNil(t, f.store.GetNode(f.provider.ID), "B still owns the canonical after A's structural reparse")
+	assert.Equal(t, beforeCanonical, contractFTSRowsForID(t, f.db, f.provider.ID),
+		"the real rebuilt canonical FTS row must survive structural eviction exactly")
+	assert.Equal(t, beforeB, contractFTSRowsForID(t, f.db, f.consumer.SymbolID),
+		"B's ordinary FTS row stays outside A's structural frontier")
+}

--- a/internal/indexer/contract_owner_writer_test.go
+++ b/internal/indexer/contract_owner_writer_test.go
@@ -1,0 +1,682 @@
+package indexer
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/contracts"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"go.uber.org/zap"
+)
+
+// Serialize the full record, including metadata and ownership, and count
+// multiplicity. An ID-keyed map would hide the exact regression under test.
+func bridgeRoundtripRecordMultiset(t *testing.T, records []contracts.Contract) map[string]int {
+	t.Helper()
+	set := make(map[string]int, len(records))
+	for _, c := range records {
+		encoded, err := json.Marshal(c)
+		require.NoError(t, err)
+		set[string(encoded)]++
+	}
+	return set
+}
+
+func bridgeRoundtripMatches(t *testing.T, reg *contracts.Registry) map[string]int {
+	t.Helper()
+	set := make(map[string]int)
+	result := contracts.Match(reg)
+	for _, match := range result.Matched {
+		// Keep both entire endpoint records: a shared ID does not identify
+		// either role, source file, symbol, or metadata payload by itself.
+		encoded, err := json.Marshal(struct {
+			Provider  contracts.Contract
+			Consumer  contracts.Contract
+			CrossRepo bool
+		}{match.Provider, match.Consumer, match.CrossRepo})
+		require.NoError(t, err)
+		set[string(encoded)]++
+	}
+	return set
+}
+
+func TestBridgeRegistryRoundtripPreservesSharedIDRecords(t *testing.T) {
+	factories := map[string]func(*testing.T) graph.Store{
+		"memory": func(t *testing.T) graph.Store { return graph.New() },
+		"sqlite": func(t *testing.T) graph.Store {
+			store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, store.Close()) })
+			return store
+		},
+	}
+	for backend, factory := range factories {
+		for _, kind := range []string{"env", "graphql"} {
+			for _, shared := range []bool{false, true} {
+				name := "unique_ids"
+				if shared {
+					name = "shared_id"
+				}
+				t.Run(backend+"/"+kind+"/"+name, func(t *testing.T) {
+					store := factory(t)
+					idx := New(store, newTestRegistry(), config.IndexConfig{}, zap.NewNop())
+					idx.SetRepoPrefix("roundtrip")
+					idx.SetWorkspaceID("workspace")
+					idx.SetProjectID("project")
+					idx.storeRootPath(t.TempDir())
+					t.Cleanup(func() { idx.Close() })
+					providerID, consumerID := "env::ROUNDTRIP_PROVIDER", "env::ROUNDTRIP_CONSUMER"
+					providerMeta := map[string]any{"var": "ROUNDTRIP_PROVIDER"}
+					consumerMeta := map[string]any{"var": "ROUNDTRIP_CONSUMER"}
+					if kind == "graphql" {
+						providerID, consumerID = "graphql::Query::Provider", "graphql::Query::Consumer"
+						providerMeta = map[string]any{"operation": "Query", "field": "Provider"}
+						consumerMeta = map[string]any{"operation": "Query", "field": "Consumer"}
+					}
+					if shared {
+						consumerID, consumerMeta = providerID, providerMeta
+					}
+					provider := contracts.Contract{
+						ID: providerID, Type: contracts.ContractType(kind), Role: contracts.Role("provider"),
+						RepoPrefix: "roundtrip", WorkspaceID: "workspace", ProjectID: "project",
+						FilePath: "roundtrip/provider.go", SymbolID: "roundtrip/provider.go::Provide", Line: 11,
+						Confidence: 1, Meta: providerMeta,
+					}
+					consumer := contracts.Contract{
+						ID: consumerID, Type: contracts.ContractType(kind), Role: contracts.Role("consumer"),
+						RepoPrefix: "roundtrip", WorkspaceID: "workspace", ProjectID: "project",
+						FilePath: "roundtrip/consumer.go", SymbolID: "roundtrip/consumer.go::Consume", Line: 22,
+						Confidence: 1, Meta: consumerMeta,
+					}
+					original := contracts.NewRegistry()
+					original.Add(provider)
+					original.Add(consumer)
+					require.Len(t, original.All(), 2, "the in-memory registry preserves both distinct roles")
+					beforeRecords := bridgeRoundtripRecordMultiset(t, original.All())
+					beforeMatches := bridgeRoundtripMatches(t, original)
+					if shared {
+						require.Len(t, beforeMatches, 1, "shared-ID fixture must establish a real initial match")
+					} else {
+						require.Empty(t, beforeMatches, "unique-ID control intentionally has no matching pair")
+					}
+
+					store.AddBatch([]*graph.Node{
+						{ID: provider.SymbolID, Kind: graph.KindFunction, RepoPrefix: "roundtrip", FilePath: provider.FilePath, WorkspaceID: "workspace", ProjectID: "project"},
+						{ID: consumer.SymbolID, Kind: graph.KindFunction, RepoPrefix: "roundtrip", FilePath: consumer.FilePath, WorkspaceID: "workspace", ProjectID: "project"},
+					}, nil)
+					idx.commitContracts(original)
+					require.Equal(t, beforeRecords, bridgeRoundtripRecordMultiset(t, original.All()), "cold in-memory records remain intact")
+					var persistedRoles []any
+					for _, n := range store.GetRepoNodes("roundtrip") {
+						if n.Kind == graph.KindContract {
+							persistedRoles = append(persistedRoles, n.Meta["role"])
+						}
+					}
+					loaded := contracts.LoadRegistryFromGraph(store, "roundtrip")
+					require.NotNil(t, loaded)
+					ownerIndexer := New(store, newTestRegistry(), config.IndexConfig{}, zap.NewNop())
+					ownerIndexer.SetRepoPrefix("roundtrip")
+					ownerIndexer.SetWorkspaceID("workspace")
+					ownerIndexer.SetProjectID("project")
+					t.Cleanup(func() { ownerIndexer.Close() })
+					ownerRecovered := ownerIndexer.ensureIncrementalContractRegistry()
+					require.Equal(t, beforeRecords, bridgeRoundtripRecordMultiset(t, ownerRecovered.All()), "existing owner edges recover both symbol-backed records")
+					require.Equal(t, beforeMatches, bridgeRoundtripMatches(t, ownerRecovered), "existing owner-edge recovery preserves matches for this fixture")
+					t.Logf("cold_records=%d stored_contract_nodes=%d stored_roles=%v warm_records=%d cold_matches=%d warm_matches=%d owner_records=%d owner_matches=%d",
+						len(original.All()), len(persistedRoles), persistedRoles, len(loaded.All()), len(beforeMatches), len(bridgeRoundtripMatches(t, loaded)), len(ownerRecovered.All()), len(bridgeRoundtripMatches(t, ownerRecovered)))
+					assert.Equal(t, beforeRecords, bridgeRoundtripRecordMultiset(t, loaded.All()), "all full records and their multiplicities must survive persistence/hydration")
+					assert.Equal(t, beforeMatches, bridgeRoundtripMatches(t, loaded), "provider-consumer matches must survive a warm registry load")
+				})
+			}
+		}
+	}
+}
+
+func TestBridgeRegistryOwnerRecoveryPreservesSymbolLessProvider(t *testing.T) {
+	for _, providerLast := range []bool{false, true} {
+		name := "provider_first"
+		if providerLast {
+			name = "provider_last"
+		}
+		t.Run(name, func(t *testing.T) {
+			store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, store.Close()) })
+			idx := New(store, newTestRegistry(), config.IndexConfig{}, zap.NewNop())
+			idx.SetRepoPrefix("roundtrip")
+			idx.SetWorkspaceID("workspace")
+			idx.SetProjectID("project")
+			idx.storeRootPath(t.TempDir())
+			t.Cleanup(func() { idx.Close() })
+			provider := contracts.Contract{
+				ID: "env::SYMBOL_LESS", Type: contracts.ContractType("env"), Role: contracts.Role("provider"),
+				RepoPrefix: "roundtrip", WorkspaceID: "workspace", ProjectID: "project",
+				FilePath: "roundtrip/.env", Line: 1, Confidence: 1,
+				Meta: map[string]any{"var": "SYMBOL_LESS"},
+			}
+			consumer := provider
+			consumer.Role = contracts.Role("consumer")
+			consumer.FilePath, consumer.SymbolID, consumer.Line = "roundtrip/consumer.go", "roundtrip/consumer.go::Consume", 22
+			store.AddBatch([]*graph.Node{
+				{ID: "roundtrip/.env", Kind: graph.KindFile, RepoPrefix: "roundtrip", FilePath: "roundtrip/.env"},
+				{ID: consumer.SymbolID, Kind: graph.KindFunction, RepoPrefix: "roundtrip", FilePath: consumer.FilePath},
+			}, nil)
+			original := contracts.NewRegistry()
+			if providerLast {
+				original.Add(consumer)
+				original.Add(provider)
+			} else {
+				original.Add(provider)
+				original.Add(consumer)
+			}
+			require.Len(t, bridgeRoundtripMatches(t, original), 1)
+			idx.commitContracts(original)
+			warm := New(store, newTestRegistry(), config.IndexConfig{}, zap.NewNop())
+			warm.SetRepoPrefix("roundtrip")
+			warm.SetWorkspaceID("workspace")
+			warm.SetProjectID("project")
+			t.Cleanup(func() { warm.Close() })
+			ownerRecovered := warm.ensureIncrementalContractRegistry()
+			node := store.GetNodesByIDs([]string{provider.ID})[provider.ID]
+			require.NotNil(t, node)
+			t.Logf("node_role=%v node_symbol=%v cold_records=%d owner_records=%d cold_matches=%d owner_matches=%d",
+				node.Meta["role"], node.Meta["symbol_id"], len(original.All()), len(ownerRecovered.All()), len(bridgeRoundtripMatches(t, original)), len(bridgeRoundtripMatches(t, ownerRecovered)))
+			assert.Equal(t, bridgeRoundtripRecordMultiset(t, original.All()), bridgeRoundtripRecordMultiset(t, ownerRecovered.All()), "an existing file node does not make the writer emit a symbol-less ownership record")
+			assert.Equal(t, bridgeRoundtripMatches(t, original), bridgeRoundtripMatches(t, ownerRecovered))
+		})
+	}
+}
+
+func TestBridgeRegistryLegacyRemovedScalarDoesNotResurrect(t *testing.T) {
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	provider := contracts.Contract{
+		ID: "env::LEGACY_REMOVAL", Type: contracts.ContractType("env"), Role: contracts.Role("provider"),
+		RepoPrefix: "repo-a", WorkspaceID: "workspace-a", ProjectID: "project-a",
+		FilePath: "repo-a/.env", Line: 1, Confidence: 1, Meta: map[string]any{"var": "LEGACY_REMOVAL"},
+	}
+	consumer := provider
+	consumer.Role = contracts.Role("consumer")
+	consumer.RepoPrefix, consumer.WorkspaceID, consumer.ProjectID = "repo-b", "workspace-b", "project-b"
+	consumer.FilePath, consumer.SymbolID, consumer.Line = "repo-b/consumer.go", "repo-b/consumer.go::Consume", 22
+	// Explicit legacy scalar fixture, deliberately without the future per-record
+	// owner marker. A had no SymbolID/owner edge; B has a surviving real owner.
+	store.AddBatch([]*graph.Node{
+		{ID: provider.FilePath, Kind: graph.KindFile, RepoPrefix: provider.RepoPrefix, FilePath: provider.FilePath},
+		{ID: consumer.SymbolID, Kind: graph.KindFunction, RepoPrefix: consumer.RepoPrefix, FilePath: consumer.FilePath},
+		{
+			ID: provider.ID, Kind: graph.KindContract, RepoPrefix: provider.RepoPrefix,
+			FilePath: provider.FilePath, WorkspaceID: provider.WorkspaceID, ProjectID: provider.ProjectID,
+			Meta: map[string]any{"type": "env", "role": "provider", "symbol_id": "", "line": 1, "confidence": float64(1), "contract_meta": provider.Meta},
+		},
+	}, []*graph.Edge{{From: consumer.SymbolID, To: provider.ID, Kind: graph.EdgeConsumes, FilePath: consumer.FilePath, Line: consumer.Line, Meta: contractOwnerEdgeMeta(consumer)}})
+	before := contracts.LoadRegistryFromGraph(store, provider.RepoPrefix)
+	require.NotNil(t, before)
+	require.Equal(t, bridgeRoundtripRecordMultiset(t, []contracts.Contract{provider}), bridgeRoundtripRecordMultiset(t, before.All()), "a recoverable unremoved legacy scalar remains compatible")
+	fixtureReceipt := store.BeginMutationReceipt()
+	result, err := graph.ReplaceContractOwners(store, graph.ContractOwnerReplacement{
+		RepoPrefix: provider.RepoPrefix, FilePaths: []string{provider.FilePath}, TouchedNodeIDs: []string{provider.ID},
+	})
+	require.NoError(t, err)
+	receipt := store.EndMutationReceipt(fixtureReceipt)
+	require.NotNil(t, store.GetNodesByIDs([]string{provider.ID})[provider.ID], "B still owns the canonical contract node")
+	var consumerOwners int
+	for _, edge := range store.GetOutEdgesByNodeIDs([]string{consumer.SymbolID})[consumer.SymbolID] {
+		if edge.To == provider.ID && edge.Kind == graph.EdgeConsumes {
+			consumerOwners++
+		}
+	}
+	require.Equal(t, 1, consumerOwners, "A's removal must retain B's owner")
+	after := contracts.LoadRegistryFromGraph(store, provider.RepoPrefix)
+	afterCount := 0
+	if after != nil {
+		afterCount = len(after.All())
+	}
+	t.Logf("legacy_before=1 after_explicit_removal=%d sibling_owners=%d nodes_changed=%d nodes_removed=%d receipt_complete=%t",
+		afterCount, consumerOwners, result.NodesChanged, result.NodesRemoved, receipt.Complete)
+	assert.Zero(t, afterCount, "explicit removal is evidence against scalar fallback; do not resurrect removed A")
+	assert.Positive(t, result.NodesChanged+result.NodesRemoved, "invalidating a removed scalar must participate in mutation bookkeeping")
+	assert.False(t, receipt.Complete, "this replacement's semantic mutation must invalidate its receipt as other owner replacements do")
+
+	_, err = graph.ReplaceContractOwners(store, graph.ContractOwnerReplacement{
+		RepoPrefix: consumer.RepoPrefix, FilePaths: []string{consumer.FilePath}, TouchedNodeIDs: []string{consumer.ID},
+	})
+	require.NoError(t, err)
+	require.Nil(t, store.GetNodesByIDs([]string{provider.ID})[provider.ID], "the canonical node may be pruned once the final real owner is removed")
+}
+
+func TestBridgeRegistryBothWritersRetainFileOwnersAndRemoveOne(t *testing.T) {
+	for _, incremental := range []bool{false, true} {
+		name := "full"
+		if incremental {
+			name = "incremental"
+		}
+		t.Run(name, func(t *testing.T) {
+			store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, store.Close()) })
+			idx := New(store, newTestRegistry(), config.IndexConfig{}, zap.NewNop())
+			idx.SetRepoPrefix("repo")
+			idx.SetWorkspaceID("workspace")
+			idx.SetProjectID("project")
+			idx.storeRootPath(t.TempDir())
+			t.Cleanup(func() { idx.Close() })
+			provider := contracts.Contract{ID: "env::FILE_OWNED", Type: contracts.ContractType("env"), Role: contracts.RoleProvider,
+				RepoPrefix: "repo", WorkspaceID: "workspace", ProjectID: "project", FilePath: "repo/provider.env", Line: 1,
+				Confidence: 1, Meta: map[string]any{"var": "FILE_OWNED"}}
+			consumer := provider
+			consumer.Role, consumer.FilePath, consumer.Line = contracts.RoleConsumer, "repo/consumer.env", 2
+			store.AddBatch([]*graph.Node{
+				{ID: provider.FilePath, Kind: graph.KindFile, RepoPrefix: "repo", FilePath: provider.FilePath},
+				{ID: consumer.FilePath, Kind: graph.KindFile, RepoPrefix: "repo", FilePath: consumer.FilePath},
+			}, nil)
+			reg := contracts.NewRegistry()
+			reg.Add(provider)
+			reg.Add(consumer)
+			for range 2 {
+				if incremental {
+					idx.commitIncrementalContractFiles(reg, []string{provider.FilePath, consumer.FilePath}, nil)
+				} else {
+					idx.commitContracts(reg)
+				}
+			}
+			loaded := contracts.LoadRegistryFromGraph(store, "repo")
+			require.NotNil(t, loaded)
+			assert.Equal(t, bridgeRoundtripRecordMultiset(t, reg.All()), bridgeRoundtripRecordMultiset(t, loaded.All()))
+			assert.Len(t, bridgeRoundtripMatches(t, loaded), 1)
+			var owners int
+			for _, edge := range store.GetInEdges(provider.ID) {
+				if edge.Kind != graph.EdgeProvides && edge.Kind != graph.EdgeConsumes {
+					continue
+				}
+				owners++
+				symbol, present := edge.Meta["contract_owner_symbol_id"]
+				assert.True(t, present)
+				assert.Equal(t, "", symbol, "file endpoint must not become the reconstructed symbol")
+			}
+			assert.Equal(t, 2, owners, "repeated commits keep one row per source/role")
+			remaining := contracts.NewRegistry()
+			remaining.Add(consumer)
+			idx.commitIncrementalContractFiles(remaining, []string{provider.FilePath}, map[string]struct{}{provider.ID: {}})
+			loaded = contracts.LoadRegistryFromGraph(store, "repo")
+			require.NotNil(t, loaded)
+			assert.Equal(t, bridgeRoundtripRecordMultiset(t, []contracts.Contract{consumer}), bridgeRoundtripRecordMultiset(t, loaded.All()))
+			assert.Empty(t, bridgeRoundtripMatches(t, loaded))
+		})
+	}
+}
+
+func TestBridgeRegistryMissingFileOwnerDoesNotFabricateSource(t *testing.T) {
+	for _, incremental := range []bool{false, true} {
+		name := "full"
+		if incremental {
+			name = "incremental"
+		}
+		t.Run(name, func(t *testing.T) {
+			store := graph.New()
+			idx := New(store, newTestRegistry(), config.IndexConfig{}, zap.NewNop())
+			idx.SetRepoPrefix("repo")
+			idx.SetWorkspaceID("workspace")
+			idx.SetProjectID("project")
+			idx.storeRootPath(t.TempDir())
+			t.Cleanup(func() { idx.Close() })
+			c := contracts.Contract{ID: "env::NO_ADMITTED_FILE", Type: contracts.ContractType("env"), Role: contracts.RoleProvider,
+				RepoPrefix: "repo", WorkspaceID: "workspace", ProjectID: "project", FilePath: "repo/missing.env", Line: 1,
+				Confidence: 1, Meta: map[string]any{"var": "NO_ADMITTED_FILE"}}
+			// A conflicting file-path row owned by another repo must not be
+			// accepted as a genuine source owner for this contract.
+			store.AddNode(&graph.Node{ID: "other/missing.env", Kind: graph.KindFile, FilePath: c.FilePath, RepoPrefix: "other"})
+			reg := contracts.NewRegistry()
+			reg.Add(c)
+			if incremental {
+				idx.commitIncrementalContractFiles(reg, []string{c.FilePath}, nil)
+			} else {
+				idx.commitContracts(reg)
+			}
+			for _, node := range store.GetFileNodes(c.FilePath) {
+				assert.False(t, node.Kind == graph.KindFile && node.RepoPrefix == "repo", "writer may not fabricate an admitted source")
+			}
+			assert.Empty(t, store.GetInEdges(c.ID))
+			canonical := store.GetNode(c.ID)
+			require.NotNil(t, canonical)
+			ownerBacked, _ := canonical.Meta["contract_owner_record"].(bool)
+			assert.False(t, ownerBacked, "do not claim the scalar has a persisted ownership row")
+			loaded := contracts.LoadRegistryFromGraph(store, "repo")
+			require.NotNil(t, loaded)
+			assert.Equal(t, bridgeRoundtripRecordMultiset(t, []contracts.Contract{c}), bridgeRoundtripRecordMultiset(t, loaded.All()), "retain the one known scalar record without inventing missing multiplicity")
+		})
+	}
+}
+
+func TestBridgeRegistryInvalidSymbolOwnerDoesNotHideScalar(t *testing.T) {
+	for _, backend := range []string{"memory", "sqlite"} {
+		for _, incremental := range []bool{false, true} {
+			for _, wrongRepo := range []bool{false, true} {
+				writer, source := "full", "missing"
+				if incremental {
+					writer = "incremental"
+				}
+				if wrongRepo {
+					source = "wrong_repo"
+				}
+				t.Run(backend+"/"+writer+"/"+source, func(t *testing.T) {
+					var store graph.Store = graph.New()
+					if backend == "sqlite" {
+						sqliteStore, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+						require.NoError(t, err)
+						t.Cleanup(func() { require.NoError(t, sqliteStore.Close()) })
+						store = sqliteStore
+					}
+					idx := New(store, newTestRegistry(), config.IndexConfig{}, zap.NewNop())
+					idx.SetRepoPrefix("a")
+					idx.SetWorkspaceID("workspace")
+					idx.SetProjectID("project")
+					idx.storeRootPath(t.TempDir())
+					t.Cleanup(func() { idx.Close() })
+					c := contracts.Contract{ID: "env::INVALID_SYMBOL_OWNER", Type: contracts.ContractType("env"), Role: contracts.RoleProvider,
+						RepoPrefix: "a", WorkspaceID: "workspace", ProjectID: "project", FilePath: "a/owner.go", SymbolID: "a/owner.go::Provide", Line: 1,
+						Confidence: 1, Meta: map[string]any{"var": "INVALID_SYMBOL_OWNER"}}
+					if wrongRepo {
+						store.AddNode(&graph.Node{ID: c.SymbolID, Kind: graph.KindFunction, RepoPrefix: "b", FilePath: c.FilePath})
+					}
+					reg := contracts.NewRegistry()
+					reg.Add(c)
+					if incremental {
+						idx.commitIncrementalContractFiles(reg, []string{c.FilePath}, nil)
+					} else {
+						idx.commitContracts(reg)
+					}
+					canonical := store.GetNode(c.ID)
+					require.NotNil(t, canonical)
+					ownerBacked, _ := canonical.Meta["contract_owner_record"].(bool)
+					assert.False(t, ownerBacked, "a symbol ID alone is not proof of a persistable correctly scoped owner row")
+					rows := graph.ReadRepoEdgesByKinds(store, []string{"a"}, []graph.EdgeKind{graph.EdgeProvides, graph.EdgeConsumes})
+					assert.Empty(t, rows)
+					loaded := contracts.LoadRegistryFromGraph(store, "a")
+					require.NotNil(t, loaded, "invalid ownership must not hide the known scalar record")
+					assert.Equal(t, bridgeRoundtripRecordMultiset(t, []contracts.Contract{c}), bridgeRoundtripRecordMultiset(t, loaded.All()))
+					t.Logf("raw_incoming_edges=%d scoped_owner_rows=%d owner_backed=%t", len(store.GetInEdges(c.ID)), len(rows), ownerBacked)
+				})
+			}
+		}
+	}
+}
+
+func producerCompatStore(t *testing.T, backend string) graph.Store {
+	t.Helper()
+	if backend == "memory" {
+		return graph.New()
+	}
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "producer.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	return store
+}
+
+func producerCompatIndexer(t *testing.T, store graph.Store) *Indexer {
+	t.Helper()
+	idx := New(store, newTestRegistry(), config.IndexConfig{}, zap.NewNop())
+	idx.SetRepoPrefix("producer")
+	idx.SetWorkspaceID("indexer-workspace")
+	idx.SetProjectID("indexer-project")
+	idx.storeRootPath(t.TempDir())
+	t.Cleanup(func() { idx.Close() })
+	return idx
+}
+
+func producerCompatRecords(t *testing.T, records []contracts.Contract) map[string]int {
+	t.Helper()
+	out := make(map[string]int, len(records))
+	for _, record := range records {
+		encoded, err := json.Marshal(record)
+		require.NoError(t, err)
+		out[string(encoded)]++
+	}
+	return out
+}
+
+func producerCompatCanonical(c contracts.Contract) *graph.Node {
+	return &graph.Node{
+		ID: c.ID, Kind: graph.KindContract, Name: c.ID,
+		RepoPrefix: c.RepoPrefix, FilePath: c.FilePath,
+		WorkspaceID: c.WorkspaceID, ProjectID: c.ProjectID,
+		Meta: map[string]any{
+			"contract_owner_record": true,
+			"type":                  string(c.Type), "role": string(c.Role),
+			"symbol_id": c.SymbolID, "line": c.Line,
+			"confidence": c.Confidence, "contract_meta": c.Meta,
+		},
+	}
+}
+
+func TestBridgeProducerRetainsContractKindSymbolOwners(t *testing.T) {
+	for _, backend := range []string{"memory", "sqlite"} {
+		for _, incremental := range []bool{false, true} {
+			writer := "full"
+			if incremental {
+				writer = "incremental"
+			}
+			for _, kind := range []graph.NodeKind{graph.KindContract, graph.KindContractBridge} {
+				for _, role := range []contracts.Role{contracts.RoleProvider, contracts.RoleConsumer} {
+					t.Run(backend+"/"+writer+"/"+string(kind)+"/"+string(role), func(t *testing.T) {
+						store := producerCompatStore(t, backend)
+						idx := producerCompatIndexer(t, store)
+						c := contracts.Contract{
+							ID: "env::COMPATIBLE_SYMBOL_OWNER", Type: contracts.ContractType("env"), Role: role,
+							RepoPrefix: "producer", WorkspaceID: "owner-workspace", ProjectID: "owner-project",
+							FilePath: "producer/source.go", SymbolID: "producer/source.go::ExistingOwner", Line: 17,
+							Confidence: 0.75, Meta: map[string]any{"var": "COMPATIBLE_SYMBOL_OWNER", "nested": map[string]any{"detail": "preserved"}},
+						}
+						store.AddBatch([]*graph.Node{{
+							ID: c.SymbolID, Kind: kind, RepoPrefix: c.RepoPrefix, FilePath: c.FilePath,
+							WorkspaceID: c.WorkspaceID, ProjectID: c.ProjectID,
+						}}, nil)
+						reg := contracts.NewRegistry()
+						reg.Add(c)
+						if incremental {
+							idx.commitIncrementalContractFiles(reg, []string{c.FilePath}, nil)
+						} else {
+							idx.commitContracts(reg)
+						}
+						wantKind := graph.EdgeProvides
+						if role == contracts.RoleConsumer {
+							wantKind = graph.EdgeConsumes
+						}
+						var owners []*graph.Edge
+						for _, edge := range store.GetInEdges(c.ID) {
+							if edge.From == c.SymbolID && edge.Kind == wantKind {
+								owners = append(owners, edge)
+							}
+						}
+						// These prerequisites must already pass with the old writers:
+						// the new admission guard cannot reject these existing kinds.
+						require.Len(t, owners, 1, "valid same-repo SymbolID must still emit one owner row")
+						require.Equal(t, c.FilePath, owners[0].FilePath)
+						require.Equal(t, c.Line, owners[0].Line)
+						wantMeta, err := json.Marshal(contractOwnerEdgeMeta(c))
+						require.NoError(t, err)
+						gotMeta, err := json.Marshal(owners[0].Meta)
+						require.NoError(t, err)
+						require.JSONEq(t, string(wantMeta), string(gotMeta), "persist every owner field and nested payload")
+						source := store.GetNode(c.SymbolID)
+						require.NotNil(t, source)
+						require.Equal(t, kind, source.Kind)
+						require.Len(t, graph.ReadRepoEdgesByKinds(store, []string{c.RepoPrefix}, []graph.EdgeKind{wantKind}), 1, "repository projection must admit the existing source kind")
+						t.Log("prerequisite passed: existing unusual-kind source and complete owner edge persisted")
+						canonical := store.GetNode(c.ID)
+						require.NotNil(t, canonical)
+						assert.Equal(t, true, canonical.Meta["contract_owner_record"], "admitted persisted owner must mark the canonical row owner-backed")
+						loaded := contracts.LoadRegistryFromGraph(store, c.RepoPrefix)
+						require.NotNil(t, loaded)
+						assert.Equal(t, producerCompatRecords(t, []contracts.Contract{c}), producerCompatRecords(t, loaded.ByID(c.ID)))
+					})
+				}
+			}
+		}
+	}
+}
+
+func TestBridgeIncrementalRegistryRetainsDistinctOwnerRows(t *testing.T) {
+	for _, backend := range []string{"memory", "sqlite"} {
+		t.Run(backend, func(t *testing.T) {
+			store := producerCompatStore(t, backend)
+			first := contracts.Contract{
+				ID: "env::DISTINCT_OWNER_ROWS", Type: contracts.ContractType("env"), Role: contracts.RoleProvider,
+				RepoPrefix: "producer", WorkspaceID: "owner-workspace", ProjectID: "owner-project",
+				FilePath: "producer/source.go", SymbolID: "producer/source.go::Owner", Line: 11,
+				Confidence: 0.5, Meta: map[string]any{"var": "DISTINCT_OWNER_ROWS", "variant": "first"},
+			}
+			second := first
+			second.Line, second.Confidence = 23, 0.9
+			second.Meta = map[string]any{"var": "DISTINCT_OWNER_ROWS", "variant": "second", "nested": map[string]any{"detail": "retained"}}
+			want := producerCompatRecords(t, []contracts.Contract{first, second})
+			original := contracts.NewRegistry()
+			original.Add(first)
+			original.Add(second)
+			require.Equal(t, want, producerCompatRecords(t, original.ByID(first.ID)))
+			require.Len(t, original.All(), 1, "fixture must actually exercise All's unchanged coalescing key")
+			// Seed representable persisted owner rows directly. The full writer
+			// legitimately consumes Registry.All(), whose historical key ignores
+			// Line/metadata; asking it to emit both would be a different contract.
+			store.AddBatch([]*graph.Node{
+				{ID: first.SymbolID, Kind: graph.KindFunction, RepoPrefix: first.RepoPrefix, FilePath: first.FilePath},
+				producerCompatCanonical(first),
+			}, []*graph.Edge{
+				{From: first.SymbolID, To: first.ID, Kind: graph.EdgeProvides, FilePath: first.FilePath, Line: first.Line, Meta: contractOwnerEdgeMeta(first)},
+				{From: second.SymbolID, To: second.ID, Kind: graph.EdgeProvides, FilePath: second.FilePath, Line: second.Line, Meta: contractOwnerEdgeMeta(second)},
+			})
+			rows := graph.ReadRepoEdgesByKinds(store, []string{first.RepoPrefix}, []graph.EdgeKind{graph.EdgeProvides})
+			require.Len(t, rows, 2, "repo projection must really admit two distinct persisted line-keyed owner rows")
+			persisted := store.GetInEdges(first.ID)
+			require.Len(t, persisted, 2)
+			byLine := map[int]contracts.Contract{first.Line: first, second.Line: second}
+			for _, edge := range persisted {
+				wantRecord, ok := byLine[edge.Line]
+				require.True(t, ok)
+				require.Equal(t, wantRecord.SymbolID, edge.From)
+				require.Equal(t, wantRecord.FilePath, edge.FilePath)
+				wantMeta, err := json.Marshal(contractOwnerEdgeMeta(wantRecord))
+				require.NoError(t, err)
+				gotMeta, err := json.Marshal(edge.Meta)
+				require.NoError(t, err)
+				require.JSONEq(t, string(wantMeta), string(gotMeta))
+			}
+			t.Log("prerequisite passed: both complete persisted owner rows admitted")
+			loaded := contracts.LoadRegistryFromGraph(store, first.RepoPrefix)
+			require.NotNil(t, loaded)
+			assert.Equal(t, want, producerCompatRecords(t, loaded.ByID(first.ID)), "public loader must retain the complete record multiset")
+			assert.Equal(t, want, producerCompatRecords(t, loaded.ByRepo(first.RepoPrefix)))
+			require.Len(t, loaded.All(), 1, "Registry.All historical logical-key coalescing is unchanged")
+			idx := producerCompatIndexer(t, store)
+			cached := idx.ensureIncrementalContractRegistry()
+			require.NotNil(t, cached)
+			assert.Equal(t, want, producerCompatRecords(t, cached.ByID(first.ID)), "cache restore must use repo records, not coalescing All()")
+			assert.Equal(t, want, producerCompatRecords(t, cached.ByFile(first.FilePath)))
+			assert.Equal(t, producerCompatRecords(t, loaded.ByID(first.ID)), producerCompatRecords(t, cached.ByID(first.ID)), "public and incremental restoration must agree on full records")
+			require.Len(t, cached.All(), 1, "do not change Registry.All semantics to hide restoration loss")
+		})
+	}
+}
+
+func TestBridgeIncrementalRegistryPreservesExplicitEmptyOwnerScope(t *testing.T) {
+	cases := []struct {
+		name             string
+		workspacePresent bool
+		workspace        string
+		projectPresent   bool
+		project          string
+	}{
+		{name: "absent_uses_indexer_fallback"},
+		{name: "explicit_empty_overrides_indexer_fallback", workspacePresent: true, projectPresent: true},
+		{name: "workspace_empty_project_absent", workspacePresent: true},
+		{name: "workspace_absent_project_empty", projectPresent: true},
+		{name: "workspace_nonempty_project_absent", workspacePresent: true, workspace: "payload-workspace"},
+		{name: "workspace_absent_project_nonempty", projectPresent: true, project: "payload-project"},
+	}
+	for _, backend := range []string{"memory", "sqlite"} {
+		for _, tc := range cases {
+			t.Run(backend+"/"+tc.name, func(t *testing.T) {
+				store := producerCompatStore(t, backend)
+				c := contracts.Contract{
+					ID: "env::OWNER_SCOPE", Type: contracts.ContractType("env"), Role: contracts.RoleProvider,
+					RepoPrefix: "producer", FilePath: "producer/scope.go", SymbolID: "producer/scope.go::Owner", Line: 7,
+					Confidence: 1, Meta: map[string]any{"var": "OWNER_SCOPE"},
+				}
+				meta := contractOwnerEdgeMeta(c)
+				// A persisted legacy row can distinguish explicit empty from
+				// absent fields even if today's writer normalizes empty scope.
+				want := c
+				want.WorkspaceID, want.ProjectID = "indexer-workspace", "indexer-project"
+				if tc.workspacePresent {
+					meta["contract_owner_workspace"] = tc.workspace
+					want.WorkspaceID = tc.workspace
+				} else {
+					delete(meta, "contract_owner_workspace")
+				}
+				if tc.projectPresent {
+					meta["contract_owner_project"] = tc.project
+					want.ProjectID = tc.project
+				} else {
+					delete(meta, "contract_owner_project")
+				}
+				store.AddBatch([]*graph.Node{
+					{ID: c.SymbolID, Kind: graph.KindFunction, RepoPrefix: c.RepoPrefix, FilePath: c.FilePath},
+					producerCompatCanonical(c),
+				}, []*graph.Edge{{From: c.SymbolID, To: c.ID, Kind: graph.EdgeProvides, FilePath: c.FilePath, Line: c.Line, Meta: meta}})
+				rows := graph.ReadRepoEdgesByKinds(store, []string{c.RepoPrefix}, []graph.EdgeKind{graph.EdgeProvides})
+				require.Len(t, rows, 1)
+				persisted := store.GetInEdges(c.ID)
+				require.Len(t, persisted, 1)
+				if tc.workspacePresent {
+					require.Equal(t, tc.workspace, persisted[0].Meta["contract_owner_workspace"])
+				} else {
+					require.NotContains(t, persisted[0].Meta, "contract_owner_workspace")
+				}
+				if tc.projectPresent {
+					require.Equal(t, tc.project, persisted[0].Meta["contract_owner_project"])
+				} else {
+					require.NotContains(t, persisted[0].Meta, "contract_owner_project")
+				}
+				idx := producerCompatIndexer(t, store)
+				cached := idx.ensureIncrementalContractRegistry()
+				require.NotNil(t, cached)
+				assert.Equal(t, producerCompatRecords(t, []contracts.Contract{want}), producerCompatRecords(t, cached.ByID(c.ID)), "explicit empty and absent metadata have different fallback semantics")
+				assert.Equal(t, producerCompatRecords(t, []contracts.Contract{want}), producerCompatRecords(t, cached.ByFile(c.FilePath)))
+			})
+		}
+	}
+}
+
+func TestBridgeIncrementalRegistryRetainsScalarScopeOverride(t *testing.T) {
+	for _, backend := range []string{"memory", "sqlite"} {
+		t.Run(backend, func(t *testing.T) {
+			store := producerCompatStore(t, backend)
+			stored := contracts.Contract{
+				ID: "env::LEGACY_SCALAR_SCOPE", Type: contracts.ContractType("env"), Role: contracts.RoleProvider,
+				RepoPrefix: "producer", FilePath: "producer/legacy.env", Line: 3,
+				WorkspaceID: "stored-workspace", ProjectID: "stored-project",
+				Confidence: 1, Meta: map[string]any{"var": "LEGACY_SCALAR_SCOPE"},
+			}
+			node := producerCompatCanonical(stored)
+			delete(node.Meta, "contract_owner_record")
+			store.AddBatch([]*graph.Node{node}, nil)
+			require.Empty(t, store.GetInEdges(stored.ID), "fixture is a legacy scalar, not owner metadata")
+			public := contracts.LoadRegistryFromGraph(store, stored.RepoPrefix)
+			require.NotNil(t, public)
+			assert.Equal(t, producerCompatRecords(t, []contracts.Contract{stored}), producerCompatRecords(t, public.ByID(stored.ID)), "public two-argument loader retains stored scalar scope")
+			idx := producerCompatIndexer(t, store)
+			cached := idx.ensureIncrementalContractRegistry()
+			require.NotNil(t, cached)
+			want := stored
+			want.WorkspaceID, want.ProjectID = "indexer-workspace", "indexer-project"
+			assert.Equal(t, producerCompatRecords(t, []contracts.Contract{want}), producerCompatRecords(t, cached.ByID(stored.ID)), "private incremental scalar restoration retains its historical indexer-scope override")
+			assert.Equal(t, producerCompatRecords(t, []contracts.Contract{want}), producerCompatRecords(t, cached.ByFile(stored.FilePath)))
+		})
+	}
+}

--- a/internal/indexer/incremental_batch.go
+++ b/internal/indexer/incremental_batch.go
@@ -90,6 +90,13 @@ func (idx *Indexer) reindexIncrementalFilesBatched(
 ) (DerivedInvalidationPlan, []string, []string, []string) {
 	idx.loadFileIndexFailures()
 	defer idx.flushFileIndexFailures()
+	// Capture persisted ownership before a deletion or structural reparse
+	// retires its source edges. Later contract refresh uses this registry to
+	// describe removed records and schedule the existing derived frontier.
+	// A true no-op batch must not hydrate any contract state.
+	if len(staleFiles) > 0 || len(deletedFiles) > 0 {
+		idx.ensureIncrementalContractRegistry()
+	}
 	var invalidation DerivedInvalidationPlan
 	deleteTiming := startReconcilePhase(idx.logger, idx.repoPrefix, "graph_delete",
 		zap.Int("deleted_files", len(deletedFiles)))
@@ -837,7 +844,7 @@ func (idx *Indexer) commitStructuralIncrementalBatch(
 ) {
 	deferResolverCatchup := markerBatch != nil && markerBatch.deferResolverCatchup
 	paths := make([]string, 0, len(stages))
-	oldNodeIDs := make([]string, 0)
+	oldFTSNodeIDs := make([]string, 0)
 	oldFuncIDs := make([]string, 0)
 	var nodes []*graph.Node
 	var edges []*graph.Edge
@@ -851,7 +858,9 @@ func (idx *Indexer) commitStructuralIncrementalBatch(
 			if node == nil {
 				continue
 			}
-			oldNodeIDs = append(oldNodeIDs, node.ID)
+			if node.Kind != graph.KindContract {
+				oldFTSNodeIDs = append(oldFTSNodeIDs, node.ID)
+			}
 			idx.removeFromSearch(node)
 			if node.Kind == graph.KindFunction || node.Kind == graph.KindMethod {
 				oldFuncIDs = append(oldFuncIDs, node.ID)
@@ -860,7 +869,9 @@ func (idx *Indexer) commitStructuralIncrementalBatch(
 	}
 
 	restubIncomingRefsFromView(idx.graph, stages, view)
-	idx.deleteSymbolFTS(oldNodeIDs)
+	// Canonical FTS lifetime follows the backend's atomic owner decision.
+	// Retained contracts keep existing rows; actual orphans are deleted there.
+	idx.deleteSymbolFTS(oldFTSNodeIDs)
 	evictFilesBatched(idx.graph, paths)
 	idx.graph.AddBatch(nodes, edges)
 
@@ -1540,6 +1551,9 @@ func (idx *Indexer) evictFileIncrementalRaw(relPath string) forcedFileEviction {
 	// bounded deletion core is idempotent and must still clear orphan mtimes,
 	// search content, ref facts, contracts, and enrichment state.
 	dependencyFiles := idx.semanticDependencyFrontierForDeletedFiles([]string{relPath})
+	// Once source ownership edges disappear, a reopened registry cannot
+	// recover this file's records from a sibling's canonical scalar payload.
+	idx.ensureIncrementalContractRegistry()
 	var invalidation DerivedInvalidationPlan
 	nodesRemoved, edgesRemoved := idx.evictDeletedFilesBatched([]string{relPath}, &invalidation)
 	graphPath := idx.prefixPath(relPath)
@@ -1608,7 +1622,7 @@ func (idx *Indexer) evictDeletedFilesBatched(deleted []string, plan *DerivedInva
 		}
 		nodesByFile := idx.graph.GetFileNodesByPaths(graphPaths)
 		stages := make([]*incrementalBatchStage, 0, len(graphPaths))
-		var nodeIDs []string
+		var nodeIDs, ftsNodeIDs []string
 		for i, graphPath := range graphPaths {
 			priorNodes := nodesByFile[graphPath]
 			stage := &incrementalBatchStage{graphPath: graphPath, priorNodes: priorNodes}
@@ -1624,6 +1638,9 @@ func (idx *Indexer) evictDeletedFilesBatched(deleted []string, plan *DerivedInva
 					continue
 				}
 				nodeIDs = append(nodeIDs, node.ID)
+				if node.Kind != graph.KindContract {
+					ftsNodeIDs = append(ftsNodeIDs, node.ID)
+				}
 				idx.removeFromSearch(node)
 			}
 			_ = i
@@ -1635,7 +1652,8 @@ func (idx *Indexer) evictDeletedFilesBatched(deleted []string, plan *DerivedInva
 		)
 		restubIncomingRefsFromView(idx.graph, stages, view)
 		idx.deleteEnrichmentByNodeIDs(nodeIDs)
-		idx.deleteSymbolFTS(nodeIDs)
+		// Canonical FTS lifetime is decided with its owners in the backend.
+		idx.deleteSymbolFTS(ftsNodeIDs)
 		idx.deleteRefFactsForFiles(idx.repoPrefix, graphPaths)
 		idx.deleteIncrementalSidecars(graphPaths)
 		idx.clearIncrementalContent(graphPaths)

--- a/internal/indexer/incremental_contracts.go
+++ b/internal/indexer/incremental_contracts.go
@@ -168,202 +168,161 @@ func (idx *Indexer) ensureIncrementalContractRegistry() *contracts.Registry {
 	if idx.contractRegistry != nil {
 		return idx.contractRegistry
 	}
-
 	reg := contracts.NewRegistry()
-	ownerRows := graph.ReadRepoEdgesByKinds(
-		idx.graph,
-		[]string{idx.repoPrefix},
-		[]graph.EdgeKind{graph.EdgeProvides, graph.EdgeConsumes},
-	)
-	ownersByContract := make(map[string][]*graph.Edge)
-	contractIDs := make(map[string]struct{})
-	for _, row := range ownerRows {
-		if row.Edge == nil || row.Edge.To == "" {
-			continue
-		}
-		ownersByContract[row.Edge.To] = append(ownersByContract[row.Edge.To], row.Edge)
-		contractIDs[row.Edge.To] = struct{}{}
-	}
-	// Symbol-less contracts have no ownership edge. Preserve the exact repo node
-	// projection for those legacy rows. Ordinary contracts are recovered from
-	// repo-owned edges, so a shared canonical node last written by another repo
-	// cannot hide this repository on a warm restart.
-	legacyNodeIDs := graph.ReadRepoNodeIDsByKinds(
-		idx.graph, []string{idx.repoPrefix}, []graph.NodeKind{graph.KindContract},
-	)
-	for _, id := range legacyNodeIDs {
-		if id != "" {
-			contractIDs[id] = struct{}{}
-		}
-	}
-	ids := make([]string, 0, len(contractIDs))
-	for id := range contractIDs {
-		ids = append(ids, id)
-	}
-	sort.Strings(ids)
-
-	for start := 0; start < len(ids); start += contractFrontierReadBatchSize {
-		end := start + contractFrontierReadBatchSize
-		if end > len(ids) {
-			end = len(ids)
-		}
-		chunk := ids[start:end]
-		nodes := idx.graph.GetNodesByIDs(chunk)
-		for _, id := range chunk {
-			node := nodes[id]
-			if node == nil || node.Kind != graph.KindContract {
-				continue
-			}
-			added := false
-			seen := make(map[string]struct{})
-			for _, edge := range ownersByContract[id] {
-				contract, ok := storedContractFromOwner(
-					node, edge, idx.repoPrefix, idx.workspaceID, idx.projectID,
-				)
-				if !ok {
-					continue
-				}
-				key := contractRegistryKey(contract)
-				if _, duplicate := seen[key]; duplicate {
-					continue
-				}
-				seen[key] = struct{}{}
-				reg.Add(contract)
-				added = true
-			}
-			if added {
-				continue
-			}
-			base, ok := storedContractFromNode(node)
-			if !ok {
-				continue
-			}
-			base.RepoPrefix = idx.repoPrefix
-			base.WorkspaceID = idx.workspaceID
-			base.ProjectID = idx.projectID
-			reg.Add(base)
+	if restored := contracts.LoadRegistryFromGraphWithScope(idx.graph, idx.repoPrefix, idx.workspaceID, idx.projectID); restored != nil {
+		for _, c := range restored.ByRepo(idx.repoPrefix) {
+			reg.Add(c)
 		}
 	}
 	idx.contractRegistry = reg
 	return reg
 }
 
-func storedContractFromNode(node *graph.Node) (contracts.Contract, bool) {
-	if node == nil || node.Kind != graph.KindContract || node.ID == "" {
-		return contracts.Contract{}, false
+func contractOwnerEdgeMeta(c contracts.Contract) map[string]any {
+	return map[string]any{
+		"contract_owner_repo_prefix": c.RepoPrefix,
+		"contract_owner_workspace":   c.EffectiveWorkspace(),
+		"contract_owner_project":     c.EffectiveProject(),
+		"contract_owner_type":        string(c.Type),
+		"contract_owner_confidence":  c.Confidence,
+		"contract_owner_meta":        c.Meta,
+		"contract_owner_symbol_id":   c.SymbolID,
 	}
-	contract := contracts.Contract{
-		ID:          node.ID,
-		FilePath:    node.FilePath,
-		RepoPrefix:  node.RepoPrefix,
-		WorkspaceID: node.WorkspaceID,
-		ProjectID:   node.ProjectID,
+}
+
+type contractFileOwnerKey struct{ repo, file string }
+
+type contractSymbolOwnerKey struct{ repo, symbol string }
+
+// contractSymbolOwners validates source existence and repository ownership in
+// bounded ID batches. Raw AddBatch accepts dangling and wrong-repo owner rows,
+// but repo-scoped reconstruction cannot discover those rows for this record.
+// Retain only the identity result, not the hydrated source metadata.
+func contractSymbolOwners(store graph.Store, all []contracts.Contract) map[contractSymbolOwnerKey]string {
+	wanted := make(map[contractSymbolOwnerKey]struct{})
+	idsSet := make(map[string]struct{})
+	for _, c := range all {
+		if c.SymbolID == "" {
+			continue
+		}
+		wanted[contractSymbolOwnerKey{c.RepoPrefix, c.SymbolID}] = struct{}{}
+		idsSet[c.SymbolID] = struct{}{}
 	}
-	if node.Meta != nil {
-		contract.Type = contracts.ContractType(contractStringMeta(node.Meta, "type"))
-		contract.Role = contracts.Role(contractStringMeta(node.Meta, "role"))
-		contract.SymbolID = contractStringMeta(node.Meta, "symbol_id")
-		contract.Line = contractIntValue(node.Meta["line"])
-		contract.Confidence = contractFloatValue(node.Meta["confidence"])
-		if meta, ok := node.Meta["contract_meta"].(map[string]any); ok {
-			contract.Meta = meta
+	ids := make([]string, 0, len(idsSet))
+	for id := range idsSet {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	owners := make(map[contractSymbolOwnerKey]string, len(wanted))
+	for start := 0; start < len(ids); start += contractFrontierReadBatchSize {
+		for _, node := range store.GetNodesByIDs(ids[start:min(start+contractFrontierReadBatchSize, len(ids))]) {
+			if node == nil || node.ID == "" {
+				continue
+			}
+			key := contractSymbolOwnerKey{node.RepoPrefix, node.ID}
+			if _, keep := wanted[key]; keep {
+				owners[key] = node.ID
+			}
 		}
 	}
-	return contract, true
+	return owners
 }
 
-func storedContractFromOwner(
-	node *graph.Node,
-	edge *graph.Edge,
-	repoPrefix, workspaceID, projectID string,
-) (contracts.Contract, bool) {
-	contract, ok := storedContractFromNode(node)
-	if !ok || edge == nil {
-		return contracts.Contract{}, false
+// contractFileOwners queries only files of symbol-less records. An admitted
+// genuine KindFile node is required: do not fabricate source nodes or use a
+// contract canonical node as an ownership endpoint.
+func contractFileOwners(store graph.Store, all []contracts.Contract) map[contractFileOwnerKey]string {
+	files := make([]string, 0)
+	wanted := make(map[contractFileOwnerKey]struct{})
+	for _, c := range all {
+		if c.SymbolID != "" || c.FilePath == "" {
+			continue
+		}
+		key := contractFileOwnerKey{c.RepoPrefix, c.FilePath}
+		if _, duplicate := wanted[key]; duplicate {
+			continue
+		}
+		wanted[key] = struct{}{}
+		files = append(files, c.FilePath)
 	}
-	contract.SymbolID = edge.From
-	contract.FilePath = edge.FilePath
-	contract.Line = edge.Line
-	contract.RepoPrefix = repoPrefix
-	contract.WorkspaceID = workspaceID
-	contract.ProjectID = projectID
-	if edge.Kind == graph.EdgeConsumes {
-		contract.Role = contracts.RoleConsumer
-	} else {
-		contract.Role = contracts.RoleProvider
+	owners := make(map[contractFileOwnerKey]string, len(wanted))
+	if len(files) == 0 {
+		return owners
 	}
-	if edge.Meta == nil {
-		return contract, true
+	for node := range graph.NodesInScopeSeq(store, nil, files, graph.KindFile) {
+		if node == nil || node.Kind != graph.KindFile || node.ID == "" {
+			continue
+		}
+		key := contractFileOwnerKey{node.RepoPrefix, node.FilePath}
+		if _, keep := wanted[key]; !keep {
+			continue
+		}
+		if current := owners[key]; current == "" || node.ID < current {
+			owners[key] = node.ID
+		}
 	}
-	if value, exists := edge.Meta["contract_owner_repo_prefix"].(string); exists {
-		contract.RepoPrefix = value
-	}
-	if value, exists := edge.Meta["contract_owner_workspace"].(string); exists {
-		contract.WorkspaceID = value
-	}
-	if value, exists := edge.Meta["contract_owner_project"].(string); exists {
-		contract.ProjectID = value
-	}
-	if value, exists := edge.Meta["contract_owner_type"].(string); exists {
-		contract.Type = contracts.ContractType(value)
-	}
-	if value, exists := edge.Meta["contract_owner_confidence"]; exists {
-		contract.Confidence = contractFloatValue(value)
-	}
-	if value, exists := edge.Meta["contract_owner_meta"].(map[string]any); exists {
-		contract.Meta = value
-	}
-	return contract, true
+	return owners
 }
 
-func contractOwnerEdgeMeta(contract contracts.Contract) map[string]any {
-	return map[string]any{
-		"contract_owner_repo_prefix": contract.RepoPrefix,
-		"contract_owner_workspace":   contract.EffectiveWorkspace(),
-		"contract_owner_project":     contract.EffectiveProject(),
-		"contract_owner_type":        string(contract.Type),
-		"contract_owner_confidence":  contract.Confidence,
-		"contract_owner_meta":        contract.Meta,
+func contractOwnerEndpoint(c contracts.Contract, files map[contractFileOwnerKey]string, symbols map[contractSymbolOwnerKey]string) string {
+	if c.SymbolID != "" {
+		return symbols[contractSymbolOwnerKey{c.RepoPrefix, c.SymbolID}]
 	}
+	return files[contractFileOwnerKey{c.RepoPrefix, c.FilePath}]
 }
 
-func contractStringMeta(meta map[string]any, key string) string {
-	value, _ := meta[key].(string)
-	return value
-}
-
-func contractIntValue(value any) int {
-	switch number := value.(type) {
-	case int:
-		return number
-	case int64:
-		return int(number)
-	case float64:
-		return int(number)
-	case json.Number:
-		parsed, _ := number.Int64()
-		return int(parsed)
-	default:
-		return 0
+// contractGraphRows is the common persistence emitter. Full passes leave
+// dependency nodes to their pre-resolution single writer; incremental refresh
+// includes dependencies as before. No extraction/enrichment work moves here.
+func contractGraphRows(store graph.Store, all []contracts.Contract, includeDependencies bool) (nodes []*graph.Node, edges []*graph.Edge, missingSourceOwners int) {
+	if !includeDependencies {
+		eligible := make([]contracts.Contract, 0, len(all))
+		for _, c := range all {
+			if c.Type != contracts.ContractDependency {
+				eligible = append(eligible, c)
+			}
+		}
+		all = eligible
 	}
-}
-
-func contractFloatValue(value any) float64 {
-	switch number := value.(type) {
-	case float64:
-		return number
-	case float32:
-		return float64(number)
-	case int:
-		return float64(number)
-	case int64:
-		return float64(number)
-	case json.Number:
-		parsed, _ := number.Float64()
-		return parsed
-	default:
-		return 0
+	fileOwners := contractFileOwners(store, all)
+	symbolOwners := contractSymbolOwners(store, all)
+	nodes = make([]*graph.Node, 0, len(all))
+	edges = make([]*graph.Edge, 0, len(all)*2)
+	for _, c := range all {
+		ownerID := contractOwnerEndpoint(c, fileOwners, symbolOwners)
+		if ownerID == "" {
+			missingSourceOwners++
+		}
+		nodes = append(nodes, &graph.Node{
+			ID: c.ID, Kind: graph.KindContract, Name: c.ID, FilePath: c.FilePath, Language: "contract",
+			RepoPrefix: c.RepoPrefix, WorkspaceID: c.EffectiveWorkspace(), ProjectID: c.EffectiveProject(),
+			Meta: map[string]any{
+				"type": string(c.Type), "role": string(c.Role), "symbol_id": c.SymbolID,
+				"line": c.Line, "confidence": c.Confidence, "contract_meta": c.Meta,
+				"contract_owner_record": ownerID != "",
+			},
+		})
+		if ownerID == "" {
+			continue
+		}
+		kind := graph.EdgeProvides
+		if c.Role == contracts.RoleConsumer {
+			kind = graph.EdgeConsumes
+		}
+		edges = append(edges, &graph.Edge{
+			From: ownerID, To: c.ID, Kind: kind, FilePath: c.FilePath, Line: c.Line, Meta: contractOwnerEdgeMeta(c),
+		})
+		// File ownership does not make a symbol-less provider a route handler.
+		if c.SymbolID != "" && c.Role == contracts.RoleProvider && isRouteContractType(c.Type) {
+			meta := contractOwnerEdgeMeta(c)
+			meta["contract_type"] = string(c.Type)
+			edges = append(edges, &graph.Edge{
+				From: c.SymbolID, To: c.ID, Kind: graph.EdgeHandlesRoute,
+				FilePath: c.FilePath, Line: c.Line, Meta: meta,
+			})
+		}
 	}
+	return nodes, edges, missingSourceOwners
 }
 
 // expandIncrementalContractFrontier promotes only cross-file contract constructs
@@ -440,51 +399,12 @@ func (idx *Indexer) commitIncrementalContractFiles(
 		return contractRegistryKey(unique[i]) < contractRegistryKey(unique[j])
 	})
 
-	nodes := make([]*graph.Node, 0, len(unique))
-	edges := make([]*graph.Edge, 0, len(unique)*2)
+	nodes, edges, missingOwners := contractGraphRows(idx.graph, unique, true)
 	touchedIDs := append([]string(nil), ids...)
 	for _, contract := range unique {
-		nodes = append(nodes, &graph.Node{
-			ID:          contract.ID,
-			Kind:        graph.KindContract,
-			Name:        contract.ID,
-			FilePath:    contract.FilePath,
-			Language:    "contract",
-			RepoPrefix:  contract.RepoPrefix,
-			WorkspaceID: contract.EffectiveWorkspace(),
-			ProjectID:   contract.EffectiveProject(),
-			Meta: map[string]any{
-				"type":          string(contract.Type),
-				"role":          string(contract.Role),
-				"symbol_id":     contract.SymbolID,
-				"line":          contract.Line,
-				"confidence":    contract.Confidence,
-				"contract_meta": contract.Meta,
-			},
-		})
 		touchedIDs = append(touchedIDs, contract.ID)
-		if contract.SymbolID == "" {
-			continue
-		}
-		edgeKind := graph.EdgeProvides
-		if contract.Role == contracts.RoleConsumer {
-			edgeKind = graph.EdgeConsumes
-		}
-		edges = append(edges, &graph.Edge{
-			From: contract.SymbolID, To: contract.ID, Kind: edgeKind,
-			FilePath: contract.FilePath, Line: contract.Line,
-			Meta: contractOwnerEdgeMeta(contract),
-		})
-		if contract.Role == contracts.RoleProvider && isRouteContractType(contract.Type) {
-			routeMeta := contractOwnerEdgeMeta(contract)
-			routeMeta["contract_type"] = string(contract.Type)
-			edges = append(edges, &graph.Edge{
-				From: contract.SymbolID, To: contract.ID, Kind: graph.EdgeHandlesRoute,
-				FilePath: contract.FilePath, Line: contract.Line,
-				Meta: routeMeta,
-			})
-		}
 	}
+	idx.warnMissingContractOwners(missingOwners)
 	if _, err := graph.ReplaceContractOwners(idx.graph, graph.ContractOwnerReplacement{
 		RepoPrefix:     idx.repoPrefix,
 		FilePaths:      changedFiles,

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -2413,6 +2413,8 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 	idx.deferredAttempt = nil
 	var coldManifests *coldManifestCensus
 	var censusMtimes map[string]int64
+	var sizeReceipts []fileReadReceipt
+	sizeReceiptCtx := ctx
 	var fileFailed atomic.Bool
 	var successfulFiles sync.Map
 	recordFileOutcome := func(path string, err error) {
@@ -2461,6 +2463,10 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 			}
 		}()
 		defer recoverIndexCtxRawStoragePanic(&result, &retErr)
+		published := retErr == nil && result != nil && censusMtimes != nil
+		if idx.finishColdSizeSkips(sizeReceiptCtx, sizeReceipts, censusMtimes, published) {
+			fileFailed.Store(true)
+		}
 		idx.finishColdIndexCensus(ctx, result, retErr, censusMtimes, coldManifests, fileFailed.Load())
 	}()
 	defer recoverIndexCtxRawStoragePanic(&result, &retErr)
@@ -2599,6 +2605,11 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 				skippedBySize = append(skippedBySize, skippedFile{
 					relPath: idx.relKey(path), lang: adm.lang, size: info.Size(),
 				})
+				// Keep the walk's no-follow identity: a symlink cannot earn a
+				// target-follow receipt from its own DirEntry metadata.
+				if info.Mode().IsRegular() && supportsColdManifestReceipts(idx.graph) {
+					sizeReceipts = append(sizeReceipts, idx.coldSizeSkipReceipt(path, info))
+				}
 				return nil
 			}
 			if adm.lang == "" && idx.isIncrementalContractManifest(path) && !idx.shouldExclude(path, absRoot, false) {
@@ -6246,7 +6257,14 @@ func (idx *Indexer) incrementalReindexPathsMode(
 	// comes from a content-addressed tree diff over the whole repo,
 	// then intersected back down to the requested scope.
 	if merkleMode {
-		for _, abs := range idx.merkleStaleFiles(absRoot, diskFiles) {
+		var merkleChanges []string
+		if fullRoot {
+			merkleChanges = idx.merkleStaleFiles(absRoot, diskFiles)
+		} else {
+			merkleScope := func(rel string) bool { return relPathInScope(rel, scopeRels) }
+			merkleChanges = idx.merkleStaleFilesInScope(absRoot, diskFiles, merkleScope)
+		}
+		for _, abs := range merkleChanges {
 			rel, relErr := filepath.Rel(absRoot, abs)
 			if relErr != nil {
 				continue
@@ -9159,6 +9177,7 @@ func (idx *Indexer) changedSinceMtimesCensus(root string) (
 		return nil, nil, 0, absErr
 	}
 	idx.storeRootPath(absRoot)
+	sizeSkips := idx.sizeSkipCensusNodes()
 
 	diskFiles := make(map[string]bool)
 	projectionCandidates := make([]string, 0, 1)
@@ -9172,7 +9191,8 @@ func (idx *Indexer) changedSinceMtimesCensus(root string) (
 			}
 			return nil
 		}
-		if _, ok := idx.effectiveLanguage(path, nil); !ok && !idx.isIncrementalContractManifest(path) {
+		_, supported := idx.effectiveLanguage(path, nil)
+		if !supported && !idx.isIncrementalContractManifest(path) {
 			return nil
 		}
 		if idx.shouldExclude(path, absRoot, false) {
@@ -9183,7 +9203,14 @@ func (idx *Indexer) changedSinceMtimesCensus(root string) (
 		if filepath.Base(filepath.FromSlash(rel)) == "parser.c" {
 			projectionCandidates = append(projectionCandidates, rel)
 		}
-		if idx.IsStale(rel) {
+		// Reuse IsStale's stat for the current size policy as well as mtime.
+		info, statErr := os.Stat(path)
+		if statErr != nil {
+			changed = append(changed, rel)
+			return nil
+		}
+		oversize := supported && idx.config.MaxFileSize > 0 && info.Size() > idx.config.MaxFileSize
+		if idx.sizeSkipCensusIsStale(rel, info, oversize, sizeSkips) {
 			changed = append(changed, rel)
 		}
 		return nil

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -148,8 +148,41 @@ type IndexError struct {
 	Error    string `json:"error"`
 }
 
+// Only root go.mod/go.work need deferred receipts. census is the existing
+// full-index candidate map, retained until authoritative pruning is safe.
+// Workers keep using successfulFiles; they never mutate this bundle.
+type coldManifestCensus struct {
+	ctx            context.Context
+	registry       *contracts.Registry
+	manifests      map[string]*coldManifestRead
+	census         map[string]int64
+	failed         bool
+	graphReady     bool
+	contractsReady bool
+}
+
+type coldManifestRead struct {
+	source          []byte
+	receipt         fileReadReceipt
+	err             error // never cleared inside this attempt
+	dependencyDone  bool
+	modulesDone     bool
+	modulesRequired bool
+}
+
+// deferredPassAttempt distinguishes deferred runs even when their expected
+// contract registry is nil. Access is protected by the repository mutation lane.
+type deferredPassAttempt struct {
+	indexer  *Indexer
+	registry *contracts.Registry
+	enrich   bool
+}
+
 // Indexer walks a repository and populates the graph.
 type Indexer struct {
+	pendingColdManifests *coldManifestCensus
+	deferredAttempt      *deferredPassAttempt
+
 	graph             graph.Store
 	fileIndexFailures fileIndexFailureState
 	parseErrorsMu     sync.RWMutex
@@ -1276,12 +1309,18 @@ func (idx *Indexer) MaybeSeedPendingEnrich() bool {
 // binding types are resolved in one batch from SQLite, with the provider's
 // compact string index as the in-memory-store fallback.
 func (idx *Indexer) runDeferredContracts() {
-	if idx.pendingContractReg == nil {
+	reg := idx.pendingContractReg
+	if reg == nil {
 		return
 	}
-	idx.extractExternalModules()
-	idx.extractDIContracts(idx.pendingContractReg)
-	idx.commitContracts(idx.pendingContractReg)
+	b := idx.coldManifestsForRegistry(reg)
+	idx.extractExternalModulesForCensus(reg)
+	idx.extractDIContracts(reg)
+	idx.commitContracts(reg)
+	if b != nil {
+		b.contractsReady = true
+		idx.finishColdManifests(b)
+	}
 	idx.pendingContractReg = nil
 	idx.deferredGoModDone = false
 }
@@ -2370,9 +2409,20 @@ func (idx *Indexer) IndexCtx(ctx context.Context, root string) (*IndexResult, er
 // repository mutation lane.
 func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *IndexResult, retErr error) {
 	idx.loadFileIndexFailures()
+	idx.pendingColdManifests = nil // older attempts cannot publish into this one
+	idx.deferredAttempt = nil
+	var coldManifests *coldManifestCensus
+	var censusMtimes map[string]int64
+	var fileFailed atomic.Bool
 	var successfulFiles sync.Map
 	recordFileOutcome := func(path string, err error) {
 		if err != nil {
+			fileFailed.Store(true)
+			if idx.contentSource() == nil && idx.isIncrementalContractManifest(path) {
+				if _, ok := idx.effectiveLanguage(path, nil); !ok {
+					idx.captureColdManifest(&coldManifests, ctx, path, err)
+				}
+			}
 			successfulFiles.Delete(path)
 			idx.noteFileIndexFailure(path, err)
 		} else {
@@ -2401,6 +2451,17 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 			}
 		}
 		idx.flushFileIndexFailures()
+	}()
+	// Runs after shadow/FTS/vector publication and its panic recovery, but
+	// before the existing successful-file failure acknowledgements above.
+	defer func() {
+		defer func() {
+			if retErr != nil && idx.pendingColdManifests == coldManifests {
+				idx.pendingColdManifests = nil
+			}
+		}()
+		defer recoverIndexCtxRawStoragePanic(&result, &retErr)
+		idx.finishColdIndexCensus(ctx, result, retErr, censusMtimes, coldManifests, fileFailed.Load())
 	}()
 	defer recoverIndexCtxRawStoragePanic(&result, &retErr)
 
@@ -2525,7 +2586,7 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 			if statErr != nil {
 				// Couldn't read FileInfo (race with deletion, broken
 				// symlink, …). Skip — the worker would fail too.
-				if !os.IsNotExist(statErr) && idx.admitWalkEntry(absRoot, path, -1, false).admit {
+				if !os.IsNotExist(statErr) && idx.admitScopedWalkFile(absRoot, path) {
 					recordFileOutcome(path, statErr)
 					walkFailures = append(walkFailures, IndexError{FilePath: path, Error: statErr.Error()})
 				}
@@ -2539,6 +2600,9 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 					relPath: idx.relKey(path), lang: adm.lang, size: info.Size(),
 				})
 				return nil
+			}
+			if adm.lang == "" && idx.isIncrementalContractManifest(path) && !idx.shouldExclude(path, absRoot, false) {
+				idx.captureColdManifest(&coldManifests, ctx, path, nil)
 			}
 			if !adm.admit {
 				return nil
@@ -3841,41 +3905,16 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 	idx.emitContentSkipNodes(skippedByContent)
 	idx.emitParseFailedSkipNodes(parseFailedFiles)
 
-	// Populate fileMtimes for all detected files. Keyed through
-	// relKey so the mtime map agrees with the graph's file-node keys
-	// (and with the incremental / git-watcher paths) on the NFC form
-	// of every non-ASCII filename. Mtimes are the walk-time values
-	// captured via d.Info(); no per-file os.Stat round-trip here.
-	idx.mtimeMu.Lock()
-	idx.fileMtimes = make(map[string]int64, len(files))
-	idx.fileMtimesShared = false
+	// Keep the existing parser outcome ledger and walk-time versions.
+	// Publish only after the replacement graph and search indexes commit;
+	// newly admitted manifests have bounded version receipts.
+	censusMtimes = make(map[string]int64, len(files))
 	for _, f := range files {
-		if f.mtimeNano > 0 {
-			idx.fileMtimes[idx.relKey(f.path)] = f.mtimeNano
+		if _, ok := successfulFiles.Load(f.path); ok && f.mtimeNano > 0 {
+			censusMtimes[idx.relKey(f.path)] = f.mtimeNano
 		}
 	}
-	// Bulk persistence consumes the snapshot after mtimeMu is released.
-	// Publish it immutably so later mutations detach before writing.
-	idx.fileMtimesShared = true
-	mtimeSnapshot := idx.fileMtimes
-	idx.mtimeMu.Unlock()
 
-	// Persist the per-file mtimes through the store's optional
-	// FileMtime sidecar table. On the on-disk backend this lets warm
-	// restarts seed ReconcileRepoCtx without having to read them back
-	// out of the gob+gzip metadata snapshot; on the in-memory
-	// backend the capability isn't implemented and the assertion
-	// short-circuits.
-	//
-	// Multi-repo bug: when the shadow-swap path is active, idx.graph
-	// is the in-memory shadow graph at this point — graph.Graph does
-	// NOT implement FileMtimeWriter, so the type assertion fails and
-	// persistence is silently skipped. The actual disk store is
-	// the local diskTarget variable; checking it first ensures warm-
-	// restart-skip-reindex actually works. The defer that swaps
-	// idx.graph back to diskTarget runs LATER, when IndexCtx returns,
-	// so we can't rely on it here. Falls through to idx.graph for the
-	// non-shadow path.
 	idx.logger.Info("indexer: parse subphases",
 		zap.String("repo", idx.repoPrefix),
 		zap.Duration("wall", time.Since(parseWallStart)),
@@ -3885,41 +3924,6 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 		zap.Duration("batch_workers", time.Duration(atomic.LoadInt64(&parseBatchNS))),
 		zap.Int("workers", workers),
 		zap.Int("files", totalFiles))
-	mtimeTarget := graph.Store(idx.graph)
-	if diskTarget != nil {
-		mtimeTarget = diskTarget
-	}
-	// Full-index persist is AUTHORITATIVE: replace the repo's entire mtime
-	// set so files deleted since the last index are pruned. An upsert-only
-	// write (BulkSetFileMtimes) leaves deleted-file rows behind, and warm-
-	// restart reconcile then detects them as phantom deletions on every
-	// restart — forcing a full re-track that never converges. Prefer the
-	// replace capability; fall back to upsert for backends without it.
-	if len(mtimeSnapshot) > 0 {
-		var perr error
-		persisted := false
-		authoritative := false
-		if r, ok := mtimeTarget.(graph.FileMtimeReplacer); ok {
-			perr, persisted, authoritative = r.ReplaceFileMtimes(idx.repoPrefix, mtimeSnapshot), true, true
-		} else if w, ok := mtimeTarget.(graph.FileMtimeWriter); ok {
-			perr, persisted = w.BulkSetFileMtimes(idx.repoPrefix, mtimeSnapshot), true
-		}
-		if persisted {
-			if perr != nil {
-				idx.markFileMtimePersistenceDirty()
-				idx.logger.Warn("persist file mtimes failed",
-					zap.String("repo", idx.repoPrefix), zap.Error(perr))
-			} else {
-				if authoritative {
-					idx.fileMtimePersistenceDirty.Store(false)
-				}
-				idx.logger.Info("persisted file mtimes",
-					zap.String("repo", idx.repoPrefix),
-					zap.Int("count", len(mtimeSnapshot)))
-			}
-		}
-
-	}
 
 	// Crash-safe content finalization is coupled to the completed authoritative
 	// walk above, not to mtimes. Snapshot ContentSources deliberately have no
@@ -3955,6 +3959,9 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 	idx.totalDetected = len(files)
 	idx.lastIndexTime = time.Now()
 
+	if coldManifests != nil {
+		coldManifests.registry = contractReg
+	}
 	if idx.deferResolve.Load() {
 		// Multi-repo orchestrator runs these serially after wg.Wait()
 		// to avoid races on the shared graph between this goroutine's
@@ -4040,9 +4047,12 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 		// nodes were available during ResolveAll's import-bridge pass;
 		// commitContracts is idempotent for those.
 		reporter.Report("extracting contracts", 0, 0)
-		idx.extractExternalModules()
+		idx.extractExternalModulesForCensus(contractReg)
 		idx.extractDIContracts(contractReg)
 		idx.commitContracts(contractReg)
+		if coldManifests != nil {
+			coldManifests.contractsReady = true
+		}
 
 		// Test-edge pass — runs once the call graph is final. Skipped
 		// under deferGlobalPasses so a batch caller can fold this into
@@ -8766,10 +8776,23 @@ func readGoModModulePath(src []byte) string {
 // goes through the normal commit path which depends on a resolved
 // graph (UpgradeBareTypeRefs, resolveProviderHandlers).
 func (idx *Indexer) extractGoModContracts(reg *contracts.Registry) {
-	goModPath := filepath.Join(idx.rootPath, "go.mod")
-	goModSrc, err := idx.readFileContent(goModPath)
-	if err != nil {
-		return
+	var manifest *coldManifestRead
+	if b := idx.coldManifestsForRegistry(reg); b != nil {
+		manifest = b.manifests["go.mod"]
+	}
+	var goModSrc []byte
+	if manifest != nil {
+		if manifest.err != nil {
+			return
+		}
+		goModSrc = manifest.source
+	} else {
+		goModPath := filepath.Join(idx.rootPath, "go.mod")
+		var err error
+		goModSrc, err = idx.readFileContent(goModPath)
+		if err != nil {
+			return
+		}
 	}
 	goModExtractor := &contracts.GoModExtractor{TrackedRepos: idx.trackedRepoModules}
 	goModFilePath := "go.mod"
@@ -8808,6 +8831,9 @@ func (idx *Indexer) extractGoModContracts(reg *contracts.Registry) {
 	}
 	if len(nodes) > 0 {
 		idx.graph.AddBatch(nodes, nil)
+	}
+	if manifest != nil {
+		manifest.dependencyDone = true
 	}
 }
 

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -6774,72 +6774,8 @@ func (idx *Indexer) commitContracts(reg *contracts.Registry) {
 	idx.inlineEnvelopeShapes(reg)
 
 	all := reg.All()
-	nodes := make([]*graph.Node, 0, len(all))
-	edges := make([]*graph.Edge, 0, len(all))
-	for _, c := range all {
-		// dep::<module> nodes were materialised by extractGoModContracts
-		// before ResolveAll (so the import bridge could find them);
-		// re-emitting them here would PK-collide on backends whose bulk
-		// load is INSERT-only (the on-disk backend). The pre-pass is the single
-		// writer for that contract type.
-		if c.Type == contracts.ContractDependency {
-			continue
-		}
-		nodes = append(nodes, &graph.Node{
-			ID:          c.ID,
-			Kind:        graph.KindContract,
-			Name:        c.ID,
-			FilePath:    c.FilePath,
-			Language:    "contract",
-			RepoPrefix:  c.RepoPrefix,
-			WorkspaceID: c.EffectiveWorkspace(),
-			ProjectID:   c.EffectiveProject(),
-			Meta: map[string]any{
-				"type":          string(c.Type),
-				"role":          string(c.Role),
-				"symbol_id":     c.SymbolID,
-				"line":          c.Line,
-				"confidence":    c.Confidence,
-				"contract_meta": c.Meta,
-			},
-		})
-
-		if c.SymbolID == "" {
-			continue
-		}
-		edgeKind := graph.EdgeProvides
-		if c.Role == contracts.RoleConsumer {
-			edgeKind = graph.EdgeConsumes
-		}
-		edges = append(edges, &graph.Edge{
-			From:     c.SymbolID,
-			To:       c.ID,
-			Kind:     edgeKind,
-			FilePath: c.FilePath,
-			Line:     c.Line,
-			Meta:     contractOwnerEdgeMeta(c),
-		})
-		// Framework-layer EdgeHandlesRoute. Emitted alongside
-		// EdgeProvides for HTTP / gRPC / WS / GraphQL / topic
-		// providers so `analyze kind=routes` and other
-		// framework-aware tools walk one targeted edge instead
-		// of filtering EdgeProvides by contract type. Consumers
-		// (callers of routes) and non-route contract types (env,
-		// OpenAPI specs, DI tokens) intentionally skip this
-		// edge — they aren't route handlers.
-		if c.Role == contracts.RoleProvider && isRouteContractType(c.Type) {
-			routeMeta := contractOwnerEdgeMeta(c)
-			routeMeta["contract_type"] = string(c.Type)
-			edges = append(edges, &graph.Edge{
-				From:     c.SymbolID,
-				To:       c.ID,
-				Kind:     graph.EdgeHandlesRoute,
-				FilePath: c.FilePath,
-				Line:     c.Line,
-				Meta:     routeMeta,
-			})
-		}
-	}
+	nodes, edges, missingOwners := contractGraphRows(idx.graph, all, false)
+	idx.warnMissingContractOwners(missingOwners)
 
 	bulkStart := time.Now()
 	idx.bulkCommit(nodes, edges)
@@ -6855,6 +6791,14 @@ func (idx *Indexer) commitContracts(reg *contracts.Registry) {
 		zap.String("repo", repo),
 		zap.Int("count", len(all)),
 		zap.Duration("commit_bulk_elapsed", bulkElapsed))
+}
+
+func (idx *Indexer) warnMissingContractOwners(count int) {
+	if count == 0 {
+		return
+	}
+	idx.logger.Warn("contract records missing an admitted source owner",
+		zap.String("repo", idx.repoPrefix), zap.Int("count", count))
 }
 
 // recordContractStateMarker persists this repo's contract-tier completion

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -2528,7 +2528,7 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 	// same bytes would — save for the per-directory ignore files a snapshot
 	// cannot consult, which shouldExclude names and the producer state
 	// declares.
-	admitWalkedFile := func(wf walkedFile) {
+	admitWalkedFile := func(wf walkedFile, info os.FileInfo) {
 		if reason, skip := untrackedGate.skip(wf.lang, wf.path); skip {
 			skippedContentBytes += wf.size
 			relPath := idx.relKey(wf.path)
@@ -2543,6 +2543,12 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 			skippedByContent = append(skippedByContent, skippedFile{
 				relPath: relPath, lang: wf.lang, size: wf.size, reason: reason,
 			})
+			// Content-policy stubs share the metadata-only, post-publication
+			// receipt boundary with size stubs. Snapshot and untracked-asset
+			// skips deliberately do not receive filesystem receipts here.
+			if info != nil && info.Mode().IsRegular() && supportsColdManifestReceipts(idx.graph) {
+				sizeReceipts = append(sizeReceipts, idx.coldSizeSkipReceipt(wf.path, info))
+			}
 			return
 		}
 		files = append(files, wf)
@@ -2564,7 +2570,7 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 				})
 				return nil
 			}
-			admitWalkedFile(wf)
+			admitWalkedFile(wf, nil)
 			return nil
 		})
 	} else {
@@ -2623,7 +2629,7 @@ func (idx *Indexer) indexCtxRaw(ctx context.Context, root string) (result *Index
 				lang:      adm.lang,
 				size:      info.Size(),
 				mtimeNano: info.ModTime().UnixNano(),
-			})
+			}, info)
 			return nil
 		})
 	}
@@ -9122,6 +9128,8 @@ func (idx *Indexer) changedSinceMtimesCensus(root string) (
 	}
 	idx.storeRootPath(absRoot)
 	sizeSkips := idx.sizeSkipCensusNodes()
+	contentGate := idx.newContentAdmissionGate()
+	var contentCandidates []contentPolicyCensusCandidate
 
 	diskFiles := make(map[string]bool)
 	projectionCandidates := make([]string, 0, 1)
@@ -9135,7 +9143,7 @@ func (idx *Indexer) changedSinceMtimesCensus(root string) (
 			}
 			return nil
 		}
-		_, supported := idx.effectiveLanguage(path, nil)
+		lang, supported := idx.effectiveLanguage(path, nil)
 		if !supported && !idx.isIncrementalContractManifest(path) {
 			return nil
 		}
@@ -9156,6 +9164,10 @@ func (idx *Indexer) changedSinceMtimesCensus(root string) (
 		oversize := supported && idx.config.MaxFileSize > 0 && info.Size() > idx.config.MaxFileSize
 		if idx.sizeSkipCensusIsStale(rel, info, oversize, sizeSkips) {
 			changed = append(changed, rel)
+		} else if !oversize && contentPolicyCensusAsset(contentGate, lang) {
+			contentCandidates = append(contentCandidates, contentPolicyCensusCandidate{
+				relPath: rel, lang: lang, size: info.Size(),
+			})
 		}
 		return nil
 	})
@@ -9163,6 +9175,8 @@ func (idx *Indexer) changedSinceMtimesCensus(root string) (
 		returned = true
 		return nil, nil, 0, walkErr
 	}
+
+	changed = append(changed, idx.staleContentPolicyFiles(contentGate, contentCandidates)...)
 
 	projectionRefresh := idx.staleGeneratedParserProjectionPaths(projectionCandidates)
 	changed = appendUniqueSorted(changed, projectionRefresh...)

--- a/internal/indexer/merkle/merkle.go
+++ b/internal/indexer/merkle/merkle.go
@@ -58,6 +58,34 @@ type Tree struct {
 	Dirs map[string]string `json:"dirs"`
 }
 
+// MergeScope combines a rebuilt scope with untouched leaves from the previous
+// repository baseline. A nil contains predicate means a full replacement.
+// Leaves outside the scope are copied verbatim, including empty hashes and
+// old extractor salts: this operation does not read or certify those files.
+// Neither input tree is mutated.
+func MergeScope(prior, scoped *Tree, contains func(string) bool) *Tree {
+	merged := &Tree{
+		Files: make(map[string]FileNode),
+		Dirs:  make(map[string]string),
+	}
+	if prior != nil && contains != nil {
+		for rel, leaf := range prior.Files {
+			if !contains(rel) {
+				merged.Files[rel] = leaf
+			}
+		}
+	}
+	if scoped != nil {
+		for rel, leaf := range scoped.Files {
+			if contains == nil || contains(rel) {
+				merged.Files[rel] = leaf
+			}
+		}
+	}
+	merged.aggregate()
+	return merged
+}
+
 // Build constructs a Merkle tree for the files (forward-slash repo-
 // relative paths) under rootAbs. When prior is non-nil, a file whose
 // on-disk mtime matches prior's reuses the prior content hash and is

--- a/internal/indexer/merkle/scope_merge_test.go
+++ b/internal/indexer/merkle/scope_merge_test.go
@@ -1,0 +1,83 @@
+package merkle
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestMergeScopePreservesUnprocessedLeaves(t *testing.T) {
+	prior := &Tree{
+		Root: "old-root",
+		Files: map[string]FileNode{
+			"outside/kept.go":   {Hash: strings.Repeat("a", 64), Mtime: 11, Salt: "old-extractor"},
+			"outside/failed.go": {Hash: "", Mtime: 12, Salt: "failed-extractor"},
+			"scope/changed.go":  {Hash: strings.Repeat("b", 64), Mtime: 13, Salt: "before"},
+			"scope/deleted.go":  {Hash: strings.Repeat("c", 64), Mtime: 14, Salt: "before"},
+		},
+		Dirs: map[string]string{"old-only-directory": "obsolete"},
+	}
+	scoped := &Tree{
+		Root: "partial-root",
+		Files: map[string]FileNode{
+			"scope/changed.go": {Hash: strings.Repeat("d", 64), Mtime: 21, Salt: "new-extractor"},
+			"scope/added.go":   {Hash: strings.Repeat("e", 64), Mtime: 22, Salt: "new-extractor"},
+			"outside/kept.go":  {Hash: strings.Repeat("f", 64), Mtime: 99, Salt: "must-not-certify"},
+			"outside/stray.go": {Hash: strings.Repeat("f", 64), Mtime: 99, Salt: "must-not-add"},
+		},
+		Dirs: map[string]string{"partial-only-directory": "obsolete"},
+	}
+	wantFiles := map[string]FileNode{
+		"outside/kept.go":   prior.Files["outside/kept.go"],
+		"outside/failed.go": prior.Files["outside/failed.go"],
+		"scope/changed.go":  scoped.Files["scope/changed.go"],
+		"scope/added.go":    scoped.Files["scope/added.go"],
+	}
+	got := MergeScope(prior, scoped, func(rel string) bool { return strings.HasPrefix(rel, "scope/") })
+	if !reflect.DeepEqual(wantFiles, got.Files) {
+		t.Fatalf("merged leaves = %#v, want %#v", got.Files, wantFiles)
+	}
+	want := &Tree{Files: wantFiles, Dirs: make(map[string]string)}
+	want.aggregate()
+	if got.Root != want.Root || !reflect.DeepEqual(got.Dirs, want.Dirs) {
+		t.Fatalf("merged directories/root were not recomputed: %#v", got)
+	}
+	if prior.Root != "old-root" || scoped.Root != "partial-root" ||
+		prior.Files["scope/changed.go"].Mtime != 13 ||
+		scoped.Files["outside/kept.go"].Mtime != 99 {
+		t.Fatal("merge mutated an input tree")
+	}
+	delete(got.Files, "outside/kept.go")
+	if _, ok := prior.Files["outside/kept.go"]; !ok {
+		t.Fatal("merged map aliases prior input")
+	}
+	delete(got.Files, "scope/changed.go")
+	if _, ok := scoped.Files["scope/changed.go"]; !ok {
+		t.Fatal("merged map aliases scoped input")
+	}
+}
+
+func TestMergeScopeEmptyAndFullReplacement(t *testing.T) {
+	prior := &Tree{Files: map[string]FileNode{
+		"outside.go": {Hash: strings.Repeat("a", 64), Mtime: 1, Salt: "old"},
+		"scope.go":   {Hash: strings.Repeat("b", 64), Mtime: 2, Salt: "old"},
+	}}
+	contains := func(rel string) bool { return rel == "scope.go" }
+	got := MergeScope(prior, nil, contains)
+	if len(got.Files) != 1 || got.Files["outside.go"] != prior.Files["outside.go"] {
+		t.Fatalf("empty scope must remove only in-scope leaves: %#v", got.Files)
+	}
+	replacement := &Tree{Files: map[string]FileNode{"new.go": {Hash: strings.Repeat("c", 64), Mtime: 3}}}
+	got = MergeScope(prior, replacement, nil)
+	if !reflect.DeepEqual(got.Files, replacement.Files) {
+		t.Fatalf("nil predicate must replace the full baseline: %#v", got.Files)
+	}
+	got = MergeScope(nil, replacement, func(rel string) bool { return rel == "new.go" })
+	if !reflect.DeepEqual(got.Files, replacement.Files) {
+		t.Fatalf("missing prior must retain rebuilt scope: %#v", got.Files)
+	}
+	got = MergeScope(nil, nil, nil)
+	if len(got.Files) != 0 {
+		t.Fatalf("empty inputs produced leaves: %#v", got.Files)
+	}
+}

--- a/internal/indexer/merkle_reindex.go
+++ b/internal/indexer/merkle_reindex.go
@@ -74,14 +74,26 @@ func (c *merkleBaselineCollector) take() map[string]merkle.FileNode {
 // touched without a content change is not reported, unlike the
 // bare-mtime path.
 func (idx *Indexer) merkleStaleFiles(rootAbs string, diskFiles map[string]bool) []string {
+	return idx.merkleStaleFilesInScope(rootAbs, diskFiles, nil)
+}
+
+// A scoped pass cannot replace the repository baseline with only its frontier:
+// the next full pass would then rediscover unchanged files outside that scope.
+// Preserve those prior leaves verbatim, without reading or re-salting them.
+func (idx *Indexer) merkleStaleFilesInScope(rootAbs string, diskFiles map[string]bool, contains func(string) bool) []string {
 	rels := make([]string, 0, len(diskFiles))
 	for rel := range diskFiles {
-		rels = append(rels, rel)
+		if contains == nil || contains(rel) {
+			rels = append(rels, rel)
+		}
 	}
 	treePath := merkleTreeFile(rootAbs)
 	prior, _ := merkle.Load(treePath)
 	tree := merkle.Build(rootAbs, rels, prior, merkleSaltFor)
 	changed, _ := tree.Diff(prior)
+	if contains != nil {
+		tree = merkle.MergeScope(prior, tree, contains)
+	}
 	if err := tree.Save(treePath); err != nil {
 		idx.logger.Warn("indexer: merkle tree save failed", zap.Error(err))
 	}

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -3157,13 +3157,13 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 			// one changed go.mod must not look like >40% source churn in a tiny
 			// repository. The scoped refresh records its mtime and converges.
 			route = "scoped"
-			result, receipt, batch, err = idx.incrementalReindexPathsWithReceipt(absPath, append(changed, deleted...), true)
+			result, receipt, batch, err = idx.incrementalReindexPathsWithReceiptMode(absPath, append(changed, deleted...), incrementalPathMode{detectDeletions: true, forceExplicitFiles: true})
 		case priorCount > 0 && churn*100 > priorCount*40:
 			route = "full_retrack"
 			result, err = fullRetrack()
 		default:
 			route = "scoped"
-			result, receipt, batch, err = idx.incrementalReindexPathsWithReceipt(absPath, append(changed, deleted...), true)
+			result, receipt, batch, err = idx.incrementalReindexPathsWithReceiptMode(absPath, append(changed, deleted...), incrementalPathMode{detectDeletions: true, forceExplicitFiles: true})
 		}
 		applyTiming.complete(err, zap.String("route", route))
 		if err != nil {

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -581,10 +581,30 @@ func (mi *MultiIndexer) RunDeferredPassesAllResult(ctx context.Context) Deferred
 // repeating the whole-graph cross-repository resolver. The receipt-guided tail
 // already performs either exact cross-repository catch-up or a fail-closed full
 // pass; only contract-bridge reconciliation remains afterward.
-func (mi *MultiIndexer) finishColdDeferredPasses(ctx context.Context) DeferredPassesResult {
-	result := mi.RunDeferredPassesAllResult(ctx)
+func (mi *MultiIndexer) finishColdDeferredPasses(ctx context.Context, completedIndexers []*Indexer) DeferredPassesResult {
+	result := mi.beginDeferredPasses(ctx, nil, completedIndexers, true).FinishTailResult()
 	mi.ReconcileContractEdges()
 	return result
+}
+
+// current requires this Indexer's repository mutation lane to be held.
+func (a *deferredPassAttempt) current() bool {
+	return a.indexer.deferredAttempt == a && a.indexer.pendingContractReg == a.registry
+}
+
+// lanesHeld is valid only for the explicit completed cold cohort whose
+// repository lanes the caller already holds, never the global registered set.
+func (mi *MultiIndexer) withDeferredRepositoryMutation(idx *Indexer, lanesHeld bool, fn func()) error {
+	if lanesHeld {
+		fn()
+		return nil
+	}
+	// BeginDeferredPasses previously ignored its context. Do not introduce
+	// cancellation of an admitted pipeline as an incidental ownership change.
+	return idx.coordinateRepositoryMutation(context.Background(), func() error {
+		fn()
+		return nil
+	})
 }
 
 // DeferredPassesRun is one in-flight execution of the deferred pass pipeline,
@@ -597,6 +617,9 @@ func (mi *MultiIndexer) finishColdDeferredPasses(ctx context.Context) DeferredPa
 type DeferredPassesRun struct {
 	mi              *MultiIndexer
 	workIndexers    []*Indexer
+	attempts        []*deferredPassAttempt
+	lanesHeld       bool
+	attemptAborted  bool
 	enrichScheduled int
 	catchupNeeded   bool
 	catchupKnown    bool
@@ -653,63 +676,64 @@ func (r *DeferredPassesRun) BeginApplyMutationReceipt() {
 // Without an apply gate the receipt opens here. With overlap, delaying it until
 // the apply boundary excludes resolver writes while still observing every
 // semantic apply and contract commit, preserving an exact file frontier.
-func (mi *MultiIndexer) BeginDeferredPasses(_ context.Context, applyGate <-chan struct{}) *DeferredPassesRun {
+func (mi *MultiIndexer) BeginDeferredPasses(ctx context.Context, applyGate <-chan struct{}) *DeferredPassesRun {
 	mi.mu.RLock()
 	indexers := make([]*Indexer, 0, len(mi.indexers))
 	for _, idx := range mi.indexers {
 		indexers = append(indexers, idx)
 	}
 	mi.mu.RUnlock()
+	return mi.beginDeferredPasses(ctx, applyGate, indexers, false)
+}
+
+// The lanes-held route receives only completed cold indexers already covered
+// by the caller's mutation lanes; the public route coordinates each indexer.
+func (mi *MultiIndexer) beginDeferredPasses(_ context.Context, applyGate <-chan struct{}, indexers []*Indexer, lanesHeld bool) *DeferredPassesRun {
+	indexers = append([]*Indexer(nil), indexers...)
 	sort.Slice(indexers, func(i, j int) bool {
 		return indexers[i].repoPrefix < indexers[j].repoPrefix
 	})
 	forced := os.Getenv("GORTEX_WARMUP_FORCE_ENRICH") == "1"
+	// Catch-up scope is compared with the complete registered universe,
+	// independently of the explicit cold cohort admitted as work below.
+	mi.mu.RLock()
+	repoCount := len(mi.indexers)
+	mi.mu.RUnlock()
 	run := &DeferredPassesRun{
-		mi:           mi,
-		catchupKnown: true,
-		catchupScope: make(map[string]struct{}),
-		indexerCount: len(indexers),
-		poolDone:     make(chan struct{}),
-		// The deferred phase is the second half of the same allocation burst
-		// IndexCtx tunes for — go/packages closures, tree-sitter parses, and
-		// the catch-up resolve — but it runs OUTSIDE any IndexCtx window, so
-		// on a daemon with a default standing limit it was paced against the
-		// lean steady-state ceiling. Hold one ref-counted tuning window
-		// across the whole span (pool + contracts + catch-up resolve);
-		// FinishTail restores the standing knobs exactly.
+		mi:            mi,
+		lanesHeld:     lanesHeld,
+		catchupKnown:  true,
+		catchupScope:  make(map[string]struct{}),
+		indexerCount:  repoCount,
+		poolDone:      make(chan struct{}),
 		restoreGCTune: applyIndexGCTuning(mi.logger),
 	}
 	for _, idx := range indexers {
-		enrich := idx.semanticMgr != nil && idx.semanticMgr.Enabled() && idx.semanticMgr.HasProviders() &&
-			(idx.pendingEnrich.Load() || forced)
-		if enrich {
-			run.enrichScheduled++
+		err := mi.withDeferredRepositoryMutation(idx, lanesHeld, func() {
+			enrich := idx.semanticMgr != nil && idx.semanticMgr.Enabled() && idx.semanticMgr.HasProviders() &&
+				(idx.pendingEnrich.Load() || forced)
+			if !enrich && idx.pendingContractReg == nil {
+				return
+			}
+			attempt := &deferredPassAttempt{indexer: idx, registry: idx.pendingContractReg, enrich: enrich}
+			idx.deferredAttempt = attempt
+			idx.SetSkipResolveInDeferred(true)
+			idx.deferredApplyGate = applyGate
+			run.attempts = append(run.attempts, attempt)
+			run.catchupNeeded = true
+			if idx.repoPrefix == "" {
+				run.catchupKnown = false
+			} else {
+				run.catchupScope[idx.repoPrefix] = struct{}{}
+			}
+		})
+		if err != nil {
+			run.attemptAborted = true
+			mi.logger.Warn("deferred attempt admission failed", zap.String("repo", idx.repoPrefix), zap.Error(err))
 		}
-		// Only repositories with actual deferred work enter the language-stats,
-		// enrichment, contract, and retained-state pipeline. This keeps a warm or
-		// partial restart proportional to its changed repositories.
-		if !enrich && idx.pendingContractReg == nil {
-			continue
-		}
-		run.workIndexers = append(run.workIndexers, idx)
-		run.catchupNeeded = true
-		if idx.repoPrefix == "" {
-			run.catchupKnown = false
-			continue
-		}
-		run.catchupScope[idx.repoPrefix] = struct{}{}
-	}
-	for _, idx := range run.workIndexers {
-		idx.SetSkipResolveInDeferred(true)
-		idx.deferredApplyGate = applyGate
 	}
 
-	// Keep the receipt window exact: only go.mod materialisation, semantic
-	// enrichment, and contract commits are observed. Without an apply gate the
-	// deferred pipeline starts after base resolution, so the window may open
-	// now and include go.mod work. With overlap, warmup opens it later — after
-	// pre-enrichment resolution and immediately before releasing parked applies.
-	// Unsupported stores retain the conservative scheduled-work fallback.
+	// Preserve the existing observational receipt order before GoMod mutations.
 	run.receiptStore, _ = mi.graph.(graph.MutationReceiptStore)
 	run.unresolvedCounter, _ = mi.graph.(graph.UnresolvedInsertionCounter)
 	if applyGate == nil {
@@ -718,12 +742,30 @@ func (mi *MultiIndexer) BeginDeferredPasses(_ context.Context, applyGate <-chan 
 		run.SnapshotUnresolvedBase()
 	}
 
-	// Per-repo deferred work starts with serial go.mod materialisation.
-	// Semantic enrichment then runs in bounded parallel lanes on its own
-	// goroutine so the caller may overlap it with the resolve phase.
-	for _, idx := range run.workIndexers {
-		idx.runDeferredGoMod()
+	started := make([]*deferredPassAttempt, 0, len(run.attempts))
+	for _, attempt := range run.attempts {
+		owned := false
+		err := mi.withDeferredRepositoryMutation(attempt.indexer, lanesHeld, func() {
+			if !attempt.current() {
+				return
+			}
+			attempt.indexer.runDeferredGoMod()
+			owned = true
+		})
+		if err != nil {
+			mi.logger.Warn("deferred dependency admission failed", zap.String("repo", attempt.indexer.repoPrefix), zap.Error(err))
+		}
+		if !owned {
+			run.attemptAborted = true
+			continue
+		}
+		started = append(started, attempt)
+		run.workIndexers = append(run.workIndexers, attempt.indexer)
+		if attempt.enrich {
+			run.enrichScheduled++
+		}
 	}
+	run.attempts = started
 	go func() {
 		defer close(run.poolDone)
 		mi.runDeferredEnrichPool(run.workIndexers)
@@ -738,28 +780,20 @@ func (r *DeferredPassesRun) Wait() { <-r.poolDone }
 // the receipt window, and performs the deferred-mutation catch-up resolve.
 func (r *DeferredPassesRun) FinishTailResult() DeferredPassesResult {
 	r.Wait()
-	// Contract passes run serially only after every enrichment lane has
-	// drained: the "no contract mutation overlaps enrichment" invariant
-	// holds globally instead of per batch, and each repo's retained
-	// compiler state is the compact binding projection, which stays
-	// cheap to hold until its pass releases it here.
-	for _, idx := range r.workIndexers {
-		idx.runDeferredContractsAndReleaseSemanticState()
-	}
+	// This run's enrichment lanes have drained. Complete only its still-owned
+	// attempts; an older run must not consume or certify a newer registry.
+	r.finishOwnedContractTails()
 	var mutationReceipt *graph.MutationReceipt
 	if r.receiptStore != nil && r.receiptOpen {
 		receipt := r.receiptStore.EndMutationReceipt(r.receiptToken)
 		mutationReceipt = &receipt
 		r.receiptOpen = false
 	}
-	for _, idx := range r.workIndexers {
-		idx.SetSkipResolveInDeferred(false)
-		idx.deferredApplyGate = nil
-	}
 	scope := normalizeDeferredCatchupScope(r.catchupScope, r.catchupKnown, r.indexerCount)
 	noNewUnresolved := r.unresolvedCounter != nil &&
 		r.unresolvedCounter.UnresolvedEdgeInsertions() == r.unresolvedBase
 	mode, crossRepoComplete := r.mi.resolveDeferredMutations(mutationReceipt, r.catchupNeeded, scope, noNewUnresolved)
+	crossRepoComplete = crossRepoComplete && !r.attemptAborted
 	var mutationRevision uint64
 	var mutationRevisionKnown bool
 	if crossRepoComplete {
@@ -774,6 +808,30 @@ func (r *DeferredPassesRun) FinishTailResult() DeferredPassesResult {
 		CrossRepoComplete:              crossRepoComplete,
 		CrossRepoMutationRevision:      mutationRevision,
 		CrossRepoMutationRevisionKnown: mutationRevisionKnown,
+	}
+}
+
+func (r *DeferredPassesRun) finishOwnedContractTails() {
+	for _, attempt := range r.attempts {
+		owned := false
+		err := r.mi.withDeferredRepositoryMutation(attempt.indexer, r.lanesHeld, func() {
+			if !attempt.current() {
+				return
+			}
+			idx := attempt.indexer
+			idx.runDeferredContractsAndReleaseSemanticState()
+			r.mi.refreshColdCensusMetadata(idx)
+			idx.SetSkipResolveInDeferred(false)
+			idx.deferredApplyGate = nil
+			idx.deferredAttempt = nil
+			owned = true
+		})
+		if err != nil {
+			r.mi.logger.Warn("deferred contract admission failed", zap.String("repo", attempt.indexer.repoPrefix), zap.Error(err))
+		}
+		if !owned {
+			r.attemptAborted = true
+		}
 	}
 }
 
@@ -2248,7 +2306,11 @@ func (mi *MultiIndexer) indexMultiRepo(repos []config.RepoEntry) (map[string]*In
 			if err := mi.RunPreEnrichResolve(deferCtx, nil, nil); err != nil {
 				return results, fmt.Errorf("multi-repo pre-enrichment resolve: %w", err)
 			}
-			deferredResult := mi.finishColdDeferredPasses(deferCtx)
+			completedIndexers := make([]*Indexer, 0, len(completed))
+			for _, rr := range completed {
+				completedIndexers = append(completedIndexers, rr.idx)
+			}
+			deferredResult := mi.finishColdDeferredPasses(deferCtx, completedIndexers)
 			mi.logger.Info("multi-repo coordinated deferred passes complete",
 				zap.Int("repos_indexed", len(results)),
 				zap.Int("repos_failed", len(indexErrors)),

--- a/internal/indexer/multi_cold_orchestration_test.go
+++ b/internal/indexer/multi_cold_orchestration_test.go
@@ -98,7 +98,7 @@ func TestFinishColdDeferredPassesDoesNotRepeatFullCrossRepoResolve(t *testing.T)
 	store := &coldOrchestrationProbeStore{Graph: graph.New()}
 	mi := newColdOrchestrationMulti(store, zap.NewNop())
 
-	result := mi.finishColdDeferredPasses(t.Context())
+	result := mi.finishColdDeferredPasses(t.Context(), nil)
 
 	assert.True(t, result.ExactCrossRepoComplete)
 	assert.Zero(t, store.unresolvedScans.Load(),

--- a/internal/indexer/reconcile_clean_census_manifest_test.go
+++ b/internal/indexer/reconcile_clean_census_manifest_test.go
@@ -1,8 +1,10 @@
 package indexer
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,7 +34,14 @@ func TestReconcileRepoCtxRoutesManifestOnlyChurnScopedAndConverges(t *testing.T)
 	require.NoError(t, err)
 	prior := seed.GetIndexer("repo").FileMtimes()
 	_, manifestTrackedByFullIndex := prior["go.mod"]
-	assert.False(t, manifestTrackedByFullIndex)
+	require.True(t, manifestTrackedByFullIndex)
+
+	// Create real manifest-only churn. A completed cold index now records
+	// its successful manifest receipt, so an unchanged restart is a no-op.
+	manifestPath := filepath.Join(root, "go.mod")
+	writeFile(t, manifestPath, "module example.com/sample\nrequire example.com/dependency v1.0.0\n")
+	changedAt := time.Unix(0, prior["go.mod"]).Add(time.Second)
+	require.NoError(t, os.Chtimes(manifestPath, changedAt, changedAt))
 
 	core, logs := observer.New(zap.DebugLevel)
 	firstRestart := NewMultiIndexer(graph.Store(store), newTestRegistry(), search.NewNull(), cm, zap.New(core))
@@ -40,6 +49,7 @@ func TestReconcileRepoCtxRoutesManifestOnlyChurnScopedAndConverges(t *testing.T)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.False(t, result.FullRetrack)
+	assert.Equal(t, 1, result.StaleFileCount)
 	entries := logs.FilterMessage("daemon: reconciled repo from snapshot").All()
 	require.Len(t, entries, 1)
 	assert.Equal(t, "scoped", entries[0].ContextMap()["route"])
@@ -53,6 +63,7 @@ func TestReconcileRepoCtxRoutesManifestOnlyChurnScopedAndConverges(t *testing.T)
 	result, err = secondRestart.ReconcileRepoCtx(t.Context(), entry, convergedMtimes)
 	require.NoError(t, err)
 	require.NotNil(t, result)
+	assert.Zero(t, result.StaleFileCount)
 	entries = logs.FilterMessage("daemon: reconciled repo from snapshot").All()
 	require.Len(t, entries, 1)
 	assert.Equal(t, "census_noop", entries[0].ContextMap()["route"])

--- a/internal/indexer/size_skip_census.go
+++ b/internal/indexer/size_skip_census.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/pathkey"
@@ -77,11 +78,40 @@ func sizeSkipMetaInt64(value any) (int64, bool) {
 // read into memory merely to mint a receipt. The normal post-publication
 // receipt validator must still check this version before persisting it.
 func (idx *Indexer) coldSizeSkipReceipt(path string, info os.FileInfo) fileReadReceipt {
-	return fileReadReceipt{
-		absPath: path, mtimeKey: idx.relKey(path),
-		readVersion: fileReadVersion{
+	receipt := fileReadReceipt{absPath: path, mtimeKey: idx.relKey(path)}
+	if runtime.GOOS == "windows" {
+		// Some Windows directory metadata defers identity lookup until
+		// SameFile. Freeze it now, before the path can be replaced.
+		receipt.readVersion = coldSizeSkipDescriptorVersion(path, info)
+	} else {
+		receipt.readVersion = fileReadVersion{
 			info: info, mtime: info.ModTime().UnixNano(), size: info.Size(), valid: true,
-		},
+		}
+	}
+	return receipt
+}
+
+// File.Stat captures identity from the open handle without reading file bytes.
+// The helper is platform-neutral so its failure and identity boundaries can be
+// tested directly; only Windows cold capture needs this extra handle. A failed
+// capture returns an invalid version, which the normal receipt finalizer marks
+// stale and invalidates rather than certifying an old durable mtime.
+func coldSizeSkipDescriptorVersion(path string, walked os.FileInfo) fileReadVersion {
+	if walked == nil || !walked.Mode().IsRegular() {
+		return fileReadVersion{}
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return fileReadVersion{}
+	}
+	info, statErr := file.Stat()
+	closeErr := file.Close()
+	if statErr != nil || closeErr != nil || !info.Mode().IsRegular() ||
+		info.Size() != walked.Size() || info.ModTime().UnixNano() != walked.ModTime().UnixNano() {
+		return fileReadVersion{}
+	}
+	return fileReadVersion{
+		info: info, mtime: info.ModTime().UnixNano(), size: info.Size(), valid: true,
 	}
 }
 

--- a/internal/indexer/size_skip_census.go
+++ b/internal/indexer/size_skip_census.go
@@ -1,0 +1,121 @@
+package indexer
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/pathkey"
+)
+
+// Load once per census. SQLite restricts repo/kind/current generation before
+// hydration; adapters retain their existing view-aware projection semantics.
+// This intentionally reuses the existing API rather than a new schema or
+// decoder. Its cost is proportional to the repository's file-node population.
+func (idx *Indexer) sizeSkipCensusNodes() map[string]*graph.Node {
+	// A repository-wide census must include legacy file stubs whose workspace
+	// was never stamped. Repo prefix and the selected store still scope the
+	// read; an optional workspace filter would hide those legitimate stubs.
+	nodes := graph.ReadRepoNodesByKindsWithMetaKey(idx.graph, idx.repoPrefix,
+		"", []graph.NodeKind{graph.KindFile}, "skipped_due_to_size")
+	out := make(map[string]*graph.Node, len(nodes))
+	for _, node := range nodes {
+		// Keep malformed prior markers too: an equal-mtime policy increase
+		// must not mistake a damaged skip stub for an already parsed file.
+		if rel, ok := idx.graphPathRelKey(node.FilePath); ok {
+			out[rel] = node
+		}
+	}
+	return out
+}
+
+// info must come from the census's os.Stat so policy and mtime checks reuse
+// one syscall and preserve IsStale's follow-stat behavior. The caller has
+// already applied the existing language/manifest and exclusion gates.
+func (idx *Indexer) sizeSkipCensusIsStale(relPath string, info os.FileInfo, oversize bool, prior map[string]*graph.Node) bool {
+	relPath = pathkey.Normalize(filepath.ToSlash(relPath))
+	idx.mtimeMu.RLock()
+	storedMtime, known := idx.fileMtimes[relPath]
+	idx.mtimeMu.RUnlock()
+	if !known || info == nil || info.ModTime().UnixNano() != storedMtime {
+		return true
+	}
+	stub := prior[relPath]
+	// The caller reuses its one language check and central strict size-cap
+	// predicate. Language-less root manifests are not subject to that cap.
+	if !oversize {
+		return stub != nil // equal-mtime policy increase admits the prior skip
+	}
+	if stub == nil || stub.Meta["skipped_due_to_size"] != true || stub.Meta["skip_reason"] != "size" {
+		return true // formerly parsed/missing/wrong stub must refresh, not hide
+	}
+	size, sizeOK := sizeSkipMetaInt64(stub.Meta["file_size_bytes"])
+	limit, limitOK := sizeSkipMetaInt64(stub.Meta["max_file_size_bytes"])
+	return !sizeOK || !limitOK || size != info.Size() || limit != idx.config.MaxFileSize
+}
+
+func sizeSkipMetaInt64(value any) (int64, bool) {
+	switch value := value.(type) {
+	case int64:
+		return value, true
+	case int:
+		return int64(value), true
+	case float64:
+		integer := int64(value)
+		return integer, float64(integer) == value
+	case json.Number:
+		integer, err := value.Int64()
+		return integer, err == nil
+	default:
+		return 0, false
+	}
+}
+
+// Capture metadata identity only: intentionally skipped assets must never be
+// read into memory merely to mint a receipt. The normal post-publication
+// receipt validator must still check this version before persisting it.
+func (idx *Indexer) coldSizeSkipReceipt(path string, info os.FileInfo) fileReadReceipt {
+	return fileReadReceipt{
+		absPath: path, mtimeKey: idx.relKey(path),
+		readVersion: fileReadVersion{
+			info: info, mtime: info.ModTime().UnixNano(), size: info.Size(), valid: true,
+		},
+	}
+}
+
+// Invoked by the existing post-publication full-index defer, before its
+// manifest census finalizer. Capture callers must first require
+// supportsColdManifestReceipts, so failed receipts remain invalidatable.
+// The slice belongs only to this raw-index attempt; no deferred state is
+// introduced for policy skips.
+func (idx *Indexer) finishColdSizeSkips(ctx context.Context, receipts []fileReadReceipt, mtimes map[string]int64, published bool) bool {
+	if len(receipts) == 0 {
+		return false
+	}
+	if !published || ctx.Err() != nil {
+		paths := make([]string, 0, len(receipts))
+		for _, receipt := range receipts {
+			paths = append(paths, receipt.mtimeKey)
+		}
+		idx.invalidateColdFileMtimes(paths)
+		return true
+	}
+	fresh, stale := idx.recordFileReadVersionsBatched(receipts)
+	accepted := make(map[string]struct{}, len(fresh))
+	for _, path := range fresh {
+		accepted[idx.relKey(path)] = struct{}{}
+	}
+	for _, receipt := range receipts {
+		if _, ok := accepted[receipt.mtimeKey]; ok {
+			mtimes[receipt.mtimeKey] = receipt.readVersion.mtime
+		}
+	}
+	failed := make([]string, 0, len(stale))
+	for _, path := range stale {
+		failed = append(failed, idx.relKey(path))
+	}
+	idx.invalidateColdFileMtimes(failed)
+	return len(stale) != 0
+}

--- a/internal/indexer/size_skip_census_test.go
+++ b/internal/indexer/size_skip_census_test.go
@@ -1,0 +1,865 @@
+package indexer
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"image"
+	"image/color"
+	"image/gif"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/parser/languages"
+	"github.com/zzet/gortex/internal/search"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"gopkg.in/yaml.v3"
+)
+
+type sizeCensusFixture struct {
+	t            *testing.T
+	root, dbPath string
+	store        *store_sqlite.Store
+	idx          *Indexer
+	mtime        time.Time
+}
+
+func newSizeCensusFixture(t *testing.T, limit int64) *sizeCensusFixture {
+	t.Helper()
+	f := &sizeCensusFixture{t: t, root: t.TempDir(), dbPath: filepath.Join(t.TempDir(), "graph.sqlite")}
+	t.Cleanup(f.close)
+	require.NoError(t, os.WriteFile(filepath.Join(f.root, "main.go"), []byte("package fixture\nfunc Main() {}\n"), 0600))
+	writeSizeCensusGIF(t, filepath.Join(f.root, "demo.gif"), 512)
+	info, err := os.Stat(filepath.Join(f.root, "demo.gif"))
+	require.NoError(t, err)
+	f.mtime = info.ModTime()
+	f.open(limit)
+	_, err = f.idx.IndexCtx(context.Background(), f.root)
+	require.NoError(t, err)
+	f.idx.RunDeferredPasses(context.Background())
+	return f
+}
+
+func writeSizeCensusGIF(t *testing.T, path string, size int) {
+	t.Helper()
+	var body bytes.Buffer
+	im := image.NewPaletted(image.Rect(0, 0, 2, 2), color.Palette{color.Black, color.White})
+	im.SetColorIndex(1, 1, 1)
+	require.NoError(t, gif.Encode(&body, im, nil))
+	require.LessOrEqual(t, body.Len(), size)
+	data := append(body.Bytes(), make([]byte, size-body.Len())...)
+	// A real GIF, with permitted trailing padding; eligible re-indexes exercise
+	// the actual ImageAssetExtractor, not only a synthetic skip marker.
+	_, err := gif.Decode(bytes.NewReader(data))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0600))
+}
+
+func (f *sizeCensusFixture) open(limit int64) {
+	f.t.Helper()
+	var err error
+	f.store, err = store_sqlite.Open(f.dbPath)
+	require.NoError(f.t, err)
+	registry := newTestRegistry()
+	registry.Register(languages.NewImageAssetExtractor())
+	f.idx = New(f.store, registry, config.IndexConfig{MaxFileSize: limit}, zap.NewNop())
+	f.idx.SetRepoPrefix("repo")
+	f.idx.SetDeferResolve(true)
+	f.idx.SetDeferGlobalPasses(true)
+	f.idx.storeRootPath(f.root)
+	f.idx.SetFileMtimes(f.store.LoadFileMtimes("repo"))
+}
+
+func (f *sizeCensusFixture) close() {
+	if f.idx != nil {
+		f.idx.Close()
+		f.idx = nil
+	}
+	if f.store != nil {
+		require.NoError(f.t, f.store.Close())
+		f.store = nil
+	}
+}
+
+func (f *sizeCensusFixture) reopen(limit int64) { f.close(); f.open(limit) }
+
+func (f *sizeCensusFixture) fileNode() *graph.Node {
+	f.t.Helper()
+	node := f.store.GetNodesByIDs([]string{"repo/demo.gif"})["repo/demo.gif"]
+	require.NotNil(f.t, node)
+	return node
+}
+
+// Equal-mtime cases deliberately establish a known receipt after actual cold
+// indexing, so the older missing-cold-receipt bug cannot mask policy staleness.
+func (f *sizeCensusFixture) establishKnownReceipt() {
+	f.t.Helper()
+	require.NoError(f.t, f.store.BulkSetFileMtimes("repo", map[string]int64{"demo.gif": f.mtime.UnixNano()}))
+	f.idx.SetFileMtimes(f.store.LoadFileMtimes("repo"))
+}
+
+func (f *sizeCensusFixture) census(wantChanged, wantDeleted []string, detected int) []string {
+	f.t.Helper()
+	changed, deleted, gotDetected, err := f.idx.changedSinceMtimesCensus(f.root)
+	require.NoError(f.t, err)
+	sort.Strings(changed)
+	sort.Strings(deleted)
+	require.ElementsMatch(f.t, wantChanged, changed)
+	require.ElementsMatch(f.t, wantDeleted, deleted)
+	require.Equal(f.t, detected, gotDetected)
+	return changed
+}
+
+func (f *sizeCensusFixture) applyCensus(changed []string) {
+	f.t.Helper()
+	// This is the existing receipt-aware incremental API used by Reconcile's
+	// explicit census frontier; policy changes may have an unchanged mtime.
+	_, _, _, err := f.idx.incrementalReindexPathsWithReceiptMode(f.root, changed,
+		incrementalPathMode{forceExplicitFiles: true, detectDeletions: true})
+	require.NoError(f.t, err)
+}
+
+func TestSizeSkipCensusColdGIFRepeatedRestartNoop(t *testing.T) {
+	f := newSizeCensusFixture(t, 128)
+	stub := f.fileNode()
+	require.Equal(t, true, stub.Meta["skipped_due_to_size"])
+	require.Equal(t, "size", stub.Meta["skip_reason"])
+	require.EqualValues(t, 512, stub.Meta["file_size_bytes"])
+	require.EqualValues(t, 128, stub.Meta["max_file_size_bytes"])
+	seeded := []*graph.Edge{
+		{From: "repo/main.go", To: "repo/demo.gif", Kind: "co_change", FilePath: "repo/main.go"},
+		{From: "repo/demo.gif", To: "repo/main.go", Kind: "co_change", FilePath: "repo/demo.gif"},
+	}
+	f.store.AddBatch(nil, seeded)
+	stored := f.store.GetOutEdgesByNodeIDs([]string{"repo/main.go", "repo/demo.gif"})
+	for _, want := range seeded {
+		found := 0
+		for _, got := range stored[want.From] {
+			if got.From == want.From && got.To == want.To && got.Kind == want.Kind {
+				found++
+			}
+		}
+		require.Equal(t, 1, found, "seeded co_change edge %s -> %s must exist before parity snapshot", want.From, want.To)
+	}
+	require.Equal(t, f.mtime.UnixNano(), f.store.LoadFileMtimes("repo")["demo.gif"], "cold graph publication must persist the actual oversized GIF receipt")
+	before := sizeCensusGraphRows(t, f.store)
+	for restart := 0; restart < 2; restart++ {
+		f.reopen(128)
+		f.census(nil, nil, 2)
+		result, err := f.idx.incrementalReindexPathsMode(f.root, []string{"main.go", "demo.gif"}, incrementalPathMode{})
+		require.NoError(t, err)
+		require.Zero(t, result.StaleFileCount)
+		require.Equal(t, before, sizeCensusGraphRows(t, f.store))
+	}
+}
+
+func TestSizeSkipCensusEqualMtimePolicyTransitions(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		before, after int64
+		wantSkip      bool
+	}{
+		{"cap_increase_admits", 128, 1024, false},
+		{"cap_disabled_admits", 128, 0, false},
+		{"cap_decrease_skips", 1024, 128, true},
+		{"still_oversize_new_cap", 128, 256, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newSizeCensusFixture(t, tc.before)
+			f.establishKnownReceipt()
+			f.reopen(tc.after)
+			changed := f.census([]string{"demo.gif"}, nil, 2)
+			f.applyCensus(changed)
+			node := f.fileNode()
+			if tc.wantSkip {
+				require.Equal(t, true, node.Meta["skipped_due_to_size"])
+				require.EqualValues(t, tc.after, node.Meta["max_file_size_bytes"])
+			} else {
+				require.NotEqual(t, true, node.Meta["skipped_due_to_size"])
+			}
+			require.Equal(t, f.mtime.UnixNano(), f.store.LoadFileMtimes("repo")["demo.gif"])
+			f.reopen(tc.after)
+			f.census(nil, nil, 2)
+		})
+	}
+}
+
+func TestSizeSkipCensusEqualMtimeSizeChange(t *testing.T) {
+	for _, size := range []int{768, 96} {
+		name := "still_oversize"
+		if size == 96 {
+			name = "shrunk_under_cap"
+		}
+		t.Run(name, func(t *testing.T) {
+			f := newSizeCensusFixture(t, 128)
+			f.establishKnownReceipt()
+			path := filepath.Join(f.root, "demo.gif")
+			writeSizeCensusGIF(t, path, size)
+			require.NoError(t, os.Chtimes(path, f.mtime, f.mtime))
+			f.reopen(128)
+			changed := f.census([]string{"demo.gif"}, nil, 2)
+			f.applyCensus(changed)
+			if size > 128 {
+				require.EqualValues(t, size, f.fileNode().Meta["file_size_bytes"])
+			} else {
+				require.NotEqual(t, true, f.fileNode().Meta["skipped_due_to_size"])
+			}
+			f.reopen(128)
+			f.census(nil, nil, 2)
+		})
+	}
+}
+
+func TestSizeSkipCensusMissingOrInvalidStubCannotCertifyReceipt(t *testing.T) {
+	for _, name := range []string{"missing", "wrong_kind", "false_skip", "wrong_reason", "wrong_size", "wrong_limit", "missing_size", "missing_limit", "nonnumeric_size"} {
+		t.Run(name, func(t *testing.T) {
+			f := newSizeCensusFixture(t, 128)
+			node := f.fileNode()
+			if name == "missing" {
+				f.store.EvictFile("repo/demo.gif")
+			} else {
+				copyNode := *node
+				copyNode.Meta = make(map[string]any, len(node.Meta))
+				for key, value := range node.Meta {
+					copyNode.Meta[key] = value
+				}
+				switch name {
+				case "wrong_kind":
+					copyNode.Kind = graph.KindFunction
+				case "false_skip":
+					copyNode.Meta["skipped_due_to_size"] = false
+				case "wrong_reason":
+					copyNode.Meta["skip_reason"] = "unsupported"
+				case "wrong_size":
+					copyNode.Meta["file_size_bytes"] = int64(511)
+				case "wrong_limit":
+					copyNode.Meta["max_file_size_bytes"] = int64(127)
+				case "missing_size":
+					delete(copyNode.Meta, "file_size_bytes")
+				case "missing_limit":
+					delete(copyNode.Meta, "max_file_size_bytes")
+				case "nonnumeric_size":
+					copyNode.Meta["file_size_bytes"] = "512"
+				}
+				f.store.AddBatch([]*graph.Node{&copyNode}, nil)
+			}
+			f.establishKnownReceipt()
+			f.reopen(128)
+			changed := f.census([]string{"demo.gif"}, nil, 2)
+			f.applyCensus(changed)
+			require.Equal(t, graph.KindFile, f.fileNode().Kind)
+			require.Equal(t, true, f.fileNode().Meta["skipped_due_to_size"])
+			f.reopen(128)
+			f.census(nil, nil, 2)
+		})
+	}
+}
+
+func TestSizeSkipCensusDeletionRetainsDetection(t *testing.T) {
+	f := newSizeCensusFixture(t, 128)
+	f.establishKnownReceipt()
+	f.reopen(128)
+	require.NoError(t, os.Remove(filepath.Join(f.root, "demo.gif")))
+	changed := f.census(nil, []string{"demo.gif"}, 1)
+	f.applyCensus(changed)
+	require.NotContains(t, f.store.LoadFileMtimes("repo"), "demo.gif")
+	require.Nil(t, f.store.GetNodesByIDs([]string{"repo/demo.gif"})["repo/demo.gif"])
+	f.reopen(128)
+	f.census(nil, nil, 1)
+}
+
+func TestSizeSkipCensusMalformedMarkerStillRequiresEligibleParse(t *testing.T) {
+	for _, malformed := range []string{"false_flag", "string_flag", "wrong_reason"} {
+		t.Run(malformed, func(t *testing.T) {
+			f := newSizeCensusFixture(t, 128)
+			stub := *f.fileNode()
+			stub.Meta = make(map[string]any)
+			for key, value := range f.fileNode().Meta {
+				stub.Meta[key] = value
+			}
+			switch malformed {
+			case "false_flag":
+				stub.Meta["skipped_due_to_size"] = false
+			case "string_flag":
+				stub.Meta["skipped_due_to_size"] = "true"
+			case "wrong_reason":
+				stub.Meta["skip_reason"] = "unsupported"
+			}
+			f.store.AddBatch([]*graph.Node{&stub}, nil)
+			f.establishKnownReceipt()
+			f.reopen(1024)
+			changed := f.census([]string{"demo.gif"}, nil, 2)
+			f.applyCensus(changed)
+			// Require evidence of real asset extraction, not merely that the
+			// malformed old flag was already unequal to boolean true.
+			parsedAsset := false
+			for _, node := range f.store.GetRepoNodes("repo") {
+				if node.FilePath == "repo/demo.gif" && node.Kind != graph.KindFile {
+					parsedAsset = true
+				}
+			}
+			require.True(t, parsedAsset, "eligible image must be parsed despite malformed old skip marker")
+			f.reopen(1024)
+			f.census(nil, nil, 2)
+		})
+	}
+}
+
+func TestSizeSkipCensusForeignRepoOrGenerationCannotSupplyStub(t *testing.T) {
+	for _, scope := range []string{"sibling_repo", "other_generation"} {
+		t.Run(scope, func(t *testing.T) {
+			f := newSizeCensusFixture(t, 128)
+			foreign := *f.fileNode()
+			foreign.ID = "foreign-size-stub"
+			if scope == "sibling_repo" {
+				foreign.RepoPrefix = "sibling"
+			}
+			// Preserve the colliding FilePath deliberately: repository/generation
+			// boundaries must be applied before path-key projection.
+			f.store.EvictFile("repo/demo.gif")
+			f.store.AddBatch([]*graph.Node{&foreign}, nil)
+			f.establishKnownReceipt()
+			f.close()
+			if scope == "other_generation" {
+				// Test-only database, Store closed; metadata encoded by real AddBatch.
+				db, err := sql.Open("sqlite", f.dbPath)
+				require.NoError(t, err)
+				result, err := db.Exec(`UPDATE nodes SET view_gen = 7 WHERE id = ?`, foreign.ID)
+				require.NoError(t, err)
+				rows, err := result.RowsAffected()
+				require.NoError(t, err)
+				require.EqualValues(t, 1, rows)
+				require.NoError(t, db.Close())
+			}
+			f.open(128)
+			f.census([]string{"demo.gif"}, nil, 2)
+		})
+	}
+}
+
+func TestSizeSkipCensusKnownStubWorkspaceDoesNotHideRepoFiles(t *testing.T) {
+	for _, workspace := range []string{"", "current-workspace", "old-workspace"} {
+		name := workspace
+		if name == "" {
+			name = "legacy_blank"
+		}
+		t.Run(name, func(t *testing.T) {
+			f := newSizeCensusFixture(t, 128)
+			stub := *f.fileNode()
+			stub.WorkspaceID = workspace
+			f.store.AddBatch([]*graph.Node{&stub}, nil)
+			f.establishKnownReceipt()
+			f.reopen(128)
+			f.idx.SetWorkspaceID("current-workspace")
+			// Repository-wide census must recognize a legacy or reassigned
+			// workspace's persisted stub, without pruning its durable receipt.
+			f.census(nil, nil, 2)
+			result, err := f.idx.incrementalReindexPathsMode(f.root,
+				[]string{"main.go", "demo.gif"}, incrementalPathMode{})
+			require.NoError(t, err)
+			require.Zero(t, result.StaleFileCount)
+			require.Equal(t, f.mtime.UnixNano(), f.store.LoadFileMtimes("repo")["demo.gif"])
+		})
+	}
+}
+
+func TestSizeSkipCensusReconcileUsesExplicitPolicyFrontier(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		name := "mtime"
+		if enabled {
+			name = "merkle"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("GORTEX_MERKLE", "")
+			f := newSizeCensusFixture(t, 1024)
+			// Four unchanged Go files plus one GIF keep a single policy transition
+			// below the 40% full-retrack threshold. Even if the local configuration
+			// file is admitted, two changes among six files remain below that limit.
+			for i := 1; i <= 3; i++ {
+				body := fmt.Sprintf("package fixture\nfunc Stable%d() {}\n", i)
+				require.NoError(t, os.WriteFile(filepath.Join(f.root, fmt.Sprintf("stable%d.go", i)), []byte(body), 0600))
+			}
+			writeConfig := func(limit int64) {
+				cfg := config.Default()
+				cfg.Index.MaxFileSize = limit
+				cfg.Index.Merkle = enabled
+				encoded, err := yaml.Marshal(cfg)
+				require.NoError(t, err)
+				// Marshal the real configuration's tags; no guessed YAML key names.
+				require.NoError(t, os.WriteFile(filepath.Join(f.root, ".gortex.yaml"), encoded, 0600))
+			}
+			writeConfig(1024)
+			f.idx.config.Merkle = enabled
+			require.Equal(t, enabled, f.idx.merkleEnabled())
+			_, err := f.idx.IndexCtx(context.Background(), f.root)
+			require.NoError(t, err)
+			f.idx.RunDeferredPasses(context.Background())
+			f.establishKnownReceipt()
+			if enabled {
+				encoded, err := os.ReadFile(merkleTreeFile(f.root))
+				require.NoError(t, err)
+				var baseline map[string]any
+				require.NoError(t, json.Unmarshal(encoded, &baseline))
+				files, ok := baseline["files"].(map[string]any)
+				require.True(t, ok, "test-created baseline must contain its files map")
+				leaf, ok := files["demo.gif"].(map[string]any)
+				require.True(t, ok, "cold eligible GIF must have an actual leaf before cap decrease")
+				hash, ok := leaf["hash"].(string)
+				require.True(t, ok)
+				require.Len(t, hash, 64)
+			}
+			require.GreaterOrEqual(t, len(f.store.LoadFileMtimes("repo")), 5)
+			require.NotEqual(t, true, f.fileNode().Meta["skipped_due_to_size"])
+
+			// A full retrack would lose this edge between unchanged files; a scoped
+			// GIF refresh must leave it intact. This distinguishes the two routes
+			// without binding the test to diagnostic log wording.
+			unchanged := &graph.Edge{From: "repo/stable1.go", To: "repo/stable2.go",
+				Kind: "co_change", FilePath: "repo/stable1.go", Line: 777}
+			f.store.AddBatch(nil, []*graph.Edge{unchanged})
+			assertUnchangedEdge := func() {
+				edges := f.store.GetOutEdgesByNodeIDs([]string{unchanged.From})[unchanged.From]
+				found := 0
+				for _, edge := range edges {
+					if edge.From == unchanged.From && edge.To == unchanged.To && edge.Kind == unchanged.Kind && edge.Line == unchanged.Line {
+						found++
+					}
+				}
+				require.Equal(t, 1, found, "scoped policy refresh must retain unchanged-file edge")
+			}
+			assertUnchangedEdge()
+
+			entry := config.RepoEntry{Path: f.root, Name: "repo"}
+			configPath := filepath.Join(t.TempDir(), "config.yaml")
+			global := &config.GlobalConfig{Repos: []config.RepoEntry{entry}}
+			global.SetConfigPath(configPath)
+			require.NoError(t, global.Save())
+			reconcile := func(limit int64, wantStale bool) {
+				f.reopen(limit)
+				f.idx.Close()
+				f.idx = nil
+				manager, err := config.NewConfigManager(configPath)
+				require.NoError(t, err)
+				registry := newTestRegistry()
+				registry.Register(languages.NewImageAssetExtractor())
+				mi := NewMultiIndexer(f.store, registry, search.NewNull(), manager, zap.NewNop())
+				// New MI is essential: already-registered repositories short-circuit.
+				result, err := mi.ReconcileRepoCtx(context.Background(), entry, f.store.LoadFileMtimes("repo"))
+				f.idx = mi.indexers["repo"]
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				require.NotNil(t, f.idx)
+				require.EqualValues(t, limit, f.idx.config.MaxFileSize, "real repo config override must have loaded")
+				require.Equal(t, enabled, f.idx.merkleEnabled())
+				if wantStale {
+					require.Positive(t, result.StaleFileCount)
+				} else {
+					require.Zero(t, result.StaleFileCount)
+				}
+				if limit < 512 {
+					require.Equal(t, true, f.fileNode().Meta["skipped_due_to_size"])
+					require.EqualValues(t, limit, f.fileNode().Meta["max_file_size_bytes"])
+				} else {
+					require.NotEqual(t, true, f.fileNode().Meta["skipped_due_to_size"])
+				}
+				require.Equal(t, f.mtime.UnixNano(), f.store.LoadFileMtimes("repo")["demo.gif"])
+				assertUnchangedEdge()
+			}
+			writeConfig(128)
+			reconcile(128, true)
+			reconcile(128, false)
+			writeConfig(1024)
+			reconcile(1024, true)
+			reconcile(1024, false)
+		})
+	}
+}
+
+func sizeCensusGraphRows(t *testing.T, store graph.Store) map[string]string {
+	t.Helper()
+	rows := make(map[string]string)
+	var ids []string
+	for _, node := range store.AllNodes() {
+		body, err := json.Marshal(node)
+		require.NoError(t, err)
+		rows["node:"+node.ID] = string(body)
+		ids = append(ids, node.ID)
+	}
+	for _, edges := range store.GetOutEdgesByNodeIDs(ids) {
+		for _, edge := range edges {
+			body, err := json.Marshal(edge)
+			require.NoError(t, err)
+			rows["edge:"+string(body)] = string(body)
+		}
+	}
+	return rows
+}
+
+func TestSizeSkipReceiptPublicationDoesNotRequireReadableContent(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "unreadable.gif")
+	var encoded bytes.Buffer
+	picture := image.NewPaletted(image.Rect(0, 0, 2, 2), color.Palette{color.Black, color.White})
+	picture.SetColorIndex(1, 1, 1)
+	require.NoError(t, gif.Encode(&encoded, picture, nil))
+	const size = 512
+	const limit = 128
+	require.Less(t, encoded.Len(), size)
+	content := append(encoded.Bytes(), make([]byte, size-encoded.Len())...)
+	_, err := gif.Decode(bytes.NewReader(content))
+	require.NoError(t, err, "fixture must be an actual GIF, not a fake extension")
+	require.NoError(t, os.WriteFile(path, content, 0600))
+	t.Cleanup(func() { require.NoError(t, os.Chmod(path, 0600)) })
+	require.NoError(t, os.Chmod(path, 0000))
+	// Root/elevated readers and some platforms ignore permission bits. Such
+	// environments cannot prove this property through a chmod fixture.
+	if _, err = os.ReadFile(path); err == nil {
+		t.Skip("current platform/user can read mode-000 files; content-read prohibition is not exercised")
+	}
+	require.ErrorIs(t, err, fs.ErrPermission)
+	info, err := os.Stat(path)
+	require.NoError(t, err, "metadata remains available without content permission")
+	require.True(t, info.Mode().IsRegular())
+	require.EqualValues(t, size, info.Size())
+	t.Log("permission preflight exercised: content read denied, metadata stat succeeds")
+
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "graph.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	registry := newTestRegistry()
+	registry.Register(languages.NewImageAssetExtractor())
+	idx := New(store, registry, config.IndexConfig{MaxFileSize: limit}, zap.NewNop())
+	idx.SetRepoPrefix("repo")
+	idx.SetDeferResolve(true)
+	idx.SetDeferGlobalPasses(true)
+	t.Cleanup(idx.Close)
+	result, err := idx.IndexCtx(context.Background(), root)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Empty(t, result.FailedFiles, "deliberate size skip must not become a read failure")
+	require.Empty(t, idx.fileIndexFailurePaths())
+	stub := store.GetNodesByIDs([]string{"repo/unreadable.gif"})["repo/unreadable.gif"]
+	require.NotNil(t, stub, "real cold graph publication must contain the skip stub")
+	require.Equal(t, graph.KindFile, stub.Kind)
+	require.Equal(t, true, stub.Meta["skipped_due_to_size"])
+	require.Equal(t, "size", stub.Meta["skip_reason"])
+	require.EqualValues(t, size, stub.Meta["file_size_bytes"])
+	require.EqualValues(t, limit, stub.Meta["max_file_size_bytes"])
+	_, err = os.ReadFile(path)
+	require.ErrorIs(t, err, fs.ErrPermission, "indexing must not change file permissions")
+	// This assertion is after the actual IndexCtx publication boundary and
+	// before any deferred pass. No file bytes are supplied to the Indexer.
+	require.Equal(t, info.ModTime().UnixNano(), store.LoadFileMtimes("repo")["unreadable.gif"],
+		"a successfully published size skip must receive a durable metadata-only receipt")
+	require.Equal(t, info.ModTime().UnixNano(), idx.publishFileMtimes()["unreadable.gif"])
+}
+
+func sizeFailureBoundaryWriteGIF(t *testing.T, path string, size int) {
+	t.Helper()
+	var encoded bytes.Buffer
+	picture := image.NewPaletted(image.Rect(0, 0, 2, 2), color.Palette{color.Black, color.White})
+	picture.SetColorIndex(1, 1, 1)
+	require.NoError(t, gif.Encode(&encoded, picture, nil))
+	require.Less(t, encoded.Len(), size)
+	content := append(encoded.Bytes(), make([]byte, size-encoded.Len())...)
+	_, err := gif.Decode(bytes.NewReader(content))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, content, 0600))
+}
+
+// This tests the real durable receipt finalizers, not the raw IndexCtx call
+// site. It deliberately supplies the publication outcome/captured version at
+// that boundary. The actual IndexCtx tests below separately exercise the
+// publication wiring through a source-verified log callback; no arbitrary
+// AddBatch callback is used as a substitute for that boundary.
+func TestSizeSkipFailureBoundaryRemovesOldReceiptAndRetries(t *testing.T) {
+	for _, scenario := range []string{
+		"publication_failed",
+		"publication_cancelled",
+		"same_mtime_size_changed",
+		"same_mtime_same_size_file_replaced",
+	} {
+		t.Run(scenario, func(t *testing.T) {
+			root := t.TempDir()
+			gifPath := filepath.Join(root, "demo.gif")
+			const oldSize = 512
+			const limit = 128
+			sizeFailureBoundaryWriteGIF(t, gifPath, oldSize)
+			capturedInfo, err := os.Stat(gifPath)
+			require.NoError(t, err)
+			oldMtime := capturedInfo.ModTime().UnixNano()
+			peerPath := filepath.Join(root, "durable-only.go")
+			require.NoError(t, os.WriteFile(peerPath, []byte("package fixture\n"), 0600))
+			peerInfo, err := os.Stat(peerPath)
+			require.NoError(t, err)
+			peerMtime := peerInfo.ModTime().UnixNano()
+			dbPath := filepath.Join(t.TempDir(), "graph.sqlite")
+			var store *store_sqlite.Store
+			var idx *Indexer
+			closeFixture := func() {
+				if idx != nil {
+					idx.Close()
+					idx = nil
+				}
+				if store != nil {
+					require.NoError(t, store.Close())
+					store = nil
+				}
+			}
+			t.Cleanup(closeFixture)
+			openFixture := func() {
+				var err error
+				store, err = store_sqlite.Open(dbPath)
+				require.NoError(t, err)
+				registry := newTestRegistry()
+				registry.Register(languages.NewImageAssetExtractor())
+				idx = New(store, registry, config.IndexConfig{MaxFileSize: limit}, zap.NewNop())
+				idx.SetRepoPrefix("repo")
+				idx.storeRootPath(root)
+			}
+			openFixture()
+			store.AddBatch([]*graph.Node{{
+				ID: "repo/demo.gif", Kind: graph.KindFile, RepoPrefix: "repo", FilePath: "repo/demo.gif",
+				Meta: map[string]any{
+					"skipped_due_to_size": true, "skip_reason": "size",
+					"file_size_bytes": int64(oldSize), "max_file_size_bytes": int64(limit),
+				},
+			}}, nil)
+			require.NotNil(t, store.GetNodesByIDs([]string{"repo/demo.gif"})["repo/demo.gif"])
+			require.NoError(t, store.BulkSetFileMtimes("repo", map[string]int64{
+				"demo.gif": oldMtime, "durable-only.go": peerMtime,
+			}))
+			// The unrelated key is intentionally absent from this Indexer's
+			// map. A fallback replacement from local state must not prune it.
+			idx.SetFileMtimes(map[string]int64{"demo.gif": oldMtime})
+			receipt := idx.coldSizeSkipReceipt(gifPath, capturedInfo)
+			require.Equal(t, "demo.gif", receipt.mtimeKey)
+			require.True(t, receipt.readVersion.valid)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			published := true
+			var publicationErr error
+			switch scenario {
+			case "publication_failed":
+				published = false
+				publicationErr = errors.New("injected final graph publication failure")
+			case "publication_cancelled":
+				cancel()
+			case "same_mtime_size_changed":
+				sizeFailureBoundaryWriteGIF(t, gifPath, 768)
+				require.NoError(t, os.Chtimes(gifPath, capturedInfo.ModTime(), capturedInfo.ModTime()))
+				currentInfo, err := os.Stat(gifPath)
+				require.NoError(t, err)
+				require.Equal(t, oldMtime, currentInfo.ModTime().UnixNano())
+				require.NotEqual(t, capturedInfo.Size(), currentInfo.Size())
+			case "same_mtime_same_size_file_replaced":
+				replacement := filepath.Join(root, "replacement.gif")
+				sizeFailureBoundaryWriteGIF(t, replacement, oldSize)
+				require.NoError(t, os.Chtimes(replacement, capturedInfo.ModTime(), capturedInfo.ModTime()))
+				require.NoError(t, os.Remove(gifPath))
+				require.NoError(t, os.Rename(replacement, gifPath))
+				currentInfo, err := os.Stat(gifPath)
+				require.NoError(t, err)
+				require.Equal(t, oldMtime, currentInfo.ModTime().UnixNano())
+				require.Equal(t, capturedInfo.Size(), currentInfo.Size())
+				require.False(t, os.SameFile(capturedInfo, currentInfo), "fixture must actually replace the file identity")
+			}
+
+			candidateMtimes := map[string]int64{}
+			hadFailure := idx.finishColdSizeSkips(ctx, []fileReadReceipt{receipt}, candidateMtimes, published)
+			require.True(t, hadFailure, "failure must suppress authoritative census pruning")
+			require.NotContains(t, candidateMtimes, "demo.gif", "rejected version must not enter the candidate census")
+			require.NotContains(t, idx.publishFileMtimes(), "demo.gif")
+			require.Equal(t, map[string]int64{"durable-only.go": peerMtime}, store.LoadFileMtimes("repo"))
+			// Exercise the next real finalizer too: forwarding hadFailure must
+			// not turn the now-empty candidate map into authoritative deletion
+			// of an unrelated persisted-only row.
+			idx.finishColdIndexCensus(ctx, &IndexResult{}, publicationErr, candidateMtimes, nil, hadFailure)
+			require.Equal(t, map[string]int64{"durable-only.go": peerMtime}, store.LoadFileMtimes("repo"))
+			closeFixture()
+			openFixture()
+			idx.SetFileMtimes(store.LoadFileMtimes("repo"))
+			idx.loadFileIndexFailures()
+			require.NotContains(t, store.LoadFileMtimes("repo"), "demo.gif")
+			require.Equal(t, peerMtime, store.LoadFileMtimes("repo")["durable-only.go"])
+			changed, deleted, detected, err := idx.changedSinceMtimesCensus(root)
+			require.NoError(t, err)
+			require.Equal(t, []string{"demo.gif"}, changed, "reopened census must retry the rejected GIF receipt")
+			require.Empty(t, deleted)
+			require.Equal(t, 2, detected)
+		})
+	}
+}
+
+// The exact raw IndexCtx source logs "indexer: parse subphases" after
+// emitSizeSkipNodes and construction of the candidate census, before vector /
+// final graph publication and the receipt finalizers. A synchronous zap hook
+// at that message therefore changes the file or cancels the actual IndexCtx
+// AFTER the walk captured its size-skip version. No sleeps, production hooks,
+// or manually supplied receipt/completion state are involved in these cases.
+func TestSizeSkipFailureBoundaryIndexCtxWiring(t *testing.T) {
+	for _, scenario := range []string{"cancel_after_capture", "same_mtime_size_change_after_capture"} {
+		t.Run(scenario, func(t *testing.T) {
+			root := t.TempDir()
+			gifPath := filepath.Join(root, "demo.gif")
+			const oldSize = 512
+			const limit = 128
+			sizeFailureBoundaryWriteGIF(t, gifPath, oldSize)
+			capturedInfo, err := os.Stat(gifPath)
+			require.NoError(t, err)
+			oldMtime := capturedInfo.ModTime().UnixNano()
+			peerPath := filepath.Join(root, "durable-only.go")
+			require.NoError(t, os.WriteFile(peerPath, []byte("package fixture\n"), 0600))
+			peerInfo, err := os.Stat(peerPath)
+			require.NoError(t, err)
+			peerMtime := peerInfo.ModTime().UnixNano()
+			dbPath := filepath.Join(t.TempDir(), "graph.sqlite")
+			var idx *Indexer
+			var store *store_sqlite.Store
+			t.Cleanup(func() {
+				if idx != nil {
+					idx.Close()
+				}
+				if store != nil {
+					require.NoError(t, store.Close())
+				}
+			})
+			store, err = store_sqlite.Open(dbPath)
+			require.NoError(t, err)
+			newIndexer := func(logger *zap.Logger) *Indexer {
+				registry := newTestRegistry()
+				registry.Register(languages.NewImageAssetExtractor())
+				result := New(store, registry, config.IndexConfig{MaxFileSize: limit}, logger)
+				result.SetRepoPrefix("repo")
+				result.SetDeferResolve(true)
+				result.SetDeferGlobalPasses(true)
+				result.storeRootPath(root)
+				return result
+			}
+			// Establish a real previous graph, not only a synthetic file row.
+			// Seed the old receipt explicitly so this fixture also works before
+			// the separate missing-cold-receipt fix has landed.
+			idx = newIndexer(zap.NewNop())
+			_, err = idx.IndexCtx(context.Background(), root)
+			require.NoError(t, err)
+			idx.Close()
+			idx = nil
+			require.NotNil(t, store.GetNodesByIDs([]string{"repo/demo.gif"})["repo/demo.gif"])
+			require.NoError(t, store.BulkSetFileMtimes("repo", map[string]int64{
+				"demo.gif": oldMtime, "durable-only.go": peerMtime,
+			}))
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			var callbackHits atomic.Int32
+			var callbackErr error
+			var observedKind graph.NodeKind
+			var observedSkip, observedSize, observedLimit any
+			core := zapcore.NewCore(zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()), zapcore.AddSync(io.Discard), zap.InfoLevel)
+			logger := zap.New(core, zap.Hooks(func(entry zapcore.Entry) error {
+				if entry.Message != "indexer: parse subphases" {
+					return nil
+				}
+				if callbackHits.Add(1) != 1 {
+					callbackErr = errors.New("publication callback unexpectedly ran more than once")
+					return nil
+				}
+				if ctx.Err() != nil {
+					callbackErr = errors.New("context was cancelled before the intended publication seam")
+					return nil
+				}
+				// Read the active graph: on a shadow path it has not drained
+				// to the durable Store yet. This proves size-node emission has
+				// occurred without assuming a specific publication backend.
+				stub := idx.graph.GetNodesByIDs([]string{"repo/demo.gif"})["repo/demo.gif"]
+				if stub == nil {
+					callbackErr = errors.New("size skip node absent at the publication callback")
+					return nil
+				}
+				observedKind = stub.Kind
+				observedSkip = stub.Meta["skipped_due_to_size"]
+				observedSize = stub.Meta["file_size_bytes"]
+				observedLimit = stub.Meta["max_file_size_bytes"]
+				if scenario == "cancel_after_capture" {
+					cancel()
+					return nil
+				}
+				// Preserve a valid GIF and its mtime while invalidating the
+				// captured size version. The synchronous hook finishes before
+				// IndexCtx can execute either receipt finalizer.
+				data, err := os.ReadFile(gifPath)
+				if err == nil {
+					err = os.WriteFile(gifPath, append(data, make([]byte, 256)...), 0600)
+				}
+				if err == nil {
+					err = os.Chtimes(gifPath, capturedInfo.ModTime(), capturedInfo.ModTime())
+				}
+				callbackErr = err
+				return nil
+			}))
+			idx = newIndexer(logger)
+			// The peer is durable-only at entry, so receipt publication must
+			// not reconstruct an authoritative old roster from this map.
+			idx.SetFileMtimes(map[string]int64{"demo.gif": oldMtime})
+			result, indexErr := idx.IndexCtx(ctx, root)
+			require.EqualValues(t, 1, callbackHits.Load(), "the source-verified publication seam must actually execute")
+			require.NoError(t, callbackErr)
+			require.Equal(t, graph.KindFile, observedKind)
+			require.Equal(t, true, observedSkip)
+			require.EqualValues(t, oldSize, observedSize, "the stub must describe the pre-callback version")
+			require.EqualValues(t, limit, observedLimit)
+			if scenario == "cancel_after_capture" {
+				require.ErrorIs(t, ctx.Err(), context.Canceled)
+				// Some publication backends acknowledge this late cancellation
+				// with an error, while others have already produced a result.
+				// Both must withhold the cancelled attempt's receipt.
+				if indexErr != nil {
+					require.ErrorIs(t, indexErr, context.Canceled)
+				} else {
+					require.NotNil(t, result)
+				}
+			} else {
+				require.NoError(t, indexErr)
+				require.NotNil(t, result)
+				currentInfo, err := os.Stat(gifPath)
+				require.NoError(t, err)
+				require.EqualValues(t, oldSize+256, currentInfo.Size())
+				require.Equal(t, oldMtime, currentInfo.ModTime().UnixNano())
+			}
+			assert.NotContains(t, idx.publishFileMtimes(), "demo.gif", "the actual IndexCtx must invalidate the old local receipt")
+			assert.NotContains(t, store.LoadFileMtimes("repo"), "demo.gif", "the actual IndexCtx must invalidate the old durable receipt")
+			assert.Equal(t, peerMtime, store.LoadFileMtimes("repo")["durable-only.go"])
+			idx.Close()
+			idx = nil
+			require.NoError(t, store.Close())
+			store = nil
+			store, err = store_sqlite.Open(dbPath)
+			require.NoError(t, err)
+			idx = newIndexer(zap.NewNop())
+			idx.SetFileMtimes(store.LoadFileMtimes("repo"))
+			idx.loadFileIndexFailures()
+			assert.NotContains(t, store.LoadFileMtimes("repo"), "demo.gif")
+			assert.Equal(t, peerMtime, store.LoadFileMtimes("repo")["durable-only.go"])
+			changed, deleted, detected, err := idx.changedSinceMtimesCensus(root)
+			require.NoError(t, err)
+			assert.Equal(t, []string{"demo.gif"}, changed)
+			require.Empty(t, deleted)
+			require.Equal(t, 2, detected)
+		})
+	}
+}

--- a/internal/indexer/size_skip_census_test.go
+++ b/internal/indexer/size_skip_census_test.go
@@ -668,6 +668,14 @@ func TestSizeSkipFailureBoundaryRemovesOldReceiptAndRetries(t *testing.T) {
 				require.Equal(t, oldMtime, currentInfo.ModTime().UnixNano())
 				require.NotEqual(t, capturedInfo.Size(), currentInfo.Size())
 			case "same_mtime_same_size_file_replaced":
+				// The oracle must not freeze capturedInfo: Windows Stat may
+				// defer its identity lookup until after the replacement.
+				original, err := os.Open(gifPath)
+				require.NoError(t, err)
+				originalIdentity, statErr := original.Stat()
+				closeErr := original.Close()
+				require.NoError(t, statErr)
+				require.NoError(t, closeErr)
 				replacement := filepath.Join(root, "replacement.gif")
 				sizeFailureBoundaryWriteGIF(t, replacement, oldSize)
 				require.NoError(t, os.Chtimes(replacement, capturedInfo.ModTime(), capturedInfo.ModTime()))
@@ -677,7 +685,7 @@ func TestSizeSkipFailureBoundaryRemovesOldReceiptAndRetries(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, oldMtime, currentInfo.ModTime().UnixNano())
 				require.Equal(t, capturedInfo.Size(), currentInfo.Size())
-				require.False(t, os.SameFile(capturedInfo, currentInfo), "fixture must actually replace the file identity")
+				require.False(t, os.SameFile(originalIdentity, currentInfo), "fixture must actually replace the file identity")
 			}
 
 			candidateMtimes := map[string]int64{}
@@ -860,6 +868,101 @@ func TestSizeSkipFailureBoundaryIndexCtxWiring(t *testing.T) {
 			assert.Equal(t, []string{"demo.gif"}, changed)
 			require.Empty(t, deleted)
 			require.Equal(t, 2, detected)
+		})
+	}
+}
+
+func TestSizeSkipDescriptorVersionFreezesIdentity(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "demo.gif")
+	writeSizeCensusGIF(t, path, 512)
+	walked, err := os.Stat(path)
+	require.NoError(t, err)
+	original, err := os.Open(path)
+	require.NoError(t, err)
+	originalIdentity, statErr := original.Stat()
+	closeErr := original.Close()
+	require.NoError(t, statErr)
+	require.NoError(t, closeErr)
+
+	version := coldSizeSkipDescriptorVersion(path, walked)
+	require.True(t, version.valid)
+	require.Equal(t, walked.Size(), version.size)
+	require.Equal(t, walked.ModTime().UnixNano(), version.mtime)
+
+	replacement := filepath.Join(root, "replacement.gif")
+	writeSizeCensusGIF(t, replacement, 512)
+	require.NoError(t, os.Chtimes(replacement, walked.ModTime(), walked.ModTime()))
+	require.NoError(t, os.Remove(path))
+	require.NoError(t, os.Rename(replacement, path))
+	current, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, walked.Size(), current.Size())
+	require.Equal(t, walked.ModTime().UnixNano(), current.ModTime().UnixNano())
+	// Both identity checks are independent of the metadata-only walked
+	// value, which must remain unfrozen so it cannot hide a lazy-ID bug.
+	require.False(t, os.SameFile(originalIdentity, current))
+	require.False(t, sameFileVersion(version.info, current))
+}
+
+func TestSizeSkipDescriptorCaptureFailureInvalidatesOldReceipt(t *testing.T) {
+	for _, scenario := range []string{
+		"missing", "current_directory", "changed_size", "changed_mtime",
+		"unreadable", "nil_walk", "directory_walk",
+	} {
+		t.Run(scenario, func(t *testing.T) {
+			f := newSizeCensusFixture(t, 128)
+			path := filepath.Join(f.root, "demo.gif")
+			walked, err := os.Stat(path)
+			require.NoError(t, err)
+			f.establishKnownReceipt()
+			require.NoError(t, f.store.BulkSetFileMtimes("repo", map[string]int64{"durable-only.go": 7}))
+			wantMtimes := f.store.LoadFileMtimes("repo")
+			delete(wantMtimes, "demo.gif")
+			f.idx.SetFileMtimes(map[string]int64{"demo.gif": f.mtime.UnixNano()})
+
+			switch scenario {
+			case "missing":
+				require.NoError(t, os.Remove(path))
+			case "current_directory":
+				require.NoError(t, os.Remove(path))
+				require.NoError(t, os.Mkdir(path, 0700))
+			case "changed_size":
+				writeSizeCensusGIF(t, path, 768)
+				require.NoError(t, os.Chtimes(path, walked.ModTime(), walked.ModTime()))
+			case "changed_mtime":
+				require.NoError(t, os.Chtimes(path, walked.ModTime(), walked.ModTime().Add(time.Second)))
+			case "unreadable":
+				require.NoError(t, os.Chmod(path, 0000))
+				t.Cleanup(func() { require.NoError(t, os.Chmod(path, 0600)) })
+				file, openErr := os.Open(path)
+				if openErr == nil {
+					require.NoError(t, file.Close())
+					t.Skip("current platform/user can open mode-000 files")
+				}
+				require.ErrorIs(t, openErr, fs.ErrPermission)
+			case "nil_walk":
+				walked = nil
+			case "directory_walk":
+				walked, err = os.Stat(f.root)
+				require.NoError(t, err)
+			}
+			version := coldSizeSkipDescriptorVersion(path, walked)
+			require.False(t, version.valid)
+			receipt := fileReadReceipt{absPath: path, mtimeKey: "demo.gif", readVersion: version}
+			mtimes := make(map[string]int64)
+			failed := f.idx.finishColdSizeSkips(context.Background(), []fileReadReceipt{receipt}, mtimes, true)
+			require.True(t, failed)
+			require.NotContains(t, mtimes, "demo.gif")
+			require.NotContains(t, f.idx.publishFileMtimes(), "demo.gif")
+			require.Equal(t, wantMtimes, f.store.LoadFileMtimes("repo"))
+			// Invalid capture is nonfatal to graph publication, but must
+			// suppress authoritative pruning of unrelated durable-only keys.
+			require.NotNil(t, f.fileNode())
+			f.idx.finishColdIndexCensus(context.Background(), &IndexResult{}, nil, mtimes, nil, failed)
+			require.Equal(t, wantMtimes, f.store.LoadFileMtimes("repo"))
+			f.reopen(128)
+			require.Equal(t, wantMtimes, f.store.LoadFileMtimes("repo"))
 		})
 	}
 }

--- a/internal/mcp/checkout_control_test.go
+++ b/internal/mcp/checkout_control_test.go
@@ -167,14 +167,26 @@ func TestCheckoutControlNeverRecoversUnregisteredNestedCheckoutAsParent(t *testi
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ran := false
-			res, err := stack.callWithView(t, tc.cwd, tc.operation, tc.args,
-				func(context.Context) (*mcp.CallToolResult, error) {
-					ran = true
-					return mcp.NewToolResultText(`{"ok":true}`), nil
-				})
-			require.NoError(t, err)
-			assertToolError(t, res, graphview.CodeCheckoutInaccessible)
-			require.False(t, ran)
+			deadline := time.Now().Add(10 * time.Second)
+			for {
+				res, err := stack.callWithView(t, tc.cwd, tc.operation, tc.args,
+					func(context.Context) (*mcp.CallToolResult, error) {
+						ran = true
+						return mcp.NewToolResultText(`{"ok":true}`), nil
+					})
+				require.NoError(t, err)
+				require.False(t, ran, "nested checkout must never invoke the parent handler")
+				require.True(t, res.IsError, viewResultText(t, res))
+				// Git discovery may outlast the short per-request admission budget.
+				// Retry pending discovery, but retain isolation on every attempt
+				// and require the same terminal error once discovery completes.
+				if strings.Contains(viewResultText(t, res), indexer.ErrCheckoutMutationBusy.Error()) {
+					require.True(t, time.Now().Before(deadline), "checkout discovery did not finish: %s", viewResultText(t, res))
+					continue
+				}
+				assertToolError(t, res, graphview.CodeCheckoutInaccessible)
+				break
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the four findings from isolated cold-index / warm-restart profiling:

- Scoped contract/ownership loading avoids ordinary-node hydration while preserving full persisted records, shared-ID roles, and repository/generation isolation.
- Empty-repository eviction skips require proof under the writer lock/transaction; retain the repository-leading ingestion index and verify query plans.
- Publish manifest, SIZE, and content-policy skip census receipts only after successful publication/version revalidation. Preserve shared contracts, incoming ownership and canonical FTS through restart deletion and structural refresh; prune actual final orphans transactionally.
- Sparse missing-ownership eligibility avoids no-op backfill scans while preserving fill-only builtin/project-only/partial ownership and configuration reevaluation.

Regression coverage includes fresh index→reopen parity, policy/size changes, failed/cancelled publication and retry, Merkle preservation, Windows identity capture, shared-ID metadata, opaque adapters, sibling generations, real structural reparse/derived dispatch, retained FTS and transaction rollback.

## Validation and provenance

Final source: **5b17b56d** (27 atomic commits, pushed); final clean-VCS binary SHA256: `54464ea1c6402328a5543cd01ff8848b9308656ad64792de39340a4f90fc8df3`.

- **Final production core a39ba439:** actual no-overlay affected-package normal and race suites both pass: 3 packages, 2,233 passing test/subtest records, 2 opt-in measurement skips, zero failures per run. Indexer package: normal **377.808 s**, race **983.954 s**; both logs complete.
- **5b17b56d adds tests only:** 459 added lines, original bodies and production unchanged. Expanded eight-test selection passes actual normal **2.767 s** / race **28.024 s**; build, vet, lint (0 issues), formatting/diff checks pass. Broad core binaries compiled before this expansion; do not count the focused selection as another full-package run.
- Earlier whole-repository normal/race suites passed on **e0f9a1f3**, with 193 package results each (40 normal entries had no test files). **dc849275** only reformatted tests; its follow-up static/fixture checks passed. Those whole suites were not rerun after the later production policy fix.
- Native analysis remains a lower-bound contract warning; it mapped tests to none of four changed anchors. Actual build/race execution is separate evidence, not a claim that this warning or graph coverage was cleared.

## Measured tradeoff and remaining costs

All **40 serial microbenchmark samples** passed on **dc849275**: scalar loader median **68.926→0.969 ms** (allocated **54.240→0.604 MB/op**); no-op backfill **9.016→0.053 ms**; absent eviction **9.670→0.148 ms**;
tiny eviction **113.304→78.436 ms**; recount **852.449→0.996 ms**.  **100k-node insertion costs 2.170→2.337 s (+7.67%).** These are fixture-level results, not startup gains: scalar loader has no owners; maintenance compares current-code index availability; insertion has no edges. Five samples per loader variant, three for the other variants.

The earlier 29-repository checkpoint measured cold queryable/full **468.999 / 1122.688 s**, warm1 **22.298 /31.666 s**. It still spent warm **11.038 s** in reconciliation, **6.555 s** rehydrating contracts and **5.123 s** seeding enrichment. Cold index/finalization **289.608 s**, enrichment **236.219 s**, end-batch **205.479 s** (framework **126.377 s** nested), and resolver tail **210.011 s** remain material costs—not all proven waste or LSP startup. Do not double-count nested/overlapping timers or infer a historical causal speedup.

## Explicit validation gap and compatibility limits

The dc849275 real-config cold→warm1 comparison found exactly **2 added census entries and 4 removed co-change edges**; all 609,749 node payloads and 3,478,038 retained edge payloads were equal. This was not parity. The final policy fix covers the reproduced receipt loss in passing regression tests.

**Final targeted real replay was NOT RUN:** its preflight exited before daemon launch because free space was below the unchanged **20 GiB** safety gate. No gate relaxation or evidence deletion was used. Therefore no final real-config cold/warm parity or final targeted timing is claimed. The earlier stable-input measurement also qualifies 1,644 unfollowed symlink targets.

Empty repo scope remains exact, never global; backfills remain fill-only. Opaque adapters omit ambiguous scalars; overwritten/never-persisted legacy fields cannot be reconstructed. Dependency contracts retain sparse cold single-writer payloads. The historical exact bridge split remains incompletely attributed.

**PR merge-ref CI: results pending.** GitHub checks will provide integration results; Windows runtime validation is distinct from local macOS execution.
