### PR TITLE
fix(sqlite): eliminate unchanged reference-fact rewrites

### DIFF
--- a/cmd/gortex/issue767_idle_io_integration_test.go
+++ b/cmd/gortex/issue767_idle_io_integration_test.go
@@ -1,0 +1,690 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	_ "modernc.org/sqlite"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestIssue767IdleIOIntegration launches only explicitly supplied binaries.
+// Every process owns private XDG directories, SQLite storage and a Git fixture.
+// It never addresses the default daemon.
+//
+// GORTEX_ISSUE767_TEST_BINARY is required; BASELINE_BINARY optionally runs first.
+// GORTEX_ISSUE767_ARTIFACT_DIR preserves logs/reports when supplied.
+// GORTEX_ISSUE767_IDLE_DURATION defaults to 45s, bounded 15s–1h; cold idle caps 60s.
+// GORTEX_ISSUE767_WRITE_BUDGET_BYTES is optional; absent/zero means no assertion.
+// The 5s janitor interval accelerates this regression scenario; measurements are
+// not default-configuration idle performance or physical NAND writes.
+func TestIssue767IdleIOIntegration(t *testing.T) {
+	fixed := os.Getenv("GORTEX_ISSUE767_TEST_BINARY")
+	if fixed == "" {
+		t.Skip("set GORTEX_ISSUE767_TEST_BINARY to opt into isolated daemon validation")
+	}
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skip("process I/O sampler supports Darwin and Linux")
+	}
+	idle := 45 * time.Second
+	if value := os.Getenv("GORTEX_ISSUE767_IDLE_DURATION"); value != "" {
+		var err error
+		idle, err = time.ParseDuration(value)
+		if err != nil || idle < 15*time.Second || idle > time.Hour {
+			t.Fatal("GORTEX_ISSUE767_IDLE_DURATION must be between 15s and 1h")
+		}
+	}
+	var budget uint64
+	if value := os.Getenv("GORTEX_ISSUE767_WRITE_BUDGET_BYTES"); value != "" {
+		var err error
+		budget, err = strconv.ParseUint(value, 10, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	required := issue767RequiredTimeout(idle, os.Getenv("GORTEX_ISSUE767_BASELINE_BINARY") != "")
+	if deadline, ok := t.Deadline(); ok && time.Until(deadline) < required {
+		t.Fatalf("isolated scenario needs at least %s remaining; increase go test -timeout before launching daemon children", required)
+	}
+	for _, variant := range []struct{ name, binary string }{{"baseline", os.Getenv("GORTEX_ISSUE767_BASELINE_BINARY")}, {"fixed", fixed}} {
+		if variant.binary == "" {
+			continue
+		}
+		t.Run(variant.name, func(t *testing.T) {
+			binary, err := filepath.Abs(variant.binary)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := os.Stat(binary); err != nil {
+				t.Fatal(err)
+			}
+			f := newIssue767Fixture(t, binary)
+			coldStart := time.Now()
+			f.start()
+			f.command(10*time.Second, f.primary, "daemon", "status", "--no-progress")
+			f.awaitSymbol(f.primary, "Issue767PrimaryMarker")
+			t.Logf("configured cold startup to selected primary query: %s", time.Since(coldStart))
+			f.write(filepath.Join(f.primary, "marker.go"), issue767MarkerSource("Issue767PrimaryMarker", "Issue767DirtyMarker"))
+			f.awaitSymbol(f.primary, "Issue767DirtyMarker")
+			f.git(f.primary, "worktree", "add", "-b", "issue767-linked", f.linked)
+			f.write(filepath.Join(f.linked, "marker.go"), issue767MarkerSource("Issue767PrimaryMarker", "Issue767LinkedMarker"))
+			// The linked checkout is intentionally never explicitly tracked.
+			f.awaitSymbol(f.linked, "Issue767LinkedMarker")
+			leaked, err := f.trySearchSymbol(f.primary, "Issue767LinkedMarker")
+			if err != nil {
+				t.Fatalf("primary isolation query failed: %v", err)
+			}
+			if leaked {
+				t.Fatal("linked-checkout symbol leaked into primary view")
+			}
+			f.git(f.primary, "worktree", "remove", "--force", f.linked)
+			f.awaitRemoved()
+			f.awaitSymbol(f.primary, "Issue767DirtyMarker")
+			f.settle()
+			cold := f.measureIdle("cold_idle", min(idle, time.Minute))
+			f.stop()
+			warmStart := time.Now()
+			f.start()
+			f.awaitSymbol(f.primary, "Issue767DirtyMarker")
+			t.Logf("warm startup to selected primary query: %s", time.Since(warmStart))
+			f.awaitRemoved()
+			f.settle()
+			warm := f.measureIdle("warm_idle", idle)
+			if warm.Before.Sequence != cold.After.Sequence {
+				t.Errorf("unchanged warm restart allocated new generations: cold=%d warm=%d", cold.After.Sequence, warm.Before.Sequence)
+			}
+			if variant.name == "fixed" && budget > 0 {
+				for _, report := range []issue767IdleReport{cold, warm} {
+					if report.ProcessBytesWritten > budget {
+						t.Errorf("%s wrote %d process-accounted bytes, budget %d", report.Phase, report.ProcessBytesWritten, budget)
+					}
+				}
+			}
+		})
+	}
+}
+
+func issue767RequiredTimeout(idle time.Duration, baseline bool) time.Duration {
+	variants := 1
+	if baseline {
+		variants++
+	}
+	return time.Duration(variants) * (min(idle, time.Minute) + idle + 3*time.Minute)
+}
+
+type issue767Fixture struct {
+	t                                    *testing.T
+	binary, root, primary, linked, store string
+	env                                  []string
+	cmd                                  *exec.Cmd
+	cancel                               context.CancelFunc
+	done                                 chan error
+	log                                  *os.File
+	run                                  int
+	lastOutput                           string
+}
+
+func newIssue767Fixture(t *testing.T, binary string) *issue767Fixture {
+	t.Helper()
+	parent := os.Getenv("GORTEX_ISSUE767_ARTIFACT_DIR")
+	preserve := parent != ""
+	if !preserve {
+		parent = "/tmp"
+	}
+	var err error
+	parent, err = filepath.Abs(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(parent, 0700); err != nil {
+		t.Fatal(err)
+	}
+	root, err := os.MkdirTemp(parent, "gx767-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err = filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !preserve {
+		t.Cleanup(func() { _ = os.RemoveAll(root) })
+	}
+	f := &issue767Fixture{t: t, binary: binary, root: root, primary: filepath.Join(root, "repo"), linked: filepath.Join(root, "linked"), store: filepath.Join(root, "store.sqlite")}
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		if strings.HasPrefix(key, "GORTEX_") || strings.HasPrefix(key, "XDG_") || strings.HasPrefix(key, "GIT_") {
+			continue
+		}
+		f.env = append(f.env, entry)
+	}
+	f.env = append(f.env,
+		"XDG_CONFIG_HOME="+filepath.Join(root, "config"), "XDG_DATA_HOME="+filepath.Join(root, "data"), "XDG_CACHE_HOME="+filepath.Join(root, "cache"),
+		"GORTEX_DAEMON_PPROF_ADDR=127.0.0.1:0", "GORTEX_RECONCILE_INTERVAL=5s",
+		"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL="+filepath.Join(root, "gitconfig"), "GIT_TERMINAL_PROMPT=0", "GOWORK=off", "NO_COLOR=1", "CI=1")
+	f.write(filepath.Join(root, "gitconfig"), "[user]\n\tname = Issue767 Test\n\temail = issue767@example.invalid\n[commit]\n\tgpgsign = false\n")
+	f.write(filepath.Join(f.primary, "go.mod"), "module example.invalid/issue767\n\ngo 1.24\n")
+	f.write(filepath.Join(f.primary, "marker.go"), issue767MarkerSource("Issue767PrimaryMarker"))
+	for i := 0; i < 32; i++ {
+		f.write(filepath.Join(f.primary, fmt.Sprintf("file%02d.go", i)), fmt.Sprintf("package fixture\nfunc Issue767Target%02d() int { return %d }\nfunc Issue767Caller%02d() int { return Issue767Target00() }\n", i, i, i))
+	}
+	f.git(f.primary, "init", "-b", "main")
+	f.git(f.primary, "add", ".")
+	f.git(f.primary, "commit", "-m", "isolated fixture")
+	// Match configured cold startup; runtime track is a separate scenario.
+	f.write(filepath.Join(root, "config", "gortex", "config.yaml"), "repos:\n  - path: "+strconv.Quote(f.primary)+"\n    name: issue767\n")
+	t.Cleanup(f.stop)
+	t.Logf("isolated fixture artifacts: %s", root)
+	return f
+}
+
+func issue767MarkerSource(names ...string) string {
+	source := "package fixture\n"
+	for _, name := range names {
+		source += "func " + name + "() int { return Issue767Target00() }\n"
+	}
+	return source
+}
+
+func (f *issue767Fixture) write(path, content string) {
+	f.t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		f.t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		f.t.Fatal(err)
+	}
+}
+
+func (f *issue767Fixture) git(dir string, args ...string) {
+	f.t.Helper()
+	ctx, cancel := context.WithTimeout(f.t.Context(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir, cmd.Env = dir, f.env
+	if output, err := cmd.CombinedOutput(); err != nil {
+		f.t.Fatalf("fixture git %v: %v\n%s", args, err, output)
+	}
+}
+
+func (f *issue767Fixture) command(timeout time.Duration, dir string, args ...string) []byte {
+	f.t.Helper()
+	output, err := f.tryCommand(timeout, dir, args...)
+	if err != nil {
+		f.t.Fatalf("isolated CLI %v: %v\n%s", args, err, output)
+	}
+	return output
+}
+
+func (f *issue767Fixture) tryCommand(timeout time.Duration, dir string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(f.t.Context(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, f.binary, args...)
+	cmd.Dir, cmd.Env = dir, f.env
+	output, err := cmd.CombinedOutput()
+	f.lastOutput = string(output)
+	if len(f.lastOutput) > 4096 {
+		f.lastOutput = f.lastOutput[len(f.lastOutput)-4096:]
+	}
+	return output, err
+}
+
+func (f *issue767Fixture) start() {
+	f.t.Helper()
+	f.run++
+	var err error
+	f.log, err = os.Create(filepath.Join(f.root, fmt.Sprintf("daemon-%d.log", f.run)))
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(f.t.Context())
+	if deadline, ok := f.t.Deadline(); ok {
+		cancel()
+		ctx, cancel = context.WithDeadline(f.t.Context(), deadline.Add(-time.Minute))
+	}
+	f.cancel = cancel
+	cmd := exec.CommandContext(ctx, f.binary, "daemon", "start", "--embeddings=false", "--backend", "sqlite", "--backend-path", f.store, "--no-progress")
+	// Global testing timeout bypasses Cleanup. This captured child receives
+	// SIGINT and a bounded forced exit before the parent testing deadline.
+	cmd.Cancel = func() error { return cmd.Process.Signal(os.Interrupt) }
+	cmd.WaitDelay = 10 * time.Second
+	cmd.Dir, cmd.Env, cmd.Stdout, cmd.Stderr = f.primary, f.env, f.log, f.log
+	if err := cmd.Start(); err != nil {
+		cancel()
+		_ = f.log.Close()
+		f.t.Fatal(err)
+	}
+	f.cmd, f.done = cmd, make(chan error, 1)
+	done := f.done
+	go func() { done <- cmd.Wait() }()
+	f.await("isolated daemon socket", time.Minute, func() bool {
+		select {
+		case err := <-f.done:
+			f.cmd = nil
+			_ = f.log.Close()
+			f.t.Fatalf("isolated daemon exited during start: %v; log %s", err, f.log.Name())
+		default:
+		}
+		_, err := f.tryCommand(5*time.Second, f.primary, "daemon", "status", "--no-progress")
+		return err == nil
+	})
+}
+
+func (f *issue767Fixture) stop() {
+	if cancel := f.cancel; cancel != nil {
+		f.cancel = nil
+		defer cancel()
+	}
+	if f.cmd == nil {
+		return
+	}
+	cmd, done := f.cmd, f.done
+	f.cmd = nil
+	_ = cmd.Process.Signal(os.Interrupt)
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		_ = cmd.Process.Kill()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			f.t.Errorf("isolated child %d did not exit after kill", cmd.Process.Pid)
+		}
+		f.t.Errorf("isolated child %d required force kill", cmd.Process.Pid)
+	}
+	_ = f.log.Close()
+}
+
+func (f *issue767Fixture) await(label string, timeout time.Duration, ready func() bool) {
+	f.t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if ready() {
+			return
+		}
+		select {
+		case <-f.t.Context().Done():
+			f.t.Fatal(f.t.Context().Err())
+		case <-time.After(250 * time.Millisecond):
+		}
+	}
+	f.t.Fatalf("timed out waiting for %s; artifacts %s; last CLI response: %s", label, f.root, f.lastOutput)
+}
+
+func (f *issue767Fixture) searchHasSymbol(root, name string) bool {
+	found, err := f.trySearchSymbol(root, name)
+	return err == nil && found
+}
+
+func (f *issue767Fixture) trySearchSymbol(root, name string) (bool, error) {
+	request := map[string]any{"operation": "symbols", "query": name, "options": map[string]any{"limit": 10, "query_class": "symbol", "expand": "off"}}
+	if root != f.primary {
+		request["view"] = map[string]any{"kind": "worktree", "path": root}
+	}
+	payload, err := json.Marshal(request)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	output, err := f.tryCommand(10*time.Second, root, "call", "search", "--index", root, "--json", string(payload), "--format", "json")
+	if err != nil {
+		return false, fmt.Errorf("search command: %w: %s", err, output)
+	}
+	var value any
+	if err := json.Unmarshal(output, &value); err != nil {
+		return false, fmt.Errorf("search response: %w: %s", err, output)
+	}
+	found, fallback := issue767JSONEvidence(value, name)
+	if fallback {
+		return false, errors.New("search returned fallback or tool error")
+	}
+	if root != f.primary && !issue767JSONExact(value) {
+		return false, errors.New("automatic checkout search did not prove exact freshness")
+	}
+	if found && !issue767JSONSource(value, name, root) {
+		return false, errors.New("symbol did not belong to selected source root and repository")
+	}
+	return found, nil
+}
+
+func issue767JSONEvidence(value any, name string) (found, fallback bool) {
+	merge := func(child any) {
+		childFound, childFallback := issue767JSONEvidence(child, name)
+		found, fallback = found || childFound, fallback || childFallback
+	}
+	switch value := value.(type) {
+	case map[string]any:
+		exact, hasExact := value["exact"].(bool)
+		fallback = hasExact && !exact
+		if code, ok := value["error_code"].(string); ok && code != "" {
+			fallback = true
+		}
+		if isError, ok := value["isError"].(bool); ok && isError {
+			fallback = true
+		}
+		found = value["name"] == name
+		for _, child := range value {
+			merge(child)
+		}
+	case []any:
+		for _, child := range value {
+			merge(child)
+		}
+	case string:
+		var child any
+		if strings.HasPrefix(value, "{") || strings.HasPrefix(value, "[") {
+			if json.Unmarshal([]byte(value), &child) == nil {
+				merge(child)
+			}
+		}
+	}
+	return found, fallback
+}
+
+func issue767JSONExact(value any) bool {
+	switch value := value.(type) {
+	case map[string]any:
+		if exact, ok := value["exact"].(bool); ok && exact {
+			return true
+		}
+		for _, child := range value {
+			if issue767JSONExact(child) {
+				return true
+			}
+		}
+	case []any:
+		for _, child := range value {
+			if issue767JSONExact(child) {
+				return true
+			}
+		}
+	case string:
+		var child any
+		if (strings.HasPrefix(value, "{") || strings.HasPrefix(value, "[")) && json.Unmarshal([]byte(value), &child) == nil {
+			return issue767JSONExact(child)
+		}
+	}
+	return false
+}
+
+func issue767JSONSource(value any, name, root string) bool {
+	switch value := value.(type) {
+	case map[string]any:
+		if value["name"] == name && value["repo_prefix"] == "issue767" {
+			path, ok := value["absolute_file_path"].(string)
+			if ok && filepath.Clean(path) == filepath.Join(root, "marker.go") {
+				return true
+			}
+		}
+		for _, child := range value {
+			if issue767JSONSource(child, name, root) {
+				return true
+			}
+		}
+	case []any:
+		for _, child := range value {
+			if issue767JSONSource(child, name, root) {
+				return true
+			}
+		}
+	case string:
+		var child any
+		if (strings.HasPrefix(value, "{") || strings.HasPrefix(value, "[")) && json.Unmarshal([]byte(value), &child) == nil {
+			return issue767JSONSource(child, name, root)
+		}
+	}
+	return false
+}
+
+func (f *issue767Fixture) awaitSymbol(root, name string) {
+	f.t.Helper()
+	f.await("selected symbol "+name, 2*time.Minute, func() bool { return f.searchHasSymbol(root, name) })
+}
+
+func (f *issue767Fixture) openReadOnly() *sql.DB {
+	f.t.Helper()
+	u := &url.URL{Scheme: "file", Path: filepath.ToSlash(f.store), RawQuery: "mode=ro"}
+	db, err := sql.Open("sqlite", u.String())
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	db.SetMaxOpenConns(1)
+	f.t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func (f *issue767Fixture) awaitRemoved() {
+	db := f.openReadOnly()
+	defer db.Close()
+	f.await("removed checkout cleanup", 2*time.Minute, func() bool {
+		ctx, cancel := context.WithTimeout(f.t.Context(), time.Second)
+		defer cancel()
+		var count int
+		return db.QueryRowContext(ctx, "SELECT COUNT(*) FROM checkouts WHERE root_path=?", f.linked).Scan(&count) == nil && count == 0
+	})
+}
+
+type issue767GenerationSnapshot struct {
+	Count, Max, Sequence                    int64
+	Nodes, Edges, RefFacts, PrimaryRefFacts int64
+}
+
+func issue767ReadGenerations(ctx context.Context, db *sql.DB) (issue767GenerationSnapshot, error) {
+	result := issue767GenerationSnapshot{Sequence: -1}
+	err := db.QueryRowContext(ctx, "SELECT COUNT(*), COALESCE(MAX(generation_id),0) FROM view_generations").Scan(&result.Count, &result.Max)
+	if err != nil {
+		return result, err
+	}
+	err = db.QueryRowContext(ctx, "SELECT (SELECT COUNT(*) FROM nodes), (SELECT COUNT(*) FROM edges), (SELECT COUNT(*) FROM ref_facts), (SELECT COUNT(*) FROM ref_facts WHERE view_gen=0 AND repo_prefix='issue767')").Scan(&result.Nodes, &result.Edges, &result.RefFacts, &result.PrimaryRefFacts)
+	if err != nil {
+		return result, err
+	}
+	err = db.QueryRowContext(ctx, "SELECT seq FROM sqlite_sequence WHERE name='view_generations'").Scan(&result.Sequence)
+	if err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func (f *issue767Fixture) settle() {
+	db := f.openReadOnly()
+	defer db.Close()
+	var previous issue767GenerationSnapshot
+	stable := 0
+	f.await("three stable generation samples", 2*time.Minute, func() bool {
+		ctx, cancel := context.WithTimeout(f.t.Context(), 3*time.Second)
+		defer cancel()
+		current, err := issue767ReadGenerations(ctx, db)
+		if err != nil {
+			return false
+		}
+		if current == previous {
+			stable++
+		} else {
+			stable = 0
+		}
+		previous = current
+		if stable < 3 {
+			time.Sleep(5 * time.Second)
+		}
+		return stable >= 3
+	})
+}
+
+type issue767ProcessIO struct {
+	BytesWritten        uint64
+	LogicalBytesWritten *uint64
+	StartTicks          uint64
+}
+
+const issue767DarwinIOScript = "import ctypes,json,sys\nfields='user_time system_time pkg_idle_wkups interrupt_wkups pageins wired_size resident_size phys_footprint proc_start_abstime proc_exit_abstime child_user_time child_system_time child_pkg_idle_wkups child_interrupt_wkups child_pageins child_elapsed_abstime diskio_bytesread diskio_byteswritten cpu_time_qos_default cpu_time_qos_maintenance cpu_time_qos_background cpu_time_qos_utility cpu_time_qos_legacy cpu_time_qos_user_initiated cpu_time_qos_user_interactive billed_system_time serviced_system_time logical_writes lifetime_max_phys_footprint instructions cycles billed_energy serviced_energy interval_max_phys_footprint runnable_time'.split()\nclass R(ctypes.Structure):\n _fields_=[('uuid',ctypes.c_uint8*16)]+[(n,ctypes.c_uint64) for n in fields]\nr=R();lib=ctypes.CDLL('/usr/lib/libproc.dylib',use_errno=True);fn=lib.proc_pid_rusage;fn.argtypes=[ctypes.c_int,ctypes.c_int,ctypes.c_void_p];fn.restype=ctypes.c_int\nif fn(int(sys.argv[1]),4,ctypes.byref(r))!=0: raise OSError(ctypes.get_errno(),'proc_pid_rusage')\nprint(json.dumps({'BytesWritten':r.diskio_byteswritten,'LogicalBytesWritten':r.logical_writes,'StartTicks':r.proc_start_abstime}))\n"
+
+func issue767ReadProcessIO(ctx context.Context, pid int) (issue767ProcessIO, error) {
+	var result issue767ProcessIO
+	if runtime.GOOS == "darwin" {
+		output, err := exec.CommandContext(ctx, "python3", "-c", issue767DarwinIOScript, strconv.Itoa(pid)).Output()
+		if err != nil {
+			return result, err
+		}
+		err = json.Unmarshal(output, &result)
+		return result, err
+	}
+	stat, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return result, err
+	}
+	end := strings.LastIndexByte(string(stat), ')')
+	if end < 0 {
+		return result, errors.New("invalid process stat")
+	}
+	fields := strings.Fields(string(stat[end+1:]))
+	if len(fields) < 20 {
+		return result, errors.New("process starttime missing")
+	}
+	result.StartTicks, err = strconv.ParseUint(fields[19], 10, 64)
+	if err != nil {
+		return result, err
+	}
+	raw, err := os.ReadFile(fmt.Sprintf("/proc/%d/io", pid))
+	if err != nil {
+		return result, err
+	}
+	for _, line := range strings.Split(string(raw), "\n") {
+		if value, found := strings.CutPrefix(line, "write_bytes:"); found {
+			result.BytesWritten, err = strconv.ParseUint(strings.TrimSpace(value), 10, 64)
+			return result, err
+		}
+	}
+	return result, errors.New("process write_bytes counter not found")
+}
+
+type issue767IdleReport struct {
+	Phase                         string
+	ElapsedSeconds                float64
+	ProcessBytesWritten           uint64
+	ProcessLogicalBytesWritten    *uint64 `json:",omitempty"`
+	WALBeforeBytes, WALAfterBytes int64
+	Before, After                 issue767GenerationSnapshot
+}
+
+func (f *issue767Fixture) measureIdle(phase string, duration time.Duration) issue767IdleReport {
+	f.t.Helper()
+	db := f.openReadOnly()
+	defer db.Close()
+	ctx, cancel := context.WithTimeout(f.t.Context(), duration+30*time.Second)
+	defer cancel()
+	before, err := issue767ReadGenerations(ctx, db)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	first, err := issue767ReadProcessIO(ctx, f.cmd.Process.Pid)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	if before.PrimaryRefFacts == 0 {
+		f.t.Fatal("selected primary did not persist reference facts; idle I/O would not exercise the repaired projection")
+	}
+	report := issue767IdleReport{Phase: phase, Before: before, WALBeforeBytes: issue767FileSize(f.store + "-wal")}
+	start := time.Now()
+	for time.Since(start) < duration {
+		if !f.searchHasSymbol(f.primary, "Issue767DirtyMarker") {
+			f.t.Fatal("read-only query lost the selected ready symbol")
+		}
+		select {
+		case <-ctx.Done():
+			f.t.Fatal(ctx.Err())
+		case <-time.After(5 * time.Second):
+		}
+	}
+	last, err := issue767ReadProcessIO(ctx, f.cmd.Process.Pid)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	if first.StartTicks != last.StartTicks || last.BytesWritten < first.BytesWritten {
+		f.t.Fatal("process identity/counter changed during sample")
+	}
+	report.ProcessBytesWritten = last.BytesWritten - first.BytesWritten
+	if first.LogicalBytesWritten != nil && last.LogicalBytesWritten != nil {
+		if *last.LogicalBytesWritten < *first.LogicalBytesWritten {
+			f.t.Fatal("logical write counter regressed during sample")
+		}
+		delta := *last.LogicalBytesWritten - *first.LogicalBytesWritten
+		report.ProcessLogicalBytesWritten = &delta
+	}
+	report.ElapsedSeconds = time.Since(start).Seconds()
+	report.WALAfterBytes = issue767FileSize(f.store + "-wal")
+	report.After, err = issue767ReadGenerations(ctx, db)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	if report.After.PrimaryRefFacts == 0 {
+		f.t.Error("selected primary lost its reference facts during the idle phase")
+	}
+	if report.Before.Sequence != report.After.Sequence {
+		f.t.Errorf("settled unchanged fixture allocated new generations: before=%+v after=%+v", report.Before, report.After)
+	}
+	// Retired payload may legitimately be collected during a long sample.
+	// Counts are evidence, not proof that no existing rows were rewritten.
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	f.write(filepath.Join(f.root, phase+".json"), string(data)+"\n")
+	f.t.Logf("%s: %s", f.root, data)
+	return report
+}
+
+func issue767FileSize(path string) int64 {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return info.Size()
+}
+
+func TestIssue767JSONEvidence(t *testing.T) {
+	for _, tc := range []struct {
+		name                   string
+		value                  any
+		wantFound, wantRefusal bool
+	}{
+		{"exact", map[string]any{"results": []any{map[string]any{"name": "marker"}}, "freshness": map[string]any{"exact": true}}, true, false},
+		{"sibling_fallback", map[string]any{"results": []any{map[string]any{"name": "marker"}}, "freshness": map[string]any{"exact": false}}, true, true},
+		{"wrapped", map[string]any{"text": "{\"name\":\"marker\",\"freshness\":{\"exact\":false}}"}, true, true},
+		{"tool_error", map[string]any{"error_code": "view_building"}, false, true},
+		{"missing", map[string]any{"results": []any{}}, false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			found, refusal := issue767JSONEvidence(tc.value, "marker")
+			if found != tc.wantFound || refusal != tc.wantRefusal {
+				t.Fatalf("got found=%v refusal=%v, want found=%v refusal=%v", found, refusal, tc.wantFound, tc.wantRefusal)
+			}
+		})
+	}
+}
+
+func TestIssue767RequiredTimeout(t *testing.T) {
+	for _, tc := range []struct {
+		idle     time.Duration
+		baseline bool
+		want     time.Duration
+	}{
+		{45 * time.Second, false, 270 * time.Second},
+		{time.Minute, true, 10 * time.Minute},
+		{30 * time.Minute, false, 34 * time.Minute},
+		{time.Hour, true, 128 * time.Minute},
+	} {
+		if got := issue767RequiredTimeout(tc.idle, tc.baseline); got != tc.want {
+			t.Errorf("idle=%s baseline=%v: got %s, want %s", tc.idle, tc.baseline, got, tc.want)
+		}
+	}
+}

--- a/docs/reference-fact-write-convergence.md
+++ b/docs/reference-fact-write-convergence.md
@@ -1,0 +1,131 @@
+# Reference-fact write convergence
+
+Performance specification and validation for [issue #767](https://github.com/zzet/gortex/issues/767).
+For checkout mutation routing, see [worktree-source-mutations.md](worktree-source-mutations.md).
+
+## Evidence and scope
+
+The September 2026 investigation identified a concrete source of write amplification in
+`Store.replaceRefFactsForFiles`: refreshing an unchanged frontier deleted its existing
+reference facts and inserted the same projection again. A controlled 1,000-fact frontier
+therefore performed 2,000 row mutations per call. A target-only change affecting one fact
+also rewrote all 1,000 facts. A 15-second sample of the active production daemon showed
+94.7% cumulative sampled CPU beneath this refresh path; that is CPU-stack attribution,
+not a measurement of its share of disk bytes or evidence that the daemon was idle.
+
+This fixes the demonstrated incremental reference-fact rewrite mechanism. It does not
+establish that this mechanism explains every observation in issue #767. Mutation-batch
+counts from different daemon lifetimes must not be used to calculate bytes per batch.
+Repository watermarks are generation-scoped; a different checkout SHA alone is not proof
+of cross-checkout corruption.
+
+## Required behavior and implementation
+
+For one `(view_gen, repo_prefix, source-file frontier)`, recomputing an identical reference-fact
+projection must not mutate its persisted rows. Changed facts must update only their changed
+payload; newly eligible facts must be inserted, and obsolete or newly ineligible facts removed.
+File moves, target-name changes, candidates, language, resolution origin/tier, source deletion,
+and cross-generation isolation must retain their existing semantics. A source-content hash
+cannot replace this comparison: unchanged source can have changed resolution or target metadata.
+
+The implementation retains a two-statement transaction: scoped deletion of identities no longer
+in the desired projection, followed by an UPSERT whose update predicate compares all six non-key
+payload columns using null-safe comparisons. The projection starts from requested files. Its
+fact-identity collisions are collapsed deterministically before reconciliation; each statement
+materializes its own desired set. The embedded SQLite plan must use a keyed anti-join lookup,
+not a correlated full scan of the desired set for every old fact.
+
+There is no schema migration, new index, public signature, full-repository rebuild, checkpoint
+policy, or automatic compaction change. The query must not introduce a hard dependency on the
+optional `nodes_by_file` index, which bulk loading can temporarily remove. The existing transaction
+helpers return a plain SQL transaction and do not themselves advance graph revisions or invalidate
+analysis on this reference-fact path. This does not rule out surrounding indexer activity.
+
+## Measured storage regression
+
+Apple M1 Pro, darwin/arm64, Go 1.27.0, embedded modernc SQLite v1.58.0; baseline
+`0f462eff08089704618be886b221a5412feff04d`. Each case has 1,000 facts plus 10,000 unrelated
+nodes. Results are medians of three 20-iteration runs; final timing was rerun after the heavy
+race suite finished.
+
+| Refresh | Baseline time | Fixed time | Baseline rows/op | Fixed rows/op | Baseline WAL bytes/op | Fixed WAL bytes/op |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Unchanged | 38.018 ms | 29.519 ms | 2,000 | 0 | 255,442 | 0 |
+| One changed target | 38.032 ms | 30.229 ms | 2,000 | 1 | 267,802 | 20,602 |
+
+The changed-target case includes the underlying target-node update in its time and WAL accounting;
+the row-mutation metric counts only reference-fact refresh. A separate repeated-refresh test
+asserts zero row mutations and WAL growth for identical facts. The changed-target WAL reduction
+is 92.3%; these figures must not be extrapolated directly to whole-daemon or SSD NAND writes.
+
+```sh
+go test ./internal/graph/store_sqlite -run '^$' -bench '^BenchmarkRefFactRefreshWrites$' -benchtime=20x -count=3 -benchmem
+go test -race ./internal/graph/store_sqlite -timeout=30m
+```
+
+Correctness tests cover generation/source/target isolation, eligibility boundaries, duplicate-edge
+identity convergence, payload-only changes, moved/deleted source files, missing optional indexes,
+existing rollback behavior, and the actual embedded-driver query plan. Normal storage/indexer
+suites, the full storage race suite, targeted indexer and helper race tests, build, and scoped lint
+are the validation gates for this change.
+
+## Isolated daemon validation
+
+The opt-in `TestIssue767IdleIOIntegration` uses explicit test binaries and private XDG
+configuration/data/cache roots. It never invokes a global daemon restart, store deletion, or
+re-track. Its primary checkout stays dirty while an automatic linked worktree is created, edited,
+queried with an exact selector, and removed. Primary queries use its own CWD. Assertions cover
+primary isolation, removal cleanup, warm restart, selected-primary facts before and after idle,
+generation allocation (including create-and-GC cycles), and same-process I/O counters.
+
+Default CI skips the daemon test unless a binary is supplied. Requested durations are bounded
+and checked against Go's test deadline before creating fixtures; captured children have
+cancellation/exit deadlines and identity-bound cleanup. The optional write budget is an explicit
+assertion, not an invented default SLO.
+
+The matched baseline/fixed 60-second lifecycle smoke passed, as did the final safeguarded
+15-second cold/warm smoke and deadline-refusal tests. The final binary's continuous warm window
+lasted 1,804.759 seconds: 1,212,416 process disk-accounted bytes (about 672 B/s) and 43,778,776
+logical bytes (about 24.3 kB/s). WAL size changed from 78,312 to 539,752 bytes; this was not a
+zero-I/O run. The primary stayed at 101 nodes, 200 edges, and two reference facts. Generation
+allocation stayed at 2 with zero retained overlay generations, including six external progress
+samples. Independent checks before the phase and after clean teardown confirmed both facts
+belonged to primary generation 0 and repository `issue767`, with only the primary checkout left.
+No restart or safety-cap crossing occurred during the window. The captured child, socket, and
+PID file were absent after teardown.
+
+The long run used the same final production binary as the final guarded short smoke
+(SHA-256 `e1c8433ab2839513a87bac20a81b9f13d2e4282b28a916fb2e934402c32dfc9f`). It began
+before the two harness safeguards were added; its 45-minute test deadline and independent
+primary-scope checks supplied those protections. The finalized guarded harness was separately
+smoke-tested, including refusal of a one-hour request under a five-second test deadline before
+any fixture or child existed.
+
+For a 30-minute warm run, supply absolute disposable outer XDG directories too:
+
+```sh
+env XDG_CONFIG_HOME=/absolute/disposable/check/config \
+    XDG_DATA_HOME=/absolute/disposable/check/data \
+    XDG_CACHE_HOME=/absolute/disposable/check/cache \
+    GORTEX_ISSUE767_TEST_BINARY=/absolute/path/to/gortex \
+    GORTEX_ISSUE767_ARTIFACT_DIR=/absolute/disposable/artifacts \
+    GORTEX_ISSUE767_IDLE_DURATION=30m \
+    go test ./cmd/gortex -run '^TestIssue767IdleIOIntegration$' -count=1 -timeout=45m -v
+```
+
+`GORTEX_ISSUE767_BASELINE_BINARY` optionally adds a matched baseline run; allow a larger test
+deadline for two long runs. `GORTEX_ISSUE767_WRITE_BUDGET_BYTES` optionally sets a positive
+per-phase disk-accounted write budget for the fixed binary; unset or zero is measurement-only.
+
+## Limits of the claim
+
+The small fixture validates lifecycle and convergence, not reproduction of the production-scale
+incident. Both baseline and fixed short runs had low, nonzero logical/WAL activity. Background
+metadata/log/checkpoint activity is not synonymous with reference-fact rewrites. Constant database
+or WAL sizes alone do not prove an absence of writes; process counters are not NAND measurements.
+
+The measured SQL frontier is 1,000 facts. Larger 10,000/100,000-fact frontiers and transient
+sort/materialization spills are not covered: zero persisted changes and WAL growth do not guarantee
+zero temporary-file I/O. Incident-scale post-deployment profiling remains a follow-up. This change
+also does not shrink an already enlarged store; it avoids unnecessary incremental rewrites
+without destructive cleanup.

--- a/internal/graph/store_sqlite/ref_facts_rebuild.go
+++ b/internal/graph/store_sqlite/ref_facts_rebuild.go
@@ -137,10 +137,70 @@ WHERE view_gen = ?
 	return statements, nil
 }
 
-// ReplaceRefFactsForFiles atomically delete-then-refills the exact changed-file
-// frontier. The delete is deliberately scoped by repo even though graph paths
-// are normally prefixed: stale facts for a now-empty/removed file still need
-// deletion, and a same-named file in another repository must survive.
+// refFactFileProjection starts with the requested files, not the whole repo.
+// Fact identity omits edge.file_path: collapse collisions before comparing
+// payloads, with highest edge rowid as a deterministic winner matching the
+// existing adjacency traversal. Otherwise colliding facts can oscillate even
+// when the graph is unchanged. Each statement materializes its own desired
+// set within the same transaction, avoiding a projection per old fact.
+const refFactFileProjection = `WITH selected AS (
+    SELECT n.repo_prefix, e.from_id, e.to_id, e.kind,
+           COALESCE(t.name, '') AS ref_name, e.line,
+           ` + refFactOriginExpr + ` AS effective_origin,
+           n.file_path, n.language, e.id AS edge_id
+    FROM json_each(?) AS requested
+    CROSS JOIN nodes AS n
+      ON n.repo_prefix = ? AND n.file_path = CAST(requested.value AS TEXT)
+    JOIN edges AS e INDEXED BY edges_by_from
+      ON e.from_id = n.id AND e.view_gen = n.view_gen
+    LEFT JOIN nodes AS t ON t.id = e.to_id AND t.view_gen = e.view_gen
+    WHERE ` + refFactEligiblePredicate + ` AND n.view_gen = ?
+), ranked AS (
+    SELECT ? AS view_gen, repo_prefix, from_id, to_id, kind, ref_name, line,
+           effective_origin AS origin,
+           CASE effective_origin
+               WHEN 'lsp_resolved' THEN 'lsp'
+               WHEN 'lsp_dispatch' THEN 'lsp'
+               WHEN 'ast_resolved' THEN 'ast'
+               ELSE 'heuristic'
+           END AS tier,
+           '' AS candidates, file_path, language AS lang,
+           ROW_NUMBER() OVER (
+               PARTITION BY repo_prefix, from_id, to_id, kind, line
+               ORDER BY edge_id DESC
+           ) AS fact_rank
+    FROM selected
+), desired AS MATERIALIZED (
+    SELECT ` + refFactColumns + ` FROM ranked WHERE fact_rank = 1
+)
+`
+
+const refFactDeleteObsolete = refFactFileProjection + `DELETE FROM ref_facts
+WHERE view_gen = ? AND repo_prefix = ?
+  AND file_path IN (SELECT CAST(value AS TEXT) FROM json_each(?))
+  AND NOT EXISTS (
+      SELECT 1 FROM desired AS d
+      WHERE d.view_gen = ref_facts.view_gen AND d.repo_prefix = ref_facts.repo_prefix
+        AND d.from_id = ref_facts.from_id AND d.to_id = ref_facts.to_id
+        AND d.kind = ref_facts.kind AND d.line = ref_facts.line
+  )`
+
+const refFactUpsertChanged = refFactFileProjection + `INSERT INTO ref_facts (` + refFactColumns + `)
+SELECT ` + refFactColumns + ` FROM desired WHERE true
+ON CONFLICT (view_gen, repo_prefix, from_id, to_id, kind, line) DO UPDATE SET
+    ref_name = excluded.ref_name, origin = excluded.origin, tier = excluded.tier,
+    candidates = excluded.candidates, file_path = excluded.file_path, lang = excluded.lang
+WHERE ref_facts.ref_name IS NOT excluded.ref_name
+   OR ref_facts.origin IS NOT excluded.origin
+   OR ref_facts.tier IS NOT excluded.tier
+   OR ref_facts.candidates IS NOT excluded.candidates
+   OR ref_facts.file_path IS NOT excluded.file_path
+   OR ref_facts.lang IS NOT excluded.lang`
+
+// ReplaceRefFactsForFiles atomically applies only changed reference facts in
+// the exact file frontier. Unchanged payloads perform no persistent writes.
+// Deletion remains repo-scoped so removed/empty files lose stale facts without
+// disturbing a same-named file in another repository or generation.
 func (s *Store) ReplaceRefFactsForFiles(repoPrefix string, files []string) error {
 	_, err := s.replaceRefFactsForFiles(repoPrefix, files)
 	return err
@@ -164,18 +224,13 @@ func (s *Store) replaceRefFactsForFiles(repoPrefix string, files []string) (stat
 	}
 	defer tx.Rollback() //nolint:errcheck // no-op after Commit
 
-	if _, err := tx.Exec(`DELETE FROM ref_facts
-WHERE view_gen = ?
-  AND repo_prefix = ?
-  AND file_path IN (SELECT CAST(value AS TEXT) FROM json_each(?))`, s.viewGen, repoPrefix, string(filesJSON)); err != nil {
+	if _, err := tx.Exec(refFactDeleteObsolete,
+		string(filesJSON), repoPrefix, s.viewGen, s.viewGen,
+		s.viewGen, repoPrefix, string(filesJSON)); err != nil {
 		return statements, err
 	}
 	statements++
-	insert := refFactInsertPrefix + `    FROM json_each(?) AS requested
-    JOIN nodes AS n
-      ON n.repo_prefix = ? AND n.file_path = CAST(requested.value AS TEXT)
-    JOIN edges AS e INDEXED BY edges_by_from ON e.from_id = n.id AND e.view_gen = n.view_gen` + refFactInsertSuffix
-	if _, err := tx.Exec(insert, string(filesJSON), repoPrefix, s.viewGen, s.viewGen); err != nil {
+	if _, err := tx.Exec(refFactUpsertChanged, string(filesJSON), repoPrefix, s.viewGen, s.viewGen); err != nil {
 		return statements, fmt.Errorf("ref-facts refill: %w", err)
 	}
 	statements++

--- a/internal/graph/store_sqlite/ref_facts_write_amplification_test.go
+++ b/internal/graph/store_sqlite/ref_facts_write_amplification_test.go
@@ -1,0 +1,334 @@
+package store_sqlite
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+// The fixture includes unrelated files in the same repository: an incremental
+// refresh must not require a repository-wide node scan to find its frontier.
+func seedRefFactWriteFixture(tb testing.TB, store *Store, count, unrelated int) {
+	tb.Helper()
+	nodes := make([]*graph.Node, 0, count*2+unrelated)
+	edges := make([]*graph.Edge, 0, count)
+	for i := 0; i < count; i++ {
+		from, to := fmt.Sprintf("repo::Caller%d", i), fmt.Sprintf("repo::Target%d", i)
+		nodes = append(nodes,
+			refFactTestNode(from, "Caller", "repo/changed.go", "repo", graph.KindFunction),
+			refFactTestNode(to, "Target", "repo/targets.go", "repo", graph.KindFunction))
+		edges = append(edges, &graph.Edge{From: from, To: to, Kind: graph.EdgeCalls, FilePath: "repo/changed.go", Line: i + 1, Confidence: 1})
+	}
+	for i := 0; i < unrelated; i++ {
+		nodes = append(nodes, refFactTestNode(fmt.Sprintf("repo::Other%d", i), "Other", fmt.Sprintf("repo/other%d.go", i), "repo", graph.KindFunction))
+	}
+	store.AddBatch(nodes, edges)
+	require.NoError(tb, store.ReplaceRefFactsForFiles("repo", []string{"repo/changed.go"}))
+}
+
+func refFactTotalChanges(tb testing.TB, store *Store) int64 {
+	tb.Helper()
+	var changes int64
+	require.NoError(tb, store.writerDB.QueryRow(`SELECT total_changes()`).Scan(&changes))
+	return changes
+}
+
+func TestRefFactRefreshUnchangedWritesNothing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "no-op.sqlite")
+	store, err := Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	seedRefFactWriteFixture(t, store, 100, 1000)
+	// This is a disposable test store, never the user's daemon database.
+	_, err = store.writerDB.Exec(`PRAGMA wal_checkpoint(TRUNCATE)`)
+	require.NoError(t, err)
+	before := refFactTotalChanges(t, store)
+	for i := 0; i < 5; i++ {
+		require.NoError(t, store.ReplaceRefFactsForFiles("repo", []string{"repo/changed.go", "", "repo/missing.go", "repo/changed.go"}))
+	}
+	require.Equal(t, int64(0), refFactTotalChanges(t, store)-before, "unchanged facts must not be deleted, inserted, or updated")
+	wal, err := os.Stat(path + "-wal")
+	require.NoError(t, err)
+	require.Zero(t, wal.Size(), "unchanged refreshes must not append WAL frames")
+}
+
+func TestRefFactRefreshOnlyWritesChangedFacts(t *testing.T) {
+	store := openRefFactRebuildStore(t)
+	seedRefFactWriteFixture(t, store, 20, 20)
+	_, err := store.writerDB.Exec(`UPDATE nodes SET name = 'Renamed' WHERE id = 'repo::Target0' AND view_gen = 0`)
+	require.NoError(t, err)
+	before := refFactTotalChanges(t, store)
+	require.NoError(t, store.ReplaceRefFactsForFiles("repo", []string{"repo/changed.go"}))
+	require.Equal(t, int64(1), refFactTotalChanges(t, store)-before, "target-only renames update exactly one fact")
+	facts, err := store.LoadRefFactsByFiles("repo", []string{"repo/changed.go"})
+	require.NoError(t, err)
+	require.Len(t, facts, 20)
+	require.Equal(t, "Renamed", factsByKey(facts)["repo::Caller0->repo::Target0:calls"].RefName)
+
+	_, err = store.writerDB.Exec(`UPDATE edges SET origin = 'lsp_resolved' WHERE from_id = 'repo::Caller0' AND view_gen = 0`)
+	require.NoError(t, err)
+	before = refFactTotalChanges(t, store)
+	require.NoError(t, store.ReplaceRefFactsForFiles("repo", []string{"repo/changed.go"}))
+	require.Equal(t, int64(1), refFactTotalChanges(t, store)-before)
+	facts, err = store.LoadRefFactsByFiles("repo", []string{"repo/changed.go"})
+	require.NoError(t, err)
+	fact := factsByKey(facts)["repo::Caller0->repo::Target0:calls"]
+	require.Equal(t, "lsp_resolved", fact.Origin)
+	require.Equal(t, "lsp", fact.Tier)
+
+	_, err = store.writerDB.Exec(`DELETE FROM edges WHERE from_id = 'repo::Caller0' AND view_gen = 0`)
+	require.NoError(t, err)
+	before = refFactTotalChanges(t, store)
+	require.NoError(t, store.ReplaceRefFactsForFiles("repo", []string{"repo/changed.go"}))
+	require.Equal(t, int64(1), refFactTotalChanges(t, store)-before, "only the obsolete fact is deleted")
+
+	_, err = store.writerDB.Exec(`DELETE FROM nodes WHERE file_path = 'repo/changed.go' AND view_gen = 0`)
+	require.NoError(t, err)
+	before = refFactTotalChanges(t, store)
+	require.NoError(t, store.ReplaceRefFactsForFiles("repo", []string{"repo/changed.go"}))
+	require.Equal(t, int64(19), refFactTotalChanges(t, store)-before)
+	facts, err = store.LoadRefFactsByFiles("repo", []string{"repo/changed.go"})
+	require.NoError(t, err)
+	require.Empty(t, facts, "a removed/empty file must not retain facts")
+	before = refFactTotalChanges(t, store)
+	require.NoError(t, store.ReplaceRefFactsForFiles("repo", []string{"repo/changed.go"}))
+	require.Equal(t, before, refFactTotalChanges(t, store))
+}
+
+func TestRefFactRefreshPreservesOtherGenerations(t *testing.T) {
+	store := openRefFactRebuildStore(t)
+	seedRefFactWriteFixture(t, store, 2, 0)
+	_, err := store.writerDB.Exec(`INSERT INTO ref_facts (` + refFactColumns + `)
+SELECT 17, repo_prefix, from_id, to_id, kind, 'Foreign', line, origin, tier, candidates, file_path, lang FROM ref_facts WHERE view_gen = 0`)
+	require.NoError(t, err)
+	_, err = store.writerDB.Exec(`DELETE FROM edges WHERE view_gen = 0`)
+	require.NoError(t, err)
+	require.NoError(t, store.ReplaceRefFactsForFiles("repo", []string{"repo/changed.go"}))
+	var count int
+	require.NoError(t, store.db.QueryRow(`SELECT COUNT(*) FROM ref_facts WHERE view_gen = 17 AND ref_name = 'Foreign'`).Scan(&count))
+	require.Equal(t, 2, count)
+}
+
+func TestRefFactRefreshDuplicateEdgeIdentityConverges(t *testing.T) {
+	store := openRefFactRebuildStore(t)
+	seedRefFactWriteFixture(t, store, 1, 0)
+	// Edge identity includes file_path; fact identity deliberately does not.
+	// Preserve the legacy adjacency traversal's last-row winner for collisions.
+	store.AddBatch(nil, []*graph.Edge{{From: "repo::Caller0", To: "repo::Target0", Kind: graph.EdgeCalls, FilePath: "repo/alternate.go", Line: 1, Confidence: 0.6}})
+	require.NoError(t, store.RebuildRefFactsForRepos([]string{"repo"}))
+	want, err := store.LoadRefFactsByFiles("repo", nil)
+	require.NoError(t, err)
+	require.Len(t, want, 1)
+	require.Equal(t, "ast_inferred", want[0].Origin)
+	before := refFactTotalChanges(t, store)
+	require.NoError(t, store.ReplaceRefFactsForFiles("repo", []string{"repo/changed.go"}))
+	got, err := store.LoadRefFactsByFiles("repo", nil)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+	require.Equal(t, before, refFactTotalChanges(t, store), "colliding projected identities must converge without alternating payloads")
+}
+
+func TestRefFactRefreshSourceAndTargetGenerationIsolation(t *testing.T) {
+	store := openRefFactRebuildStore(t)
+	for _, fixture := range []struct {
+		generation int64
+		targetName string
+		language   string
+	}{{0, "CanonicalTarget", "go"}, {17, "OverlayTarget", "typescript"}} {
+		layer := store.AtGeneration(fixture.generation)
+		source := refFactTestNode("repo::Caller", "Caller", "repo/changed.go", "repo", graph.KindFunction)
+		source.Language = fixture.language
+		layer.AddBatch([]*graph.Node{source, refFactTestNode("repo::Target", fixture.targetName, "repo/targets.go", "repo", graph.KindFunction)}, []*graph.Edge{{From: "repo::Caller", To: "repo::Target", Kind: graph.EdgeCalls, Line: 7, Confidence: 1}})
+	}
+	for _, generation := range []int64{0, 17} {
+		require.NoError(t, store.AtGeneration(generation).ReplaceRefFactsForFiles("repo", []string{"repo/changed.go"}))
+	}
+	for _, want := range []struct {
+		generation int64
+		targetName string
+		language   string
+	}{{0, "CanonicalTarget", "go"}, {17, "OverlayTarget", "typescript"}} {
+		var count int
+		var targetName, language string
+		require.NoError(t, store.db.QueryRow(`SELECT COUNT(*) FROM ref_facts WHERE view_gen = ?`, want.generation).Scan(&count))
+		require.Equal(t, 1, count, "same node IDs in another generation must not multiply facts")
+		require.NoError(t, store.db.QueryRow(`SELECT ref_name, lang FROM ref_facts WHERE view_gen = ?`, want.generation).Scan(&targetName, &language))
+		require.Equal(t, want.targetName, targetName, "target join must use the edge generation")
+		require.Equal(t, want.language, language, "source join must use the edge generation")
+	}
+	before := refFactTotalChanges(t, store)
+	for _, generation := range []int64{17, 0, 17} {
+		require.NoError(t, store.AtGeneration(generation).ReplaceRefFactsForFiles("repo", []string{"repo/changed.go"}))
+	}
+	require.Equal(t, before, refFactTotalChanges(t, store), "unchanged refresh must not rewrite either generation")
+}
+
+func TestRefFactRefreshMovedSourceAndPayloadConverge(t *testing.T) {
+	store := openRefFactRebuildStore(t)
+	seedRefFactWriteFixture(t, store, 1, 0)
+	files := []string{"repo/changed.go"}
+	_, err := store.writerDB.Exec(`UPDATE ref_facts SET candidates = 'stale-candidate' WHERE view_gen = 0 AND repo_prefix = 'repo'`)
+	require.NoError(t, err)
+	before := refFactTotalChanges(t, store)
+	require.NoError(t, store.ReplaceRefFactsForFiles("repo", files))
+	require.Equal(t, int64(1), refFactTotalChanges(t, store)-before, "candidate-only mismatch must update one fact")
+	var candidates string
+	require.NoError(t, store.db.QueryRow(`SELECT candidates FROM ref_facts WHERE view_gen = 0 AND repo_prefix = 'repo'`).Scan(&candidates))
+	require.Empty(t, candidates)
+
+	_, err = store.writerDB.Exec(`UPDATE nodes SET language = 'typescript' WHERE view_gen = 0 AND id = 'repo::Caller0'`)
+	require.NoError(t, err)
+	before = refFactTotalChanges(t, store)
+	require.NoError(t, store.ReplaceRefFactsForFiles("repo", files))
+	require.Equal(t, int64(1), refFactTotalChanges(t, store)-before, "language-only mismatch must update one fact")
+	var language string
+	require.NoError(t, store.db.QueryRow(`SELECT lang FROM ref_facts WHERE view_gen = 0 AND repo_prefix = 'repo'`).Scan(&language))
+	require.Equal(t, "typescript", language)
+
+	_, err = store.writerDB.Exec(`UPDATE nodes SET file_path = 'repo/moved.go' WHERE view_gen = 0 AND id = 'repo::Caller0'`)
+	require.NoError(t, err)
+	files = []string{"repo/changed.go", "repo/moved.go"}
+	before = refFactTotalChanges(t, store)
+	require.NoError(t, store.ReplaceRefFactsForFiles("repo", files))
+	require.Equal(t, int64(1), refFactTotalChanges(t, store)-before, "file-only mismatch must update one fact")
+	var count int
+	var file string
+	require.NoError(t, store.db.QueryRow(`SELECT COUNT(*) FROM ref_facts WHERE view_gen = 0 AND repo_prefix = 'repo'`).Scan(&count))
+	require.Equal(t, 1, count, "moving a source must remove its obsolete file frontier")
+	require.NoError(t, store.db.QueryRow(`SELECT file_path, lang, candidates FROM ref_facts WHERE view_gen = 0 AND repo_prefix = 'repo'`).Scan(&file, &language, &candidates))
+	require.Equal(t, "repo/moved.go", file)
+	require.Equal(t, "typescript", language)
+	require.Empty(t, candidates)
+	before = refFactTotalChanges(t, store)
+	require.NoError(t, store.ReplaceRefFactsForFiles("repo", []string{"repo/moved.go", "repo/changed.go", "repo/moved.go"}))
+	require.Equal(t, before, refFactTotalChanges(t, store), "reordered duplicate frontiers must converge")
+}
+
+func TestRefFactRefreshRemovesNewlyIneligibleFacts(t *testing.T) {
+	for _, fixture := range []struct {
+		name     string
+		target   string
+		kind     string
+		eligible bool
+	}{
+		{"missing_named_target", "repo::Missing", "calls", true},
+		{"empty_target", "", "calls", false},
+		{"unresolved", "unresolved::Missing", "calls", false},
+		{"prefixed_unresolved", "repo::unresolved::Missing", "calls", false},
+		{"stdlib", "stdlib::Print", "calls", false},
+		{"prefixed_stdlib", "repo::stdlib::Print", "calls", false},
+		{"external", "external_call::Print", "calls", false},
+		{"builtin", "builtin::Print", "calls", false},
+		{"module", "module::Print", "calls", false},
+		{"case_sensitive_id", "Unresolved::StillNamed", "calls", true},
+		{"different_reference_kind", "repo::Target0", "references", true},
+		{"non_reference_kind", "repo::Target0", "contains", false},
+	} {
+		t.Run(fixture.name, func(t *testing.T) {
+			store := openRefFactRebuildStore(t)
+			seedRefFactWriteFixture(t, store, 1, 0)
+			_, err := store.writerDB.Exec(`UPDATE edges SET to_id = ?, kind = ? WHERE view_gen = 0 AND from_id = 'repo::Caller0'`, fixture.target, fixture.kind)
+			require.NoError(t, err)
+			require.NoError(t, store.ReplaceRefFactsForFiles("repo", []string{"repo/changed.go"}))
+			var count int
+			require.NoError(t, store.db.QueryRow(`SELECT COUNT(*) FROM ref_facts WHERE view_gen = 0 AND repo_prefix = 'repo'`).Scan(&count))
+			want := 0
+			if fixture.eligible {
+				want = 1
+			}
+			require.Equal(t, want, count)
+			if fixture.eligible {
+				var target, kind string
+				require.NoError(t, store.db.QueryRow(`SELECT to_id, kind FROM ref_facts WHERE view_gen = 0 AND repo_prefix = 'repo'`).Scan(&target, &kind))
+				require.Equal(t, fixture.target, target)
+				require.Equal(t, fixture.kind, kind)
+			}
+			before := refFactTotalChanges(t, store)
+			require.NoError(t, store.ReplaceRefFactsForFiles("repo", []string{"repo/changed.go"}))
+			require.Equal(t, before, refFactTotalChanges(t, store), "the eligibility state must settle without further writes")
+		})
+	}
+}
+
+func TestRefFactRefreshWithoutOptionalNodeFileIndex(t *testing.T) {
+	store := openRefFactRebuildStore(t)
+	seedRefFactWriteFixture(t, store, 10, 10)
+	_, err := store.writerDB.Exec(`DROP INDEX nodes_by_file`)
+	require.NoError(t, err)
+	before := refFactTotalChanges(t, store)
+	require.NoError(t, store.ReplaceRefFactsForFiles("repo", []string{"repo/changed.go"}), "bulk loading may temporarily remove the optional node-file index")
+	require.Equal(t, before, refFactTotalChanges(t, store))
+}
+
+func TestRefFactRefreshEmbeddedQueryPlanUsesIndexedFrontier(t *testing.T) {
+	store := openRefFactRebuildStore(t)
+	seedRefFactWriteFixture(t, store, 256, 1024)
+	filesJSON := `["repo/changed.go"]`
+	for _, fixture := range []struct {
+		name string
+		sql  string
+		args []any
+	}{
+		{"obsolete", refFactDeleteObsolete, []any{filesJSON, "repo", store.viewGen, store.viewGen, store.viewGen, "repo", filesJSON}},
+		{"changed", refFactUpsertChanged, []any{filesJSON, "repo", store.viewGen, store.viewGen}},
+	} {
+		t.Run(fixture.name, func(t *testing.T) {
+			rows, err := store.db.Query("EXPLAIN QUERY PLAN "+fixture.sql, fixture.args...)
+			require.NoError(t, err)
+			defer func() { require.NoError(t, rows.Close()) }()
+			var details []string
+			for rows.Next() {
+				var id, parent, unused int
+				var detail string
+				require.NoError(t, rows.Scan(&id, &parent, &unused, &detail))
+				details = append(details, detail)
+			}
+			require.NoError(t, rows.Err())
+			plan := fmt.Sprint(details)
+			t.Logf("embedded SQLite %s plan: %s", fixture.name, plan)
+			require.Contains(t, plan, "nodes_by_file", "file-frontier refresh must not scan all repository source nodes")
+			require.Contains(t, plan, "edges_by_from", "edge lookup must start from selected source IDs")
+			if fixture.name == "obsolete" {
+				require.Regexp(t, `\bSEARCH d\b`, plan, "each old fact must probe the indexed desired-key set")
+				require.NotRegexp(t, `\bSCAN d\b`, plan, "a correlated full desired-set scan makes no-op refresh quadratic")
+			}
+		})
+	}
+}
+
+func BenchmarkRefFactRefreshWrites(b *testing.B) {
+	for _, changed := range []bool{false, true} {
+		b.Run(fmt.Sprintf("changed=%t", changed), func(b *testing.B) {
+			path := filepath.Join(b.TempDir(), "facts.sqlite")
+			store, err := Open(path)
+			require.NoError(b, err)
+			b.Cleanup(func() { require.NoError(b, store.Close()) })
+			seedRefFactWriteFixture(b, store, 1000, 10000)
+			_, err = store.writerDB.Exec(`PRAGMA wal_autocheckpoint=0`)
+			require.NoError(b, err)
+			_, err = store.writerDB.Exec(`PRAGMA wal_checkpoint(TRUNCATE)`)
+			require.NoError(b, err)
+			var rows int64
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if changed {
+					_, err = store.writerDB.Exec(`UPDATE nodes SET name = ? WHERE id = 'repo::Target0' AND view_gen = 0`, fmt.Sprintf("Renamed%d", i))
+					require.NoError(b, err)
+				}
+				before := refFactTotalChanges(b, store)
+				require.NoError(b, store.ReplaceRefFactsForFiles("repo", []string{"repo/changed.go"}))
+				rows += refFactTotalChanges(b, store) - before
+			}
+			b.StopTimer()
+			b.ReportMetric(float64(rows)/float64(b.N), "rows/op")
+			wal, err := os.Stat(path + "-wal")
+			require.NoError(b, err)
+			b.ReportMetric(float64(wal.Size())/float64(b.N), "wal-B/op")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Refs #767.

- Replace incremental reference-fact delete/refill with scoped deletion of obsolete facts and a conditional UPSERT of changed payloads.
- Start the projection from the requested file frontier, collapse duplicate fact identities deterministically, and preserve generation isolation and transaction semantics.
- Add regression tests, embedded SQLite query-plan checks, a reproducible write benchmark, and an opt-in isolated worktree lifecycle/idle-I/O harness.
- Document the evidence, invariant, measurements, and limitations in [the performance specification](docs/reference-fact-write-convergence.md).

No schema migration, new index, public API change, checkpoint tuning, store deletion, or live-daemon restart.

## Measured result

1,000 facts + 10,000 unrelated nodes; Apple M1 Pro, Go 1.27.0, modernc SQLite v1.58.0; baseline `0f462eff`. Medians of three 20-iteration runs.

| Refresh | Row mutations, before → after | WAL bytes/op, before → after | Time, before → after |
| --- | ---: | ---: | ---: |
| Unchanged | 2,000 → 0 | 255,442 → 0 | 38.018 → 29.519 ms |
| One changed target | 2,000 → 1 | 267,802 → 20,602 | 38.032 → 30.229 ms |

The changed-target case includes the underlying node update in WAL/time, but counts only fact refreshes in the row metric. This is a 92.3% WAL reduction for that case, not a whole-daemon/SSD-write claim.

## Validation

Passed locally on the final production code:

- Full normal storage suite (55.606s) and final full indexer suite (410.317s).
- Full storage race suite (1,073.317s); targeted indexer race (10.838s), reference-fact race (30.007s), and harness-helper race (1.627s).
- Build, gofmt/whitespace checks, and scoped linter: zero issues.
- Baseline/fixed isolated lifecycle smoke (382.805s).
- Final safeguarded lifecycle smoke (98.719s), including selected-primary facts and preflight deadline refusal before creating a fixture/child.
- Continuous 30-minute warm soak: 1,804.759s, **1,212,416 disk-accounted bytes** and **43,778,776 logical bytes**. Generation allocation stayed at 2; 101 nodes, 200 edges, and 2 primary-scoped facts stayed unchanged. The captured child/socket/PID file were cleaned up.

The lifecycle leaves the primary dirty after creating, editing, querying, and removing an automatic linked worktree, then warm-restarts only the isolated child. The long run began before the two final harness safeguards; an explicit 45-minute deadline and independent before/after primary-scope checks supplied those protections. The finalized harness was separately smoke-tested against the same daemon binary.

The daemon harness is opt-in; ordinary CI runs its helper tests without launching a daemon. Reproduction commands and binary fingerprint are in the specification.

## Scope and remaining uncertainty

This fixes a proven, profiled incremental write-amplification mechanism. It does **not** establish that it explains every observation in #767: both baseline and fixed tiny-fixture runs had low, nonzero background I/O and did not reproduce the production-scale incident.

The measured SQL frontier is 1,000 facts. Larger-frontier/transient-sort I/O and incident-scale post-deployment profiling remain follow-ups. Zero fact-row/WAL writes is not a guarantee of zero temporary-file or other daemon writes. Existing enlarged stores are not automatically compacted.

## Commits

- `627432c5`: storage fix, correctness regressions, and benchmark.
- `c1e0d8eb`: isolated validation harness and specification.
