### PR TITLE
fix(worktrees): prioritize selected views and bound sparse scans

### DIFF
--- a/cmd/gortex/issue767_worktree_readiness_integration_test.go
+++ b/cmd/gortex/issue767_worktree_readiness_integration_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestIssue767WorktreeReadinessIntegration exercises the agent workflow against
+// an explicitly supplied binary in a private daemon, store, and Git fixture.
+// It never connects to or restarts the user's daemon. Admission under an occupied
+// build gate is covered by deterministic coordinator tests, not wall-clock races
+// between child processes here.
+func TestIssue767WorktreeReadinessIntegration(t *testing.T) {
+	binary := os.Getenv("GORTEX_ISSUE767_READINESS_BINARY")
+	if binary == "" {
+		t.Skip("set GORTEX_ISSUE767_READINESS_BINARY for isolated worktree validation")
+	}
+	if deadline, ok := t.Deadline(); ok && time.Until(deadline) < 6*time.Minute {
+		t.Fatal("use go test -timeout 10m or longer for isolated worktree validation")
+	}
+	binary, err := filepath.Abs(binary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(binary); err != nil {
+		t.Fatal(err)
+	}
+	f := newIssue767Fixture(t, binary)
+	f.start()
+	f.awaitSymbol(f.primary, "Issue767PrimaryMarker")
+
+	// A clean checkout at the same HEAD is automatically discovered. No track
+	// call or tracking-config edit is permitted for this linked checkout.
+	started := time.Now()
+	f.git(f.primary, "worktree", "add", "-b", "issue767-readiness", f.linked)
+	f.awaitSymbol(f.linked, "Issue767PrimaryMarker")
+	t.Logf("new clean worktree to exact search: %s", time.Since(started))
+	path := filepath.Join(f.linked, "marker.go")
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	match := "func Issue767PrimaryMarker()"
+	replacement := "func Issue767EditedMarker()"
+	if strings.Count(string(before), match) != 1 {
+		t.Fatal("fixture must contain exactly one edit target")
+	}
+	f.readinessEdit(path, match, replacement, true)
+	afterPreview, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(afterPreview) != string(before) {
+		t.Fatal("edit dry run modified the working copy")
+	}
+
+	started = time.Now()
+	f.readinessEdit(path, match, replacement, false)
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := strings.Replace(string(before), match, replacement, 1); string(after) != want {
+		t.Fatalf("edit wrote unexpected source: %q", after)
+	}
+	f.awaitSymbol(f.linked, "Issue767EditedMarker")
+	t.Logf("worktree edit to exact refreshed search: %s", time.Since(started))
+	if old, err := f.trySearchSymbol(f.linked, "Issue767PrimaryMarker"); err != nil || old {
+		t.Fatalf("replaced base symbol leaked through overlay: found=%v err=%v", old, err)
+	}
+	f.awaitSymbol(f.primary, "Issue767PrimaryMarker")
+	if leaked, err := f.trySearchSymbol(f.primary, "Issue767EditedMarker"); err != nil || leaked {
+		t.Fatalf("worktree edit leaked into primary: found=%v err=%v", leaked, err)
+	}
+
+	// Restart only the captured private child, then recheck exact dirty-view
+	// routing and primary isolation before exercising automatic removal cleanup.
+	f.stop()
+	started = time.Now()
+	f.start()
+	f.awaitSymbol(f.linked, "Issue767EditedMarker")
+	f.awaitSymbol(f.primary, "Issue767PrimaryMarker")
+	t.Logf("private warm restart to exact worktree search: %s", time.Since(started))
+	f.git(f.primary, "worktree", "remove", "--force", f.linked)
+	f.awaitRemoved()
+	f.awaitSymbol(f.primary, "Issue767PrimaryMarker")
+}
+
+func (f *issue767Fixture) readinessEdit(path, match, replacement string, dryRun bool) {
+	f.t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"operation": "file",
+		"target":    map[string]any{"file": path},
+		"match":     match, "replacement": replacement, "dry_run": dryRun,
+		"view": map[string]any{"kind": "worktree", "path": f.linked},
+	})
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	// Never retry a mutation automatically: a timed-out response may have
+	// committed bytes. A failed call leaves its private fixture logs as evidence.
+	ctx, cancel := context.WithTimeout(f.t.Context(), 45*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, f.binary, "call", "edit", "--index", f.linked, "--json", string(payload), "--format", "json")
+	cmd.Dir, cmd.Env = f.linked, f.env
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	output, err := cmd.Output()
+	if err != nil {
+		f.t.Fatalf("isolated edit command: %v\nstdout: %s\nstderr: %s", err, output, stderr.String())
+	}
+	if err := issue767ExactEditResponse(output); err != nil {
+		f.t.Fatalf("worktree edit dry_run=%v: %v", dryRun, err)
+	}
+}
+
+func issue767ExactEditResponse(output []byte) error {
+	var value any
+	if err := json.Unmarshal(output, &value); err != nil {
+		return fmt.Errorf("edit response is not JSON: %w: %s", err, output)
+	}
+	_, refused := issue767JSONEvidence(value, "")
+	if refused || !issue767JSONExact(value) {
+		return fmt.Errorf("edit response did not prove exact non-error view: %s", output)
+	}
+	return nil
+}
+
+func TestIssue767ExactEditResponse(t *testing.T) {
+	for _, tc := range []struct {
+		name, response string
+		wantError      bool
+	}{
+		{"exact", `{"freshness":{"exact":true},"success":true}`, false},
+		{"fallback", `{"freshness":{"exact":false},"success":true}`, true},
+		{"unlabelled", `{"success":true}`, true},
+		{"error", `{"freshness":{"exact":true},"isError":true}`, true},
+		{"view_building", `{"error_code":"view_building"}`, true},
+		{"invalid", "not json", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := issue767ExactEditResponse([]byte(tc.response)); (err != nil) != tc.wantError {
+				t.Fatalf("err=%v, wantError=%v", err, tc.wantError)
+			}
+		})
+	}
+}

--- a/docs/worktree-readiness-performance.md
+++ b/docs/worktree-readiness-performance.md
@@ -1,0 +1,118 @@
+# Worktree readiness and sparse-generation scans
+
+Follow-up to issue #767. This change addresses admission priority and a confirmed
+generation-scan amplification path. It does not claim to resolve every source of
+startup latency, write amplification, or first-view latency.
+
+## Observed failure
+
+A newly selected automatic checkout was registered but had no published route.
+The primary was ready, and its recorded HEAD tree matched the new checkout.
+Nevertheless, the initial route waited for physical-build admission. A preceding
+worktree commit-layer rebuild took 252 seconds, including 44 seconds parsing 202
+files; another rebuild followed it. Repeated selections did not promote an
+already-running coordinator. Runtime stacks showed background admission waits,
+but did not expose checkout IDs, so an exact queue position was not established.
+
+The active builder also reached `ScanRepoCapabilityEdges`. Its predicates kept
+results generation-isolated, but `NOT INDEXED` forced traversal of shared edge-ID
+ranges before filtering to the requested generation. The page limit bounded
+matching results, not examined rows. This is keyset pagination, not an OFFSET
+rescan of the same prefix on every page.
+
+## Behavior and invariants
+
+- Selecting an automatic checkout coalesces admission demand. Both a newly
+  activated coordinator and an already-queued coordinator can become interactive.
+- Demand does not cancel a running build, reset debounce, or schedule redundant
+  reconcile cycles. The gate consumes demand under its mutex when making
+  admission decisions, avoiding a missed-promotion race with slot release.
+- A promoted request joins the interactive queue's tail. If that queue is full,
+  it keeps its background position and pending promotion. Existing queue bounds,
+  FIFO order within each class, and the four-interactive-build fairness rule are
+  preserved. There is still only one active physical build.
+- Queue statistics can continue to classify buffered demand as background until
+  the next scheduling decision. No checkout identity is added to metric labels.
+- Positive-generation capability scans and their high-water lookup explicitly
+  satisfy the existing partial `edges_by_generation(view_gen, id)` index. The
+  generation-zero query is unchanged. No schema migration or new index is needed.
+- Projection fields, generation-aware joins, repository filtering, pagination,
+  high-water behavior, and enrichment remain intact. The optional index is not
+  forced with `INDEXED BY`, so its absence does not turn a query into an error.
+- Base fallback remains read-only and is never advertised as an exact checkout.
+
+## Validation
+
+Deterministic gate/coordinator tests hold the physical slot, queue background
+work, select a later checkout, and verify admission order. They cover saturation,
+fairness, cancellation, repeated requests, transition-owned coordinators, and
+concurrent coalescing. The focused gate and coordinator suites also run under the
+race detector.
+
+Scanner tests cover colliding logical IDs in different generations, nil/empty/
+scoped repository selections, more than 4,096 candidates, callback re-entry,
+high-water stability, early termination, and operation without the optional
+index. Query-plan assertions exercise the production SQL, not an approximation.
+
+The isolated scanner benchmark uses the same file-backed store for legacy and
+indexed controls, with 128 target edges and either zero or 50,000 foreign edges.
+On the development machine, three 500 ms samples with foreign edges measured
+4.84–5.02 ms/op for the legacy query and 0.502–0.537 ms/op for the indexed query
+(about 9.2x at the medians). The zero-foreign case was noisy and did not show a
+universal improvement. These are query microbenchmarks, not end-to-end latency or
+SSD NAND-write measurements.
+
+Three gate microbenchmark samples measured ordinary admission at a median
+170.8 ns/op, admission with an undemanded channel at 180.9 ns/op, and prebuffered
+demand at 209.5 ns/op (264 B and five allocations for each path). Scanning 1,024
+promotable waiters measured 9.48 microseconds with no allocations. Repeated
+coalesced coordinator notification measured 14.63–21.77 ns/op with no allocations.
+These compare paths in the patched implementation; they are not a historical
+before/after benchmark or a prediction of end-to-end latency.
+
+An opt-in subprocess test exercises configured cold startup, automatic discovery
+of a clean linked checkout, exact search, edit dry-run, real MCP edit, refreshed
+search, replacement masking, primary isolation, warm restart, and removal. It
+uses a private Git fixture, XDG directories, store, socket, and captured child PID;
+it never restarts or addresses the user's daemon. It does not simulate an
+occupied build slot; deterministic coordinator tests cover that condition.
+
+The fixed-binary lifecycle run passed in 43.30 seconds, including automatic
+removal grace. Its observed clean-worktree search, edit-to-search, and private
+warm-restart-to-search times were 3.21 s, 1.24 s, and 1.91 s respectively. Other
+tests were running concurrently, so these are successful-run observations, not
+comparative performance results.
+
+The existing isolated idle-I/O regression also passed cold and warm 15-second
+intervals. Neither interval changed graph counts or allocated generations. The
+process disk-write counter delta was zero in both, but logical-write deltas were
+360,448 and 344,064 bytes, and each WAL grew 24,720 bytes. This is deliberately
+not reported as zero I/O or proof of production-scale behavior. The fixture uses
+an accelerated five-second janitor interval and an 8 MiB write-budget assertion.
+
+```sh
+go test ./internal/graph/store_sqlite -run '^TestCapabilityGeneration' -count=3
+go test -race ./internal/indexer -run '^Test(ViewBuildGate|CheckoutSelection)' -count=10
+go test ./internal/graph/store_sqlite -run '^$' -bench CapabilityGeneration -benchmem
+go test ./internal/indexer -run '^$' -bench 'ViewBuildGate|CheckoutSelectionDemand' -benchmem
+
+go build -o /absolute/private/path/gortex ./cmd/gortex
+GORTEX_ISSUE767_READINESS_BINARY=/absolute/private/path/gortex \
+  go test ./cmd/gortex -run '^TestIssue767WorktreeReadinessIntegration$' \
+  -count=1 -timeout=10m -v
+```
+
+## Remaining work
+
+An active expensive build can still delay first use. A same-tree check alone is
+not a safe admission bypass: dirty construction re-samples the checkout, and an
+adopted generation can enter a physical parse even when a provisional plan is
+empty. An eventual metadata-only path needs an explicit empty-only builder
+contract that refuses nonempty/adopted work before parsing or enrichment and
+preserves final base/configuration/dirty identity validation and route CAS.
+
+Large-generation retirement was another sampled cost during an abandoned build.
+Its core deletion queries already use generation indexes; this patch does not
+change cleanup scheduling, reference checks, leases, sealing, or chunk semantics.
+Phase attribution and production-shaped cold/warm/retirement replay remain
+necessary before making broader performance claims.

--- a/internal/graph/store_sqlite/capability_projection.go
+++ b/internal/graph/store_sqlite/capability_projection.go
@@ -1,42 +1,22 @@
 package store_sqlite
 
-import "github.com/zzet/gortex/internal/graph"
+import (
+	"strings"
 
-// ScanRepoCapabilityEdges reads only source repository and logical identity
-// columns needed by capability synthesis. nil repoPrefixes scans all sources;
-// a non-nil empty slice scans none. The id keyset freezes the generation and
-// bounds every allocation; each cursor is closed before yield runs so the
-// callback may safely re-enter the store.
-func (s *Store) ScanRepoCapabilityEdges(
-	repoPrefixes []string,
-	pageSize int,
-	yield func([]graph.RepoCapabilityEdge) bool,
-) {
-	if yield == nil || (repoPrefixes != nil && len(repoPrefixes) == 0) {
-		return
-	}
-	allRepos := repoPrefixes == nil
-	var reposJSON string
-	if !allRepos {
-		var ok bool
-		reposJSON, ok = projectionJSON(repoPrefixes)
-		if !ok {
-			return
-		}
-	}
-	if pageSize <= 0 {
-		pageSize = 4096
-	}
+	"github.com/zzet/gortex/internal/graph"
+)
 
-	var highWater int64
-	if err := s.db.QueryRow(`SELECT COALESCE(MAX(id), 0) FROM edges WHERE view_gen = ?`, s.viewGen).Scan(&highWater); err != nil {
-		panicOnFatal(err)
-		return
+// capabilityProjectionHighWaterQuery keeps the legacy base-corpus access path,
+// but makes the partial (view_gen, id) index eligible for derived generations.
+func capabilityProjectionHighWaterQuery(viewGen int64) string {
+	const query = `SELECT COALESCE(MAX(id), 0) FROM edges WHERE view_gen = ?`
+	if viewGen > 0 {
+		return query + ` AND view_gen > 0`
 	}
-	if highWater == 0 {
-		return
-	}
+	return query
+}
 
+func capabilityProjectionPageQuery(viewGen int64, allRepos bool) string {
 	const scopedQuery = `
 WITH requested_repos(repo_prefix) AS (
     SELECT CAST(value AS TEXT) FROM json_each(?)
@@ -67,7 +47,54 @@ LIMIT ?`
 	if allRepos {
 		query = allQuery
 	}
-	stmt, err := s.db.Prepare(query)
+	if viewGen > 0 {
+		// A sparse generation can sit behind millions of unrelated corpus
+		// rows in this shared table. Do not force a global row-id traversal.
+		// The explicit positive predicate proves eligibility for the existing
+		// partial edges_by_generation index; equality to a parameter does not.
+		// This is not INDEXED BY: an optional index being absent remains safe.
+		query = strings.Replace(query, "edges AS e NOT INDEXED", "edges AS e", 1)
+		query = strings.Replace(query, "e.view_gen = ?", "e.view_gen = ? AND e.view_gen > 0", 1)
+	}
+	return query
+}
+
+// ScanRepoCapabilityEdges reads only source repository and logical identity
+// columns needed by capability synthesis. nil repoPrefixes scans all sources;
+// a non-nil empty slice scans none. The id keyset freezes the generation and
+// bounds every allocation; each cursor is closed before yield runs so the
+// callback may safely re-enter the store.
+func (s *Store) ScanRepoCapabilityEdges(
+	repoPrefixes []string,
+	pageSize int,
+	yield func([]graph.RepoCapabilityEdge) bool,
+) {
+	if yield == nil || (repoPrefixes != nil && len(repoPrefixes) == 0) {
+		return
+	}
+	allRepos := repoPrefixes == nil
+	var reposJSON string
+	if !allRepos {
+		var ok bool
+		reposJSON, ok = projectionJSON(repoPrefixes)
+		if !ok {
+			return
+		}
+	}
+	if pageSize <= 0 {
+		pageSize = 4096
+	}
+
+	var highWater int64
+	if err := s.db.QueryRow(capabilityProjectionHighWaterQuery(s.viewGen), s.viewGen).Scan(&highWater); err != nil {
+		panicOnFatal(err)
+		return
+	}
+	if highWater == 0 {
+		return
+	}
+
+	stmt, err := s.db.Prepare(capabilityProjectionPageQuery(s.viewGen, allRepos))
 	if err != nil {
 		panicOnFatal(err)
 		return

--- a/internal/graph/store_sqlite/capability_projection_generation_test.go
+++ b/internal/graph/store_sqlite/capability_projection_generation_test.go
@@ -1,0 +1,289 @@
+package store_sqlite
+
+import (
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/zzet/gortex/internal/graph"
+)
+
+func newCapabilityGenerationStore(tb testing.TB) *Store {
+	tb.Helper()
+	s, err := Open(filepath.Join(tb.TempDir(), "capability.sqlite"))
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func addCapabilityGenerationCalls(tb testing.TB, s *Store, generation int64, prefix string, start, count int) {
+	tb.Helper()
+	target := prefix + "::target"
+	nodes := make([]*graph.Node, 0, count+1)
+	nodes = append(nodes, &graph.Node{ID: target, Name: "target", Kind: graph.KindFunction, RepoPrefix: prefix})
+	edges := make([]*graph.Edge, 0, count)
+	for i := start; i < start+count; i++ {
+		id := fmt.Sprintf("%s::caller::%d", prefix, i)
+		nodes = append(nodes, &graph.Node{ID: id, Name: "caller", Kind: graph.KindFunction, RepoPrefix: prefix, FilePath: prefix + "/calls.go"})
+		edges = append(edges, &graph.Edge{From: id, To: target, Kind: graph.EdgeCalls, FilePath: prefix + "/calls.go", Line: i + 1})
+	}
+	s.AtGeneration(generation).AddBatch(nodes, edges)
+}
+
+func capabilityGenerationArgs(generation, lastID, highWater int64, reposJSON string, allRepos bool, pageSize int) []any {
+	args := make([]any, 0, 12)
+	if !allRepos {
+		args = append(args, reposJSON)
+	}
+	return append(args, lastID, highWater, generation,
+		string(graph.EdgeReadsConfig), string(graph.EdgeReads), string(graph.EdgeWrites), string(graph.EdgeCalls),
+		string(graph.EdgeReads), string(graph.EdgeWrites), string(graph.KindField), pageSize)
+}
+
+// Both controls execute the same projection/paging code over the same data.
+// legacy selects the unchanged generation-zero SQL but still binds generation,
+// reproducing the old access path for a positive-generation handle.
+func scanCapabilityGenerationControl(tb testing.TB, s *Store, generation int64, prefixes []string, legacy bool) []graph.RepoCapabilityEdge {
+	tb.Helper()
+	if prefixes != nil && len(prefixes) == 0 {
+		return nil
+	}
+	allRepos := prefixes == nil
+	var reposJSON string
+	if !allRepos {
+		var ok bool
+		reposJSON, ok = projectionJSON(prefixes)
+		if !ok {
+			return nil
+		}
+	}
+	queryGeneration := generation
+	if legacy {
+		queryGeneration = 0
+	}
+	var highWater int64
+	if err := s.db.QueryRow(capabilityProjectionHighWaterQuery(queryGeneration), generation).Scan(&highWater); err != nil {
+		tb.Fatal(err)
+	}
+	if highWater == 0 {
+		return nil
+	}
+	stmt, err := s.db.Prepare(capabilityProjectionPageQuery(queryGeneration, allRepos))
+	if err != nil {
+		tb.Fatal(err)
+	}
+	defer stmt.Close()
+	const pageSize = 4096
+	var out []graph.RepoCapabilityEdge
+	for lastID := int64(0); lastID < highWater; {
+		rows, err := stmt.Query(capabilityGenerationArgs(generation, lastID, highWater, reposJSON, allRepos, pageSize)...)
+		if err != nil {
+			tb.Fatal(err)
+		}
+		count := 0
+		for rows.Next() {
+			var row graph.RepoCapabilityEdge
+			if err := rows.Scan(&lastID, &row.RepoPrefix, &row.Identity.From, &row.Identity.To, &row.Identity.Kind, &row.Identity.FilePath, &row.Identity.Line); err != nil {
+				_ = rows.Close()
+				tb.Fatal(err)
+			}
+			out = append(out, row)
+			count++
+		}
+		rowsErr := rows.Err()
+		closeErr := rows.Close()
+		if rowsErr != nil {
+			tb.Fatal(rowsErr)
+		}
+		if closeErr != nil {
+			tb.Fatal(closeErr)
+		}
+		if count < pageSize {
+			break
+		}
+	}
+	return out
+}
+
+func TestCapabilityGenerationProjectionParity(t *testing.T) {
+	s := newCapabilityGenerationStore(t)
+	for _, generation := range []int64{0, 7, 9} {
+		prefix := "foreign"
+		fieldKind := graph.KindVariable
+		if generation == 7 {
+			prefix = "alpha"
+			fieldKind = graph.KindField
+		}
+		s.AtGeneration(generation).AddBatch([]*graph.Node{
+			{ID: "shared-source", Name: "source", Kind: graph.KindFunction, RepoPrefix: prefix},
+			{ID: "shared-field", Name: "field", Kind: fieldKind, RepoPrefix: prefix},
+			{ID: "shared-function", Name: "function", Kind: graph.KindFunction, RepoPrefix: prefix},
+		}, []*graph.Edge{
+			{From: "shared-source", To: "shared-function", Kind: graph.EdgeCalls, FilePath: "shared.go", Line: 1},
+			{From: "shared-source", To: "shared-field", Kind: graph.EdgeReads, FilePath: "shared.go", Line: 2},
+			{From: "shared-source", To: "shared-field", Kind: graph.EdgeWrites, FilePath: "shared.go", Line: 3},
+			{From: "shared-source", To: "cfg::env::TOKEN", Kind: graph.EdgeReadsConfig, FilePath: "shared.go", Line: 4},
+			{From: "shared-source", To: "shared-function", Kind: graph.EdgeReads, FilePath: "shared.go", Line: 5},
+			{From: "shared-source", To: "missing", Kind: graph.EdgeWrites, FilePath: "shared.go", Line: 6},
+			{From: "shared-source", To: "shared-field", Kind: graph.EdgeReferences, FilePath: "shared.go", Line: 7},
+		})
+	}
+	addCapabilityGenerationCalls(t, s, 7, "beta", 0, 1)
+	for _, generation := range []int64{0, 7, 9, 11} {
+		for _, prefixes := range [][]string{nil, {}, {"alpha"}, {"beta"}, {"foreign"}, {"missing"}, {"alpha", "beta"}, {"alpha", "alpha"}} {
+			t.Run(fmt.Sprintf("generation_%d/repos_%v", generation, prefixes), func(t *testing.T) {
+				want := scanCapabilityGenerationControl(t, s, generation, prefixes, true)
+				var got []graph.RepoCapabilityEdge
+				s.AtGeneration(generation).ScanRepoCapabilityEdges(prefixes, 2, func(page []graph.RepoCapabilityEdge) bool {
+					got = append(got, page...)
+					return true
+				})
+				if !reflect.DeepEqual(got, want) {
+					t.Fatalf("projection mismatch:\ngot  %#v\nwant %#v", got, want)
+				}
+				if generation == 7 && prefixes == nil && len(got) != 5 {
+					t.Fatalf("got %d eligible edges, want 5 (including own-generation field reads/writes)", len(got))
+				}
+			})
+		}
+	}
+}
+
+func TestCapabilityGenerationPaginationAndHighWater(t *testing.T) {
+	s := newCapabilityGenerationStore(t)
+	addCapabilityGenerationCalls(t, s, 0, "before", 0, 100)
+	addCapabilityGenerationCalls(t, s, 7, "alpha", 0, 4097)
+	addCapabilityGenerationCalls(t, s, 9, "after", 0, 100)
+	want := scanCapabilityGenerationControl(t, s, 7, nil, true)
+	var got []graph.RepoCapabilityEdge
+	var sizes []int
+	s.AtGeneration(7).ScanRepoCapabilityEdges(nil, 0, func(page []graph.RepoCapabilityEdge) bool {
+		sizes = append(sizes, len(page))
+		got = append(got, page...)
+		if len(sizes) == 1 {
+			// The reader is closed before yield; a same-generation write can
+			// re-enter safely but must not escape the scan's frozen highwater.
+			addCapabilityGenerationCalls(t, s, 7, "late", 0, 1)
+		}
+		return true
+	})
+	if !reflect.DeepEqual(sizes, []int{4096, 1}) || !reflect.DeepEqual(got, want) {
+		t.Fatalf("pagination/highwater mismatch: page sizes %v, got %d, want %d", sizes, len(got), len(want))
+	}
+	calls := 0
+	s.AtGeneration(7).ScanRepoCapabilityEdges(nil, 1, func([]graph.RepoCapabilityEdge) bool {
+		calls++
+		return false
+	})
+	if calls != 1 {
+		t.Fatalf("yield cancellation called %d times, want 1", calls)
+	}
+	s.AtGeneration(7).ScanRepoCapabilityEdges(nil, 1, nil)
+	s.AtGeneration(7).ScanRepoCapabilityEdges([]string{}, 1, func([]graph.RepoCapabilityEdge) bool {
+		t.Fatal("exact empty repository scope yielded a page")
+		return false
+	})
+}
+
+func capabilityGenerationPlan(tb testing.TB, s *Store, query string, args ...any) string {
+	tb.Helper()
+	rows, err := s.db.Query("EXPLAIN QUERY PLAN "+query, args...)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	defer rows.Close()
+	var plan []string
+	for rows.Next() {
+		var id, parent, unused int
+		var detail string
+		if err := rows.Scan(&id, &parent, &unused, &detail); err != nil {
+			tb.Fatal(err)
+		}
+		plan = append(plan, detail)
+	}
+	if err := rows.Err(); err != nil {
+		tb.Fatal(err)
+	}
+	return strings.Join(plan, "\n")
+}
+
+func TestCapabilityGenerationQueryPlan(t *testing.T) {
+	s := newCapabilityGenerationStore(t)
+	addCapabilityGenerationCalls(t, s, 0, "foreign", 0, 100)
+	addCapabilityGenerationCalls(t, s, 7, "alpha", 0, 2)
+	for _, allRepos := range []bool{true, false} {
+		query := capabilityProjectionPageQuery(7, allRepos)
+		plan := capabilityGenerationPlan(t, s, query, capabilityGenerationArgs(7, 0, 1<<60, `["alpha"]`, allRepos, 4096)...)
+		if !strings.Contains(plan, "edges_by_generation") || strings.Contains(plan, "SEARCH e USING INTEGER PRIMARY KEY") {
+			t.Fatalf("derived page must use generation index (all=%v):\n%s", allRepos, plan)
+		}
+		if strings.Contains(plan, "USE TEMP B-TREE FOR ORDER BY") {
+			t.Fatalf("derived keyset page needs no global sort:\n%s", plan)
+		}
+		baseQuery := capabilityProjectionPageQuery(0, allRepos)
+		if !strings.Contains(baseQuery, "edges AS e NOT INDEXED") || strings.Contains(baseQuery, "e.view_gen > 0") {
+			t.Fatal("base-generation access path changed")
+		}
+	}
+	plan := capabilityGenerationPlan(t, s, capabilityProjectionHighWaterQuery(7), int64(7))
+	if !strings.Contains(plan, "edges_by_generation") {
+		t.Fatalf("derived highwater must use generation index:\n%s", plan)
+	}
+	if got := capabilityProjectionHighWaterQuery(0); got != `SELECT COALESCE(MAX(id), 0) FROM edges WHERE view_gen = ?` {
+		t.Fatalf("base highwater changed: %s", got)
+	}
+}
+
+func TestCapabilityGenerationOptionalIndexAbsent(t *testing.T) {
+	s := newCapabilityGenerationStore(t)
+	addCapabilityGenerationCalls(t, s, 0, "foreign", 0, 10)
+	addCapabilityGenerationCalls(t, s, 7, "alpha", 0, 3)
+	want := scanCapabilityGenerationControl(t, s, 7, nil, true)
+	if _, err := s.writerDB.Exec(`DROP INDEX edges_by_generation`); err != nil {
+		t.Fatal(err)
+	}
+	var got []graph.RepoCapabilityEdge
+	s.AtGeneration(7).ScanRepoCapabilityEdges(nil, 2, func(page []graph.RepoCapabilityEdge) bool {
+		got = append(got, page...)
+		return true
+	})
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("optional-index absence changed results: got %d, want %d", len(got), len(want))
+	}
+}
+
+func BenchmarkCapabilityGenerationProjection(b *testing.B) {
+	for _, foreign := range []int{0, 50000} {
+		b.Run(fmt.Sprintf("foreign_%d", foreign), func(b *testing.B) {
+			s := newCapabilityGenerationStore(b)
+			if foreign > 0 {
+				addCapabilityGenerationCalls(b, s, 0, "before", 0, foreign/2)
+			}
+			addCapabilityGenerationCalls(b, s, 7, "alpha", 0, 128)
+			if foreign > 0 {
+				addCapabilityGenerationCalls(b, s, 9, "after", 0, foreign-foreign/2)
+			}
+			for _, legacy := range []bool{true, false} {
+				name := "generation_sql"
+				if legacy {
+					name = "legacy_sql"
+				}
+				b.Run(name, func(b *testing.B) {
+					b.ReportAllocs()
+					b.ResetTimer()
+					for i := 0; i < b.N; i++ {
+						if got := scanCapabilityGenerationControl(b, s, 7, nil, legacy); len(got) != 128 {
+							b.Fatalf("got %d own-generation edges, want 128", len(got))
+						}
+					}
+					b.ReportMetric(float64(foreign), "foreign_edges")
+					b.ReportMetric(128, "target_edges")
+				})
+			}
+		})
+	}
+}

--- a/internal/indexer/checkout_coordinator.go
+++ b/internal/indexer/checkout_coordinator.go
@@ -294,6 +294,32 @@ type CheckoutCoordinator struct {
 	// settledWithoutBuild and has no barrier.
 	cyclePreflight func(context.Context) (CheckoutCycle, bool)
 	cycleBarrier   func(context.Context)
+
+	// selectionDemand promotes a queued build independently of the debounce
+	// signal. mu guards initialization; the buffered channel coalesces demand.
+	selectionDemand chan struct{}
+}
+
+func (c *CheckoutCoordinator) selectionRequests() chan struct{} {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.selectionDemand == nil {
+		c.selectionDemand = make(chan struct{}, 1)
+	}
+	return c.selectionDemand
+}
+
+// PrioritizeSelection promotes queued work without cancelling an active build
+// or resetting the quiet window. A repeated request contributes at most one
+// buffered demand token; it does not schedule another reconcile cycle.
+func (c *CheckoutCoordinator) PrioritizeSelection() {
+	if c == nil {
+		return
+	}
+	select {
+	case c.selectionRequests() <- struct{}{}:
+	default:
+	}
 }
 
 // retainedCommitLayer is one commit generation kept for re-routing, keyed by
@@ -581,7 +607,7 @@ func (c *CheckoutCoordinator) cycle(ctx context.Context) {
 	if through != 0 {
 		priority = ViewBuildInteractive
 	}
-	release, err := c.gate.Acquire(ctx, priority)
+	release, err := c.gate.AcquirePromotable(ctx, priority, c.selectionRequests())
 	if err != nil {
 		if errors.Is(err, ErrViewBuildQueueFull) {
 			c.logger.Debug("checkout coordinator: build deferred by admission capacity",

--- a/internal/indexer/checkout_lifecycle.go
+++ b/internal/indexer/checkout_lifecycle.go
@@ -1685,6 +1685,7 @@ func (l *CheckoutLifecycle) ActivateCheckout(checkoutID, reason string) bool {
 	// closing or the id is empty (nudgeCheckout's fallback relies on false).
 	started, already := l.beginCheckoutActivation(checkoutID)
 	if already {
+		l.prioritizeCheckout(checkoutID)
 		return true
 	}
 	if !started {
@@ -1694,6 +1695,29 @@ func (l *CheckoutLifecycle) ActivateCheckout(checkoutID, reason string) bool {
 		zap.String("checkout", checkoutID), zap.String("reason", reason))
 	go l.activateCheckout(l.transitionCtx, checkoutID)
 	return true
+}
+
+// prioritizeCheckout reaches both registered loops and transition-owned loops
+// that have started but are not installed yet. Selection changes only their
+// admission priority; no registry lock is held while touching a coordinator.
+func (l *CheckoutLifecycle) prioritizeCheckout(checkoutID string) {
+	l.coordMu.Lock()
+	if l.coordinatorClosing {
+		l.coordMu.Unlock()
+		return
+	}
+	coordinator := l.coordinators[checkoutID]
+	if coordinator == nil || !coordinator.Running() {
+		coordinator = nil
+		for _, candidate := range l.started[checkoutID] {
+			if candidate.Running() {
+				coordinator = candidate
+				break
+			}
+		}
+	}
+	l.coordMu.Unlock()
+	coordinator.PrioritizeSelection()
 }
 
 // beginCheckoutActivation admits one activation. It returns (true, false) when
@@ -1761,6 +1785,7 @@ func (l *CheckoutLifecycle) activateCheckout(ctx context.Context, checkoutID str
 	// coordinator's quiet window and delay that build — the same starvation
 	// ActivateCheckout avoids on a live coordinator.
 	l.ensureCoordinator(ctx, primary.GraphID, checkout)
+	l.prioritizeCheckout(checkoutID)
 }
 
 // ensureCoordinator brings up the coordinator for one automatic checkout, or

--- a/internal/indexer/checkout_selection_priority_test.go
+++ b/internal/indexer/checkout_selection_priority_test.go
@@ -1,0 +1,207 @@
+package indexer
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// These seams exercise the real coordinator admission path without opening a
+// store or parsing a repository. Once admitted, a cycle waits at its barrier;
+// cancellation releases it before reconcile can touch the nil catalog.
+func startCheckoutSelectionCycle(t *testing.T, gate *ViewBuildGate, entered chan<- string, name string, selected bool) (*CheckoutCoordinator, context.CancelFunc) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	c := &CheckoutCoordinator{
+		checkoutID:     name,
+		gate:           gate,
+		logger:         zap.NewNop(),
+		signal:         make(chan struct{}, 1),
+		done:           make(chan struct{}),
+		lifetime:       ctx,
+		cyclePreflight: func(context.Context) (CheckoutCycle, bool) { return CheckoutCycle{}, false },
+		cycleBarrier: func(ctx context.Context) {
+			entered <- name
+			<-ctx.Done()
+		},
+	}
+	if selected {
+		c.PrioritizeSelection()
+	}
+	go func() {
+		defer close(c.done)
+		c.cycle(ctx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-c.done:
+		case <-time.After(3 * time.Second):
+			t.Errorf("coordinator cycle %s did not stop", name)
+		}
+	})
+	return c, cancel
+}
+
+func awaitCheckoutSelectionQueues(t *testing.T, gate *ViewBuildGate, interactive, background int) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		stats := gate.Stats()
+		if stats.InteractiveQueued == interactive && stats.BackgroundQueued == background {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("queue did not reach interactive=%d background=%d: %+v", interactive, background, gate.Stats())
+}
+
+func awaitCheckoutSelectionName(t *testing.T, entered <-chan string, want string) {
+	t.Helper()
+	select {
+	case got := <-entered:
+		if got != want {
+			t.Fatalf("admitted %s before selected %s", got, want)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("selected coordinator %s was not admitted", want)
+	}
+}
+
+func awaitCheckoutSelectionStopped(t *testing.T, c *CheckoutCoordinator) {
+	t.Helper()
+	select {
+	case <-c.done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("selected cycle did not release admission after cancellation")
+	}
+}
+
+func TestCheckoutSelectionPromotesExistingQueuedCoordinator(t *testing.T) {
+	for _, startedOnly := range []bool{false, true} {
+		name := "registered"
+		if startedOnly {
+			name = "transition_started"
+		}
+		t.Run(name, func(t *testing.T) {
+			gate := NewViewBuildGate()
+			gate.Open()
+			release, err := gate.Acquire(t.Context(), ViewBuildBackground)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer release()
+			entered := make(chan string, 2)
+			background, cancelBackground := startCheckoutSelectionCycle(t, gate, entered, "background", false)
+			awaitCheckoutSelectionQueues(t, gate, 0, 1)
+			selected, cancelSelected := startCheckoutSelectionCycle(t, gate, entered, "selected", false)
+			awaitCheckoutSelectionQueues(t, gate, 0, 2)
+
+			lifecycle := &CheckoutLifecycle{}
+			if startedOnly {
+				lifecycle.started = map[string][]*CheckoutCoordinator{"selected": {selected}}
+			} else {
+				lifecycle.coordinators = map[string]*CheckoutCoordinator{"selected": selected}
+			}
+			for i := 0; i < 100; i++ {
+				if !lifecycle.ActivateCheckout("selected", "test selection") {
+					t.Fatal("existing coordinator selection was refused")
+				}
+			}
+			if len(selected.signal) != 0 {
+				t.Fatal("selection reset the coordinator debounce signal")
+			}
+			// Gate promotion is applied atomically when deciding the next grant;
+			// transient queue counters need not change before this release.
+			release()
+			awaitCheckoutSelectionName(t, entered, "selected")
+
+			for i := 0; i < 100; i++ {
+				if !lifecycle.ActivateCheckout("selected", "selected while active") {
+					t.Fatal("active coordinator selection was refused")
+				}
+			}
+			if selected.lifetime.Err() != nil || !selected.Running() {
+				t.Fatal("repeated selection cancelled the admitted cycle")
+			}
+			if len(selected.signal) != 0 {
+				t.Fatal("active selection scheduled another debounce cycle")
+			}
+			if got := len(selected.selectionRequests()); got != 1 {
+				t.Fatalf("active selections did not coalesce into one pending token: %d", got)
+			}
+			select {
+			case other := <-entered:
+				t.Fatalf("%s entered while selected cycle still owns admission", other)
+			default:
+			}
+			cancelSelected()
+			awaitCheckoutSelectionStopped(t, selected)
+			awaitCheckoutSelectionName(t, entered, "background")
+			cancelBackground()
+			awaitCheckoutSelectionStopped(t, background)
+		})
+	}
+}
+
+func TestCheckoutSelectionBeforeFirstCycleUsesInteractiveAdmission(t *testing.T) {
+	gate := newViewBuildGateWithLimits(2, 2)
+	gate.Open()
+	release, err := gate.Acquire(t.Context(), ViewBuildBackground)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+	limit := gate.Stats().BackgroundLimit
+	if limit < 1 || limit > 256 {
+		t.Fatalf("unexpected background limit for bounded fixture: %d", limit)
+	}
+	entered := make(chan string, limit+1)
+	for i := 0; i < limit; i++ {
+		startCheckoutSelectionCycle(t, gate, entered, fmt.Sprintf("background-%d", i), false)
+	}
+	awaitCheckoutSelectionQueues(t, gate, 0, limit)
+	selected, cancelSelected := startCheckoutSelectionCycle(t, gate, entered, "new-selection", true)
+	awaitCheckoutSelectionQueues(t, gate, 1, limit)
+	release()
+	awaitCheckoutSelectionName(t, entered, "new-selection")
+	cancelSelected()
+	awaitCheckoutSelectionStopped(t, selected)
+}
+
+func TestCheckoutSelectionDemandCoalescesWithoutSignal(t *testing.T) {
+	var absent *CheckoutCoordinator
+	absent.PrioritizeSelection()
+	c := &CheckoutCoordinator{signal: make(chan struct{}, 1)}
+	var workers sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			for i := 0; i < 100; i++ {
+				c.PrioritizeSelection()
+			}
+		}()
+	}
+	workers.Wait()
+	if got := len(c.selectionRequests()); got != 1 {
+		t.Fatalf("concurrent selections should retain one token, got %d", got)
+	}
+	if len(c.signal) != 0 {
+		t.Fatal("selection must not send the dirty/debounce signal")
+	}
+}
+
+func BenchmarkCheckoutSelectionDemand(b *testing.B) {
+	c := &CheckoutCoordinator{}
+	c.PrioritizeSelection()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.PrioritizeSelection()
+	}
+}

--- a/internal/indexer/view_build_gate.go
+++ b/internal/indexer/view_build_gate.go
@@ -47,6 +47,9 @@ type viewBuildWaiter struct {
 	enqueuedAt time.Time
 	granted    bool
 	canceled   bool
+	// demand and promotionRequested are guarded by the gate mutex.
+	demand             <-chan struct{}
+	promotionRequested bool
 }
 
 // ViewBuildGateStats is a fixed-cardinality process-local snapshot. Queue
@@ -89,6 +92,8 @@ type ViewBuildGate struct {
 
 	interactive []*viewBuildWaiter
 	background  []*viewBuildWaiter
+	// Avoid scanning ordinary Acquire queues which contain no demand signals.
+	promotableQueued int
 
 	interactiveBurst int
 	interactiveLimit int
@@ -175,6 +180,17 @@ func (g *ViewBuildGate) Open() {
 // Acquire waits for the one physical build lane. Capacity applies only while a
 // caller must wait: even a zero-capacity gate admits an idle open lane.
 func (g *ViewBuildGate) Acquire(ctx context.Context, priority ViewBuildPriority) (func(), error) {
+	return g.AcquirePromotable(ctx, priority, nil)
+}
+
+// AcquirePromotable is Acquire with a coalesced demand signal. A signal promotes
+// a queued background waiter to the interactive tail; it never preempts an
+// active build. If the interactive queue is full, the waiter retains its
+// background place and promotion is retried as capacity becomes available.
+// Demand is consumed under the gate mutex before admission decisions; queue
+// statistics may still classify it as background until that scheduling point.
+// The caller owns demand; a buffered channel of capacity one coalesces signals.
+func (g *ViewBuildGate) AcquirePromotable(ctx context.Context, priority ViewBuildPriority, demand <-chan struct{}) (func(), error) {
 	if g == nil {
 		return func() {}, nil
 	}
@@ -185,12 +201,31 @@ func (g *ViewBuildGate) Acquire(ctx context.Context, priority ViewBuildPriority)
 		return nil, err
 	}
 	priority = normalizeViewBuildPriority(priority)
+	promotionRequested := false
 
 	g.mu.Lock()
 	// Restore the invariant before evaluating the immediate path. Normally all
 	// state transitions already call grantNextLocked.
 	g.grantNextLocked()
-	if g.open && !g.active && len(g.interactive) == 0 && len(g.background) == 0 {
+	idle := g.open && !g.active && len(g.interactive) == 0 && len(g.background) == 0
+	canWait := len(g.interactive) < g.interactiveLimit
+	if priority == ViewBuildBackground {
+		canWait = canWait || len(g.background) < g.backgroundLimit
+	}
+	// Leave demand buffered when admission must reject; a caller can retry
+	// without losing the selection which gave the request priority.
+	if idle || canWait {
+		select {
+		case <-demand:
+			promotionRequested = true
+			demand = nil
+		default:
+		}
+	}
+	if idle {
+		if promotionRequested {
+			priority = ViewBuildInteractive
+		}
 		g.active = true
 		g.recordPriorityLocked(priority)
 		g.recordAdmittedLocked(priority)
@@ -200,6 +235,14 @@ func (g *ViewBuildGate) Acquire(ctx context.Context, priority ViewBuildPriority)
 	if err := ctx.Err(); err != nil {
 		g.mu.Unlock()
 		return nil, err
+	}
+
+	if promotionRequested && priority == ViewBuildBackground && len(g.interactive) < g.interactiveLimit {
+		priority = ViewBuildInteractive
+	}
+	if priority == ViewBuildInteractive {
+		demand = nil
+		promotionRequested = false
 	}
 
 	limit, queued := g.backgroundLimit, len(g.background)
@@ -213,9 +256,11 @@ func (g *ViewBuildGate) Acquire(ctx context.Context, priority ViewBuildPriority)
 	}
 
 	waiter := &viewBuildWaiter{
-		ready:      make(chan struct{}),
-		priority:   priority,
-		enqueuedAt: time.Now(),
+		ready:              make(chan struct{}),
+		priority:           priority,
+		enqueuedAt:         time.Now(),
+		demand:             demand,
+		promotionRequested: promotionRequested,
 	}
 	if priority == ViewBuildInteractive {
 		g.interactive = append(g.interactive, waiter)
@@ -224,6 +269,9 @@ func (g *ViewBuildGate) Acquire(ctx context.Context, priority ViewBuildPriority)
 		}
 	} else {
 		g.background = append(g.background, waiter)
+		if waiter.demand != nil || waiter.promotionRequested {
+			g.promotableQueued++
+		}
 		if len(g.background) > g.backgroundHighWater {
 			g.backgroundHighWater = len(g.background)
 		}
@@ -279,6 +327,7 @@ func (g *ViewBuildGate) release() {
 }
 
 func (g *ViewBuildGate) grantNextLocked() {
+	g.promoteDemandedLocked()
 	if !g.open || g.active {
 		return
 	}
@@ -312,6 +361,42 @@ func (g *ViewBuildGate) grantNextLocked() {
 	}
 }
 
+// promoteDemandedLocked also samples signals in the granting goroutine, so
+// a release cannot overlook buffered demand merely because the waiting
+// goroutine has not been scheduled yet. Compaction preserves background FIFO;
+// promotions join the interactive tail and keep their original wait start.
+func (g *ViewBuildGate) promoteDemandedLocked() {
+	if g.promotableQueued == 0 {
+		return
+	}
+	kept := g.background[:0]
+	for _, waiter := range g.background {
+		if waiter.demand != nil {
+			select {
+			case <-waiter.demand:
+				waiter.demand = nil
+				waiter.promotionRequested = true
+			default:
+			}
+		}
+		if waiter.promotionRequested && len(g.interactive) < g.interactiveLimit {
+			g.promotableQueued--
+			waiter.promotionRequested = false
+			waiter.priority = ViewBuildInteractive
+			g.interactive = append(g.interactive, waiter)
+			if len(g.interactive) > g.interactiveHighWater {
+				g.interactiveHighWater = len(g.interactive)
+			}
+			viewmetrics.AddGauge(viewmetrics.ViewBuildQueue, -1, viewBuildPriorityLabel(ViewBuildBackground))
+			viewmetrics.AddGauge(viewmetrics.ViewBuildQueue, 1, viewBuildPriorityLabel(ViewBuildInteractive))
+			continue
+		}
+		kept = append(kept, waiter)
+	}
+	clear(g.background[len(kept):])
+	g.background = kept
+}
+
 func (g *ViewBuildGate) recordPriorityLocked(priority ViewBuildPriority) {
 	if priority == ViewBuildInteractive {
 		if g.interactiveBurst < maxInteractiveBuildBurst {
@@ -323,6 +408,9 @@ func (g *ViewBuildGate) recordPriorityLocked(priority ViewBuildPriority) {
 }
 
 func (g *ViewBuildGate) recordDequeuedLocked(waiter *viewBuildWaiter) {
+	if waiter.priority == ViewBuildBackground && (waiter.demand != nil || waiter.promotionRequested) {
+		g.promotableQueued--
+	}
 	priority := viewBuildPriorityLabel(waiter.priority)
 	viewmetrics.AddGauge(viewmetrics.ViewBuildQueue, -1, priority)
 	waited := time.Since(waiter.enqueuedAt)

--- a/internal/indexer/view_build_gate_promotion_test.go
+++ b/internal/indexer/view_build_gate_promotion_test.go
@@ -1,0 +1,324 @@
+package indexer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+)
+
+type promotionTestAcquisition struct {
+	done    chan struct{}
+	release func()
+	err     error
+	cancel  context.CancelFunc
+}
+
+func queuePromotionTestAcquisition(t *testing.T, g *ViewBuildGate, priority ViewBuildPriority, demand <-chan struct{}) *promotionTestAcquisition {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	acquisition := &promotionTestAcquisition{done: make(chan struct{}), cancel: cancel}
+	go func() {
+		acquisition.release, acquisition.err = g.AcquirePromotable(ctx, priority, demand)
+		close(acquisition.done)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-acquisition.done:
+			if acquisition.release != nil {
+				acquisition.release()
+			}
+		case <-time.After(5 * time.Second):
+			t.Error("gate acquisition did not stop after cancellation")
+		}
+	})
+	return acquisition
+}
+
+func waitPromotionTestQueued(t *testing.T, g *ViewBuildGate, count int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		stats := g.Stats()
+		if stats.InteractiveQueued+stats.BackgroundQueued == count {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("queue never reached %d: %+v", count, g.Stats())
+}
+
+func (a *promotionTestAcquisition) admitted(t *testing.T) func() {
+	t.Helper()
+	select {
+	case <-a.done:
+		if a.err != nil || a.release == nil {
+			t.Fatalf("acquisition failed: %v", a.err)
+		}
+		return a.release
+	case <-time.After(5 * time.Second):
+		t.Fatal("acquisition was not admitted")
+		return nil
+	}
+}
+
+func (a *promotionTestAcquisition) stillQueued(t *testing.T) {
+	t.Helper()
+	select {
+	case <-a.done:
+		t.Fatalf("acquisition admitted early: %v", a.err)
+	default:
+	}
+}
+
+func holdPromotionTestGate(t *testing.T, g *ViewBuildGate) func() {
+	t.Helper()
+	g.Open()
+	release, err := g.Acquire(context.Background(), ViewBuildBackground)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(release)
+	return release
+}
+
+func assertPromotionTestDrained(t *testing.T, g *ViewBuildGate) {
+	t.Helper()
+	stats := g.Stats()
+	g.mu.Lock()
+	promotable := g.promotableQueued
+	g.mu.Unlock()
+	if stats.Active || stats.InteractiveQueued != 0 || stats.BackgroundQueued != 0 || promotable != 0 {
+		t.Fatalf("gate not drained: %+v promotable=%d", stats, promotable)
+	}
+}
+
+func TestViewBuildGateQueuedDemandPromotesAtGrant(t *testing.T) {
+	g := NewViewBuildGate()
+	releaseHolder := holdPromotionTestGate(t, g)
+	background := queuePromotionTestAcquisition(t, g, ViewBuildBackground, nil)
+	waitPromotionTestQueued(t, g, 1)
+	demand := make(chan struct{}, 1)
+	selected := queuePromotionTestAcquisition(t, g, ViewBuildBackground, demand)
+	waitPromotionTestQueued(t, g, 2)
+	demand <- struct{}{}
+	selected.stillQueued(t)
+	background.stillQueued(t)
+	if !g.Stats().Active {
+		t.Fatal("selection preempted the active build")
+	}
+	releaseHolder()
+	releaseSelected := selected.admitted(t)
+	background.stillQueued(t)
+	releaseSelected()
+	background.admitted(t)()
+	assertPromotionTestDrained(t, g)
+	stats := g.Stats()
+	if stats.AdmittedInteractive != 1 || stats.AdmittedBackground != 2 || stats.WaitSamples != 2 {
+		t.Fatalf("promotion double-counted admission or wait: %+v", stats)
+	}
+}
+
+func TestViewBuildGatePromotionPreservesInteractiveFIFO(t *testing.T) {
+	g := NewViewBuildGate()
+	releaseHolder := holdPromotionTestGate(t, g)
+	first := queuePromotionTestAcquisition(t, g, ViewBuildInteractive, nil)
+	waitPromotionTestQueued(t, g, 1)
+	demand := make(chan struct{}, 1)
+	selected := queuePromotionTestAcquisition(t, g, ViewBuildBackground, demand)
+	waitPromotionTestQueued(t, g, 2)
+	close(demand)
+	releaseHolder()
+	releaseFirst := first.admitted(t)
+	selected.stillQueued(t)
+	releaseFirst()
+	selected.admitted(t)()
+	assertPromotionTestDrained(t, g)
+}
+
+func TestViewBuildGatePromotionsPreserveBackgroundBurstFairness(t *testing.T) {
+	g := newViewBuildGateWithLimits(8, 8)
+	releaseHolder := holdPromotionTestGate(t, g)
+	background := queuePromotionTestAcquisition(t, g, ViewBuildBackground, nil)
+	waitPromotionTestQueued(t, g, 1)
+	var selected []*promotionTestAcquisition
+	for i := 0; i < maxInteractiveBuildBurst+1; i++ {
+		demand := make(chan struct{}, 1)
+		selected = append(selected, queuePromotionTestAcquisition(t, g, ViewBuildBackground, demand))
+		waitPromotionTestQueued(t, g, i+2)
+		demand <- struct{}{}
+	}
+	releaseHolder()
+	for i := 0; i < maxInteractiveBuildBurst; i++ {
+		release := selected[i].admitted(t)
+		background.stillQueued(t)
+		release()
+	}
+	releaseBackground := background.admitted(t)
+	selected[maxInteractiveBuildBurst].stillQueued(t)
+	releaseBackground()
+	selected[maxInteractiveBuildBurst].admitted(t)()
+	assertPromotionTestDrained(t, g)
+}
+
+func TestViewBuildGateFullInteractiveQueueRetainsPendingPromotion(t *testing.T) {
+	g := newViewBuildGateWithLimits(1, 2)
+	releaseHolder := holdPromotionTestGate(t, g)
+	first := queuePromotionTestAcquisition(t, g, ViewBuildInteractive, nil)
+	waitPromotionTestQueued(t, g, 1)
+	demand := make(chan struct{}, 1)
+	demand <- struct{}{}
+	selected := queuePromotionTestAcquisition(t, g, ViewBuildBackground, demand)
+	waitPromotionTestQueued(t, g, 2)
+	background := queuePromotionTestAcquisition(t, g, ViewBuildBackground, nil)
+	waitPromotionTestQueued(t, g, 3)
+	stats := g.Stats()
+	if stats.InteractiveQueued != 1 || stats.BackgroundQueued != 2 {
+		t.Fatalf("promotion exceeded queue limits: %+v", stats)
+	}
+	releaseHolder()
+	releaseFirst := first.admitted(t)
+	selected.stillQueued(t)
+	releaseFirst()
+	releaseSelected := selected.admitted(t)
+	background.stillQueued(t)
+	releaseSelected()
+	background.admitted(t)()
+	assertPromotionTestDrained(t, g)
+	stats = g.Stats()
+	if stats.InteractiveHighWater > 1 || stats.BackgroundHighWater > 2 ||
+		stats.AdmittedInteractive != 2 || stats.WaitSamples != 3 {
+		t.Fatalf("pending promotion accounting: %+v", stats)
+	}
+}
+
+func TestViewBuildGatePromotionOverloadDoesNotConsumeDemand(t *testing.T) {
+	g := newViewBuildGateWithLimits(0, 0)
+	demand := make(chan struct{}, 1)
+	demand <- struct{}{}
+	release, err := g.AcquirePromotable(context.Background(), ViewBuildBackground, demand)
+	if release != nil || !errors.Is(err, ErrViewBuildQueueFull) || len(demand) != 1 {
+		t.Fatalf("overload lost demand: release=%v err=%v buffered=%d", release != nil, err, len(demand))
+	}
+	g.Open()
+	release, err = g.AcquirePromotable(context.Background(), ViewBuildBackground, demand)
+	if err != nil {
+		t.Fatal(err)
+	}
+	release()
+	if len(demand) != 0 || g.Stats().AdmittedInteractive != 1 {
+		t.Fatalf("retry ignored demand: %+v buffered=%d", g.Stats(), len(demand))
+	}
+	assertPromotionTestDrained(t, g)
+}
+
+func TestViewBuildGateDemandCancellationAndGrantRace(t *testing.T) {
+	for iteration := 0; iteration < 50; iteration++ {
+		g := newViewBuildGateWithLimits(1, 1)
+		releaseHolder := holdPromotionTestGate(t, g)
+		demand := make(chan struct{}, 1)
+		selected := queuePromotionTestAcquisition(t, g, ViewBuildBackground, demand)
+		waitPromotionTestQueued(t, g, 1)
+		close(demand)
+		cancelled := make(chan struct{})
+		go func() {
+			selected.cancel()
+			close(cancelled)
+		}()
+		releaseHolder()
+		<-cancelled
+		select {
+		case <-selected.done:
+			if selected.err != nil && !errors.Is(selected.err, context.Canceled) {
+				t.Fatal(selected.err)
+			}
+			if selected.release != nil {
+				selected.release()
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("cancel/grant race did not finish")
+		}
+		assertPromotionTestDrained(t, g)
+		stats := g.Stats()
+		if stats.WaitSamples != 1 || stats.AdmittedInteractive+stats.AdmittedBackground+
+			stats.CanceledInteractive+stats.CanceledBackground != 2 {
+			t.Fatalf("race accounting: %+v", stats)
+		}
+	}
+}
+
+func TestViewBuildGateCancelledPendingPromotionKeepsActiveHolder(t *testing.T) {
+	g := newViewBuildGateWithLimits(0, 1)
+	releaseHolder := holdPromotionTestGate(t, g)
+	demand := make(chan struct{}, 1)
+	close(demand)
+	selected := queuePromotionTestAcquisition(t, g, ViewBuildBackground, demand)
+	waitPromotionTestQueued(t, g, 1)
+	selected.cancel()
+	select {
+	case <-selected.done:
+		if !errors.Is(selected.err, context.Canceled) {
+			t.Fatalf("cancel result: %v", selected.err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("closed demand channel blocked cancellation")
+	}
+	if !g.Stats().Active {
+		t.Fatal("queued cancellation released another build's slot")
+	}
+	releaseHolder()
+	assertPromotionTestDrained(t, g)
+}
+
+func BenchmarkViewBuildGatePromotableIdle(b *testing.B) {
+	for _, mode := range []string{"ordinary", "undemanded", "prebuffered"} {
+		b.Run(mode, func(b *testing.B) {
+			g := NewViewBuildGate()
+			g.Open()
+			ctx := context.Background()
+			demand := make(chan struct{}, 1)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				var release func()
+				var err error
+				switch mode {
+				case "ordinary":
+					release, err = g.Acquire(ctx, ViewBuildBackground)
+				case "undemanded":
+					release, err = g.AcquirePromotable(ctx, ViewBuildBackground, demand)
+				case "prebuffered":
+					demand <- struct{}{}
+					release, err = g.AcquirePromotable(ctx, ViewBuildBackground, demand)
+				}
+				if err != nil {
+					b.Fatal(err)
+				}
+				release()
+			}
+		})
+	}
+}
+
+func BenchmarkViewBuildGatePendingDemandScan(b *testing.B) {
+	for _, count := range []int{1, 128, 1024} {
+		b.Run(fmt.Sprint(count), func(b *testing.B) {
+			g := newViewBuildGateWithLimits(1, count)
+			g.active = true
+			demand := make(chan struct{}, 1)
+			for i := 0; i < count; i++ {
+				g.background = append(g.background, &viewBuildWaiter{demand: demand})
+			}
+			g.promotableQueued = count
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				g.mu.Lock()
+				g.grantNextLocked()
+				g.mu.Unlock()
+			}
+		})
+	}
+}

--- a/internal/semantic/lsp/enrich_budget_test.go
+++ b/internal/semantic/lsp/enrich_budget_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -16,17 +17,20 @@ import (
 	"github.com/zzet/gortex/internal/semantic"
 )
 
-// TestLSP_Enrich_ConfirmDoesNotStarveAddPhase is the WS-D acceptance: a slow
-// references server that — with the old sequential, full-deadline confirm pass
-// — would burn the entire per-repo window before any hover / hierarchy work
-// ran, now leaves the add phase productive. Two levers make it so: the confirm
-// reference sweep fans out across maxParallel, and a fraction of the deadline
-// is reserved for the post-confirm sweep. The result is that both the confirm
-// counters AND the hover / hierarchy add counters come back non-zero under a
-// deadline that a sequential confirm pass alone (8 files x 60ms = 480ms > 400ms
-// budget) would have exhausted.
+// TestLSP_Enrich_ConfirmDoesNotStarveAddPhase verifies that a slow references
+// server leaves the reserved post-confirm budget productive. The fake server
+// dispatches requests serially: all eight references would consume 480ms of a
+// 400ms budget without the reserve. This tests the phase budget, not RPC fanout.
 func TestLSP_Enrich_ConfirmDoesNotStarveAddPhase(t *testing.T) {
 	t.Setenv("GORTEX_LSP_SWEEP", "full") // exercise the full post-confirm sweep, not the demand-gated default
+	// Keep every timer, pipe, and RPC goroutine in the same clock bubble. CPU
+	// contention and race/coverage instrumentation must not spend the budget;
+	// only the fake server's intentional delays should advance it.
+	synctest.Test(t, testConfirmDoesNotStarveAddPhase)
+}
+
+func testConfirmDoesNotStarveAddPhase(t *testing.T) {
+	t.Helper()
 	const n = 8
 	const refDelay = 60 * time.Millisecond
 


### PR DESCRIPTION
## Summary

- Prioritize demand-selected worktree builds, including coordinators already queued at background priority. Promotion is coalesced, bounded and non-preemptive; it does not reset debounce or cancel active builds.
- Use the existing generation index for positive-generation capability scans and high-water lookup. Preserve generation-zero SQL, isolation, pagination and enrichment.
- Add deterministic scheduling/race regressions, generation-isolation/query-plan tests, same-store benchmarks, and an opt-in isolated daemon test for new worktree → exact search → dry-run/edit → refreshed search → warm restart → removal.
- Document measured results and remaining limitations in `docs/worktree-readiness-performance.md`.

Refs #767.

## Validation

- Full SQLite, indexer and CLI package suites: PASS (59.46s, 462.75s, 67.62s).
- Focused scanner tests ×3 and race ×3; gate/coordinator tests and race ×10.
- Scoped golangci-lint: 0 issues.
- Fixed-binary isolated worktree lifecycle: PASS (43.30s).
- Existing cold/warm isolated idle-I/O regression: PASS; stable generation sequence and graph counts. Process disk-write counter deltas were zero, but logical writes and WAL growth were nonzero.
- Same-store scan benchmark, 128 target edges + 50,000 foreign edges: legacy 4.84–5.02 ms/op vs generation-indexed 0.502–0.537 ms/op (~9.2× at medians). No universal improvement claimed for the small zero-foreign case.
- Independent peer reviews of scanner, gate and lifecycle changes found no blocking issues.

The user's live daemon was not restarted and its store/configuration were not changed. Gortex post-edit certification remained unavailable while the checkout graph rebuilt; reported test results come from local tests and isolated private daemons.

## Scope / remaining latency

This does not bypass an already-running physical build or promise immediate first use under active load. A safe same-tree metadata-only route needs an empty-only builder contract: an empty preliminary plan can still adopt physical work or encounter a changed dirty snapshot. Retirement and other full-finalization costs remain separate profiling work. No schema migration, new index, tracking requirement or relaxed edit/fallback guard is introduced.
