### PR TITLE
daemon: give the detached Windows daemon an invisible console instead of none

### DIFF
--- a/internal/platform/detach_windows_test.go
+++ b/internal/platform/detach_windows_test.go
@@ -1,0 +1,34 @@
+//go:build windows
+
+package platform
+
+import (
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+// A detached daemon must own an invisible console, not no console at all.
+// Under DETACHED_PROCESS the daemon has no console, so every console child
+// that does not opt out gets a fresh visible window of its own — and the
+// children that cannot opt out are the ones spawned by code we do not own:
+// go/packages runs `go list` / `go env` through x/tools' own exec.Command,
+// which never sets HideWindow. CREATE_NO_WINDOW gives the daemon a console
+// with no window that all its descendants inherit; the two flags are
+// mutually exclusive, so the swap is total. The new process group stays: it
+// is what keeps a Ctrl-C in the parent console from reaching the daemon.
+func TestDetachSysProcAttrGivesTheDaemonAnInvisibleConsole(t *testing.T) {
+	attr := DetachSysProcAttr()
+	if attr == nil {
+		t.Fatal("DetachSysProcAttr() = nil")
+	}
+	if attr.CreationFlags&windows.CREATE_NO_WINDOW == 0 {
+		t.Error("detached daemon must be created with CREATE_NO_WINDOW so its console children inherit a windowless console")
+	}
+	if attr.CreationFlags&windows.DETACHED_PROCESS != 0 {
+		t.Error("DETACHED_PROCESS leaves the daemon console-less; every console child then opens a visible window")
+	}
+	if attr.CreationFlags&windows.CREATE_NEW_PROCESS_GROUP == 0 {
+		t.Error("the detached daemon must stay in its own process group")
+	}
+}

--- a/internal/platform/platform_windows.go
+++ b/internal/platform/platform_windows.go
@@ -60,12 +60,22 @@ func KillProcess(pid int) error {
 	return p.Kill()
 }
 
-// DetachSysProcAttr returns the SysProcAttr that fully detaches a
-// spawned child: a new process group, so a Ctrl-C in the parent console
-// isn't forwarded, plus DETACHED_PROCESS so the child runs with no
-// inherited console.
+// DetachSysProcAttr returns the SysProcAttr that detaches a spawned child
+// from the parent's console: a new process group, so a Ctrl-C in the
+// parent console isn't forwarded, plus CREATE_NO_WINDOW so the child owns
+// a console of its own that has no window.
+//
+// Not DETACHED_PROCESS. A console-less daemon makes Windows allocate a
+// fresh, visible console for every console child that does not opt out —
+// and the children that cannot opt out are the ones spawned by code we
+// don't own: go/packages runs `go list` / `go env` through x/tools' own
+// exec.Command, which never sets HideWindow, so a Go repository's
+// enrichment popped a blank go.exe window per invocation (issue #783).
+// ConfigureBackgroundCommand covers the spawns we construct ourselves;
+// this covers everything underneath them, because a windowless console is
+// inherited by every descendant. The two flags are mutually exclusive.
 func DetachSysProcAttr() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{
-		CreationFlags: windows.CREATE_NEW_PROCESS_GROUP | windows.DETACHED_PROCESS,
+		CreationFlags: windows.CREATE_NEW_PROCESS_GROUP | windows.CREATE_NO_WINDOW,
 	}
 }


### PR DESCRIPTION
Fixes #783.

## What users see

On Windows, `gortex daemon start --detach` followed a few minutes later by blank terminal windows titled with the Go toolchain path (`C:\Program Files\Go\bin\go.exe`), each open for well under a second, and the same again after edits in a Go repository. Two independent reports (#783 and this machine).

## Cause

Two halves, and the fix is on the half we control.

- `go/packages` (used by the `go-types` provider for its dependency index and package load) runs `go list` through x/tools' own `exec.Command` in `internal/gocommand/invoke.go`, with no `SysProcAttr`, so `platform.ConfigureBackgroundCommand` from #217 cannot reach it. Those are the only spawns in the tree that bypass the helper, which is why the popups are always `go.exe` and never `gopls.exe` or `git.exe`.
- The detached daemon was created with `DETACHED_PROCESS`, so it had no console. A console-less parent makes Windows allocate a fresh visible console for every console child that does not opt out. Third-party code will never opt out for us.

## Fix

`platform.DetachSysProcAttr` now uses `CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW` instead of `CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS`. The daemon owns a console with no window, and every descendant inherits it, the x/tools `go list` calls included. Ctrl-C isolation from the user's terminal is unchanged, since console control events are delivered per console and the daemon's is not the user's. The two flags are mutually exclusive, so the swap is total, and the stop path never depended on the daemon being console-less (control socket first, `TerminateProcess` as the fallback). A Windows test pins the attribute set.

## Verification (Windows 11, default terminal host = Windows Terminal)

Throwaway daemon under its own home and door, started through the real `--detach` path, tracking a 387-file Go repository; an observer enumerating visible console and Terminal windows every 25 to 100 ms and resolving each new window's owner and the `go.exe` children alive at that instant.

- Before (v0.64 binary): the moment `go-types` logged its dependency index and package load, a Windows Terminal window titled `C:\Program Files\Go\bin\go.exe` appeared, with the daemon's only `go.exe` children being `go list -e -f {{context.ReleaseTags}} -- unsafe` and `go list -f "{{context.GOARCH}} {{context.Compiler}}" -- unsafe`, followed by two more windows within 300 ms.
- After (this branch): the same track, and an untrack plus re-track for a second pass, ran `go-types` to the same result (1,178 confirmed, 3,615 added) with no new window in either pass, and none seen by the person watching the screen.
- `daemon stop` over the socket, `track`, `untrack --confirm` and `daemon status` behave as before against the fixed daemon.

Not covered by CI, since hosted runners cannot observe windows: the observer script is the reproduction if anyone wants to rerun it.
