### PR TITLE
fix(savings): claude-sonnet-5 bills at the permanent $2/M intro rate

### DIFF
--- a/internal/savings/pricing.go
+++ b/internal/savings/pricing.go
@@ -36,7 +36,10 @@ var defaultPricing = []Price{
 	{"claude-opus-4-8", 5.00},
 	{"claude-opus-4-7", 5.00},
 	{"claude-opus-4-6", 5.00},
-	{"claude-sonnet-5", 3.00},
+	// claude-sonnet-5 bills at its $2/M introductory input rate, which
+	// Anthropic made permanent on 2026-08-10 (the planned $3/$15 increase
+	// was withdrawn), unlike sonnet-4-6 which lists at $3.
+	{"claude-sonnet-5", 2.00},
 	{"claude-sonnet-4-6", 3.00},
 	{"claude-haiku-4-5", 1.00},
 	// OpenAI (also reachable via Azure). The gpt-5.6 tiers are the slugs the

--- a/internal/savings/pricing_test.go
+++ b/internal/savings/pricing_test.go
@@ -92,7 +92,7 @@ func TestDefaultPricingCoversCurrentGeneration(t *testing.T) {
 		"claude-mythos-5":   10.00,
 		"claude-opus-5":     5.00,
 		"claude-opus-4-8":   5.00,
-		"claude-sonnet-5":   3.00,
+		"claude-sonnet-5":   2.00,
 		"claude-sonnet-4-6": 3.00,
 		"claude-haiku-4-5":  1.00,
 		// OpenAI slugs the codex CLI reports into savings attribution.
@@ -121,8 +121,8 @@ func TestPricingExactMatchBeatsSubstring(t *testing.T) {
 	if got := CostAvoided(1_000_000, "claude-opus-5"); got != 5.00 {
 		t.Errorf("CostAvoided(1M, claude-opus-5) = %.4f, want 5.00", got)
 	}
-	if got := CostAvoided(1_000_000, "claude-sonnet-5"); got != 3.00 {
-		t.Errorf("CostAvoided(1M, claude-sonnet-5) = %.4f, want 3.00", got)
+	if got := CostAvoided(1_000_000, "claude-sonnet-5"); got != 2.00 {
+		t.Errorf("CostAvoided(1M, claude-sonnet-5) = %.4f, want 2.00", got)
 	}
 	if got := CostAvoided(1_000_000, "claude-fable-5"); got != 10.00 {
 		t.Errorf("CostAvoided(1M, claude-fable-5) = %.4f, want 10.00", got)


### PR DESCRIPTION
## What

`internal/savings/pricing.go` bills `claude-sonnet-5` at 3.00 USD/M input, but Anthropic made Sonnet 5's \$2/M introductory input pricing **permanent** on 2026-08-10 and withdrew the planned \$3/\$15 increase (their changelog: "Sonnet 5's introductory pricing of \$2 per million input tokens is now permanent"). The savings ledger has been over-crediting avoided cost for sonnet-5 traffic since then.

## Changes

- `defaultPricing`: `claude-sonnet-5` 3.00 → **2.00**, with a comment citing the 2026-08-10 announcement and noting `claude-sonnet-4-6` keeps its \$3.00 list rate
- `pricing_test.go`: `TestDefaultPricingCoversCurrentGeneration` expectation 3.00 → 2.00; `TestPricingExactMatchBeatsSubstring` now asserts `CostAvoided(1M, claude-sonnet-5) == 2.00`

`claude-sonnet-4-6` is untouched at 3.00 — the intro rate applies to the sonnet-5 line only.

## Verification

- `go test ./internal/savings/...` passes
- `go build ./...` passes

Fixes #784
