### PR TITLE
fix(pi): hold the first turn until gortex tools are registered

### DIFF
--- a/cmd/gortex/testdata/agent-render/pi.txt
+++ b/cmd/gortex/testdata/agent-render/pi.txt
@@ -446,18 +446,14 @@ function piAliasName(name: string): string {
   return PI_RESERVED_TOOL_NAMES.has(name) ? PI_ALIAS_PREFIX + name : name;
 }
 
-// piAliasNote tells the model which tools got aliased this session, so it
-// can translate bare names in Gortex's own guidance. Pi-local by design —
-// not a fact any other agent needs.
-function piAliasNote(): string {
-  const aliased = Array.from(gortexToolNames).filter((n) => n.startsWith(PI_ALIAS_PREFIX));
-  if (aliased.length === 0) return "";
-  const pairs = aliased
-    .map((n) => `\`${n.slice(PI_ALIAS_PREFIX.length)}\` -> \`${n}\``)
-    .join(", ");
+// piAliasedDescription front-loads the rename into the tool's own
+// description.
+function piAliasedDescription(bare: string, aliased: string, description: string): string {
+  if (bare === aliased) return description;
   return (
-    `[Gortex] This session renamed these Gortex tools to avoid colliding with Pi's own built-ins ` +
-    `of the same name: ${pairs}. Wherever Gortex's guidance or tool descriptions mention the bare name, call the renamed one instead.`
+    `Gortex's \`${bare}\` tool, registered as \`${aliased}\` because Pi has a built-in ` +
+    `\`${bare}\`. Gortex guidance and denial messages that name \`${bare}\` mean this tool.` +
+    `\n\n${description}`
   );
 }
 
@@ -513,7 +509,7 @@ function registerOneTool(pi: any, desc: ToolDescriptor): void {
   const def: any = {
     name,
     label: name,
-    description: (desc.description || name).trim(),
+    description: piAliasedDescription(name, piAliasName(name), (desc.description || name).trim()),
     parameters,
     async execute(_id: string, params: Record<string, unknown>) {
       if (!client) throw new Error(`gortex ${name}: MCP bridge is not connected`);
@@ -587,6 +583,16 @@ function scheduleSyncTools(pi: any): void {
 // Extension entry point
 // ---------------------------------------------------------------------------
 
+// How long before_agent_start waits for session_start to finish. Pi arms
+// the editor's submit handler well before session_start runs — at startup
+// (interactive-mode.js init()), across /reload (agent-session.js reload()
+// awaits a settings + resource reload first) and across /new
+// (agent-session-runtime.js newSession() awaits teardown + runtime build
+// first) — so a fast prompt can reach the agent loop while registration is
+// still pending or hasn't even begun. Capped so a wedged daemon costs the
+// first turn seconds; start() alone can take ~2 min.
+const READY_WAIT_MS = 15_000;
+
 export default function (pi: any) {
   let orientationInjected = false;
   // Orientation awaiting injection into the next LLM call. The `context`
@@ -594,6 +600,46 @@ export default function (pi: any) {
   // systemPrompt: a systemPrompt change sits at messages[0] and invalidates
   // prefix prompt caching. Computed once per session.
   let pendingOrientation = "";
+
+  // Settles when the current session_start handler is done — bridge up and
+  // tools registered, or the handshake failed. Never rejects.
+  //
+  // Armed at factory time: /reload re-imports this module (resource-loader.js
+  // clears the extension cache, and the loader runs jiti with
+  // moduleCache:false) and /new builds a fresh runtime, so an instance can be
+  // asked for a turn before its own session_start fires. Every path that
+  // constructs an extension goes on to emit session_start, so the wait ends.
+  let sessionReady!: Promise<void>;
+  let settleSessionReady: () => void = () => {};
+  let sessionReadyPending = false;
+
+  function armSessionReady(): void {
+    if (sessionReadyPending) return; // keep the promise parked waiters hold
+    sessionReadyPending = true;
+    sessionReady = new Promise<void>((resolve) => {
+      settleSessionReady = () => {
+        sessionReadyPending = false;
+        resolve();
+      };
+    });
+  }
+  armSessionReady();
+
+  function waitForSession(ms: number): Promise<void> {
+    const ready = sessionReady;
+    return new Promise<void>((resolve) => {
+      let settled = false;
+      const done = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve();
+      };
+      const timer = setTimeout(done, ms);
+      (timer as any)?.unref?.();
+      ready.then(done, done);
+    });
+  }
 
   // Pi resets the session's tool registry on every session_start, so
   // (re)register here. Clear the name guard first — it persists across
@@ -603,6 +649,17 @@ export default function (pi: any) {
     orientationInjected = false;
     pendingOrientation = "";
     bridgeError = "";
+    armSessionReady(); // no-op when a turn is already parked on this session
+    try {
+      await startSession();
+    } finally {
+      settleSessionReady();
+    }
+  });
+
+  // startSession holds the body of session_start so the readiness promise
+  // above settles on every exit path, early returns included.
+  async function startSession(): Promise<void> {
     ensureDaemon();
     gortexToolNames.clear();
     if (syncTimer) {
@@ -635,12 +692,15 @@ export default function (pi: any) {
         bridgeError = err?.message || String(err);
       }
     }
-  });
+  }
 
   // Fires before the agent loop's first LLM call. It can't mutate messages
   // itself, so it just parks the orientation for the `context` hook.
-  pi.on("before_agent_start", () => {
+  pi.on("before_agent_start", async () => {
     if (orientationInjected) return;
+    // Pi awaits each listener, so this holds the turn until the tools are
+    // registered and bridgeError reflects the handshake (or the cap expires).
+    await waitForSession(READY_WAIT_MS);
     const decision = callHook({ event: "session_start", cwd: pi?.cwd ?? process.cwd() });
     const parts: string[] = [];
     if (bridgeError) {
@@ -651,8 +711,6 @@ export default function (pi: any) {
       bridgeError = "";
     }
     if (decision.orientation) parts.push(decision.orientation);
-    const aliasNote = piAliasNote();
-    if (aliasNote) parts.push(aliasNote);
     if (parts.length > 0) {
       pendingOrientation = parts.join("\n\n");
       orientationInjected = true;
@@ -662,13 +720,14 @@ export default function (pi: any) {
 
   // Fires before each LLM call with a mutable message array. Append the
   // parked orientation once, then clear it so it isn't repeated each call.
+  // Cleared once the push lands, so the orientation survives a context shape
+  // this hook can't append to.
   pi.on("context", (event: any) => {
     if (!pendingOrientation) return;
-    const text = pendingOrientation;
-    pendingOrientation = "";
     try {
       if (event && Array.isArray(event.messages)) {
-        event.messages.push({ role: "user", content: text });
+        event.messages.push({ role: "user", content: pendingOrientation });
+        pendingOrientation = "";
         return { messages: event.messages };
       }
     } catch {
@@ -1165,18 +1224,14 @@ function piAliasName(name: string): string {
   return PI_RESERVED_TOOL_NAMES.has(name) ? PI_ALIAS_PREFIX + name : name;
 }
 
-// piAliasNote tells the model which tools got aliased this session, so it
-// can translate bare names in Gortex's own guidance. Pi-local by design —
-// not a fact any other agent needs.
-function piAliasNote(): string {
-  const aliased = Array.from(gortexToolNames).filter((n) => n.startsWith(PI_ALIAS_PREFIX));
-  if (aliased.length === 0) return "";
-  const pairs = aliased
-    .map((n) => `\`${n.slice(PI_ALIAS_PREFIX.length)}\` -> \`${n}\``)
-    .join(", ");
+// piAliasedDescription front-loads the rename into the tool's own
+// description.
+function piAliasedDescription(bare: string, aliased: string, description: string): string {
+  if (bare === aliased) return description;
   return (
-    `[Gortex] This session renamed these Gortex tools to avoid colliding with Pi's own built-ins ` +
-    `of the same name: ${pairs}. Wherever Gortex's guidance or tool descriptions mention the bare name, call the renamed one instead.`
+    `Gortex's \`${bare}\` tool, registered as \`${aliased}\` because Pi has a built-in ` +
+    `\`${bare}\`. Gortex guidance and denial messages that name \`${bare}\` mean this tool.` +
+    `\n\n${description}`
   );
 }
 
@@ -1232,7 +1287,7 @@ function registerOneTool(pi: any, desc: ToolDescriptor): void {
   const def: any = {
     name,
     label: name,
-    description: (desc.description || name).trim(),
+    description: piAliasedDescription(name, piAliasName(name), (desc.description || name).trim()),
     parameters,
     async execute(_id: string, params: Record<string, unknown>) {
       if (!client) throw new Error(`gortex ${name}: MCP bridge is not connected`);
@@ -1306,6 +1361,16 @@ function scheduleSyncTools(pi: any): void {
 // Extension entry point
 // ---------------------------------------------------------------------------
 
+// How long before_agent_start waits for session_start to finish. Pi arms
+// the editor's submit handler well before session_start runs — at startup
+// (interactive-mode.js init()), across /reload (agent-session.js reload()
+// awaits a settings + resource reload first) and across /new
+// (agent-session-runtime.js newSession() awaits teardown + runtime build
+// first) — so a fast prompt can reach the agent loop while registration is
+// still pending or hasn't even begun. Capped so a wedged daemon costs the
+// first turn seconds; start() alone can take ~2 min.
+const READY_WAIT_MS = 15_000;
+
 export default function (pi: any) {
   let orientationInjected = false;
   // Orientation awaiting injection into the next LLM call. The `context`
@@ -1313,6 +1378,46 @@ export default function (pi: any) {
   // systemPrompt: a systemPrompt change sits at messages[0] and invalidates
   // prefix prompt caching. Computed once per session.
   let pendingOrientation = "";
+
+  // Settles when the current session_start handler is done — bridge up and
+  // tools registered, or the handshake failed. Never rejects.
+  //
+  // Armed at factory time: /reload re-imports this module (resource-loader.js
+  // clears the extension cache, and the loader runs jiti with
+  // moduleCache:false) and /new builds a fresh runtime, so an instance can be
+  // asked for a turn before its own session_start fires. Every path that
+  // constructs an extension goes on to emit session_start, so the wait ends.
+  let sessionReady!: Promise<void>;
+  let settleSessionReady: () => void = () => {};
+  let sessionReadyPending = false;
+
+  function armSessionReady(): void {
+    if (sessionReadyPending) return; // keep the promise parked waiters hold
+    sessionReadyPending = true;
+    sessionReady = new Promise<void>((resolve) => {
+      settleSessionReady = () => {
+        sessionReadyPending = false;
+        resolve();
+      };
+    });
+  }
+  armSessionReady();
+
+  function waitForSession(ms: number): Promise<void> {
+    const ready = sessionReady;
+    return new Promise<void>((resolve) => {
+      let settled = false;
+      const done = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve();
+      };
+      const timer = setTimeout(done, ms);
+      (timer as any)?.unref?.();
+      ready.then(done, done);
+    });
+  }
 
   // Pi resets the session's tool registry on every session_start, so
   // (re)register here. Clear the name guard first — it persists across
@@ -1322,6 +1427,17 @@ export default function (pi: any) {
     orientationInjected = false;
     pendingOrientation = "";
     bridgeError = "";
+    armSessionReady(); // no-op when a turn is already parked on this session
+    try {
+      await startSession();
+    } finally {
+      settleSessionReady();
+    }
+  });
+
+  // startSession holds the body of session_start so the readiness promise
+  // above settles on every exit path, early returns included.
+  async function startSession(): Promise<void> {
     ensureDaemon();
     gortexToolNames.clear();
     if (syncTimer) {
@@ -1354,12 +1470,15 @@ export default function (pi: any) {
         bridgeError = err?.message || String(err);
       }
     }
-  });
+  }
 
   // Fires before the agent loop's first LLM call. It can't mutate messages
   // itself, so it just parks the orientation for the `context` hook.
-  pi.on("before_agent_start", () => {
+  pi.on("before_agent_start", async () => {
     if (orientationInjected) return;
+    // Pi awaits each listener, so this holds the turn until the tools are
+    // registered and bridgeError reflects the handshake (or the cap expires).
+    await waitForSession(READY_WAIT_MS);
     const decision = callHook({ event: "session_start", cwd: pi?.cwd ?? process.cwd() });
     const parts: string[] = [];
     if (bridgeError) {
@@ -1370,8 +1489,6 @@ export default function (pi: any) {
       bridgeError = "";
     }
     if (decision.orientation) parts.push(decision.orientation);
-    const aliasNote = piAliasNote();
-    if (aliasNote) parts.push(aliasNote);
     if (parts.length > 0) {
       pendingOrientation = parts.join("\n\n");
       orientationInjected = true;
@@ -1381,13 +1498,14 @@ export default function (pi: any) {
 
   // Fires before each LLM call with a mutable message array. Append the
   // parked orientation once, then clear it so it isn't repeated each call.
+  // Cleared once the push lands, so the orientation survives a context shape
+  // this hook can't append to.
   pi.on("context", (event: any) => {
     if (!pendingOrientation) return;
-    const text = pendingOrientation;
-    pendingOrientation = "";
     try {
       if (event && Array.isArray(event.messages)) {
-        event.messages.push({ role: "user", content: text });
+        event.messages.push({ role: "user", content: pendingOrientation });
+        pendingOrientation = "";
         return { messages: event.messages };
       }
     } catch {

--- a/internal/agents/pi/extension/index.ts
+++ b/internal/agents/pi/extension/index.ts
@@ -445,18 +445,14 @@ function piAliasName(name: string): string {
   return PI_RESERVED_TOOL_NAMES.has(name) ? PI_ALIAS_PREFIX + name : name;
 }
 
-// piAliasNote tells the model which tools got aliased this session, so it
-// can translate bare names in Gortex's own guidance. Pi-local by design —
-// not a fact any other agent needs.
-function piAliasNote(): string {
-  const aliased = Array.from(gortexToolNames).filter((n) => n.startsWith(PI_ALIAS_PREFIX));
-  if (aliased.length === 0) return "";
-  const pairs = aliased
-    .map((n) => `\`${n.slice(PI_ALIAS_PREFIX.length)}\` -> \`${n}\``)
-    .join(", ");
+// piAliasedDescription front-loads the rename into the tool's own
+// description.
+function piAliasedDescription(bare: string, aliased: string, description: string): string {
+  if (bare === aliased) return description;
   return (
-    `[Gortex] This session renamed these Gortex tools to avoid colliding with Pi's own built-ins ` +
-    `of the same name: ${pairs}. Wherever Gortex's guidance or tool descriptions mention the bare name, call the renamed one instead.`
+    `Gortex's \`${bare}\` tool, registered as \`${aliased}\` because Pi has a built-in ` +
+    `\`${bare}\`. Gortex guidance and denial messages that name \`${bare}\` mean this tool.` +
+    `\n\n${description}`
   );
 }
 
@@ -512,7 +508,7 @@ function registerOneTool(pi: any, desc: ToolDescriptor): void {
   const def: any = {
     name,
     label: name,
-    description: (desc.description || name).trim(),
+    description: piAliasedDescription(name, piAliasName(name), (desc.description || name).trim()),
     parameters,
     async execute(_id: string, params: Record<string, unknown>) {
       if (!client) throw new Error(`gortex ${name}: MCP bridge is not connected`);
@@ -586,6 +582,16 @@ function scheduleSyncTools(pi: any): void {
 // Extension entry point
 // ---------------------------------------------------------------------------
 
+// How long before_agent_start waits for session_start to finish. Pi arms
+// the editor's submit handler well before session_start runs — at startup
+// (interactive-mode.js init()), across /reload (agent-session.js reload()
+// awaits a settings + resource reload first) and across /new
+// (agent-session-runtime.js newSession() awaits teardown + runtime build
+// first) — so a fast prompt can reach the agent loop while registration is
+// still pending or hasn't even begun. Capped so a wedged daemon costs the
+// first turn seconds; start() alone can take ~2 min.
+const READY_WAIT_MS = 15_000;
+
 export default function (pi: any) {
   let orientationInjected = false;
   // Orientation awaiting injection into the next LLM call. The `context`
@@ -593,6 +599,46 @@ export default function (pi: any) {
   // systemPrompt: a systemPrompt change sits at messages[0] and invalidates
   // prefix prompt caching. Computed once per session.
   let pendingOrientation = "";
+
+  // Settles when the current session_start handler is done — bridge up and
+  // tools registered, or the handshake failed. Never rejects.
+  //
+  // Armed at factory time: /reload re-imports this module (resource-loader.js
+  // clears the extension cache, and the loader runs jiti with
+  // moduleCache:false) and /new builds a fresh runtime, so an instance can be
+  // asked for a turn before its own session_start fires. Every path that
+  // constructs an extension goes on to emit session_start, so the wait ends.
+  let sessionReady!: Promise<void>;
+  let settleSessionReady: () => void = () => {};
+  let sessionReadyPending = false;
+
+  function armSessionReady(): void {
+    if (sessionReadyPending) return; // keep the promise parked waiters hold
+    sessionReadyPending = true;
+    sessionReady = new Promise<void>((resolve) => {
+      settleSessionReady = () => {
+        sessionReadyPending = false;
+        resolve();
+      };
+    });
+  }
+  armSessionReady();
+
+  function waitForSession(ms: number): Promise<void> {
+    const ready = sessionReady;
+    return new Promise<void>((resolve) => {
+      let settled = false;
+      const done = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve();
+      };
+      const timer = setTimeout(done, ms);
+      (timer as any)?.unref?.();
+      ready.then(done, done);
+    });
+  }
 
   // Pi resets the session's tool registry on every session_start, so
   // (re)register here. Clear the name guard first — it persists across
@@ -602,6 +648,17 @@ export default function (pi: any) {
     orientationInjected = false;
     pendingOrientation = "";
     bridgeError = "";
+    armSessionReady(); // no-op when a turn is already parked on this session
+    try {
+      await startSession();
+    } finally {
+      settleSessionReady();
+    }
+  });
+
+  // startSession holds the body of session_start so the readiness promise
+  // above settles on every exit path, early returns included.
+  async function startSession(): Promise<void> {
     ensureDaemon();
     gortexToolNames.clear();
     if (syncTimer) {
@@ -634,12 +691,15 @@ export default function (pi: any) {
         bridgeError = err?.message || String(err);
       }
     }
-  });
+  }
 
   // Fires before the agent loop's first LLM call. It can't mutate messages
   // itself, so it just parks the orientation for the `context` hook.
-  pi.on("before_agent_start", () => {
+  pi.on("before_agent_start", async () => {
     if (orientationInjected) return;
+    // Pi awaits each listener, so this holds the turn until the tools are
+    // registered and bridgeError reflects the handshake (or the cap expires).
+    await waitForSession(READY_WAIT_MS);
     const decision = callHook({ event: "session_start", cwd: pi?.cwd ?? process.cwd() });
     const parts: string[] = [];
     if (bridgeError) {
@@ -650,8 +710,6 @@ export default function (pi: any) {
       bridgeError = "";
     }
     if (decision.orientation) parts.push(decision.orientation);
-    const aliasNote = piAliasNote();
-    if (aliasNote) parts.push(aliasNote);
     if (parts.length > 0) {
       pendingOrientation = parts.join("\n\n");
       orientationInjected = true;
@@ -661,13 +719,14 @@ export default function (pi: any) {
 
   // Fires before each LLM call with a mutable message array. Append the
   // parked orientation once, then clear it so it isn't repeated each call.
+  // Cleared once the push lands, so the orientation survives a context shape
+  // this hook can't append to.
   pi.on("context", (event: any) => {
     if (!pendingOrientation) return;
-    const text = pendingOrientation;
-    pendingOrientation = "";
     try {
       if (event && Array.isArray(event.messages)) {
-        event.messages.push({ role: "user", content: text });
+        event.messages.push({ role: "user", content: pendingOrientation });
+        pendingOrientation = "";
         return { messages: event.messages };
       }
     } catch {


### PR DESCRIPTION
## Summary

The Pi extension could start its first LLM call before its Gortex tools were registered, and the note explaining Pi's tool renaming could be lost for the whole session.

`before_agent_start` was synchronous. It ran whenever Pi's agent loop reached it — which, at startup, can be while `session_start`'s `await c.start()` / `await registerGortexTools(pi)` is still in flight, because Pi arms the editor's submit handler before it awaits `rebindCurrentSession()`. It then latched `orientationInjected = true` unconditionally (`decision.orientation` from the Go hook is effectively always non-empty), so `piAliasNote()` — which reads the not-yet-populated `gortexToolNames` — returned `""` and was never retried.

Two consequences, both observed in a deterministic harness against the live `index.ts`:

- The first turn ran with **zero** Gortex tools registered.
- The model then followed Gortex's bare-name guidance into Pi's own `read` / `edit` and got a denial naming the tool it had just called.

The same shape reaches further than startup: `/reload` and `/new` reach `before_agent_start` before their `session_start` fires at all, and `/reload` re-imports the extension module outright.

## Changes

- **A readiness barrier.** `session_start`'s body moves into `startSession()` wrapped in `try/finally`, so a readiness promise settles on every exit path — including the early `return` when a `/reload` supersedes the bridge mid-handshake. `before_agent_start` is now `async` and awaits it; Pi's `emit()` awaits each listener, so this genuinely holds the turn. Capped at `READY_WAIT_MS = 15_000` — `start()`'s worst case is 60s + 1s backoff + 60s, which must never become first-turn latency.
- **The promise is armed at factory time.** `/reload` re-imports the module (`resource-loader.js` clears the extension cache; the loader runs jiti with `moduleCache: false`) and `/new` builds a fresh runtime, so in both cases an instance exists — and can be asked for a turn — before its own `session_start` runs. Arming at construction closes that window; `armSessionReady()` is idempotent so a turn parked in the gap holds the same promise the incoming `session_start` settles.
- **The rename now rides the tool.** `piAliasNote()` is replaced by `piAliasedDescription()`, which front-loads the explanation into the aliased tool's own description. It cannot be lost to ordering: if the model can see `gortex_read`, it can see what `gortex_read` is. Non-colliding tools are untouched, and tools promoted later by `tools_search` get it too, since they take the same registration path.
- **Orientation is cleared once the `context` push lands**, so it survives a context shape the hook cannot append to.

## Testing

- [x] All tests pass (`go test -race ./...`)
- [ ] New tests added for new functionality — **none in this PR**, see below
- [ ] Benchmarks run if performance-relevant — not performance-relevant

### Test suite

`cmd/gortex/testdata/agent-render/pi.txt` is regenerated in this PR.

### No tests are added by this PR

The behaviour changed here lives entirely in `internal/agents/pi/extension/index.ts`, and there is no JS/TS test harness in the tree today; `internal/agents/pi/adapter_test.go` covers the Go side and stops at the file boundary, so none of the behaviour above is reachable from `go test`. The change is verified by a standalone harness that derives its subject from the live `index.ts` — resolving the four `{{ SENTINEL }}` placeholders exactly as the installer does, and redirecting `node:child_process` to a mock that controls when the simulated `gortex mcp` child answers `tools/list`. It therefore cannot drift from the source: rename a sentinel and it fails loudly.

Four scenarios, 19 assertions, exit 0/1, no dependencies:

| | asserts |
|---|---|
| A — `before_agent_start` fires mid-handshake, nothing awaits `session_start` | barrier held 626ms for a 300ms×2 handshake; 3 tools live at the first LLM call; orientation present; exactly one injected message |
| B — descriptions | `read` → `gortex_read` explains its own rename and keeps its original description; `search` untouched |
| C — registration outlives the cap (forced to 20ms against a 400ms registration) | gave up at 46ms, so no unbounded wait; turn 1 keeps the orientation; nothing injected on later turns; late-registered tools still explain the rename |
| D — prompt submitted in the `/reload` gap, module re-imported | turn held through the gap; resumed only after `session_start` landed; session 2 has its tools and re-injects the orientation |

Pointed at a pre-fix tree the suite fails, on the right assertions — four of D's six, including that the pre-fix code loses the orientation entirely on `/reload` (the turn parks it, then `session_start` clears `pendingOrientation`).

**That harness is not part of this PR, so the checklist item above is unchecked.** Landing it means adding a second toolchain to a Go repo, and that is a decision worth taking on its own: where it runs, whether a missing `node` skips or fails, and whether the tree gets its first `package.json`. Filed separately. Happy to fold it into this PR instead if the maintainers would rather not merge the fix without it — in which case this PR should wait on that decision.

## Checklist

- [x] Code follows existing patterns in the codebase
- [x] No unnecessary abstractions added
- [ ] Language extractor includes `Meta["methods"]` for interfaces — n/a
- [ ] Methods have `EdgeMemberOf` edges to their containing type — n/a

## Scope and limits

- **Startup ordering is closed by construction; the rest rests on a read of Pi 0.85.1.** At startup there is no `await` between `setupEditorSubmitHandler()` and `emit(session_start)` (`interactive-mode.js:708-712` → `rebindCurrentSession` → `bindCurrentSessionExtensions` → `agent-session.js:1906`), so the handler's synchronous prologue always runs first. If a future Pi inserts an await there, the factory-time arming still covers it.
- **The 15s cap is a judgement call.** A cold daemon plus warmup could exceed it, in which case the turn proceeds without tools. Warm-daemon handshake measured at 41ms, so the cap is only reachable when something is wrong.
- **Denial text is unchanged.** `pretooluse.go:568` still renders `` `read(target:{symbol:"<id>"})` `` — bare names, in Claude Code's vocabulary — and those snippets are what a model copies. With the tool descriptions in place the model can translate those names itself. The real fix is a host-vocabulary mapping at the `internal/hooks/pi.go` boundary. Filed separately; not in this PR.
