### PR TITLE
fix(indexer): admit checkout source edits without the shared build lane

### DIFF
--- a/docs/worktree-source-mutations.md
+++ b/docs/worktree-source-mutations.md
@@ -13,9 +13,15 @@ The replacement admits only the audited checkout-aware write paths.
 
 ## Safety and freshness
 
-- Admission obtains the existing checkout coordinator's interactive build
-  admission and reconciliation lock. It verifies that the checkout and the
-  route epoch still match the view used to interpret the edit.
+- Admission obtains the existing checkout coordinator's reconciliation lock,
+  not the daemon's shared build lane: a lease builds nothing, so another
+  checkout's build in progress does not delay an edit here. When that lock is
+  held, it checks the checkout's disk against the routed generations before
+  waiting, so a moved HEAD or a changed working tree is refused as stale at
+  once rather than after the rebuild that state has queued. An edit waits only
+  for its own checkout's work, bounded by the caller deadline. Under the lock
+  it verifies that the checkout, the route epoch and the disk snapshot still
+  match the view used to interpret the edit.
 - File targets must belong to that checkout, including after resolving symlinks
   and existing parent directories. Absolute primary/sibling paths, nested Git
   repositories, and Git metadata are refused rather than redirected.

--- a/internal/indexer/checkout_coordinator.go
+++ b/internal/indexer/checkout_coordinator.go
@@ -607,6 +607,22 @@ func (c *CheckoutCoordinator) cycle(ctx context.Context) {
 	if through != 0 {
 		priority = ViewBuildInteractive
 	}
+	// Lock, then lane: the order every builder uses (RehomeTo, a lease's
+	// Refresh), so a lease that holds this lock while it queues for the lane is
+	// never waited on by a lane owner. The lock is held through the queue. A
+	// settled poll never gets here, and an edit on a checkout that needs a
+	// build is refused before it waits on this lock: view_building on a
+	// withdrawn route, stale on a moved HEAD or changed tree
+	// (refuseStaleAdmission). What remains behind the lock is this checkout's
+	// own work. The wait itself is cancellable, so stop and shutdown still
+	// reach a loop parked here.
+	if err := acquireCycleLock(ctx, c); err != nil {
+		out := CheckoutCycle{Err: err}
+		recordCoordinatorCycle(out)
+		c.reportCheckoutCycle(ctx, through, out)
+		return
+	}
+	defer c.cycleMu.Unlock()
 	release, err := c.gate.AcquirePromotable(ctx, priority, c.selectionRequests())
 	if err != nil {
 		if errors.Is(err, ErrViewBuildQueueFull) {
@@ -624,9 +640,6 @@ func (c *CheckoutCoordinator) cycle(ctx context.Context) {
 		return
 	}
 	defer release()
-
-	c.cycleMu.Lock()
-	defer c.cycleMu.Unlock()
 	if c.cycleBarrier != nil {
 		c.cycleBarrier(ctx)
 	}
@@ -825,14 +838,17 @@ func (c *CheckoutCoordinator) RehomeTo(ctx context.Context, graphID string) (Che
 		stopLifetimeCancel()
 		cancel()
 	}()
+	// Lock before lane, as cycle does; the rebuild budget and the coordinator
+	// lifetime bound the lock wait as they bound the lane wait.
+	if err := acquireCycleLock(ctx, c); err != nil {
+		return out, fmt.Errorf("indexer: wait for checkout route lock: %w", err)
+	}
+	defer c.cycleMu.Unlock()
 	release, err := c.gate.Acquire(ctx, ViewBuildInteractive)
 	if err != nil {
 		return out, fmt.Errorf("indexer: wait for checkout build admission: %w", err)
 	}
 	defer release()
-
-	c.cycleMu.Lock()
-	defer c.cycleMu.Unlock()
 
 	dedicated, found, err := c.catalog.GetDedicatedGraph(ctx, graphID)
 	if err != nil {

--- a/internal/indexer/checkout_mutation.go
+++ b/internal/indexer/checkout_mutation.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/zzet/gortex/internal/gitstate"
 	"github.com/zzet/gortex/internal/graph/store_sqlite"
 	"github.com/zzet/gortex/internal/pathkey"
 )
@@ -21,21 +22,25 @@ var ErrCheckoutMutationStale = errors.New("indexer: checkout mutation view is st
 // routed generation. It does not mean the disk mutation was rolled back.
 var ErrCheckoutMutationPending = errors.New("indexer: checkout mutation refresh is pending")
 
-// ErrCheckoutMutationBusy refuses admission before source is written when the
-// queue is full or the caller deadline expires waiting for a build lane. Retry
-// once active work releases its lane; no primary fallback writes.
+// ErrCheckoutMutationBusy reports work that ran out of the caller's budget or
+// found a queue full, with the stage named. At admission, before source is
+// written, that is this checkout's cycle lock or the lock-free snapshot
+// pre-check that runs while the lock is held; in the synchronous Refresh,
+// after the disk commit, it is the shared build lane. Retry once the active
+// work releases what it holds; no primary fallback writes. A Refresh that
+// gave up leaves its withdrawn route for Close to reschedule.
 var ErrCheckoutMutationBusy = errors.New("indexer: checkout mutation lane is busy; retry")
 
-// CheckoutMutation owns one checkout's physical build lane and route lock for
-// a source edit. Callers must Close it on every exit, including dry runs. It
-// never writes source itself and must not be used to update the primary corpus.
+// CheckoutMutation owns one checkout's route lock for a source edit; it takes
+// the shared build lane only inside Refresh, for the length of that build.
+// Callers must Close it on every exit, including dry runs. It never writes
+// source itself and must not be used to update the primary corpus.
 type CheckoutMutation struct {
 	mu              sync.Mutex
 	coordinator     *CheckoutCoordinator
 	checkout        store_sqlite.Checkout
 	rootInfo        os.FileInfo
 	route           store_sqlite.CheckoutRoute
-	release         func()
 	prepared        bool
 	fresh           bool
 	closed          bool
@@ -49,11 +54,24 @@ type CheckoutMutation struct {
 
 // BeginCheckoutMutation admits a source edit against the exact checkout route
 // the caller materialized. It changes neither disk nor catalog: a dry run may
-// simply close the lease. Gate-before-cycleMu matches background reconciliation
-// so an edit can never hold the route lock while waiting on a build that needs it.
+// simply close the lease.
+//
+// Admission takes only this checkout's cycle lock, never the daemon's one
+// physical build lane. A lease builds nothing on its own: Prepare withdraws a
+// route and EnqueueRefresh hands publication to the coordinator loop, so the
+// lane would only make every edit wait for whichever checkout happens to be
+// building. The one lease operation that does build, Refresh, queues for the
+// lane itself. Lock then lane is the order every builder uses (the
+// coordinator's cycle and RehomeTo included), so nothing that owns the lane
+// ever waits for this lock.
+//
 // Admission waits until the caller deadline or coordinator shutdown, without a
 // separate admission timeout. Dry runs take the same lease to validate the exact
-// route and disk snapshot; they may therefore also wait behind active builds.
+// route and disk snapshot; they may therefore also wait behind this checkout's
+// own work in progress (an explicit reindex of a tree the edit still matches,
+// say), but not behind another checkout's. A tree the coordinator is rebuilding
+// for is refused as stale before any wait, and a checkout being rehomed has no
+// coordinator registered, so that is refused at once as well.
 func (l *CheckoutLifecycle) BeginCheckoutMutation(ctx context.Context, checkoutID, expectedRoot string, expectedRouteEpoch int64) (*CheckoutMutation, error) {
 	if l == nil || l.catalog == nil || checkoutID == "" || expectedRoot == "" || expectedRouteEpoch <= 0 {
 		return nil, fmt.Errorf("%w: exact checkout identity and route epoch are required", ErrCheckoutMutationStale)
@@ -91,18 +109,22 @@ func (l *CheckoutLifecycle) BeginCheckoutMutation(ctx context.Context, checkoutI
 
 	waitCtx, cancel := checkoutMutationContext(ctx, c.lifetimeContext())
 	defer cancel()
-	releaseGate, err := c.gate.Acquire(waitCtx, ViewBuildInteractive)
-	if err != nil {
-		return nil, checkoutMutationAdmissionError(waitCtx, "shared view-build gate", err)
-	}
-	gateOwned := true
-	defer func() {
-		if gateOwned {
-			releaseGate()
+	// A free lock is taken at once and everything is validated under it, as
+	// before. A held lock means this checkout's coordinator is queued for the
+	// lane or building, and while that rebuild is pending the route still
+	// serves the last coherent generation: reads look exact and an edit gets
+	// this far, but the lock is held for the whole wait and the edit would be
+	// refused as stale the moment it got the lock anyway. So before waiting,
+	// admission checks lock-free whether the tree still matches the routed
+	// view and refuses a stale one now. The check under the lock below stays
+	// the authority.
+	if !c.cycleMu.TryLock() {
+		if err := c.refuseStaleAdmission(waitCtx, expectedRouteEpoch); err != nil {
+			return nil, err
 		}
-	}()
-	if err := lockCheckoutMutationCycle(waitCtx, c); err != nil {
-		return nil, checkoutMutationAdmissionError(waitCtx, "checkout cycle lock", err)
+		if err := acquireCycleLock(waitCtx, c); err != nil {
+			return nil, checkoutMutationAdmissionError(waitCtx, "checkout cycle lock", err)
+		}
 	}
 	cycleOwned := true
 	defer func() {
@@ -110,7 +132,7 @@ func (l *CheckoutLifecycle) BeginCheckoutMutation(ctx context.Context, checkoutI
 			c.cycleMu.Unlock()
 		}
 	}()
-	m := &CheckoutMutation{coordinator: c, checkout: checkout, rootInfo: rootInfo, release: releaseGate}
+	m := &CheckoutMutation{coordinator: c, checkout: checkout, rootInfo: rootInfo}
 	if err := m.validateCheckout(waitCtx); err != nil {
 		return nil, err
 	}
@@ -125,7 +147,7 @@ func (l *CheckoutLifecycle) BeginCheckoutMutation(ctx context.Context, checkoutI
 	if err := m.validateSnapshot(waitCtx); err != nil {
 		return nil, err
 	}
-	admitted, gateOwned, cycleOwned = false, false, false // Close now owns every acquired resource.
+	admitted, cycleOwned = false, false // Close now owns every acquired resource.
 	return m, nil
 }
 
@@ -175,6 +197,12 @@ func checkoutMutationAdmissionError(ctx context.Context, stage string, err error
 // Refresh publishes the edited checkout through its sparse coordinator, never
 // through the primary's incremental indexer. Nil error promises an active route
 // containing both resulting generations. A failure leaves a retry to Close.
+//
+// This is the one lease operation that builds, so it is the one that queues
+// for the shared build lane. It queues while holding the cycle lock, the same
+// lock-then-lane order the coordinator's own builds use. A wait that runs out
+// reports the same busy identity and stage admission used to, and leaves the
+// withdrawn route for Close to retry.
 func (m *CheckoutMutation) Refresh(ctx context.Context) (CheckoutCycle, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -186,6 +214,11 @@ func (m *CheckoutMutation) Refresh(ctx context.Context) (CheckoutCycle, error) {
 	if err := m.validateCheckout(ctx); err != nil {
 		return CheckoutCycle{}, err
 	}
+	releaseLane, err := m.coordinator.gate.Acquire(ctx, ViewBuildInteractive)
+	if err != nil {
+		return CheckoutCycle{}, checkoutMutationAdmissionError(ctx, "shared view-build gate", err)
+	}
+	defer releaseLane()
 	out := m.coordinator.reconcile(ctx)
 	recordCoordinatorCycle(out)
 	if out.Err != nil {
@@ -225,7 +258,6 @@ func (m *CheckoutMutation) Close() {
 		m.coordinator.Signal("source mutation needs a dirty generation refresh")
 	}
 	m.coordinator.cycleMu.Unlock()
-	m.release()
 	m.coordinator.releaseSourceMutation()
 }
 
@@ -272,23 +304,8 @@ func (m *CheckoutMutation) validateSnapshot(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("%w: sample checkout: %w", ErrCheckoutMutationStale, err)
 	}
-	base, err := c.primaryBase(ctx)
-	if err != nil {
+	if err := c.checkRoutedSnapshot(ctx, m.route, sample); err != nil {
 		return err
-	}
-	commit, found, err := c.catalog.GetViewGeneration(ctx, m.route.CommitGenerationID)
-	if err != nil {
-		return err
-	}
-	if !found || !servableGeneration(commit.State) || m.route.GraphID != base.graphID || generationRowKey(commit) != generationIdentityKey(c.commitIdentity(base, sample.HeadTree)) {
-		return fmt.Errorf("%w: checkout HEAD or primary base changed", ErrCheckoutMutationStale)
-	}
-	dirty, found, err := c.catalog.GetViewGeneration(ctx, m.route.DirtyGenerationID)
-	if err != nil {
-		return err
-	}
-	if !found || !servableGeneration(dirty.State) || dirty.BaseGenerationID != m.route.CommitGenerationID || dirty.LowerViewFingerprint != sample.Fingerprint {
-		return fmt.Errorf("%w: checkout disk changed; wait for a fresh view and retry", ErrCheckoutMutationStale)
 	}
 	if m.snapshotPinned && (m.headRef != sample.HeadRef || m.headCommit != sample.HeadCommit || m.headTree != sample.HeadTree) {
 		return fmt.Errorf("%w: checkout HEAD changed since source admission", ErrCheckoutMutationStale)
@@ -296,6 +313,59 @@ func (m *CheckoutMutation) validateSnapshot(ctx context.Context) error {
 	m.snapshotPinned = true
 	m.headRef, m.headCommit, m.headTree = sample.HeadRef, sample.HeadCommit, sample.HeadTree
 	return nil
+}
+
+// checkRoutedSnapshot refuses a sample the routed generations do not describe:
+// a HEAD the commit layer was not built for, or a working tree whose dirty
+// fingerprint the dirty layer does not carry. Under the cycle lock it is the
+// authority; refuseStaleAdmission also runs it lock-free so an edit does not
+// queue behind the very rebuild that makes it stale.
+func (c *CheckoutCoordinator) checkRoutedSnapshot(ctx context.Context, route store_sqlite.CheckoutRoute, sample gitstate.DirtySnapshot) error {
+	base, err := c.primaryBase(ctx)
+	if err != nil {
+		return err
+	}
+	commit, found, err := c.catalog.GetViewGeneration(ctx, route.CommitGenerationID)
+	if err != nil {
+		return err
+	}
+	if !found || !servableGeneration(commit.State) || route.GraphID != base.graphID || generationRowKey(commit) != generationIdentityKey(c.commitIdentity(base, sample.HeadTree)) {
+		return fmt.Errorf("%w: checkout HEAD or primary base changed", ErrCheckoutMutationStale)
+	}
+	dirty, found, err := c.catalog.GetViewGeneration(ctx, route.DirtyGenerationID)
+	if err != nil {
+		return err
+	}
+	if !found || !servableGeneration(dirty.State) || dirty.BaseGenerationID != route.CommitGenerationID || dirty.LowerViewFingerprint != sample.Fingerprint {
+		return fmt.Errorf("%w: checkout disk changed; wait for a fresh view and retry", ErrCheckoutMutationStale)
+	}
+	return nil
+}
+
+// refuseStaleAdmission is the lock-free half of admission's snapshot check. It
+// reads the route the caller materialized and the checkout's disk state
+// without holding the cycle lock, so a stale tree is refused at once instead
+// of after the coordinator's queued build. A route that is not active at the
+// expected epoch is the same refusal the locked check would give.
+func (c *CheckoutCoordinator) refuseStaleAdmission(ctx context.Context, expectedRouteEpoch int64) error {
+	route, found, err := c.catalog.GetCheckoutRoute(ctx, c.checkoutID)
+	if err != nil {
+		return err
+	}
+	if !found || route.State != store_sqlite.RouteActive || route.RouteEpoch != expectedRouteEpoch || route.CommitGenerationID <= 0 || route.DirtyGenerationID <= 0 {
+		return fmt.Errorf("%w: checkout route changed; read the current exact view and retry", ErrCheckoutMutationStale)
+	}
+	sample, err := c.sampler.Sample(ctx)
+	if err != nil {
+		// A deadline that runs out inside the git call is the caller's
+		// budget ending during admission, not a stale tree: report it the way
+		// a wait for the lock reports it, stage included.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return checkoutMutationAdmissionError(ctx, "checkout snapshot pre-check", ctxErr)
+		}
+		return fmt.Errorf("%w: sample checkout: %w", ErrCheckoutMutationStale, err)
+	}
+	return c.checkRoutedSnapshot(ctx, route, sample)
 }
 
 func checkoutMutationContext(ctx, lifetime context.Context) (context.Context, context.CancelFunc) {
@@ -310,9 +380,11 @@ func checkoutMutationContext(ctx, lifetime context.Context) (context.Context, co
 	return merged, func() { stop(); cancel() }
 }
 
-// TryLock polling avoids leaving an unbounded goroutine behind when a caller
-// cancels while another checkout transition owns cycleMu.
-func lockCheckoutMutationCycle(ctx context.Context, c *CheckoutCoordinator) error {
+// acquireCycleLock takes the coordinator's cycle lock or returns the context's
+// error. TryLock polling keeps the wait cancellable: a caller deadline, the
+// coordinator's lifetime and a rehome's rebuild budget all end it, and no
+// goroutine is left behind blocked on a Lock nobody can interrupt.
+func acquireCycleLock(ctx context.Context, c *CheckoutCoordinator) error {
 	for {
 		if err := ctx.Err(); err != nil {
 			return err

--- a/internal/indexer/checkout_mutation_contention_test.go
+++ b/internal/indexer/checkout_mutation_contention_test.go
@@ -10,75 +10,63 @@ import (
 	"time"
 )
 
+// Admission contends only for the target checkout's own cycle lock. The shared
+// view-build lane is not an admission stage: another checkout's build holding
+// it does not delay an edit here (checkout_mutation_lane_test.go).
 func TestCheckoutMutationContentionWaitsForAdmissionInsteadOfRefusingActiveWork(t *testing.T) {
-	for _, stage := range []string{"shared view-build gate", "checkout cycle lock"} {
-		t.Run(stage, func(t *testing.T) {
-			f, c, lifecycle := newCheckoutMutationFixture(t)
-			before := f.route()
-			var release func()
-			if stage == "shared view-build gate" {
-				// The daemon shares this gate across checkout/ref builders. No
-				// source mutation or cycle lock on the target checkout is needed.
-				var err error
-				release, err = c.gate.Acquire(t.Context(), ViewBuildBackground)
-				if err != nil {
-					t.Fatal(err)
-				}
-			} else {
-				c.cycleMu.Lock()
-				release = c.cycleMu.Unlock
-			}
-			defer func() {
-				if release != nil {
-					release()
-				}
-			}()
-
-			type result struct {
-				lease *CheckoutMutation
-				err   error
-			}
-			resultc := make(chan result, 1)
-			go func() {
-				lease, err := lifecycle.BeginCheckoutMutation(t.Context(), f.checkoutID, f.worktree, before.RouteEpoch)
-				resultc <- result{lease: lease, err: err}
-			}()
-
-			select {
-			case got := <-resultc:
-				if got.lease != nil {
-					got.lease.Close()
-				}
-				t.Fatalf("mutation admission returned while %s was still held: %v", stage, got.err)
-			case <-time.After(2 * 250 * time.Millisecond):
-			}
-
-			if f.route() != before {
-				t.Fatal("waiting admission changed the route")
-			}
-			c.mu.Lock()
-			active := c.sourceMutations
-			c.mu.Unlock()
-			if active != 1 {
-				t.Fatalf("waiting admission should hold one tracked source mutation, got %d", active)
-			}
-
+	f, c, lifecycle := newCheckoutMutationFixture(t)
+	before := f.route()
+	c.cycleMu.Lock()
+	release := c.cycleMu.Unlock
+	defer func() {
+		if release != nil {
 			release()
-			release = nil
+		}
+	}()
 
-			select {
-			case got := <-resultc:
-				if got.err != nil {
-					t.Fatalf("admission did not recover after release: %v", got.err)
-				}
-				got.lease.Close()
-			case <-time.After(5 * time.Second):
-				t.Fatal("mutation admission did not complete after contention released")
-			}
-			if f.route() != before || c.gate.Stats().Active {
-				t.Fatal("dry-run admission leaked gate or changed route")
-			}
-		})
+	type result struct {
+		lease *CheckoutMutation
+		err   error
+	}
+	resultc := make(chan result, 1)
+	go func() {
+		lease, err := lifecycle.BeginCheckoutMutation(t.Context(), f.checkoutID, f.worktree, before.RouteEpoch)
+		resultc <- result{lease: lease, err: err}
+	}()
+
+	select {
+	case got := <-resultc:
+		if got.lease != nil {
+			got.lease.Close()
+		}
+		t.Fatalf("mutation admission returned while the cycle lock was still held: %v", got.err)
+	case <-time.After(2 * 250 * time.Millisecond):
+	}
+
+	if f.route() != before {
+		t.Fatal("waiting admission changed the route")
+	}
+	c.mu.Lock()
+	active := c.sourceMutations
+	c.mu.Unlock()
+	if active != 1 {
+		t.Fatalf("waiting admission should hold one tracked source mutation, got %d", active)
+	}
+
+	release()
+	release = nil
+
+	select {
+	case got := <-resultc:
+		if got.err != nil {
+			t.Fatalf("admission did not recover after release: %v", got.err)
+		}
+		got.lease.Close()
+	case <-time.After(5 * time.Second):
+		t.Fatal("mutation admission did not complete after contention released")
+	}
+	if f.route() != before || c.gate.Stats().Active {
+		t.Fatal("dry-run admission leaked gate or changed route")
 	}
 }
 
@@ -109,64 +97,52 @@ func TestCheckoutMutationAdmissionReportsQueueFullAsBusy(t *testing.T) {
 }
 
 func TestCheckoutMutationContentionDeadlineReportsBusyAndReleasesAdmission(t *testing.T) {
-	for _, stage := range []string{"shared view-build gate", "checkout cycle lock"} {
-		t.Run(stage, func(t *testing.T) {
-			f, c, lifecycle := newCheckoutMutationFixture(t)
-			before := f.route()
-			path := filepath.Join(f.worktree, "helper.go")
-			original, err := os.ReadFile(path)
-			if err != nil {
-				t.Fatal(err)
-			}
-			var release func()
-			if stage == "shared view-build gate" {
-				release, err = c.gate.Acquire(t.Context(), ViewBuildBackground)
-				if err != nil {
-					t.Fatal(err)
-				}
-			} else {
-				c.cycleMu.Lock()
-				release = c.cycleMu.Unlock
-			}
-			defer func() {
-				if release != nil {
-					release()
-				}
-			}()
-			ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
-			defer cancel()
-			lease, err := lifecycle.BeginCheckoutMutation(ctx, f.checkoutID, f.worktree, before.RouteEpoch)
-			if lease != nil {
-				lease.Close()
-				t.Fatal("admitted mutation while lane was held")
-			}
-			if !errors.Is(err, ErrCheckoutMutationBusy) || !errors.Is(err, context.DeadlineExceeded) {
-				t.Fatalf("contention deadline lost busy/deadline identity: %v", err)
-			}
-			if !strings.Contains(err.Error(), "lane is busy; retry") || !strings.Contains(err.Error(), stage) {
-				t.Fatalf("contention deadline lost actionable stage diagnosis: %v", err)
-			}
-			c.mu.Lock()
-			active := c.sourceMutations
-			c.mu.Unlock()
-			stats := c.gate.Stats()
-			if active != 0 || stats.InteractiveQueued != 0 || (stage == "checkout cycle lock" && stats.Active) {
-				t.Fatalf("canceled admission leaked resources: mutations=%d gate=%+v", active, stats)
-			}
-			current, err := os.ReadFile(path)
-			if err != nil || string(current) != string(original) || f.route() != before {
-				t.Fatalf("failed admission changed source or route: %v", err)
-			}
+	f, c, lifecycle := newCheckoutMutationFixture(t)
+	before := f.route()
+	path := filepath.Join(f.worktree, "helper.go")
+	original, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.cycleMu.Lock()
+	release := c.cycleMu.Unlock
+	defer func() {
+		if release != nil {
 			release()
-			release = nil
-			lease, err = lifecycle.BeginCheckoutMutation(t.Context(), f.checkoutID, f.worktree, before.RouteEpoch)
-			if err != nil {
-				t.Fatalf("retry after contention released failed: %v", err)
-			}
-			lease.Close()
-			if c.gate.Stats().Active || f.route() != before {
-				t.Fatal("retry dry run leaked gate or changed route")
-			}
-		})
+		}
+	}()
+	ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer cancel()
+	lease, err := lifecycle.BeginCheckoutMutation(ctx, f.checkoutID, f.worktree, before.RouteEpoch)
+	if lease != nil {
+		lease.Close()
+		t.Fatal("admitted mutation while the cycle lock was held")
+	}
+	if !errors.Is(err, ErrCheckoutMutationBusy) || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("contention deadline lost busy/deadline identity: %v", err)
+	}
+	if !strings.Contains(err.Error(), "lane is busy; retry") || !strings.Contains(err.Error(), "checkout cycle lock") {
+		t.Fatalf("contention deadline lost actionable stage diagnosis: %v", err)
+	}
+	c.mu.Lock()
+	active := c.sourceMutations
+	c.mu.Unlock()
+	stats := c.gate.Stats()
+	if active != 0 || stats.InteractiveQueued != 0 || stats.Active {
+		t.Fatalf("canceled admission leaked resources: mutations=%d gate=%+v", active, stats)
+	}
+	current, err := os.ReadFile(path)
+	if err != nil || string(current) != string(original) || f.route() != before {
+		t.Fatalf("failed admission changed source or route: %v", err)
+	}
+	release()
+	release = nil
+	lease, err = lifecycle.BeginCheckoutMutation(t.Context(), f.checkoutID, f.worktree, before.RouteEpoch)
+	if err != nil {
+		t.Fatalf("retry after contention released failed: %v", err)
+	}
+	lease.Close()
+	if c.gate.Stats().Active || f.route() != before {
+		t.Fatal("retry dry run leaked gate or changed route")
 	}
 }

--- a/internal/indexer/checkout_mutation_lane_test.go
+++ b/internal/indexer/checkout_mutation_lane_test.go
@@ -1,0 +1,202 @@
+package indexer
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+)
+
+// A source-mutation lease builds nothing, so it needs its own checkout's cycle
+// lock and not the daemon's one physical build lane. Holding the lane here
+// stands in for another checkout's build in progress: the edit must be
+// admitted without waiting for it. Any success while the lane stays held is
+// the proof; the deadline only bounds a regression.
+func TestCheckoutMutationAdmissionDoesNotWaitForAnotherCheckoutsBuild(t *testing.T) {
+	f, c, lifecycle := newCheckoutMutationFixture(t)
+	before := f.route()
+	releaseLane, err := c.gate.Acquire(t.Context(), ViewBuildBackground)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseLane()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	lease, err := lifecycle.BeginCheckoutMutation(ctx, f.checkoutID, f.worktree, before.RouteEpoch)
+	if err != nil {
+		t.Fatalf("admission waited on another checkout's build: %v", err)
+	}
+	lease.Close()
+	if !c.gate.Stats().Active {
+		t.Fatal("closing a lease released a lane it never held")
+	}
+	if f.route() != before {
+		t.Fatal("dry-run admission changed the route")
+	}
+}
+
+// A tree the coordinator has to rebuild for is refused at admission BEFORE the
+// wait for the cycle lock. While that rebuild is queued or running the route
+// still serves the last coherent generation, so reads look exact and an edit
+// reaches admission; the coordinator holds the lock for the whole wait, and
+// the edit would be refused as stale the moment it got the lock anyway. The
+// held lock here stands in for that queued coordinator.
+func TestCheckoutMutationAdmissionRefusesAStaleTreeBeforeWaitingForTheLock(t *testing.T) {
+	f, c, lifecycle := newCheckoutMutationFixture(t)
+	before := f.route()
+	builderWriteFile(t, f.worktree, "helper.go", "package fixture\n\nfunc ExternallyEdited() {}\n")
+	c.cycleMu.Lock()
+	defer c.cycleMu.Unlock()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	started := time.Now()
+	lease, err := lifecycle.BeginCheckoutMutation(ctx, f.checkoutID, f.worktree, before.RouteEpoch)
+	if lease != nil {
+		lease.Close()
+		t.Fatal("admitted an edit against a tree the routed view does not describe")
+	}
+	if !errors.Is(err, ErrCheckoutMutationStale) {
+		t.Fatalf("expected the stale refusal, got: %v", err)
+	}
+	if waited := time.Since(started); waited > 3*time.Second {
+		t.Fatalf("the stale refusal waited for the lock: %v", waited)
+	}
+	if f.route() != before {
+		t.Fatal("a refused admission changed the route")
+	}
+	c.mu.Lock()
+	active := c.sourceMutations
+	c.mu.Unlock()
+	if active != 0 {
+		t.Fatalf("refused admission leaked %d tracked source mutations", active)
+	}
+}
+
+// The synchronous Refresh is the one lease operation that builds, so it is the
+// one that queues for the lane. Its wait carries the busy identity and the
+// stage a caller can act on, and it leaves no waiter behind when it gives up.
+func TestCheckoutMutationRefreshQueuesForTheSharedLane(t *testing.T) {
+	f, c, lifecycle := newCheckoutMutationFixture(t)
+	before := f.route()
+	releaseLane, err := c.gate.Acquire(t.Context(), ViewBuildBackground)
+	if err != nil {
+		t.Fatal(err)
+	}
+	held := true
+	defer func() {
+		if held {
+			releaseLane()
+		}
+	}()
+
+	lease, err := lifecycle.BeginCheckoutMutation(t.Context(), f.checkoutID, f.worktree, before.RouteEpoch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lease.Close()
+	if err := lease.Prepare(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	builderWriteFile(t, f.worktree, "helper.go", "package fixture\n\nfunc LaneQueuedHelper() {}\n")
+
+	// Generous enough that the checks before the lane acquire cannot be the
+	// ones that run out of time on a slow shard; the lane is what expires it.
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	_, err = lease.Refresh(ctx)
+	if !errors.Is(err, ErrCheckoutMutationBusy) || !errors.Is(err, context.DeadlineExceeded) || !strings.Contains(err.Error(), "shared view-build gate") {
+		t.Fatalf("refresh behind a busy lane: %v", err)
+	}
+	if stats := c.gate.Stats(); stats.InteractiveQueued != 0 {
+		t.Fatalf("timed-out refresh left a queued waiter: %+v", stats)
+	}
+	if route := f.route(); route.State != store_sqlite.RoutePending {
+		t.Fatalf("a refresh that never built changed the route: %+v", route)
+	}
+
+	releaseLane()
+	held = false
+	out, err := lease.Refresh(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !out.DirtyBuilt || f.route().DirtyGenerationID != out.DirtyGenerationID {
+		t.Fatalf("refresh after the lane freed did not publish: %+v route=%+v", out, f.route())
+	}
+	if c.gate.Stats().Active {
+		t.Fatal("refresh leaked the lane")
+	}
+}
+
+// The coordinator takes its cycle lock before it queues for the lane, so a
+// lease holding the lock never leaves a coordinator parked on the lane: other
+// builders keep moving for as long as the lease's request runs, and the cycle
+// publishes the lease's edit once the lock is released.
+func TestCheckoutCoordinatorCycleDoesNotHoldTheLaneWhileALeaseHoldsTheLock(t *testing.T) {
+	f, c, lifecycle := newCheckoutMutationFixture(t)
+	before := f.route()
+	lease, err := lifecycle.BeginCheckoutMutation(t.Context(), f.checkoutID, f.worktree, before.RouteEpoch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	closed := false
+	defer func() {
+		if !closed {
+			lease.Close()
+		}
+	}()
+	// A withdrawn dirty slot is what makes the cycle need a build rather than
+	// settle in its preflight.
+	if err := lease.Prepare(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	builderWriteFile(t, f.worktree, "helper.go", "package fixture\n\nfunc OffLaneHelper() {}\n")
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.cycle(t.Context())
+	}()
+
+	// Long enough for the cycle to run its preflight and reach the lock. In
+	// all that time it must neither take the lane nor complete.
+	settle := time.Now().Add(time.Second)
+	for time.Now().Before(settle) {
+		if c.gate.Stats().Active {
+			t.Fatal("the cycle took the lane while a lease held the cycle lock")
+		}
+		select {
+		case <-done:
+			t.Fatal("the cycle completed while the lease still held the cycle lock")
+		default:
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	otherCtx, otherCancel := context.WithTimeout(t.Context(), time.Second)
+	defer otherCancel()
+	releaseOther, err := c.gate.Acquire(otherCtx, ViewBuildInteractive)
+	if err != nil {
+		t.Fatalf("another checkout's build could not take the lane while the cycle waited for the lease: %v", err)
+	}
+	releaseOther()
+
+	lease.Close()
+	closed = true
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("the cycle did not run after the lease released the lock")
+	}
+	route := f.route()
+	if route.State != store_sqlite.RouteActive || route.DirtyGenerationID == before.DirtyGenerationID || route.DirtyGenerationID == 0 {
+		t.Fatalf("the cycle did not publish the lease's edit: %+v", route)
+	}
+	if c.gate.Stats().Active {
+		t.Fatal("the cycle leaked the lane")
+	}
+}

--- a/internal/indexer/checkout_mutation_test.go
+++ b/internal/indexer/checkout_mutation_test.go
@@ -220,10 +220,10 @@ func TestCheckoutMutationCloseJoinsLeaseAndCancelsWaitingAdmission(t *testing.T)
 
 func TestCheckoutMutationAdmissionCancellationReleasesResources(t *testing.T) {
 	f, c, l := newCheckoutMutationFixture(t)
-	block, err := c.gate.Acquire(t.Context(), ViewBuildBackground)
-	if err != nil {
-		t.Fatal(err)
-	}
+	// The cycle lock is the only thing admission waits on; the shared build
+	// lane is not an admission stage (checkout_mutation_lane_test.go).
+	c.cycleMu.Lock()
+	block := c.cycleMu.Unlock
 	ctx, cancel := context.WithTimeout(t.Context(), 25*time.Millisecond)
 	defer cancel()
 	if m, err := l.BeginCheckoutMutation(ctx, f.checkoutID, f.worktree, f.route().RouteEpoch); !errors.Is(err, context.DeadlineExceeded) {
@@ -248,9 +248,10 @@ func TestCheckoutMutationAdmissionCancellationReleasesResources(t *testing.T) {
 
 func TestCheckoutMutationAdmissionPanicReleasesResources(t *testing.T) {
 	f, c, l := newCheckoutMutationFixture(t)
-	// A backend panic recovered by MCP must not strand the shared build gate
-	// or the checkout route lock. A missing coordinator catalog injects failure after
-	// both locks have been acquired, without changing the production path.
+	// A backend panic recovered by MCP must not strand the checkout route lock,
+	// and admission must not have touched the shared build gate at all. A
+	// missing coordinator catalog injects failure after the lock has been
+	// acquired, without changing the production path.
 	catalog := c.catalog
 	c.catalog = nil
 	var panicValue any


### PR DESCRIPTION
Refs #777: the "checkout mutation lane is busy" half of it. The `view_building` window while a checkout's own dirty layer rebuilds is a different question (how long a build takes), and this PR does not change it.

## What users see

On a worktree whose route is exact and idle, `edit.write` (dry run included) is refused after the whole tool budget with

```
view_read_only: checkout mutation was not admitted; no files were changed:
indexer: checkout mutation lane is busy; retry: waiting for shared view-build gate: context deadline exceeded
```

or, when the outer tool deadline wins the race, with the generic "exceeded its deadline and was abandoned" message. The worktree being edited is not building anything. Another one is.

## Cause

`BeginCheckoutMutation` acquired the daemon's one physical view-build lane before the target checkout's cycle lock, so every edit queued behind whichever checkout happened to be building: a first-view build of a freshly selected worktree, a dirty rebuild after someone else's edit, a rehome. The lane bought nothing there. A lease builds nothing: `Prepare` withdraws a route and `EnqueueRefresh` hands publication to the coordinator loop, which queues for the lane on its own. The only lease operation that builds is the synchronous `Refresh`, which the daemon path never calls (the queued MCP path's test double panics if it does); it serves the embedded adapters and the indexer tests.

## Fix

- Admission takes only the checkout's cycle lock. A dry run or an edit on an idle worktree no longer waits for another worktree's build. An edit on a checkout whose own build is in flight still waits for that build, bounded by the caller deadline as before, and the busy error still names the stage.
- `Refresh` queues for the lane at the point it builds, while holding the lock, and a wait that runs out reports the same busy identity and stage admission used to.
- The coordinator's own builders, `cycle` and `RehomeTo`, take the lock before the lane as well. The order is lock then lane everywhere, so nothing that owns the lane ever waits for a lock a lease holds, and a lease's request-length lock hold no longer stalls every other checkout's build, which the old lane-then-lock order did. The selection-demand token that promotes a queued build is consumed exactly once, by the one acquire.
- A coordinator now holds its lock while it queues for the lane, and during that queue the route still serves the last coherent generation, so reads look exact and an edit reaches admission. When admission finds the lock held it therefore checks the checkout's disk against the routed generations before waiting (`refuseStaleAdmission`): a moved HEAD or a changed tree, the usual reasons for that rebuild, is refused as stale at once rather than after a queue the edit could never survive. A free lock is taken straight away and validated under it as before, so the uncontended path pays no extra `git status`. The check under the lock remains the authority. What is left behind the lock is the checkout's own work (an explicit reindex of a tree the edit still matches). A checkout being rehomed by set-primary has no coordinator registered and is refused at once too.
- The coordinator's lock waits in `cycle` and `RehomeTo` use the same cancellable TryLock poll admission uses, so stop, shutdown and a rehome's rebuild budget bound them as they bound the lane wait.
- `docs/worktree-source-mutations.md` states the new admission contract.

## Verification

Windows 11, this repository tracked by a throwaway daemon (2,003 files, 165k nodes), with three linked worktrees on branches away from the primary's. First-view builds hold the lane for about two minutes here (one measured at 114 s: 42 s planning the closure, 26 s parsing 808 files, 44 s resolving and writing); a one-file edit to a widely imported file holds it for 63 s (25 s of that the Go type enrichment). The same dry-run edit on an idle, exact worktree while a different worktree's first-view build held the lane:

| binary | admission | evidence |
|---|---|---|
| main (a9aa7238) | waited 59.1 s, abandoned by the outer tool deadline | goroutine dump: `ViewBuildGate.AcquirePromotable <- BeginCheckoutMutation <- prepareRoutedViewMutation` for the whole wait |
| this branch | admitted in 104, 110 and 130 ms at 15, 31 and 46 s into a 73 s build | builder goroutine active at all three samples, zero admission or gate waiters |

And the case the lock-first order created, a dry-run on a worktree whose own coordinator is queued or building for a moved HEAD or changed tree: refused in 100 to 270 ms as `checkout mutation view is stale: checkout disk changed` or `checkout HEAD or primary base changed`, every 10 s for as long as that rebuild took (21 s for a dirty layer alone, 186 to 206 s for a commit layer queued behind other builds), and admitted on the first probe after it landed. Without the pre-check the same probe sat on the cycle lock for the whole 60 s budget and was abandoned.

Unit coverage (`internal/indexer`, all fail-first, each mutation-checked):

- admission proceeds while another build holds the lane, and never touches the lane;
- a tree the routed view does not describe is refused as stale while the cycle lock is held, without waiting for the lock;
- `Refresh` behind a held lane times out busy with the stage named and leaves no waiter behind, then publishes once the lane frees;
- the coordinator's cycle does not take the lane while a lease holds the lock (another builder can take it meanwhile), and publishes the lease's edit once the lock is released;
- the two contention tests from #782 that pinned the lane as an admission stage now pin the cycle lock only, and lost their one-element stage loop with it (that file's diff is mostly reindentation; `git diff -w` shows 9 insertions and 33 deletions); the cancellation test blocks on the lock instead of the lane.

`go test -race` over the checkout mutation, coordinator, lifecycle, selection and gate tests passes on Windows/amd64, Go 1.27.0. The whole `internal/indexer` package on the same box passes apart from the four fixtures that call `os.Symlink`, a privilege this non-admin shell lacks; they fail identically on main. (With this machine's `GORTEX_WORKTREE_LAZY_ACTIVATION=1` left set, three dormancy/set-primary tests that assert the eager default fail as well, on main too.) `golangci-lint v2.13.1 --new-from-rev=a9aa7238 ./internal/indexer/...` reports 0 issues. The MCP worktree, checkout and mutation tests pass apart from the same symlink fixtures.

## Not covered

- The duration of a dirty rebuild, and the `view_building` refusals on that checkout while it runs, are unchanged. On this box the window is about a minute for an edit to a core file; the 200-file closure cap, the resolver passes and the enrichment stage each take a share, and a bigger workspace pays proportionally more.
- The outer MCP tool deadline can still fire before the admission error when the edit's own checkout is building; that message says nothing about which checkout holds the lock.
