### PR TITLE
Restore durable vector corpus on all warm reconcile routes + surface hybrid in status (#790)

### DIFF
--- a/cmd/gortex/daemon.go
+++ b/cmd/gortex/daemon.go
@@ -1375,6 +1375,15 @@ func renderDaemonHeader(w io.Writer, st daemon.StatusResponse) {
 			}
 			return fmt.Sprintf("docs=%d  ", sb.DocCount)
 		}
+		// A live vector channel is a first-class fact about the backend:
+		// text-only and hybrid ranking were indistinguishable here before
+		// #790, which made hybrid outages untriageable from status.
+		formatSearchHybrid := func(sb daemon.SearchBackendStats) string {
+			if !sb.Hybrid {
+				return ""
+			}
+			return fmt.Sprintf("  hybrid vectors=%d", sb.VectorCount)
+		}
 		switch {
 		case sb.DiskResident:
 			// No heap footprint to report — the index lives inside the
@@ -1382,11 +1391,11 @@ func renderDaemonHeader(w io.Writer, st daemon.StatusResponse) {
 			// structure. Printing "heap=0 B" here would read as "this
 			// backend costs nothing", which is false.
 			t.AppendRow(table.Row{"search", fmt.Sprintf(
-				"%s  %sdisk-resident (indexed in the graph store)",
-				sb.Name, formatSearchDocs(sb))})
+				"%s  %sdisk-resident (indexed in the graph store)%s",
+				sb.Name, formatSearchDocs(sb), formatSearchHybrid(sb))})
 		default:
 			t.AppendRow(table.Row{"search", fmt.Sprintf(
-				"%s  %sheap=%s", sb.Name, formatSearchDocs(sb), formatBytes(sb.Bytes))})
+				"%s  %sheap=%s%s", sb.Name, formatSearchDocs(sb), formatBytes(sb.Bytes), formatSearchHybrid(sb))})
 		}
 	}
 	if tc := st.TrigramCache; tc != nil {

--- a/cmd/gortex/daemon_controller.go
+++ b/cmd/gortex/daemon_controller.go
@@ -687,6 +687,10 @@ func resolveSearchBackend(b search.Backend) searchBackendInfo {
 	//    drilling into the text side for name/doc-count identification.
 	if hyb, ok := inner.(*search.HybridBackend); ok {
 		out.vectorBytes = hyb.VectorSizeBytes()
+		out.Hybrid = true
+		if vi := hyb.VectorIndex(); vi != nil {
+			out.VectorCount = vi.Count()
+		}
 		inner = hyb.TextBackend()
 		// TextBackend() itself could be a Swappable in some setups. Pin it
 		// too so a nested replacement cannot invalidate this inspection.

--- a/cmd/gortex/daemon_search_backend_test.go
+++ b/cmd/gortex/daemon_search_backend_test.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/zzet/gortex/internal/daemon"
 	"github.com/zzet/gortex/internal/graph"
@@ -110,6 +113,60 @@ func TestRenderDaemonHeader_SearchBackendRow_SymbolSearcher(t *testing.T) {
 	assert.Contains(t, out, "48572")
 	assert.Contains(t, out, "disk-resident")
 	assert.NotContains(t, out, "heap=0 B", "must not print a fabricated zero heap size")
+}
+
+// stubVectorDelegate backs a delegated vector backend for status tests; the
+// resolver never queries it, it only needs to be non-nil.
+type stubVectorDelegate struct{}
+
+func (stubVectorDelegate) SimilarTo([]float32, int) ([]graph.VectorHit, error) { return nil, nil }
+
+// statusEmbedder satisfies embedding.Provider for hybrid construction.
+type statusEmbedder struct{}
+
+func (statusEmbedder) Embed(context.Context, string) ([]float32, error) { return []float32{1, 0, 0}, nil }
+func (statusEmbedder) EmbedBatch(context.Context, []string) ([][]float32, error) {
+	return nil, nil
+}
+func (statusEmbedder) Dimensions() int { return 3 }
+func (statusEmbedder) Close() error     { return nil }
+
+func TestResolveSearchBackend_ReportsHybridVectorChannel(t *testing.T) {
+	// #790 triage failure: the status row names only the peeled text backend,
+	// so a live hybrid is indistinguishable from a text-only daemon. The
+	// resolver must disclose the vector channel and its corpus size.
+	text := search.NewSymbolSearcherBackend(countingSymbolSearcher{count: 48572})
+	vector := search.NewDelegatedVector(3, stubVectorDelegate{}, 298050, 6269)
+	sw := search.NewSwappable(search.NewHybrid(text, vector, statusEmbedder{}))
+
+	raw, err := json.Marshal(resolveSearchBackend(sw))
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"hybrid":true`,
+		"a live hybrid must be visible in status")
+	assert.Contains(t, string(raw), `"vector_count":298050`,
+		"the restored corpus size must be visible in status")
+}
+
+func TestRenderDaemonHeader_SearchBackendRow_ShowsHybridVectors(t *testing.T) {
+	// Round-trip the resolver output through JSON into the stats struct the
+	// renderer consumes, exercising the real populate → render pipeline.
+	text := search.NewSymbolSearcherBackend(countingSymbolSearcher{count: 328627})
+	vector := search.NewDelegatedVector(3, stubVectorDelegate{}, 298050, 6269)
+	raw, err := json.Marshal(resolveSearchBackend(
+		search.NewSwappable(search.NewHybrid(text, vector, statusEmbedder{}))))
+	require.NoError(t, err)
+
+	var sb daemon.SearchBackendStats
+	require.NoError(t, json.Unmarshal(raw, &sb))
+
+	st := sampleStatus()
+	st.SearchBackend = sb
+	var buf bytes.Buffer
+	renderDaemonHeader(&buf, st)
+	out := buf.String()
+	assert.Contains(t, out, "sqlite-fts5", "the row still names the text backend")
+	assert.Contains(t, out, "vectors=298050",
+		"the status row must show the live vector channel")
 }
 
 func TestRenderDaemonHeader_OmitsUnknownDocCount(t *testing.T) {

--- a/internal/daemon/proto.go
+++ b/internal/daemon/proto.go
@@ -586,6 +586,15 @@ type SearchBackendStats struct {
 	// graph store's own file — and no cheap byte count is available
 	// either. Rendering must not print a fabricated "heap=0 B" for it.
 	DiskResident bool `json:"disk_resident,omitempty"`
+	// Hybrid marks a backend whose live query path carries a vector
+	// (semantic) channel alongside the text one — a restored or freshly
+	// built HybridBackend. Its absence means text-only ranking; the two
+	// states were indistinguishable from status before #790, which made
+	// hybrid outages untriageable.
+	Hybrid bool `json:"hybrid,omitempty"`
+	// VectorCount is how many vectors the hybrid's vector channel can
+	// serve (durable corpus or in-process index).
+	VectorCount int `json:"vector_count,omitempty"`
 }
 
 // SearchSymbolsParams is the payload for ControlSearchSymbols.

--- a/internal/indexer/multi.go
+++ b/internal/indexer/multi.go
@@ -3200,6 +3200,24 @@ func (mi *MultiIndexer) ReconcileRepoCtx(ctx context.Context, entry config.RepoE
 		mi.mu.Unlock()
 		installed = true
 
+		// Warm routes other than census_noop (which restores via
+		// cleanCensusResult) and full_retrack (which publishes via
+		// indexCtxRaw) never publish to the vector channel, leaving a
+		// daemon with a durable corpus serving text-only (#790).
+		// Restore the durable corpus so the shared search backend
+		// carries the hybrid on every warm route.
+		if mi.embedder != nil && route != "census_noop" && route != "full_retrack" {
+			restored, rErr := idx.restoreDurableVectorBackend(ctx, mi.graph)
+			switch {
+			case rErr != nil:
+				mi.logger.Warn("durable vector restore after warm reconcile failed",
+					zap.String("repo", prefix), zap.String("route", route), zap.Error(rErr))
+			case restored:
+				mi.logger.Info("restored durable vector corpus after warm reconcile",
+					zap.String("repo", prefix), zap.String("route", route))
+			}
+		}
+
 		entry.Path = absPath
 		if err := mi.configMgr.Global().AddRepo(entry); err != nil {
 			mi.logger.Warn("failed to add repo to config", zap.Error(err))

--- a/internal/indexer/vector_warm_route_test.go
+++ b/internal/indexer/vector_warm_route_test.go
@@ -1,0 +1,74 @@
+package indexer
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/zzet/gortex/internal/config"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graph/store_sqlite"
+	"github.com/zzet/gortex/internal/search"
+)
+
+// A warm restart whose reconcile takes a non-census route must still publish
+// the durable vector corpus onto the daemon-level search backend. Regression
+// for https://github.com/zzet/gortex/issues/790: restore was wired only into
+// the census_noop route, so every other warm route (incremental, scoped,
+// merkle-clean, manifest-only) served text-only despite a durable corpus.
+func TestWarmScopedReconcileRestoresDurableVectorCorpus(t *testing.T) {
+	root := t.TempDir()
+	mainPath := filepath.Join(root, "main.go")
+	writeFile(t, mainPath, "package sample\nfunc Alpha() {}\n")
+	writeFile(t, filepath.Join(root, "extra.go"), "package sample\nfunc Gamma() {}\n")
+	writeFile(t, filepath.Join(root, "more.go"), "package sample\nfunc Delta() {}\n")
+	entry := config.RepoEntry{Path: root, Name: "repo"}
+	cm := newTestConfigManager(t)
+	cm.Global().Repos = []config.RepoEntry{entry}
+
+	store, err := store_sqlite.Open(filepath.Join(t.TempDir(), "store.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	seedSw := search.NewSwappable(initialSearchBackend(store))
+	seed := NewMultiIndexer(graph.Store(store), newTestRegistry(), seedSw, cm, zap.NewNop())
+	seedEmb := &poolEmbedder{}
+	seed.SetEmbedder(seedEmb)
+	results, err := seed.indexMultiRepo([]config.RepoEntry{entry})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Greater(t, seedEmb.calls, int32(0))
+
+	prior := seed.GetIndexer("repo").FileMtimes()
+	require.NotEmpty(t, prior)
+	stats, err := store.VectorCorpusStats(context.Background(), 3)
+	require.NoError(t, err)
+	require.Greater(t, stats.VectorCount, 0)
+
+	// Mutate one of three files: 33% churn keeps the reconcile off both the
+	// census_noop route (no churn) and full_retrack (>40% churn), landing on
+	// scoped — a route that previously published nothing to the vector channel.
+	writeFile(t, mainPath, "package sample\nfunc Alpha() {}\nfunc Beta() {}\n")
+
+	restartSw := search.NewSwappable(initialSearchBackend(store))
+	core, logs := observer.New(zap.DebugLevel)
+	restarted := NewMultiIndexer(graph.Store(store), newTestRegistry(), restartSw, cm, zap.New(core))
+	restartEmb := &poolEmbedder{}
+	restarted.SetEmbedder(restartEmb)
+	result, err := restarted.ReconcileRepoCtx(context.Background(), entry, prior)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	entries := logs.FilterMessage("daemon: reconciled repo from snapshot").All()
+	require.Len(t, entries, 1, "expected one reconcile snapshot log line")
+	require.Equal(t, "scoped", entries[0].ContextMap()["route"],
+		"fixture must exercise a non-census warm route")
+
+	require.Zero(t, restartEmb.calls,
+		"warm restore must publish the durable corpus without embedding")
+	requirePublishedVectorStats(t, restartSw, int(stats.VectorCount), stats.ChunkCount > 0)
+}


### PR DESCRIPTION
Fixes #790

## What

Two commits fixing the two defects identified in the issue (and refined in the [mapping comment](https://github.com/zzet/gortex/issues/790#issuecomment-5621029479)):

1. **`fix(indexer): restore durable vector corpus on all warm reconcile routes`** — `restoreDurableVectorBackend` had a single production caller (`cleanCensusResult`), reached only from the `census_noop` case of the reconcile switch in `internal/indexer/multi.go`. The incremental, scoped, merkle-clean and manifest-only warm routes published nothing to the vector channel, so a daemon whose repos took any of those routes served text-only despite a durable corpus. The fix restores the durable corpus after the reconcile result is published, for every route that doesn't already publish vectors (`census_noop` and `full_retrack` are skipped — they publish on their own).

2. **`feat(daemon): surface the hybrid vector channel in status`** — `resolveSearchBackend` reported only the peeled text backend's name, making a live `HybridBackend` indistinguishable from a text-only daemon — the observability gap that made #790 hard to triage from the outside. `SearchBackendStats` gains `Hybrid` and `VectorCount`, and the status search row renders a `hybrid vectors=N` fragment alongside the existing facts.

## Testing

TDD throughout — each change landed against a failing test first:

- `TestWarmScopedReconcileRestoresDurableVectorCorpus` — a 3-file fixture with a one-file mutation pins the reconcile to the `scoped` route; the test asserts the multi-level shared backend publishes the hybrid with **zero embedder calls** (restore, not re-embed).
- Resolver output is asserted through its JSON contract, plus a populate→render round-trip test that feeds real resolver output through the status renderer.
- Full `internal/indexer`, `cmd/gortex`, and `internal/daemon` suites green.
- End-to-end on an isolated daemon (XDG-relocated throwaway store, Ollama `nomic-embed-text-v2-moe` embedder): cold index shows `hybrid vectors=3` in status; a warm restart on the `scoped` route logs `restored durable vector corpus after warm reconcile route=scoped` and the hybrid stays live and visible.

## Notes

- Vector staleness for files changed between embed passes is unchanged by this PR — the incremental path still doesn't re-embed changed content (same as the census path today). This restores publication parity across warm routes; incremental vector maintenance is a separate concern.
- The latent invariant hazard noted in the issue comment (per-repo `swappable()` panicking if `mi.search` is not a `*search.Swappable`) is deliberately left alone: daemon wiring is safe today and it deserves its own change if wanted.
