### PR TITLE
mcp: let catalog-only checkout tools answer through an unbindable cwd

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -615,7 +615,11 @@ A ref view that is rebuilding while already serving an older generation answers 
 
 Checkout administration is one surface with two front doors; the CLI verbs under `gortex repos` call exactly these tools ([cli.md](cli.md#worktrees-and-checkouts)). Every destructive tool previews by default: a call without `confirm` reads the catalog, returns what would happen, and writes nothing.
 
-The two removal verbs — `untrack_repository` and `forget_checkout` — decide from catalog rows and read no graph, so they run **without binding the calling session's working directory to a checkout view**. Every other tool binds it first and refuses with `view_building` or `checkout_inaccessible` when that binding cannot be made. Removal must not carry that gate: `gortex untrack <path>` relays through an MCP session whose cwd IS the checkout being removed, and requiring discovery of that checkout to succeed first would make the verb unavailable in exactly the state it exists to clean up — a working copy git is slow to answer for, or one that no longer answers at all.
+Three of these verbs — `untrack_repository`, `forget_checkout` and `explain_view` — name their target explicitly, answer from catalog rows and read no graph, so they run **without binding the calling session's working directory to a checkout view**. Every other tool binds it first and refuses with `view_building` or `checkout_inaccessible` when that binding cannot be made.
+
+These three must not carry that gate, because a broken binding is the state they exist for. `gortex untrack <path>` relays through an MCP session whose cwd IS the checkout being removed, so requiring discovery of that checkout to succeed first makes the verb unavailable exactly when the working copy is one git is slow to answer for — or no longer answers for at all — and retrying the removal does not make it any easier to discover. `explain_view` is the tool you reach for to find out why, so refusing it for the reason it was called to report leaves nothing to diagnose with.
+
+A read that answers off the graph never joins them, however convenient it would be: serving it through an unbound cwd would answer from the wrong corpus.
 
 | Tool | Description |
 |------|-------------|

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -615,6 +615,8 @@ A ref view that is rebuilding while already serving an older generation answers 
 
 Checkout administration is one surface with two front doors; the CLI verbs under `gortex repos` call exactly these tools ([cli.md](cli.md#worktrees-and-checkouts)). Every destructive tool previews by default: a call without `confirm` reads the catalog, returns what would happen, and writes nothing.
 
+The two removal verbs — `untrack_repository` and `forget_checkout` — decide from catalog rows and read no graph, so they run **without binding the calling session's working directory to a checkout view**. Every other tool binds it first and refuses with `view_building` or `checkout_inaccessible` when that binding cannot be made. Removal must not carry that gate: `gortex untrack <path>` relays through an MCP session whose cwd IS the checkout being removed, and requiring discovery of that checkout to succeed first would make the verb unavailable in exactly the state it exists to clean up — a working copy git is slow to answer for, or one that no longer answers at all.
+
 | Tool | Description |
 |------|-------------|
 | `list_checkouts` | List the checkout families this daemon tracks — per family the primary corpus and epoch, its dedicated graphs, every registered working copy (mode, state, both reconciler clocks with their deadlines, path evidence, route, whether a build coordinator is live) and the views rooted in its graphs. `family` narrows by family id / graph id / repo prefix / a path inside a tracked repo. Reads the catalog only |

--- a/internal/mcp/checkout_control.go
+++ b/internal/mcp/checkout_control.go
@@ -80,26 +80,29 @@ func catalogOnlyCheckoutControl(operation string) bool {
 	return operation == "mutation_status" || operation == "reindex_repository"
 }
 
-// checkoutRemovalTool reports a tool whose whole job is to take a checkout out
-// of the catalog. Removal names its target explicitly, decides from catalog
-// rows and reads no graph, so it runs without binding the session's working
-// directory to a checkout view.
+// viewlessCatalogTool reports a tool that answers from catalog rows alone. To
+// qualify a tool must name its target explicitly rather than inferring it from
+// the session, and read no graph — so it runs without binding the session's
+// working directory to a checkout view.
 //
-// Binding it would make removal depend on discovering the very checkout being
-// removed. Automatic discovery gets a 250ms slice per request, and a working
+// These are the tools a user reaches for when a binding is already broken, and
+// binding the cwd first makes each one unavailable in exactly the state it
+// exists for. Automatic discovery gets a 250ms slice per request; a working
 // copy git is slow to answer for — a Windows checkout behind a virus scanner,
 // a network share, a tree that no longer answers at all — spends it without
-// finishing. `gortex untrack` then fails with a retryable view_building error
-// in exactly the state it exists to clean up, and no amount of retrying the
-// removal makes the checkout easier to discover.
-func (s *Server) checkoutRemovalTool(req *mcp.CallToolRequest) bool {
-	name, _ := s.legacyToolName(req)
-	return checkoutRemovalToolName(name)
-}
-
-func checkoutRemovalToolName(name string) bool {
+// finishing, and the call is refused with a retryable view_building error:
+//
+//   - removal (untrack_repository, forget_checkout) would depend on
+//     discovering the very checkout it removes, and no amount of retrying a
+//     removal makes that checkout easier to discover;
+//   - explain_view exists to say why a path cannot be served, so refusing it
+//     for the reason it was called to report leaves nothing to diagnose with.
+//
+// A read that answers off the graph does NOT belong here, however convenient:
+// serving it through an unbound cwd would answer from the wrong corpus.
+func viewlessCatalogTool(name string) bool {
 	switch name {
-	case "untrack_repository", "forget_checkout":
+	case "untrack_repository", "forget_checkout", "explain_view":
 		return true
 	default:
 		return false

--- a/internal/mcp/checkout_control.go
+++ b/internal/mcp/checkout_control.go
@@ -43,15 +43,31 @@ func withCheckoutControl(ctx context.Context, scope *checkoutControlScope) conte
 	return context.WithValue(ctx, checkoutControlKey{}, scope)
 }
 
-func (s *Server) checkoutControlOperation(req *mcp.CallToolRequest) string {
+// legacyToolName lowers a facade call to the legacy tool it dispatches, so a
+// gate keyed on tool identity sees the same name through either door. The
+// second result is false only for a facade request that names no operation
+// this server can resolve.
+func (s *Server) legacyToolName(req *mcp.CallToolRequest) (string, bool) {
 	name := req.Params.Name
-	if isFacadeToolName(name) {
-		spec, ok := s.viewFacadeOperation(req)
-		if !ok {
-			return ""
-		}
-		name = spec.Legacy
+	if !isFacadeToolName(name) {
+		return name, true
 	}
+	spec, ok := s.viewFacadeOperation(req)
+	if !ok {
+		return "", false
+	}
+	return spec.Legacy, true
+}
+
+func (s *Server) checkoutControlOperation(req *mcp.CallToolRequest) string {
+	name, _ := s.legacyToolName(req)
+	return checkoutControlOperationName(name)
+}
+
+// checkoutControlOperationName is the same decision over an already lowered
+// name, so a caller that lowers once can reach both this and the removal gate
+// without resolving the facade operation twice.
+func checkoutControlOperationName(name string) string {
 	switch name {
 	case "mutation_status", "reindex_repository", "detect_changes":
 		return name
@@ -62,6 +78,32 @@ func (s *Server) checkoutControlOperation(req *mcp.CallToolRequest) string {
 
 func catalogOnlyCheckoutControl(operation string) bool {
 	return operation == "mutation_status" || operation == "reindex_repository"
+}
+
+// checkoutRemovalTool reports a tool whose whole job is to take a checkout out
+// of the catalog. Removal names its target explicitly, decides from catalog
+// rows and reads no graph, so it runs without binding the session's working
+// directory to a checkout view.
+//
+// Binding it would make removal depend on discovering the very checkout being
+// removed. Automatic discovery gets a 250ms slice per request, and a working
+// copy git is slow to answer for — a Windows checkout behind a virus scanner,
+// a network share, a tree that no longer answers at all — spends it without
+// finishing. `gortex untrack` then fails with a retryable view_building error
+// in exactly the state it exists to clean up, and no amount of retrying the
+// removal makes the checkout easier to discover.
+func (s *Server) checkoutRemovalTool(req *mcp.CallToolRequest) bool {
+	name, _ := s.legacyToolName(req)
+	return checkoutRemovalToolName(name)
+}
+
+func checkoutRemovalToolName(name string) bool {
+	switch name {
+	case "untrack_repository", "forget_checkout":
+		return true
+	default:
+		return false
+	}
 }
 
 // Catalog lookup must not depend on a ready corpus listing its repository:

--- a/internal/mcp/checkout_removal_view_test.go
+++ b/internal/mcp/checkout_removal_view_test.go
@@ -1,0 +1,148 @@
+package mcp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	mcplib "github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/graphview"
+)
+
+// removalCalls is the removal surface, through both doors: the legacy tool
+// names and the compact facade operation that lowers onto one of them.
+func removalCalls(target string) []struct {
+	name string
+	tool string
+	args map[string]any
+} {
+	return []struct {
+		name string
+		tool string
+		args map[string]any
+	}{
+		{"untrack_repository", "untrack_repository", map[string]any{"path": target}},
+		{"forget_checkout", "forget_checkout", map[string]any{"path": target}},
+		{"facade_untrack", "workspace_admin", map[string]any{"operation": "untrack", "path": target}},
+	}
+}
+
+// selectToolSurface puts the fixture session on the surface that publishes
+// the tool under test. The surface gate refuses a name the session's preset
+// does not advertise, and it fires before view routing — a different gate to
+// the one these tests are about.
+func selectToolSurface(srv *Server, tool string) {
+	surface := "full"
+	if isFacadeToolName(tool) {
+		surface = FacadeSurfaceVersion
+	}
+	srv.NoteSessionToolPolicy(viewTestSession, surface, "")
+}
+
+// TestCheckoutRemovalRunsThroughAnUnbindableCWD is the reported failure:
+// `gortex untrack <path>` relays through an MCP session whose working
+// directory IS the checkout being removed, and the middleware refused the call
+// before the handler ran because that directory could not be bound to a
+// checkout view.
+//
+// A nested directory carrying its own .git is a checkout automatic discovery
+// has not registered. Its parent is deliberately not authority for it, so
+// binding fails for every request — which is precisely the state a removal has
+// to survive, and the one graph reads must still refuse.
+func TestCheckoutRemovalRunsThroughAnUnbindableCWD(t *testing.T) {
+	stack := newViewStack(t)
+	nested := filepath.Join(stack.repoRoot, "vendored-theme")
+	require.NoError(t, os.MkdirAll(filepath.Join(nested, ".git"), 0o755))
+
+	// The gate is real and stays real: a graph read through the same cwd is
+	// still refused rather than answered off the parent's corpus.
+	readRan := false
+	res, err := stack.callWithView(t, nested, "get_symbol", nil,
+		func(context.Context) (*mcplib.CallToolResult, error) {
+			readRan = true
+			return mcplib.NewToolResultText(`{}`), nil
+		})
+	require.NoError(t, err)
+	require.False(t, readRan, "get_symbol reached its handler through an unbindable cwd")
+	assertToolError(t, res, graphview.CodeCheckoutInaccessible)
+
+	for _, call := range removalCalls(nested) {
+		t.Run(call.name, func(t *testing.T) {
+			selectToolSurface(stack.srv, call.tool)
+			ran, bound := false, false
+			res, err := stack.callWithView(t, nested, call.tool, call.args,
+				func(ctx context.Context) (*mcplib.CallToolResult, error) {
+					ran, bound = true, requestViewFromContext(ctx) != nil
+					return mcplib.NewToolResultText(`{"status":"untracked"}`), nil
+				})
+			require.NoError(t, err)
+			require.False(t, res.IsError, viewResultText(t, res))
+			require.True(t, ran, "the removal never reached its handler")
+			require.False(t, bound, "a removal must not claim a view it never needed")
+		})
+	}
+}
+
+// TestCheckoutRemovalNeverBindsTheSessionCWD pins the skip as unconditional.
+//
+// The reported error was one binder outcome of several — automatic discovery
+// still pending, its 250ms slice spent — and a removal that skipped only that
+// outcome would still be hostage to the next one. A cwd that binds perfectly
+// well proves the difference: the same session gets a routed view for a graph
+// read and no view at all for a removal.
+func TestCheckoutRemovalNeverBindsTheSessionCWD(t *testing.T) {
+	stack := newViewStack(t)
+
+	var reader graph.Reader
+	if _, err := stack.callWithView(t, stack.worktreeRoot, "get_symbol", nil,
+		captureReader(stack.srv, &reader)); err != nil {
+		t.Fatalf("call: %v", err)
+	}
+	require.True(t, hasNode(reader, "repo/added.go::Fresh"),
+		"the fixture cwd binds to a routed view, so the skip below is what is being observed")
+
+	for _, call := range removalCalls(stack.worktreeRoot) {
+		t.Run(call.name, func(t *testing.T) {
+			selectToolSurface(stack.srv, call.tool)
+			ran, bound := false, false
+			res, err := stack.callWithView(t, stack.worktreeRoot, call.tool, call.args,
+				func(ctx context.Context) (*mcplib.CallToolResult, error) {
+					ran, bound = true, requestViewFromContext(ctx) != nil
+					return mcplib.NewToolResultText(`{"status":"untracked"}`), nil
+				})
+			require.NoError(t, err)
+			require.False(t, res.IsError, viewResultText(t, res))
+			require.True(t, ran)
+			require.False(t, bound, "a removal bound the session cwd to a view anyway")
+		})
+	}
+}
+
+// TestCheckoutRemovalToolRecognisesBothDoors keeps the predicate honest about
+// what it exempts: the two removal verbs and the facade operation that lowers
+// onto one of them, and nothing that reads a graph.
+func TestCheckoutRemovalToolRecognisesBothDoors(t *testing.T) {
+	stack := newViewStack(t)
+	for _, tc := range []struct {
+		tool string
+		args map[string]any
+		want bool
+	}{
+		{"untrack_repository", map[string]any{"path": "/tmp/x"}, true},
+		{"forget_checkout", map[string]any{"path": "/tmp/x"}, true},
+		{"workspace_admin", map[string]any{"operation": "untrack", "path": "/tmp/x"}, true},
+		{"workspace_admin", map[string]any{"operation": "track", "path": "/tmp/x"}, false},
+		{"track_repository", map[string]any{"path": "/tmp/x"}, false},
+		{"get_symbol", map[string]any{"id": "repo/keep.go::Keeper"}, false},
+	} {
+		req := mcplib.CallToolRequest{}
+		req.Params.Name = tc.tool
+		req.Params.Arguments = tc.args
+		got := stack.srv.checkoutRemovalTool(&req)
+		require.Equalf(t, tc.want, got, "%s %v", tc.tool, tc.args)
+	}
+}

--- a/internal/mcp/checkout_removal_view_test.go
+++ b/internal/mcp/checkout_removal_view_test.go
@@ -2,15 +2,21 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	mcplib "github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/require"
 
+	"github.com/zzet/gortex/internal/gitstate"
 	"github.com/zzet/gortex/internal/graph"
 	"github.com/zzet/gortex/internal/graphview"
+	"github.com/zzet/gortex/internal/indexer"
+	"github.com/zzet/gortex/internal/reconcile"
 )
 
 // removalCalls is the removal surface, through both doors: the legacy tool
@@ -145,4 +151,51 @@ func TestCheckoutRemovalToolRecognisesBothDoors(t *testing.T) {
 		got := stack.srv.checkoutRemovalTool(&req)
 		require.Equalf(t, tc.want, got, "%s %v", tc.tool, tc.args)
 	}
+}
+
+// TestUntrackSurvivesPendingCheckoutDiscovery reproduces the reported failure
+// with the error it actually carried, rather than a stand-in for it.
+//
+// A linked worktree that automatic discovery has not finished registering is
+// bound by observing it, and observation gets a 250ms slice. Blocking the HEAD
+// sampler spends that slice without finishing, which is the busy outcome a slow
+// Windows or network checkout produces on its own. A graph read through that
+// cwd is refused with the reported `view_building` message; the removal, whose
+// answer comes from catalog rows, runs.
+func TestUntrackSurvivesPendingCheckoutDiscovery(t *testing.T) {
+	t.Setenv("GORTEX_TOOLS", "facade-v1")
+	f := newRealCheckoutMutationFixture(t)
+	root := filepath.Join(filepath.Dir(f.primary), "discovery-pending")
+	checkoutMutationGit(t, f.primary, "worktree", "add", "-b", "discovery-pending", root)
+
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	unblock := func() { releaseOnce.Do(func() { close(release) }) }
+	reconcile.WithHEADSampler(func(ctx context.Context, root string) (gitstate.HEADState, error) {
+		select {
+		case <-ctx.Done():
+			return gitstate.HEADState{}, errors.New("injected Git subprocess killed")
+		case <-release:
+			return gitstate.SampleHEAD(ctx, root)
+		}
+	})(f.srv.lifecycle.Reconciler())
+	t.Cleanup(unblock)
+
+	// The binder really is wedged, and it fails the way the report did.
+	read := f.facade(t, root, "search", map[string]any{"operation": "symbols", "query": "Old"})
+	assertToolError(t, read, graphview.CodeViewBuilding)
+	require.Contains(t, viewResultText(t, read), "checkout mutation lane is busy",
+		"the control read must carry the reported cause, not some other refusal")
+
+	// Same session, same wedged cwd: the removal reaches its handler and answers
+	// from the catalog. `gortex untrack` is exactly this call.
+	removal := f.facade(t, root, "workspace_admin", map[string]any{
+		"operation": "untrack", "path": f.primary,
+	})
+	require.False(t, removal.IsError, viewResultText(t, removal))
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal([]byte(viewResultText(t, removal)), &payload))
+	require.Equal(t, "preview", payload["status"])
+	require.Equal(t, string(indexer.UntrackPlanPrimaryClosure), payload["plan"],
+		"the removal must return a real catalog-derived plan, not a refusal")
 }

--- a/internal/mcp/checkout_removal_view_test.go
+++ b/internal/mcp/checkout_removal_view_test.go
@@ -19,9 +19,9 @@ import (
 	"github.com/zzet/gortex/internal/reconcile"
 )
 
-// removalCalls is the removal surface, through both doors: the legacy tool
-// names and the compact facade operation that lowers onto one of them.
-func removalCalls(target string) []struct {
+// viewlessCalls is the catalog-only surface, through both doors: the legacy
+// tool names and the compact facade operation that lowers onto one of them.
+func viewlessCalls(target string) []struct {
 	name string
 	tool string
 	args map[string]any
@@ -33,6 +33,7 @@ func removalCalls(target string) []struct {
 	}{
 		{"untrack_repository", "untrack_repository", map[string]any{"path": target}},
 		{"forget_checkout", "forget_checkout", map[string]any{"path": target}},
+		{"explain_view", "explain_view", map[string]any{"path": target}},
 		{"facade_untrack", "workspace_admin", map[string]any{"operation": "untrack", "path": target}},
 	}
 }
@@ -76,7 +77,7 @@ func TestCheckoutRemovalRunsThroughAnUnbindableCWD(t *testing.T) {
 	require.False(t, readRan, "get_symbol reached its handler through an unbindable cwd")
 	assertToolError(t, res, graphview.CodeCheckoutInaccessible)
 
-	for _, call := range removalCalls(nested) {
+	for _, call := range viewlessCalls(nested) {
 		t.Run(call.name, func(t *testing.T) {
 			selectToolSurface(stack.srv, call.tool)
 			ran, bound := false, false
@@ -87,8 +88,8 @@ func TestCheckoutRemovalRunsThroughAnUnbindableCWD(t *testing.T) {
 				})
 			require.NoError(t, err)
 			require.False(t, res.IsError, viewResultText(t, res))
-			require.True(t, ran, "the removal never reached its handler")
-			require.False(t, bound, "a removal must not claim a view it never needed")
+			require.True(t, ran, "the catalog-only call never reached its handler")
+			require.False(t, bound, "a catalog-only call must not claim a view it never needed")
 		})
 	}
 }
@@ -111,7 +112,7 @@ func TestCheckoutRemovalNeverBindsTheSessionCWD(t *testing.T) {
 	require.True(t, hasNode(reader, "repo/added.go::Fresh"),
 		"the fixture cwd binds to a routed view, so the skip below is what is being observed")
 
-	for _, call := range removalCalls(stack.worktreeRoot) {
+	for _, call := range viewlessCalls(stack.worktreeRoot) {
 		t.Run(call.name, func(t *testing.T) {
 			selectToolSurface(stack.srv, call.tool)
 			ran, bound := false, false
@@ -123,15 +124,21 @@ func TestCheckoutRemovalNeverBindsTheSessionCWD(t *testing.T) {
 			require.NoError(t, err)
 			require.False(t, res.IsError, viewResultText(t, res))
 			require.True(t, ran)
-			require.False(t, bound, "a removal bound the session cwd to a view anyway")
+			require.False(t, bound, "a catalog-only call bound the session cwd to a view anyway")
 		})
 	}
 }
 
-// TestCheckoutRemovalToolRecognisesBothDoors keeps the predicate honest about
-// what it exempts: the two removal verbs and the facade operation that lowers
-// onto one of them, and nothing that reads a graph.
-func TestCheckoutRemovalToolRecognisesBothDoors(t *testing.T) {
+// TestViewlessCatalogToolRecognisesBothDoors keeps the predicate honest about
+// what it exempts, composing exactly the pair the middleware composes: the
+// three catalog-only verbs and the facade operation that lowers onto one of
+// them, and nothing that reads a graph.
+//
+// track_repository is the deliberate near-miss. It is the same facade group and
+// the same shape of argument, but it creates a checkout rather than reporting
+// on or removing one, and it has no reason to run through a cwd the daemon
+// cannot bind.
+func TestViewlessCatalogToolRecognisesBothDoors(t *testing.T) {
 	stack := newViewStack(t)
 	for _, tc := range []struct {
 		tool string
@@ -140,16 +147,19 @@ func TestCheckoutRemovalToolRecognisesBothDoors(t *testing.T) {
 	}{
 		{"untrack_repository", map[string]any{"path": "/tmp/x"}, true},
 		{"forget_checkout", map[string]any{"path": "/tmp/x"}, true},
+		{"explain_view", map[string]any{"path": "/tmp/x"}, true},
 		{"workspace_admin", map[string]any{"operation": "untrack", "path": "/tmp/x"}, true},
 		{"workspace_admin", map[string]any{"operation": "track", "path": "/tmp/x"}, false},
 		{"track_repository", map[string]any{"path": "/tmp/x"}, false},
+		{"list_checkouts", map[string]any{}, false},
+		{"reconcile_checkouts", map[string]any{}, false},
 		{"get_symbol", map[string]any{"id": "repo/keep.go::Keeper"}, false},
 	} {
 		req := mcplib.CallToolRequest{}
 		req.Params.Name = tc.tool
 		req.Params.Arguments = tc.args
-		got := stack.srv.checkoutRemovalTool(&req)
-		require.Equalf(t, tc.want, got, "%s %v", tc.tool, tc.args)
+		name, _ := stack.srv.legacyToolName(&req)
+		require.Equalf(t, tc.want, viewlessCatalogTool(name), "%s %v", tc.tool, tc.args)
 	}
 }
 
@@ -162,12 +172,13 @@ func TestCheckoutRemovalToolRecognisesBothDoors(t *testing.T) {
 // Windows or network checkout produces on its own. A graph read through that
 // cwd is refused with the reported `view_building` message; the removal, whose
 // answer comes from catalog rows, runs.
-func TestUntrackSurvivesPendingCheckoutDiscovery(t *testing.T) {
-	t.Setenv("GORTEX_TOOLS", "facade-v1")
-	f := newRealCheckoutMutationFixture(t)
-	root := filepath.Join(filepath.Dir(f.primary), "discovery-pending")
-	checkoutMutationGit(t, f.primary, "worktree", "add", "-b", "discovery-pending", root)
-
+// wedgeCheckoutDiscovery adds a linked worktree and blocks the HEAD sampler so
+// automatic discovery for it cannot finish inside its 250ms slice. That is the
+// busy outcome a slow Windows or network checkout produces on its own.
+func wedgeCheckoutDiscovery(t *testing.T, f *realCheckoutMutationFixture, branch string) string {
+	t.Helper()
+	root := filepath.Join(filepath.Dir(f.primary), branch)
+	checkoutMutationGit(t, f.primary, "worktree", "add", "-b", branch, root)
 	release := make(chan struct{})
 	var releaseOnce sync.Once
 	unblock := func() { releaseOnce.Do(func() { close(release) }) }
@@ -180,12 +191,26 @@ func TestUntrackSurvivesPendingCheckoutDiscovery(t *testing.T) {
 		}
 	})(f.srv.lifecycle.Reconciler())
 	t.Cleanup(unblock)
+	return root
+}
+
+// assertReportedRefusal fails unless res carries the refusal from the report.
+func assertReportedRefusal(t *testing.T, res *mcplib.CallToolResult) {
+	t.Helper()
+	assertToolError(t, res, graphview.CodeViewBuilding)
+	require.Contains(t, viewResultText(t, res), "checkout mutation lane is busy",
+		"the control read must carry the reported cause, not some other refusal")
+}
+
+func TestUntrackSurvivesPendingCheckoutDiscovery(t *testing.T) {
+	t.Setenv("GORTEX_TOOLS", "facade-v1")
+	f := newRealCheckoutMutationFixture(t)
+	root := wedgeCheckoutDiscovery(t, f, "discovery-pending")
 
 	// The binder really is wedged, and it fails the way the report did.
-	read := f.facade(t, root, "search", map[string]any{"operation": "symbols", "query": "Old"})
-	assertToolError(t, read, graphview.CodeViewBuilding)
-	require.Contains(t, viewResultText(t, read), "checkout mutation lane is busy",
-		"the control read must carry the reported cause, not some other refusal")
+	assertReportedRefusal(t, f.facade(t, root, "search", map[string]any{
+		"operation": "symbols", "query": "Old",
+	}))
 
 	// Same session, same wedged cwd: the removal reaches its handler and answers
 	// from the catalog. `gortex untrack` is exactly this call.
@@ -198,4 +223,36 @@ func TestUntrackSurvivesPendingCheckoutDiscovery(t *testing.T) {
 	require.Equal(t, "preview", payload["status"])
 	require.Equal(t, string(indexer.UntrackPlanPrimaryClosure), payload["plan"],
 		"the removal must return a real catalog-derived plan, not a refusal")
+}
+
+// TestExplainViewSurvivesPendingCheckoutDiscovery is the diagnosability half.
+//
+// explain_view exists to answer "why is this path not being served the way I
+// expect" — so a binding failure is its subject, not a reason to refuse it.
+// Through the same wedged cwd that refuses a graph read, it names the checkout
+// and the step that could not be taken.
+func TestExplainViewSurvivesPendingCheckoutDiscovery(t *testing.T) {
+	f := newRealCheckoutMutationFixture(t)
+	root := wedgeCheckoutDiscovery(t, f, "explain-pending")
+
+	legacy := func(name string, handler func(context.Context, mcplib.CallToolRequest) (*mcplib.CallToolResult, error), args map[string]any) *mcplib.CallToolResult {
+		t.Helper()
+		req := mcplib.CallToolRequest{}
+		req.Params.Name, req.Params.Arguments = name, args
+		ctx := WithSessionCWD(WithSessionID(context.Background(), "real-checkout-lifecycle"), root)
+		res, err := f.srv.wrapToolHandler(handler)(ctx, req)
+		require.NoError(t, err)
+		return res
+	}
+
+	assertReportedRefusal(t, legacy("get_symbol", f.srv.handleGetSymbol,
+		map[string]any{"id": "repo/edit.go::Old"}))
+
+	explained := legacy("explain_view", f.srv.handleExplainView, map[string]any{"path": f.primary})
+	require.False(t, explained.IsError, viewResultText(t, explained))
+	var binding map[string]any
+	require.NoError(t, json.Unmarshal([]byte(viewResultText(t, explained)), &binding))
+	require.Equal(t, true, binding["matched"],
+		"explain_view must answer from the catalog, not refuse for the reason it was called to report")
+	require.NotEmpty(t, binding["chain"], "the explanation carries the chain it walked")
 }

--- a/internal/mcp/overlay.go
+++ b/internal/mcp/overlay.go
@@ -174,9 +174,9 @@ func (s *Server) wrapToolHandlerMode(h mcpserver.ToolHandlerFunc, injectOverlay 
 			ctx = withCheckoutControl(ctx, control)
 		}
 		// Catalog authority that needs no view at all: a recovery or receipt
-		// read that must stay reachable while publication is pending, and a
-		// removal that must not be hostage to discovering what it removes.
-		viewless := catalogOnlyCheckoutControl(controlOperation) || checkoutRemovalToolName(legacyName)
+		// read that must stay reachable while publication is pending, and the
+		// tools that must not be hostage to the binding they exist to fix.
+		viewless := catalogOnlyCheckoutControl(controlOperation) || viewlessCatalogTool(legacyName)
 		var view *requestView
 		if !viewless {
 			var viewErr error

--- a/internal/mcp/overlay.go
+++ b/internal/mcp/overlay.go
@@ -162,7 +162,10 @@ func (s *Server) wrapToolHandlerMode(h mcpserver.ToolHandlerFunc, injectOverlay 
 		// overlay so a session's editor buffers layer on top of whatever
 		// answers here. The lease the materialized view holds is released
 		// with the request, on the same lifecycle that discards the overlay.
-		controlOperation := s.checkoutControlOperation(&req)
+		// A facade call is lowered to its legacy name once here; both of the
+		// gates below read that name rather than resolving it twice.
+		legacyName, _ := s.legacyToolName(&req)
+		controlOperation := checkoutControlOperationName(legacyName)
 		if controlOperation != "" {
 			control, controlErr := s.resolveCheckoutControlScope(ctx, selector, &req)
 			if controlErr != nil {
@@ -170,8 +173,12 @@ func (s *Server) wrapToolHandlerMode(h mcpserver.ToolHandlerFunc, injectOverlay 
 			}
 			ctx = withCheckoutControl(ctx, control)
 		}
+		// Catalog authority that needs no view at all: a recovery or receipt
+		// read that must stay reachable while publication is pending, and a
+		// removal that must not be hostage to discovering what it removes.
+		viewless := catalogOnlyCheckoutControl(controlOperation) || checkoutRemovalToolName(legacyName)
 		var view *requestView
-		if !catalogOnlyCheckoutControl(controlOperation) {
+		if !viewless {
 			var viewErr error
 			view, viewErr = s.resolveRequestView(ctx, selector, s.requestViewPolicy(&req))
 			if viewErr != nil {
@@ -210,12 +217,12 @@ func (s *Server) wrapToolHandlerMode(h mcpserver.ToolHandlerFunc, injectOverlay 
 		// What the view can answer, checked against what this operation
 		// needs, before the handler runs — a thin view must refuse rather
 		// than answer thinly and look complete doing it.
-		if !catalogOnlyCheckoutControl(controlOperation) {
+		if !viewless {
 			if refused := s.evaluateRequestCapabilities(ctx, &req, capabilities); refused != nil {
 				return refused, nil
 			}
 		}
-		if injectOverlay && !catalogOnlyCheckoutControl(controlOperation) && view.acceptsBufferOverlay() {
+		if injectOverlay && !viewless && view.acceptsBufferOverlay() {
 			var err error
 			ctx, _, err = s.prepareOverlayRequest(ctx)
 			if err != nil {

--- a/internal/mcp/view_request_test.go
+++ b/internal/mcp/view_request_test.go
@@ -165,6 +165,17 @@ func newViewStack(t *testing.T) *viewStack {
 	})
 	srv.SetMaterializer(&graphview.Materializer{Store: store, Catalog: store.Catalog(), Leases: stack.leases})
 	stack.srv = srv
+	// A request whose cwd is not already a registered checkout shells out to
+	// git on a background observation goroutine with a five-second budget of
+	// its own. Registered last so LIFO cleanup drains it FIRST: the store below
+	// closes next and t.TempDir unlinks the tree it is reading last, and doing
+	// either under a live observation is the teardown order that turns a
+	// background git read into a cleanup failure.
+	t.Cleanup(func() {
+		if srv.lifecycle != nil {
+			_ = srv.lifecycle.Close()
+		}
+	})
 	return stack
 }
 


### PR DESCRIPTION
## The report

A community user could not untrack a repository:

```
PS D:\KOSMOS> gortex untrack C:\laragon\www\organicgardenfood\flatsome-child

Error: view_building: automatic checkout discovery is still pending; retry this request:
indexer: checkout mutation lane is busy; retry: selected checkout discovery is pending:
context deadline exceeded
context deadline exceeded
```

## Why it happens

`gortex untrack <path>` does not use the control socket — it relays through the
`untrack_repository` MCP tool, and `untrackDaemonIndex` hands the **target path**
to the daemon as the session's working directory (`cmd/gortex/track.go:525`).
The session cwd is therefore the very checkout being removed.

The tool middleware binds the session cwd to a checkout view before any handler
runs (`internal/mcp/overlay.go`, `resolveRequestView` → `viewForSessionCWD` →
`checkoutForRequestPath` → `ObserveCheckoutPath`). `ObserveCheckoutPath` gives
each request a hard **250ms** slice (`internal/indexer/checkout_observe.go:20`);
a working copy git is slow to answer for — a Windows checkout behind a virus
scanner, a network share, a tree that no longer answers at all — spends it
without finishing, and `viewForCWDLookupError` turns the busy outcome into the
`view_building` refusal above.

So the verb is unavailable in exactly the state it exists to clean up, and the
"retry this request" advice does not help: retrying a removal does not make the
checkout easier to discover. Worse, `explain_view` — the tool you would reach
for to find out *why* — was refused by the same gate, for the same reason it was
called to report. The failure silenced the one call that could have explained it.

## The fix

Three verbs name their target explicitly, answer from catalog rows and read no
graph, so they now skip view resolution entirely — a third `viewless` case
alongside the two catalog-only checkout controls that already bypass it:

| Tool | Answers from |
|---|---|
| `untrack_repository` | `PreviewUntrack` → `resolveDestructivePrefix` → `checkoutForPath` |
| `forget_checkout` | `PreviewForget`, same path |
| `explain_view` | `ExplainView` → `checkoutForPath` + `ListDedicatedGraphs` |

All catalog reads — no git, no observation, no graph.

The predicate's doc comment states the membership test so future additions are
deliberate, and the boundary is pinned as negatives rather than left implied:
`list_checkouts` is a workspace-wide listing rather than an explicitly addressed
target, `reconcile_checkouts` does filesystem and git work of its own, and
`track_repository` is the deliberate near-miss — same facade group, same argument
shape, but it creates a checkout rather than reporting on or removing one.

Facade lowering moves into one `legacyToolName` helper so the control-operation
gate and this one share a single resolution per request; the exemption covers
`workspace_admin(operation:"untrack")` as well as the legacy names.

**The gate stays real for everything else.** A graph read through the same
wedged cwd is still refused rather than answered off the parent's corpus —
asserted in every test below, not just intended. A read that answers off the
graph never joins this list, however convenient: serving it through an unbound
cwd would answer from the wrong corpus.

## What is pinned

`internal/mcp/checkout_removal_view_test.go`, driving real requests through the
whole middleware:

- **`TestUntrackSurvivesPendingCheckoutDiscovery`** — the reported failure with
  the error it actually carried. A linked worktree whose discovery is wedged by
  a blocked HEAD sampler spends its 250ms slice without finishing; the control
  read through that cwd is refused with the report's message **verbatim**, while
  `workspace_admin(operation:"untrack")` on the same session returns a real
  `primary_closure` plan.
- **`TestExplainViewSurvivesPendingCheckoutDiscovery`** — the diagnosability
  half. Through the same wedged cwd that refuses `get_symbol`, `explain_view`
  answers `matched: true` with the chain it walked.
- **`TestCheckoutRemovalRunsThroughAnUnbindableCWD`** — a second binder failure
  class (an unregistered nested checkout), deterministic and timing-free.
  `get_symbol` is still refused with `checkout_inaccessible`; all four
  catalog-only calls reach their handler.
- **`TestCheckoutRemovalNeverBindsTheSessionCWD`** — pins the skip as
  *unconditional*. The reported error was one binder outcome of several, and a
  tool that skipped only that one would still be hostage to the next. A cwd that
  binds perfectly well shows the difference: the same session gets a routed view
  for a graph read and no view at all for these.
- **`TestViewlessCatalogToolRecognisesBothDoors`** — composes `legacyToolName`
  and the predicate exactly as the middleware does, over the positives and the
  three negatives above.

**Mutation-verified twice.** Removing the whole exemption turns every arm red;
removing only `explain_view` turns its three arms red, with the reported string
exactly:

```
--- FAIL: TestExplainViewSurvivesPendingCheckoutDiscovery
    Messages: view_building: automatic checkout discovery is still pending; retry
              this request: indexer: checkout mutation lane is busy; retry:
              selected checkout discovery is pending: context deadline exceeded
--- FAIL: TestCheckoutRemovalNeverBindsTheSessionCWD/untrack_repository
    Messages: a catalog-only call bound the session cwd to a view anyway
```

## Also fixed: a harness teardown race

`newViewStack` never closed the lifecycle it builds. A request whose cwd is not
already a registered checkout shells out to git on a background observation
goroutine with a five-second budget of its own, so the harness could be reading
a `t.TempDir()` tree while cleanup unlinked it. It now drains first, the way
`newCatalogMCPServer` already does for the same reason.

## Verification

- `go test ./internal/mcp/... ./cmd/gortex/... ./internal/indexer/...` — pass
- `go test -race ./internal/mcp/` — pass
- `golangci-lint run ./internal/mcp/...` — 0 issues
- CI green on all three legs at the previous head

## Not fixed here

The 250ms observation budget itself. It is tight enough that it shows up as
test flake under load, and a Windows or network checkout can miss it routinely.
This PR routes the catalog-only verbs around the budget rather than widening it;
whether 250ms is the right slice is a separate question with its own trade-off.