### PR TITLE
fix(astquery): stop flagging f-string SQL that interpolates constants

### DIFF
--- a/internal/astquery/rules_sast_python.go
+++ b/internal/astquery/rules_sast_python.go
@@ -1,6 +1,9 @@
 package astquery
 
-import "github.com/zzet/gortex/internal/parser"
+import (
+	"github.com/zzet/gortex/internal/parser"
+	sitter "github.com/zzet/gortex/internal/parser/tsitter"
+)
 
 // Bandit-parity Python SAST ruleset. Patterns target the tree-sitter
 // Python grammar; capture names follow the convention
@@ -822,6 +825,7 @@ func registerPythonSQLi() {
                                 arguments: (argument_list (string (interpolation)))) @match
                               (#match? @fn "^(execute|executemany|raw|fetch|fetchall|fetchone)$"))`,
 			},
+			PostFilter: fstringInterpolatesNonConstant,
 		},
 		sastRule{
 			Name:        "py-sqlalchemy-text-with-fstring",
@@ -835,8 +839,129 @@ func registerPythonSQLi() {
                                 arguments: (argument_list (string (interpolation)))) @match
                               (#eq? @fn "text"))`,
 			},
+			PostFilter: fstringInterpolatesNonConstant,
 		},
 	)
+}
+
+// fstringInterpolatesNonConstant keeps an f-string SQLi match unless every
+// `{expr}` in the call's f-string arguments is a constant by PEP 8
+// convention. SQL placeholders cannot bind identifiers, so column lists
+// and table names are routinely interpolated from module constants:
+//
+//	COLUMNS = "id, name"
+//	conn.execute(f"SELECT {COLUMNS} FROM t WHERE id = ?", (i,))
+//
+// An expression counts as constant when it is an UPPER_CASE name or an
+// attribute ending in one (`schema.COLUMNS`), or a name bound by an
+// enclosing `for` over such a constant within the same function:
+//
+//	for column, sql_type in _ADDED_COLUMNS:
+//	    conn.execute(f"ALTER TABLE t ADD COLUMN {column} {sql_type}")
+//
+// Anything else — a parameter, a call, a subscript, a lower-case name —
+// keeps the match. The check is syntactic: a constant reassigned from user
+// input is not detected, which is the convention's own failure mode.
+func fstringInterpolatesNonConstant(qr parser.QueryResult, src []byte) bool {
+	m, ok := qr.Captures["match"]
+	if !ok || m.Node == nil {
+		return true
+	}
+	args := m.Node.ChildByFieldName("arguments")
+	if args == nil {
+		return true
+	}
+	for arg := range args.NamedChildren() {
+		if arg.Type() != "string" {
+			continue
+		}
+		for part := range arg.NamedChildren() {
+			if part.Type() != "interpolation" {
+				continue
+			}
+			expr := part.ChildByFieldName("expression")
+			if expr == nil || !pyConstantExpr(expr, src, true) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// pyConstantExpr reports whether expr is an UPPER_CASE name, an attribute
+// ending in one, or (when followLoops is set) a name bound by an enclosing
+// `for` loop whose iterable is itself constant.
+func pyConstantExpr(expr *sitter.Node, src []byte, followLoops bool) bool {
+	switch expr.Type() {
+	case "attribute":
+		attr := expr.ChildByFieldName("attribute")
+		return attr != nil && isPyConstantName(attr.Content(src))
+	case "identifier":
+		name := expr.Content(src)
+		if isPyConstantName(name) {
+			return true
+		}
+		return followLoops && boundByLoopOverConstant(expr, name, src)
+	}
+	return false
+}
+
+// boundByLoopOverConstant walks outwards from n to the nearest enclosing
+// scope boundary, looking for a `for` statement whose target binds name.
+// The innermost such loop decides: it binds name to an element of its
+// iterable, so the name is constant exactly when the iterable is.
+func boundByLoopOverConstant(n *sitter.Node, name string, src []byte) bool {
+	for p := n.Parent(); p != nil; p = p.Parent() {
+		switch p.Type() {
+		case "function_definition", "lambda", "class_definition":
+			return false
+		case "for_statement":
+			if !pyTargetBinds(p.ChildByFieldName("left"), name, src) {
+				continue
+			}
+			right := p.ChildByFieldName("right")
+			return right != nil && pyConstantExpr(right, src, false)
+		}
+	}
+	return false
+}
+
+// pyTargetBinds reports whether a `for` target (a name, or a possibly nested
+// tuple/list pattern) binds name.
+func pyTargetBinds(target *sitter.Node, name string, src []byte) bool {
+	if target == nil {
+		return false
+	}
+	if target.Type() == "identifier" {
+		return target.Content(src) == name
+	}
+	for child := range target.NamedChildren() {
+		if pyTargetBinds(child, name, src) {
+			return true
+		}
+	}
+	return false
+}
+
+// isPyConstantName matches PEP 8 constant names: optional leading
+// underscores, then an upper-case letter and at least one more upper-case
+// letter, digit or underscore. A single capital (`Q`) is too ambiguous.
+func isPyConstantName(s string) bool {
+	i := 0
+	for i < len(s) && s[i] == '_' {
+		i++
+	}
+	rest := s[i:]
+	if len(rest) < 2 || rest[0] < 'A' || rest[0] > 'Z' {
+		return false
+	}
+	for j := 1; j < len(rest); j++ {
+		c := rest[j]
+		if (c < 'A' || c > 'Z') && (c < '0' || c > '9') && c != '_' {
+			return false
+		}
+	}
+	return true
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/astquery/rules_sast_python_test.go
+++ b/internal/astquery/rules_sast_python_test.go
@@ -36,6 +36,56 @@ func TestPythonRulesCompile(t *testing.T) {
 	}
 }
 
+// TestPythonSQLiFStringConstants pins the f-string SQLi PostFilter: an
+// interpolation of a PEP 8 constant, or of a loop variable drawn from one, is
+// a table/column identifier (which placeholders cannot bind), not injection.
+// Any other interpolated expression must still fire.
+func TestPythonSQLiFStringConstants(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want int
+	}{
+		{"module constant", `COLUMNS = "id, name"
+conn.execute(f"SELECT {COLUMNS} FROM t WHERE id = ?", (i,))`, 0},
+		{"private constant", `conn.execute(f"SELECT {_COLUMNS} FROM t")`, 0},
+		{"attribute constant", `conn.execute(f"SELECT {schema.COLUMNS} FROM t")`, 0},
+		{"loop over constant", `for column, sql_type in _ADDED_COLUMNS:
+    conn.execute(f"ALTER TABLE t ADD COLUMN {column} {sql_type}")`, 0},
+		{"nested loop target", `for i, (column, kind) in PAIRS:
+    conn.execute(f"ALTER TABLE t ADD COLUMN {column} {kind}")`, 0},
+		{"sqlalchemy text constant", `text(f"SELECT {COLUMNS} FROM t")`, 0},
+
+		{"lower-case name", `cursor.execute(f"SELECT * FROM t WHERE x = {v}")`, 1},
+		{"single capital", `cursor.execute(f"SELECT * FROM t WHERE x = {Q}")`, 1},
+		{"one constant, one value", `cursor.execute(f"SELECT {COLUMNS} FROM t WHERE x = {v}")`, 1},
+		{"call", `cursor.execute(f"SELECT * FROM t WHERE x = {get(v)}")`, 1},
+		{"subscript of constant", `cursor.execute(f"SELECT * FROM t WHERE x = {ROWS[i]}")`, 1},
+		{"loop over non-constant", `for column in request.args:
+    conn.execute(f"ALTER TABLE t ADD COLUMN {column}")`, 1},
+		{"loop over constant, other name", `for column in COLUMNS:
+    conn.execute(f"SELECT {column} FROM t WHERE x = {v}")`, 1},
+		{"inner loop shadows constant loop", `for column in COLUMNS:
+    for column in user_columns:
+        conn.execute(f"SELECT {column} FROM t")`, 1},
+		{"loop outside the function", `for column in COLUMNS:
+    def f(column):
+        conn.execute(f"SELECT {column} FROM t")`, 1},
+		{"sqlalchemy text value", `text(f"SELECT * FROM t WHERE x = {v}")`, 1},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			rule := "py-sqli-execute-fstring"
+			if len(c.src) >= 5 && c.src[:5] == "text(" {
+				rule = "py-sqlalchemy-text-with-fstring"
+			}
+			res := runDetector(t, rule, "python", "case.py", c.src)
+			require.Equal(t, c.want, res.Total, "%s on:\n%s", rule, c.src)
+		})
+	}
+}
+
 // Per-rule firing tests. Table-driven: each entry pairs the rule
 // name with (a) source that MUST trigger the rule and (b) source
 // that MUST NOT trigger the rule.


### PR DESCRIPTION
## Summary

Stops `py-sqli-execute-fstring` and `py-sqlalchemy-text-with-fstring` from reporting f-strings whose every interpolation is a constant. SQL placeholders cannot bind identifiers, so column lists, table names and migrations are routinely built from module constants; both rules reported them at severity `error`.

Fixes #793.

## Changes

- `internal/astquery/rules_sast_python.go` — a `PostFilter` on both rules, `fstringInterpolatesNonConstant`, which keeps the match unless every `{expr}` in the call's f-string arguments is:
  - an `UPPER_CASE` name (`COLUMNS`, `_COLUMNS`) or an attribute ending in one (`schema.COLUMNS`); or
  - a name bound by the innermost enclosing `for` over such a constant, within the same function (`for column, sql_type in _ADDED_COLUMNS:`).

  It walks the captured node rather than re-parsing, using the `tsitter` wrapper the capture already carries.
- `internal/astquery/rules_sast_python_test.go` — `TestPythonSQLiFStringConstants`, 16 cases.

## Effect

| | suppressed | still fires |
|---|---|---|
| module / private / attribute constant | ✓ | |
| loop variable over a constant, incl. nested tuple targets | ✓ | |
| lower-case name, call, subscript `ROWS[i]`, single capital `Q` | | ✓ |
| constant mixed with a value in one f-string | | ✓ |
| loop over non-constant data (`request.args`) | | ✓ |
| constant loop shadowed by an inner loop | | ✓ |
| constant loop outside the enclosing function | | ✓ |

On the first-party repo from #793, the rule's three findings (all `error`) drop to zero.

## Trade-off

The check is syntactic, following the PEP 8 convention: a constant reassigned from user input is not caught. The rest of the rule is unchanged, so any interpolation of a non-constant still fires, including one next to a constant.

## Testing

- [x] All tests pass (`go test -race ./...`) — see note below
- [x] New tests added for new functionality
- [ ] Benchmarks run if performance-relevant — not performance-relevant (a parent walk per match, only on the two rules)

`go test -race ./internal/astquery/` passes, and `golangci-lint` v2.13.1 reports 0 issues on the package. I ran the affected package rather than the full suite. With the `PostFilter` removed, exactly the 6 suppression cases fail and the 10 still-firing cases pass, so the tests pin the filter rather than the pattern.

## Checklist

- [x] Code follows existing patterns in the codebase — `PostFilter`, as `secretLiteralLooksReal` does
- [x] No unnecessary abstractions added
- [ ] Language extractor includes `Meta["methods"]` for interfaces (if applicable) — n/a
- [ ] Methods have `EdgeMemberOf` edges to their containing type (if applicable) — n/a
