### PR TITLE
fix(entrypoints): treat Pydantic validators and serializers as live roots

### DIFF
--- a/internal/entrypoints/entrypoints.go
+++ b/internal/entrypoints/entrypoints.go
@@ -1,7 +1,8 @@
 // Package entrypoints detects framework entry points — symbols and
 // files reachable only from a framework runtime, never from
-// application code. Alembic migrations, Next.js pages / routes, and
-// ASP.NET host files all look unreachable to a call-graph walk; left
+// application code. Alembic migrations, Pydantic validators, Next.js
+// pages / routes, and ASP.NET host files all look unreachable to a
+// call-graph walk; left
 // unmarked they become dead-code false positives. Detect stamps
 // Meta["entry_point"] / Meta["entry_point_kind"] so the dead-code
 // analyzer treats them as live roots.
@@ -30,7 +31,7 @@ func Detect(relPath, lang string, nodes []*graph.Node, edges []*graph.Edge) int 
 	slashed := path.Clean(strings.ReplaceAll(relPath, "\\", "/"))
 	switch lang {
 	case "python":
-		return detectAlembic(nodes)
+		return detectAlembic(nodes) + detectPydantic(nodes, edges)
 	case "typescript", "javascript":
 		return detectNextJS(slashed, nodes)
 	case "csharp":
@@ -84,6 +85,79 @@ func detectAlembic(nodes []*graph.Node) int {
 			if stamp(n, "alembic:migration") {
 				count++
 			}
+		}
+	}
+	return count
+}
+
+// pydanticCallbackDecorators are the Pydantic decorators whose target
+// method is invoked by the model machinery (validation, serialization)
+// rather than by application code, so it never has a written call site.
+// `validator` / `root_validator` are the v1 spellings, still accepted by
+// v2. `validate_call` is deliberately absent: it wraps a function that
+// application code does call.
+var pydanticCallbackDecorators = map[string]string{
+	"field_validator":  "pydantic:validator",
+	"model_validator":  "pydantic:validator",
+	"validator":        "pydantic:validator",
+	"root_validator":   "pydantic:validator",
+	"field_serializer": "pydantic:serializer",
+	"model_serializer": "pydantic:serializer",
+	"computed_field":   "pydantic:computed_field",
+}
+
+const (
+	pyAnnoPrefix       = "annotation::python::"
+	pyImportPrefix     = "unresolved::import::"
+	pydanticModuleRoot = "pydantic"
+)
+
+// detectPydantic flags Pydantic validator / serializer / computed-field
+// methods from their decorator edges. Like detectJava it stamps only the
+// decorated members, never the file: a model module can still hold
+// genuinely dead helpers. The file must import pydantic, because
+// `validator` alone is too generic a name to trust.
+func detectPydantic(nodes []*graph.Node, edges []*graph.Edge) int {
+	importsPydantic := false
+	for _, e := range edges {
+		if e.Kind != graph.EdgeImports {
+			continue
+		}
+		mod, ok := strings.CutPrefix(e.To, pyImportPrefix)
+		if ok && (mod == pydanticModuleRoot || strings.HasPrefix(mod, pydanticModuleRoot+".")) {
+			importsPydantic = true
+			break
+		}
+	}
+	if !importsPydantic {
+		return 0
+	}
+
+	kinds := map[string]string{} // symbol ID → entry kind
+	for _, e := range edges {
+		if e.Kind != graph.EdgeAnnotated {
+			continue
+		}
+		name, ok := strings.CutPrefix(e.To, pyAnnoPrefix)
+		if !ok {
+			continue
+		}
+		// `@pydantic.field_validator` arrives as a dotted name.
+		if i := strings.LastIndexByte(name, '.'); i >= 0 {
+			name = name[i+1:]
+		}
+		if kind, ok := pydanticCallbackDecorators[name]; ok {
+			kinds[e.From] = kind
+		}
+	}
+
+	count := 0
+	for _, n := range nodes {
+		if !isFnOrMethod(n.Kind) {
+			continue
+		}
+		if kind, ok := kinds[n.ID]; ok && stamp(n, kind) {
+			count++
 		}
 	}
 	return count

--- a/internal/entrypoints/entrypoints_pydantic_test.go
+++ b/internal/entrypoints/entrypoints_pydantic_test.go
@@ -1,0 +1,143 @@
+package entrypoints
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zzet/gortex/internal/graph"
+	"github.com/zzet/gortex/internal/parser/languages"
+)
+
+// detectPythonFor runs the real Python extractor over src and then the
+// detector, so the test exercises the decorator and import edges the
+// extractor actually emits rather than hand-built ones.
+func detectPythonFor(t *testing.T, relPath, src string) map[string]*graph.Node {
+	t.Helper()
+	e := languages.NewPythonExtractor()
+	result, err := e.Extract(relPath, []byte(src))
+	require.NoError(t, err)
+	Detect(relPath, "python", result.Nodes, result.Edges)
+	byName := map[string]*graph.Node{}
+	for _, n := range result.Nodes {
+		if isFnOrMethod(n.Kind) {
+			byName[n.Name] = n
+		}
+	}
+	return byName
+}
+
+func entryKind(n *graph.Node) any {
+	if n == nil || n.Meta == nil {
+		return nil
+	}
+	return n.Meta[MetaEntryKind]
+}
+
+// Pydantic invokes validators and serializers itself, so they never carry
+// a written call site and every one of them read as dead code.
+func TestDetectPydantic_V2Decorators(t *testing.T) {
+	byName := detectPythonFor(t, "models.py", `from pydantic import BaseModel, computed_field, field_serializer, field_validator, model_validator
+
+
+class Offer(BaseModel):
+    price: float
+
+    @field_validator("price")
+    @classmethod
+    def _positive(cls, value: float) -> float:
+        return value
+
+    @model_validator(mode="after")
+    def _consistent(self) -> "Offer":
+        return self
+
+    @field_serializer("price")
+    def _money_out(self, value: float) -> str:
+        return f"{value:.2f}"
+
+    @computed_field
+    @property
+    def doubled(self) -> float:
+        return self.price * 2
+
+    def _helper(self) -> None:
+        pass
+`)
+	assert.Equal(t, "pydantic:validator", entryKind(byName["_positive"]))
+	assert.Equal(t, "pydantic:validator", entryKind(byName["_consistent"]))
+	assert.Equal(t, "pydantic:serializer", entryKind(byName["_money_out"]))
+	assert.Equal(t, "pydantic:computed_field", entryKind(byName["doubled"]))
+	assert.Nil(t, entryKind(byName["_helper"]), "an undecorated helper stays a dead-code candidate")
+}
+
+func TestDetectPydantic_V1DecoratorsAndModuleImport(t *testing.T) {
+	byName := detectPythonFor(t, "models.py", `import pydantic
+
+
+class Legacy(pydantic.BaseModel):
+    name: str
+
+    @pydantic.validator("name")
+    def _strip(cls, value):
+        return value.strip()
+
+    @pydantic.root_validator
+    def _whole(cls, values):
+        return values
+`)
+	assert.Equal(t, "pydantic:validator", entryKind(byName["_strip"]))
+	assert.Equal(t, "pydantic:validator", entryKind(byName["_whole"]))
+}
+
+func TestDetectPydantic_SubmoduleImport(t *testing.T) {
+	byName := detectPythonFor(t, "models.py", `from pydantic.functional_validators import field_validator
+
+
+class M:
+    @field_validator("x")
+    def _check(cls, value):
+        return value
+`)
+	assert.Equal(t, "pydantic:validator", entryKind(byName["_check"]))
+}
+
+// `validator` is too generic a name to trust on its own: without a
+// pydantic import the decorated method stays a dead-code candidate.
+func TestDetectPydantic_RequiresPydanticImport(t *testing.T) {
+	byName := detectPythonFor(t, "forms.py", `from mylib import validator
+
+
+class Form:
+    @validator("name")
+    def _check(self, value):
+        return value
+`)
+	assert.Nil(t, entryKind(byName["_check"]))
+}
+
+// A module named like pydantic is not pydantic.
+func TestDetectPydantic_LookalikeModuleIsNotPydantic(t *testing.T) {
+	byName := detectPythonFor(t, "forms.py", `from pydantic_extra_things import field_validator
+
+
+class Form:
+    @field_validator("name")
+    def _check(self, value):
+        return value
+`)
+	assert.Nil(t, entryKind(byName["_check"]))
+}
+
+// validate_call wraps a function that application code calls directly,
+// so it is not an entry point.
+func TestDetectPydantic_ValidateCallIsNotAnEntryPoint(t *testing.T) {
+	byName := detectPythonFor(t, "svc.py", `from pydantic import validate_call
+
+
+@validate_call
+def charge(amount: int) -> int:
+    return amount
+`)
+	assert.Nil(t, entryKind(byName["charge"]))
+}

--- a/internal/indexer/entry_points_test.go
+++ b/internal/indexer/entry_points_test.go
@@ -115,3 +115,48 @@ public class UserController {
 	require.False(t, dead["listUsers"], "a public @GetMapping handler is not dead")
 	require.False(t, dead["main"], "main is the JVM entry point, not dead")
 }
+
+// TestIndex_PydanticValidatorsNotDead is the end-to-end check for the
+// Pydantic detector: validators and serializers are invoked by the model
+// machinery, so they must not be reported dead, while an uncalled helper
+// on the same model still is.
+func TestIndex_PydanticValidatorsNotDead(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "models.py"), `from pydantic import BaseModel, field_serializer, field_validator, model_validator
+
+
+class Offer(BaseModel):
+    price: float
+
+    @field_validator("price")
+    @classmethod
+    def _positive(cls, value: float) -> float:
+        return value
+
+    @model_validator(mode="after")
+    def _consistent(self) -> "Offer":
+        return self
+
+    @field_serializer("price")
+    def _money_out(self, value: float) -> str:
+        return f"{value:.2f}"
+
+    def _unused_helper(self) -> None:
+        pass
+`)
+	g := graph.New()
+	reg := parser.NewRegistry()
+	reg.Register(languages.NewPythonExtractor())
+	idx := New(g, reg, config.Default().Index, zap.NewNop())
+	_, err := idx.Index(dir)
+	require.NoError(t, err)
+
+	dead := map[string]bool{}
+	for _, d := range analysis.FindDeadCode(g, nil, nil) {
+		dead[d.Name] = true
+	}
+	require.False(t, dead["_positive"], "@field_validator is invoked by pydantic, not dead")
+	require.False(t, dead["_consistent"], "@model_validator is invoked by pydantic, not dead")
+	require.False(t, dead["_money_out"], "@field_serializer is invoked by pydantic, not dead")
+	require.True(t, dead["_unused_helper"], "an uncalled helper on the model must still be reported dead")
+}


### PR DESCRIPTION
## Summary

Marks Pydantic validators, serializers and computed fields as framework entry points, so `analyze dead_code` stops reporting them. Pydantic invokes them itself during validation and serialization; they never have a written call site. This is the remaining false-positive class on Pydantic-heavy code after #600.

Fixes #794.

## Changes

- `internal/entrypoints/entrypoints.go` — `detectPydantic`, added to the `python` arm alongside `detectAlembic`. It reads the `EdgeAnnotated` edges the Python extractor already emits for decorators (`annotation::python::<name>`) and stamps functions/methods decorated with `field_validator`, `model_validator`, `field_serializer`, `model_serializer`, `computed_field`, or the v1 `validator` / `root_validator`; a dotted `@pydantic.field_validator` is matched on its last segment.
  - **Import-gated:** only when the file imports `pydantic` or a `pydantic.*` submodule, because `validator` on its own is too generic a name. A look-alike module (`pydantic_extra_things`) does not count.
  - **Members only:** like `detectJava`, it stamps the decorated members, never the file, so genuinely dead helpers on a model are still reported.
  - `validate_call` is deliberately excluded: it wraps a function that application code calls.
- `internal/entrypoints/entrypoints_pydantic_test.go` — six tests that run the real Python extractor, following `detectRustFor`: v2 decorators, v1 spellings via `import pydantic`, a submodule import, no pydantic import, a look-alike module, and `validate_call`.
- `internal/indexer/entry_points_test.go` — `TestIndex_PydanticValidatorsNotDead`, the end-to-end check alongside the Alembic and Java ones: after indexing, the validators are not dead and an uncalled helper on the same model still is.

## Effect

On the two first-party Python repos from #794, `dead_code` goes from 18 hits (all Pydantic) to 0, with 18 methods stamped `pydantic:*`.

## Testing

- [x] All tests pass (`go test -race ./...`) — see note below
- [x] New tests added for new functionality
- [ ] Benchmarks run if performance-relevant — not performance-relevant (two passes over one file's edges, only for Python files)

`go test -race` passes on `./internal/entrypoints/` and `./internal/analysis/`, and `golangci-lint` v2.13.1 reports 0 issues. I ran the affected packages rather than the full suite. With `detectPydantic` unhooked, the three positive detector tests and the indexer test fail; with the import gate removed, the two negative gate tests fail.

In `./internal/indexer/`, everything passes except `TestBuildCommitLayerNeverFetchesPromisedRenameBlobs`. It fails identically on unmodified `main` (56a1c29d) on this machine, at its promisor-fixture probe (`warning: lazy fetching disabled ... could not fetch ... from promisor remote`), which looks like the local git (2.43.0) rather than anything in this change.

## Checklist

- [x] Code follows existing patterns in the codebase — annotation-driven detector as `detectJava`, extractor-backed tests as the Rust ones
- [x] No unnecessary abstractions added
- [ ] Language extractor includes `Meta["methods"]` for interfaces (if applicable) — n/a
- [ ] Methods have `EdgeMemberOf` edges to their containing type (if applicable) — n/a
